### PR TITLE
import egovframework.rte 를 org.egovframe.rte 로 수정 등

### DIFF
--- a/src/test/java/egovframework/com/auth/pattern/TestSessionURLPattern.java
+++ b/src/test/java/egovframework/com/auth/pattern/TestSessionURLPattern.java
@@ -9,8 +9,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
-import egovframework.com.auth.session.EgovAccessConfigTest;
-import egovframework.rte.fdl.access.interceptor.EgovAccessUtil;
+import org.egovframe.rte.fdl.access.interceptor.EgovAccessUtil;
 
 /**
  * @TestSessionURLPattern Test Class 구현 (AntPattern 검증 및 RegexPattern URL 검증)

--- a/src/test/java/egovframework/com/auth/session/EgovAccessConfigTest.java
+++ b/src/test/java/egovframework/com/auth/session/EgovAccessConfigTest.java
@@ -20,9 +20,9 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
-import egovframework.rte.fdl.access.bean.AuthorityResourceMetadata;
-import egovframework.rte.fdl.access.interceptor.EgovAccessUtil;
-import egovframework.rte.fdl.access.service.EgovUserDetailsHelper;
+import org.egovframe.rte.fdl.access.bean.AuthorityResourceMetadata;
+import org.egovframe.rte.fdl.access.interceptor.EgovAccessUtil;
+import egovframework.com.cmm.util.EgovUserDetailsHelper;
 
 /**
  * EgovAccessConfigTest Test Class 구현 (실행환경 세션접근제어 테스트)

--- a/src/test/java/egovframework/com/crypto/data/EgovDataCryptoTest.java
+++ b/src/test/java/egovframework/com/crypto/data/EgovDataCryptoTest.java
@@ -21,8 +21,8 @@ import org.junit.runner.RunWith;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
-import egovframework.rte.fdl.cryptography.EgovCryptoService;
-import egovframework.rte.fdl.cryptography.EgovDigestService;
+import org.egovframe.rte.fdl.cryptography.EgovCryptoService;
+import org.egovframe.rte.fdl.cryptography.EgovDigestService;
 
 /**
  * ID Generation Test Class 구현

--- a/src/test/java/egovframework/com/crypto/err/TestEncrypt.java
+++ b/src/test/java/egovframework/com/crypto/err/TestEncrypt.java
@@ -7,9 +7,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
-import egovframework.com.utl.wed.web.EgovWebEditorImageController;
-import egovframework.rte.fdl.cryptography.EgovEnvCryptoService;
-import egovframework.rte.fdl.cryptography.impl.EgovEnvCryptoServiceImpl;
+import org.egovframe.rte.fdl.cryptography.EgovEnvCryptoService;
+import org.egovframe.rte.fdl.cryptography.impl.EgovEnvCryptoServiceImpl;
 
 /**
  * egovframework.rte.fdl.crypto v3.7 이하의 오류 테스트
@@ -32,6 +31,7 @@ public class TestEncrypt {
 	private static final Logger LOGGER = LoggerFactory.getLogger(TestEncrypt.class);
 	private static EgovEnvCryptoService cryptoService;
 	
+	@SuppressWarnings("resource")
 	public static void main(String[] args) {
 		// TODO Auto-generated method stub
     	//WebApplicationContext wac = WebApplicationContextUtils.getRequiredWebApplicationContext(request.getServletContext());

--- a/src/test/java/egovframework/com/crypto/err/TestEncryptV37.java
+++ b/src/test/java/egovframework/com/crypto/err/TestEncryptV37.java
@@ -8,8 +8,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
-import egovframework.rte.fdl.cryptography.EgovARIACryptoService;
-import egovframework.rte.fdl.cryptography.EgovPasswordEncoder;
+import org.egovframe.rte.fdl.cryptography.EgovARIACryptoService;
+import org.egovframe.rte.fdl.cryptography.EgovPasswordEncoder;
 
 /**
  * egovframework.rte.fdl.crypto v3.7 이하의 오류 테스트
@@ -34,6 +34,7 @@ public class TestEncryptV37 {
 	private static EgovPasswordEncoder egovPasswordEncoder;
 	private static String pKey = "my-egovframe-crypto-key";
 	
+	@SuppressWarnings("resource")
 	public static void main(String[] args) {
 		// TODO Auto-generated method stub
     	//WebApplicationContext wac = WebApplicationContextUtils.getRequiredWebApplicationContext(request.getServletContext());

--- a/src/test/java/egovframework/com/crypto/xmlconfig/EgovEnvCryptoAlgorithmCreateTest.java
+++ b/src/test/java/egovframework/com/crypto/xmlconfig/EgovEnvCryptoAlgorithmCreateTest.java
@@ -3,7 +3,7 @@ package egovframework.com.crypto.xmlconfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import egovframework.rte.fdl.cryptography.EgovPasswordEncoder;
+import org.egovframe.rte.fdl.cryptography.EgovPasswordEncoder;
 
 public class EgovEnvCryptoAlgorithmCreateTest {
 

--- a/src/test/java/egovframework/com/crypto/xmlconfig/EgovEnvCryptoUserTest.java
+++ b/src/test/java/egovframework/com/crypto/xmlconfig/EgovEnvCryptoUserTest.java
@@ -5,13 +5,14 @@ import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
-import egovframework.rte.fdl.cryptography.EgovEnvCryptoService;
-import egovframework.rte.fdl.cryptography.impl.EgovEnvCryptoServiceImpl;
+import org.egovframe.rte.fdl.cryptography.EgovEnvCryptoService;
+import org.egovframe.rte.fdl.cryptography.impl.EgovEnvCryptoServiceImpl;
 
 public class EgovEnvCryptoUserTest {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(EgovEnvCryptoUserTest.class);
 	
+	@SuppressWarnings("resource")
 	public static void main(String[] args) {
 		 
 		String[] arrCryptoString = { 

--- a/src/test/java/egovframework/com/idgen/TestIDGen.java
+++ b/src/test/java/egovframework/com/idgen/TestIDGen.java
@@ -3,8 +3,8 @@ package egovframework.com.idgen;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
-import egovframework.rte.fdl.cmmn.exception.FdlException;
-import egovframework.rte.fdl.idgnr.EgovIdGnrService;
+import org.egovframe.rte.fdl.cmmn.exception.FdlException;
+import org.egovframe.rte.fdl.idgnr.EgovIdGnrService;
 
 /**
  * ID Generation Test Class 구현
@@ -25,6 +25,7 @@ import egovframework.rte.fdl.idgnr.EgovIdGnrService;
 
 public class TestIDGen {
 
+	@SuppressWarnings("resource")
 	public static void main(String[] args) {
 
 		// ApplicationContext (BeanFactory 상속 받음)

--- a/src/test/java/egovframework/com/uss/umt/TestMakePwd.java
+++ b/src/test/java/egovframework/com/uss/umt/TestMakePwd.java
@@ -3,9 +3,9 @@ package egovframework.com.uss.umt;
 import java.security.MessageDigest;
 
 import org.apache.commons.codec.binary.Hex;
-import org.springframework.security.authentication.encoding.ShaPasswordEncoder;
+//import org.springframework.security.authentication.encoding.ShaPasswordEncoder;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.security.crypto.password.StandardPasswordEncoder;
+//import org.springframework.security.crypto.password.StandardPasswordEncoder;
 
 import egovframework.com.utl.sim.service.EgovFileScrty;
 
@@ -55,14 +55,14 @@ public class TestMakePwd {
 		    String result = new String(Hex.encodeHexString(digest));
 			System.out.println("==>> MessageDigest(Spring Security sha-256) > encryptPassword = "+result);
 			
-			ShaPasswordEncoder encoder = new ShaPasswordEncoder(); 
-			String shaEncryptPassword = encoder.encodePassword(memberPwd,memberId);
-			System.out.println("==>> ShaPasswordEncoder > encryptPassword = "+shaEncryptPassword);
+//			ShaPasswordEncoder encoder = new ShaPasswordEncoder(); 
+//			String shaEncryptPassword = encoder.encodePassword(memberPwd,memberId);
+//			System.out.println("==>> ShaPasswordEncoder > encryptPassword = "+shaEncryptPassword);
 
 		
-			StandardPasswordEncoder stdEncoder = new StandardPasswordEncoder();
-			String stdEncryptPassword = stdEncoder.encode(memberPwd);
-			System.out.println("==>> StandardPasswordEncoder > encryptPassword = "+stdEncryptPassword);
+//			StandardPasswordEncoder stdEncoder = new StandardPasswordEncoder();
+//			String stdEncryptPassword = stdEncoder.encode(memberPwd);
+//			System.out.println("==>> StandardPasswordEncoder > encryptPassword = "+stdEncryptPassword);
 
 			BCryptPasswordEncoder bcEncoder = new BCryptPasswordEncoder();
 			String bcEncryptPassword = bcEncoder.encode(memberPwd);

--- a/src/test/java/egovframework/com/uss/umt/validation/JuminValidationTest.java
+++ b/src/test/java/egovframework/com/uss/umt/validation/JuminValidationTest.java
@@ -6,7 +6,7 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
-import egovframework.rte.ptl.mvc.validation.RteGenericValidator;
+import org.egovframe.rte.ptl.mvc.validation.RteGenericValidator;
 
 /**
  * 비밀번호 생성 Test Class 구현

--- a/src/test/java/egovframework/com/uss/umt/validation/PasswordValidationTest.java
+++ b/src/test/java/egovframework/com/uss/umt/validation/PasswordValidationTest.java
@@ -6,7 +6,7 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
-import egovframework.rte.ptl.mvc.validation.RteGenericValidator;
+import org.egovframe.rte.ptl.mvc.validation.RteGenericValidator;
 
 /**
  * 비밀번호 생성 Test Class 구현

--- a/src/test/resources/egovframework/spring/com/idgn/context-idgn-Test.xml
+++ b/src/test/resources/egovframework/spring/com/idgn/context-idgn-Test.xml
@@ -3,14 +3,14 @@
     xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd">
 
     <!-- TEST (Sequence) -->
-    <bean name="testSeqIdGnrService" class="egovframework.rte.fdl.idgnr.impl.EgovSequenceIdGnrService" destroy-method="destroy">
+    <bean name="testSeqIdGnrService" class="org.egovframe.rte.fdl.idgnr.impl.EgovSequenceIdGnrService" destroy-method="destroy">
         <property name="dataSource" ref="egov.dataSource" />
         <property name="strategy"   ref="prefixSeqBoard" />
         <property name="query" value="sELECT SEQ_NO.NEXTVAL FROM DUAL" />
     </bean>
     
     <!-- TEST (Table) -->
-    <bean name="testTableIdGnrService" class="egovframework.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
+    <bean name="testTableIdGnrService" class="org.egovframe.rte.fdl.idgnr.impl.EgovTableIdGnrServiceImpl" destroy-method="destroy">
         <property name="dataSource" ref="egov.dataSource" />
         <property name="strategy"   ref="prefixSeqBoard" />
         <property name="blockSize"  value="10"/>
@@ -18,7 +18,7 @@
         <property name="tableName"  value="SYH_ID"/>
     </bean>
 
-	<bean name="prefixSeqBoard" class="egovframework.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
+	<bean name="prefixSeqBoard" class="org.egovframe.rte.fdl.idgnr.impl.strategy.EgovIdGnrStrategyImpl">
 		<property name="prefix" value="TEST" />
 		<property name="cipers" value="20" />
 		<property name="fillChar" value="0" />


### PR DESCRIPTION
1. import egovframework.rte 를 org.egovframe.rte 로 수정
 - The import egovframework.rte cannot be resolved

2. TestEncrypt 사용 안 하는 import 제거 등
 - import egovframework.com.utl.wed.web.EgovWebEditorImageController;
 - @SuppressWarnings("resource") 추가

3. TestEncryptV37 @SuppressWarnings("resource") 추가

4. EgovEnvCryptoUserTest @SuppressWarnings("resource") 추가

5. TestIDGen @SuppressWarnings("resource") 추가

6. TestMakePwd deprecated 주석