### PR TITLE
2022 전자정부 표준프레임워크 컨트리뷰션 참가 - 공통 컴포넌트 안내 문서 개선 및 코딩 컨벤션 적용 #65, #69, #70, #73

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,29 @@
+# top-most EditorConfig file
+root = true
+
+[*]
+# [encoding-utf8]
+charset = utf-8
+
+# [newline-lf]
+end_of_line = lf
+
+# [newline-eof]
+insert_final_newline = true
+
+[*.bat]
+end_of_line = crlf
+
+[*.java]
+# [indentation-tab]
+indent_style = tab
+
+# [4-spaces-tab]
+indent_size = 4
+tab_width = 4
+
+# [no-trailing-spaces]
+trim_trailing_whitespace = true
+
+[line-length-120]
+max_line_length = 120

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,14 @@
 # Auto detect text files and perform LF normalization
 * text=auto
+
+# line Feed 컨벤션 설정
+*.c text eol=lf
+*.cpp text eol=lf
+*.h text eol=lf
+
+# exception for visual studio project configuration
+*.sln text eol=crlf
+*.vs text eol=crlf
+*.csproj eol=crlf
+*.props eol=crlf
+*.filters eol=crlf

--- a/Docs/egov-coding-convention.md
+++ b/Docs/egov-coding-convention.md
@@ -1,0 +1,1 @@
+# Egov Coding Convention

--- a/Docs/egov-coding-convention.md
+++ b/Docs/egov-coding-convention.md
@@ -7,6 +7,12 @@
 자세한 스펙은 [https://editorconfig.org/](https://editorconfig.org/) 에서 파악할 수 있다. 
 다양한 에디터로 파일을 고칠 때 같은 규칙을 참조할수 있도록 가급적 이 파일을 소스 저장소에서 올려서 공유하는 것을 권장한다.
 
+## 2. .gitattributes 적용
+Unix 형식의 새줄 문자(newline)인 LF(Line Feed, 0x0A)을 사용한다.
+Windows 형식인 CRLF가 섞이지 않도록 편집기와 GIT 설정 등을 확인한다.
+파일은 디렉토리별로 지정할 수 있다. 전체 프로젝트에 적용한다면 최상위 디렉토리에 둔다.
 
+
+---
 참고.
 1. [https://editorconfig](https://editorconfig.org/)

--- a/Docs/egov-coding-convention.md
+++ b/Docs/egov-coding-convention.md
@@ -1,1 +1,12 @@
 # Egov Coding Convention
+
+이 문서는 캠퍼스 핵데이 Java 코딩 컨벤션 참고하여 작성되었음.
+
+## 1. .editorconfig 적용
+다양한 에디터와 IDE에서 공통적으로 지원하는 코드 스타일에 대한 설정 파일이다. 
+자세한 스펙은 [https://editorconfig.org/](https://editorconfig.org/) 에서 파악할 수 있다. 
+다양한 에디터로 파일을 고칠 때 같은 규칙을 참조할수 있도록 가급적 이 파일을 소스 저장소에서 올려서 공유하는 것을 권장한다.
+
+
+참고.
+1. [https://editorconfig](https://editorconfig.org/)

--- a/Docs/egov-coding-convention.md
+++ b/Docs/egov-coding-convention.md
@@ -1,10 +1,10 @@
 # Egov Coding Convention
 
-이 문서는 캠퍼스 핵데이 Java 코딩 컨벤션 참고하여 작성되었음.
+이 문서는 [캠퍼스 핵데이 Java 코딩 컨벤션][캠퍼스 핵데이 Java 코딩 컨벤션] 참고하여 작성되었음.
 
 ## 1. .editorconfig 적용
 다양한 에디터와 IDE에서 공통적으로 지원하는 코드 스타일에 대한 설정 파일이다. 
-자세한 스펙은 [https://editorconfig.org/](https://editorconfig.org/) 에서 파악할 수 있다. 
+자세한 스펙은 [editorconfig 페이지][editorconfig]에서 파악할 수 있다. 
 다양한 에디터로 파일을 고칠 때 같은 규칙을 참조할수 있도록 가급적 이 파일을 소스 저장소에서 올려서 공유하는 것을 권장한다.
 
 ## 2. .gitattributes 적용
@@ -12,7 +12,39 @@ Unix 형식의 새줄 문자(newline)인 LF(Line Feed, 0x0A)을 사용한다.
 Windows 형식인 CRLF가 섞이지 않도록 편집기와 GIT 설정 등을 확인한다.
 파일은 디렉토리별로 지정할 수 있다. 전체 프로젝트에 적용한다면 최상위 디렉토리에 둔다.
 
+## 3. Checkstyle 사용법
+### 1) egov-checkstyle-rules.xml 적용
+코딩컨벤션 검사 도구이다. 이 가이드에서 안내하는 규칙을 검사하는 checkstyle 규칙 설정 파일을 제공한다.
+
+### 2) egov-checkstyle-suppressions.xml 적용
+Checkstyle에서는 검사대상에서 제외할 파일을 별도의 설정파일에서 지정할 수 있다.
+
+
+## 4. IDE Formatter 적용
+이 가이드의 규칙을 지키는데 도움이 되는 코드 편집기와 뷰어 자동 설정 방법을 정리한다.
+
+### 1) eclipse 에서 적용
+#### - Formatter 메뉴로 이동
+- Workspace 전역설정은 `Window > Preference > Java > Code style > Formatter`에서 이동한다.
+- 프로젝트별 설정은 `Project > Properties > Java Code style > Formatter`로 이동한다.
+
+#### - Formatter 항목 설정
+- 프로젝트별 설정의 경우 `Enable project specific settings`를 선택한다.
+- `[Import]` 버튼을 누른 후, 다운로드 한 egov-eclipse-formatter.xml 파일을 선택한다.
+- `[OK]`버튼을 누른다.
+
+### 2) intellij 에서 적용
+
+#### - Scheme 적용
+- `File > Settings` 메뉴로 이동한다. (단축키 `Alt + Shift + S` )
+- `Editor > Code Style > Java` 항목으로 이동한다.
+- Scheme 항목의 오른쪽에 있는 톱니바퀴 아이콘을 클릭한다.
+- `Import Scheme > IntelliJ IDEA Code Style XML` 을 선택한다.
+- `egov-intellij-formatter.xml` 파일을 선택한후 `[OK]` 버튼을 누른다.
+- Settings 레이어의 `[OK]` 버튼을 누른다.
+
 
 ---
 참고.
-1. [https://editorconfig](https://editorconfig.org/)
+1. [캠퍼스 핵데이 Java 코딩 컨벤션]: https://naver.github.io/hackday-conventions-java/
+2. [editorconfig]: https://editorconfig.org/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,54 @@
-# egovframe-common-components
+# 표준 프레임 워크 공통 컴포넌트 egovframe-common-components
  252 common functions that are reusable. 
+
+## 환경 설정
+프로젝트에서 사용된 환경 프로그램 정보는 다음과 같다.
+
+| 프로그램 명 | 버전 명 |
+| :--------- | :------ |
+| java       | 1.8     |
+| maven      | 3.8.1   |
+
+## 구동방법
+
+### 1. 구동 전 구동 환경 확인 사항 - globals.properties 설정 확인 사항 확인
+
+
+`src/main/resources/egovframework/egovProps/globals.properties` 에서
+`Globals.DbType` 과 그에 따른
+```
+Globals.[Globals.DbType 값].DriverClassName
+Globals.[Globals.DbType 값].Url
+Globals.[Globals.DbType 값].UserName
+Globals.[Globals.DbType 값].Password
+```
+이 현재 개발(테스트)환경에 맞춰져 있는지 확인한다. 자세한 사항은 [개발자 가이드 - 환경 설정][환경설정]를 확인한다.
+
+### 2.1 IDE 구동 방법
+/////////////////<정식 버전 배포전 확인 필요>////////////////////
+
+개발환경에서 프로젝트 우클릭 > Run As > Run On Server를 통해 구동한다.
+
+/////////////////<정식 버전 배포전 확인 필요>////////////////////
+
+### 2.2 CLI 구동 방법
+
+/////////////////<정식 버전 배포전 확인 필요>////////////////////
+```bash
+mvn spring-boot:run
+```
+/////////////////<정식 버전 배포전 확인 필요>////////////////////
+
+상세 구동 방법은 [개발자 가이드 - 시작하기][시작하기]를 참고한다.
+
+---
+참고
+
+세부 참고 사항은 [개발자 가이드][개발자가이드]를 확인한다.
+
+[환경설정]: https://www.egovframe.go.kr/wiki/doku.php?id=egovframework:com:v4.0:init_configration
+
+[시작하기]: https://www.egovframe.go.kr/wiki/doku.php?id=egovframework:dev4.0:gettingstarted
+
+[개발자가이드]: https://www.egovframe.go.kr/wiki/doku.php?id=egovframework:%EC%8B%A4%ED%96%89%ED%99%98%EA%B2%BD%EA%B0%80%EC%9D%B4%EB%93%9C
+

--- a/egov-checkstyle-rules.xml
+++ b/egov-checkstyle-rules.xml
@@ -1,0 +1,431 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+        "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+        "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+
+<!-- egovframework coding convention for Java (version 1.2)  -->
+<!-- This rule file requires Checkstyle version 8.24 or above. -->
+
+<!--
+The following rules in the egovframework coding convention cannot be checked by this configuration file.
+- [avoid-korean-pronounce]
+- [class-noun]
+- [interface-noun-adj]
+- [method-verb-preposition]
+- [space-after-bracket]
+- [space-around-comment]
+-->
+
+<module name = "Checker">
+    <property name="severity" value="warning"/>
+    <property name="fileExtensions" value="java"/>
+
+    <!-- [encoding-utf8] -->
+    <property name="charset" value="UTF-8"/>
+
+    <!-- [newline-lf] -->
+    <module name="RegexpMultiline">
+        <property name="format" value="\r\n"/>
+        <property name="message" value="[newline-lf] Line must end with LF, not CRLF"/>
+    </module>
+
+    <!-- [newline-eof] -->
+    <module name="NewlineAtEndOfFile">
+        <property name="lineSeparator" value="lf"/>
+    </module>
+
+    <!-- [no-trailing-spaces] -->
+    <module name="RegexpSingleline">
+        <property name="format" value="^(?!\s+\* $).*?\s+$"/>
+        <property name="message" value="[no-trailing-spaces] Line has trailing spaces."/>
+    </module>
+
+    <!-- [line-length-120] -->
+    <property name="tabWidth" value="4"/>
+    <module name="LineLength">
+        <property name="max" value="120"/>
+        <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
+        <message key="maxLineLen"
+                 value="[line-length-120] Line is longer than {0,number,integer} characters (found {1,number,integer})"/>
+    </module>
+
+    <module name="TreeWalker">
+        <!-- Start of Naming chapter -->
+
+        <!-- [list-uppercase-abbr] -->
+        <module name="AbbreviationAsWordInName">
+            <property name="ignoreFinal" value="false"/>
+            <property name="allowedAbbreviationLength" value="1"/>
+            <message key="abbreviation.as.word"
+                     value="[list-uppercase-abbr] Abbreviation in name ''{0}'' must contain no more than {1}"/>
+            <property name="allowedAbbreviations" value="DAO,BO"/>
+        </module>
+
+        <!-- [package-lowercase] -->
+        <module name="PackageName">
+            <property name="format" value="^[a-z]+(\.[a-z][a-z0-9]*)*$"/>
+            <message key="name.invalidPattern"
+                     value="[package-lowercase] Package name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+
+
+        <!-- [class-interface-lower-camelcase] -->
+        <module name="TypeName">
+            <message key="name.invalidPattern"
+                     value="[class-interface-lower-camelcase] Type name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+
+        <!-- [method-lower-camelcase] -->
+        <module name="MethodName">
+            <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9_]*$"/>
+            <message key="name.invalidPattern"
+                     value="[method-lower-camelcase] Method name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+
+        <!-- [var-lower-camelcase] -->
+        <module name="MemberName">
+            <property name="format" value="^[a-z][a-zA-Z0-9][a-zA-Z0-9]*$"/>
+            <message key="name.invalidPattern"
+                     value="[var-lower-camelcase] Member name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="ParameterName">
+            <property name="format" value="^[a-z][a-zA-Z0-9][a-zA-Z0-9]*$"/>
+            <message key="name.invalidPattern"
+                     value="[var-lower-camelcase] Parameter name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+
+        <!-- [var-lower-camelcase], [avoid-1-char-var] -->
+        <module name="LocalVariableName">
+            <property name="tokens" value="VARIABLE_DEF"/>
+            <property name="format" value="^[a-z][a-zA-Z0-9][a-zA-Z0-9]*$"/>
+            <property name="allowOneCharVarInForLoop" value="true"/>
+            <message key="name.invalidPattern"
+                     value="[var-lower-camelcase][avoid-1-char-var] Local variable name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+
+        <!-- End of Naming chapter -->
+
+        <!-- Start of Declarations chapter -->
+
+        <!-- [1-top-level-class] -->
+        <module name="OneTopLevelClass"/>
+        <message key="name.invalidPattern"
+                 value="[1-top-level-class] one.top.level.class=Top-level class {0} has to reside in its own source file."/>
+
+        <!-- [avoid-star-import] -->
+        <module name="AvoidStarImport">
+            <property name="allowStaticMemberImports" value="true"/>
+            <message key="import.avoidStar"
+                     value="[avoid-star-import] Using the ''.*'' form of import should be avoided - {0}."/>
+        </module>
+
+        <!-- [modifier-order] -->
+        <module name="ModifierOrder">
+            <message key="mod.order"
+                     value="[modifier-order] ''{0}'' modifier out of order with the JLS suggestions."/>
+            <message key="annotation.order"
+                     value="[modifier-order] ''{0}'' annotation modifier does not precede non-annotation modifiers."/>
+        </module>
+
+        <!-- [newline-after-annotation] -->
+        <module name="AnnotationLocation">
+            <property name="tokens" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF"/>
+            <property name="allowSamelineSingleParameterlessAnnotation" value="true"/>
+            <message key="annotation.location.alone"
+                     value="[newline-after-annotation] Annotation ''{0}'' should be alone on line."/>
+        </module>
+
+        <!-- [1-state-per-line] -->
+        <module name="OneStatementPerLine">
+            <message key="needBraces"
+                     value="[1-state-per-line] Only one statement per line allowed."/>
+        </module>
+
+        <!-- [1-var-per-declaration] -->
+        <module name="MultipleVariableDeclarations">
+            <message key="multiple.variable.declarations"
+                     value="[1-var-per-declaration] Only one variable definition per line allowed."/>
+            <message key="multiple.variable.declarations.comma"
+                     value="[1-var-per-declaration] Each variable declaration must be in its own statement."/>
+        </module>
+
+        <!-- [array-square-after-type] -->
+        <module name="ArrayTypeStyle">
+            <message key="array.type.style"
+                     value="[array-square-after-type] Array brackets at illegal position."/>
+        </module>
+
+        <!-- [long-value-suffix] -->
+        <module name="UpperEll">
+            <message key="upperEll" value="[long-value-suffix] Should use uppercase ''L''."/>
+        </module>
+
+        <!-- [special-escape] -->
+        <module name="IllegalTokenText">
+            <property name="tokens" value="STRING_LITERAL, CHAR_LITERAL"/>
+            <property name="format" value="\\u00(08|09|0(a|A)|0(c|C)|0(d|D)|22|27|5(C|c))|\\(0(10|11|12|14|15|42|47)|134)"/>
+            <property name="message" value="[array-square-after-type]  Avoid using corresponding octal or Unicode escape."/>
+        </module>
+
+        <!-- End of Declarations chapter -->
+
+        <!-- Start of Indentation chapter -->
+
+        <!-- [4-spaces-tab] -->
+        <property name="tabWidth" value="4"/>
+
+        <!-- [indentation-tab] -->
+        <module name="RegexpSinglelineJava">
+            <property name="format" value="^\t* "/>
+            <property name="message" value="[indentation-tab] Indent must use tab characters"/>
+            <property name="ignoreComments" value="true"/>
+        </module>
+
+        <!-- End of Indentation chapter -->
+
+        <!-- Start of Braces chapter -->
+
+        <!-- [braces-knr-style]-->
+        <module name="LeftCurly">
+            <message key="line.break.after"
+                     value="[braces-knr-style] ''{0}'' at column {1} should have line break after."/>
+            <message key="line.new"
+                     value="[braces-knr-style] ''{0}'' at column {1} should be on a new line."/>
+            <message key="line.previous"
+                     value="[braces-knr-style] ''{0}'' at column {1} should be on the previous line."/>
+        </module>
+        <module name="RightCurly">
+            <property name="option" value="alone"/>
+            <property name="tokens" value="CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, STATIC_INIT, INSTANCE_INIT"/>
+            <message key="line.alone"
+                     value="[braces-knr-style] ''{0}'' at column {1} should be alone on a line."/>
+            <message key="line.break.before"
+                     value="[braces-knr-style] =''{0}'' at column {1} should have line break before."/>
+            <message key="line.new"
+                     value="[braces-knr-style] ''{0}'' at column {1} should be on a new line."/>
+        </module>
+
+        <!-- [sub-flow-after-brace] -->
+        <module name="RightCurly">
+            <property name="option" value="same"/>
+            <property name="tokens" value="LITERAL_TRY, LITERAL_CATCH, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_DO"/>
+            <message key="line.same"
+                     value="[sub-flow-after-brace] ''{0}'' at column {1} should be on the same line as the next part of a multi-block statement (one that directly contains multiple blocks: if/else-if/else or try/catch/finally)."/>
+            <message key="line.break.before"
+                     value="[sub-flow-after-brace] ''{0}'' at column {1} should have line break before."/>
+        </module>
+
+        <!-- [need-braces] -->
+        <module name="NeedBraces">
+            <message key="needBraces"
+                     value="[need-braces] ''{0}'' statement must use '''{}'''s."/>
+        </module>
+
+        <!-- End of Braces chapter -->
+
+        <!-- Start of Line-wrapping chapter -->
+
+        <!-- [1-line-package-import]-->
+        <module name="NoLineWrap">
+            <property name="tokens" value="PACKAGE_DEF, IMPORT"/>
+            <message key="no.line.wrap"
+                     value="[1-line-package-import] {0} statement should not be line-wrapped."/>
+        </module>
+
+        <!-- [block-indentation][indentation-after-line-wrapping] -->
+        <!-- checkstyle 6.16 이상을 써야지 탭을 쓸때의 인덴트 체크가 제대로 동작함 -->
+        <module name="Indentation">
+            <property name="basicOffset" value="4"/>
+            <property name="braceAdjustment" value="0"/>
+            <property name="caseIndent" value="4"/>
+            <property name="throwsIndent" value="4"/>
+            <property name="lineWrappingIndentation" value="4"/>
+            <property name="arrayInitIndent" value="4"/>
+        </module>
+
+        <!-- [line-wrapping-position] -->
+        <module name="SeparatorWrap">
+            <property name="tokens" value="COMMA"/>
+            <property name="option" value="EOL"/>
+            <message key="line.previous"
+                     value="[line-wrapping-position] ''{0}'' should be on the previous line."/>
+        </module>
+        <module name="SeparatorWrap">
+            <property name="tokens" value="DOT"/>
+            <property name="option" value="NL"/>
+            <message key="line.new"
+                     value="[line-wrapping-position] ''{0}'' should be on a new line."/>
+        </module>
+        <module name="OperatorWrap">
+            <property name="option" value="NL"/>
+            <property name="tokens" value="BAND, BOR, BSR, BXOR, DIV, EQUAL, GE, GT, LAND, LE, LITERAL_INSTANCEOF, LOR, LT, MINUS, MOD, NOT_EQUAL, PLUS, QUESTION, SL, SR, STAR "/>
+            <message key="line.new"
+                     value="[line-wrapping-position] ''{0}'' should be on a new line."/>
+        </module>
+
+        <!-- End of Line-wrapping chapter -->
+
+        <!-- Start of Blank lines chapter -->
+
+        <!-- [blankline-after-package] -->
+        <!--
+        This module always requires an empty line between header and package.
+        But it is not forced in the egovframework guide.
+        See https://github.com/checkstyle/checkstyle/issues/1035
+        <module name="EmptyLineSeparator">
+            <property name="tokens" value="PACKAGE_DEF"/>
+            <message key="empty.line.separator"
+                value="[blankline-after-package] ''{0}'' should be separated from previous statement."/>
+        </module>
+        -->
+
+        <!-- [import-grouping] -->
+        <module name="ImportOrder">
+            <property name="groups" value="java., javax., org., net., com., /(?!java\.|javax\.|com\.|org\.|net\.)/, org.egovframe., egovframework.com"/>
+            <property name="ordered" value="true"/>
+            <property name="separated" value="true"/>
+            <property name="option" value="top"/>
+            <property name="sortStaticImportsAlphabetically" value="true"/>
+            <message key="import.groups.separated.internally"
+                     value="[import-grouping] Extra separation in import group before ''{0}''"/>
+            <message key="import.ordering"
+                     value="[import-grouping] Wrong order for ''{0}'' import."/>
+            <message key="import.separation"
+                     value="[import-grouping] ''{0}'' should be separated from previous imports."/>
+        </module>
+
+        <!-- [blankline-between-methods] -->
+        <module name="EmptyLineSeparator">
+            <property name="tokens" value="METHOD_DEF"/>
+            <message key="empty.line.separator"
+                     value="[blankline-between-methods] ''{0}'' should be separated from previous statement."/>
+        </module>
+
+        <!-- End of Blank lines chapter -->
+
+        <!-- Start of Whitespace chapter -->
+
+        <!-- [space-around-brace] -->
+        <module name="WhitespaceAround">
+            <property name="allowEmptyConstructors" value="true"/> <!-- [permit-concise-empty-block] -->
+            <property name="allowEmptyMethods" value="true"/>  <!-- [permit-concise-empty-block] -->
+            <property name="allowEmptyLoops" value="true"/>  <!-- [permit-concise-empty-block] -->
+            <property name="tokens" value="LCURLY, RCURLY, SLIST"/>
+            <message key="ws.notFollowed"
+                     value="[space-around-brace] ''{0}'' is not followed by whitespace."/>
+            <message key="ws.notPreceded"
+                     value="[space-around-brace] ''{0}'' is not preceded with whitespace."/>
+        </module>
+
+        <!-- [space-between-keyword-parentheses] -->
+        <module name="WhitespaceAround">
+            <property name="tokens" value="
+				DO_WHILE, LITERAL_ASSERT, LITERAL_CATCH, LITERAL_DO, LITERAL_ELSE, LITERAL_FINALLY, LITERAL_FOR, LITERAL_IF, LITERAL_RETURN,
+			 	LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_TRY, LITERAL_WHILE,"
+            />
+            <message key="ws.notFollowed"
+                     value="[space-between-keyword-parentheses] ''{0}'' is not followed by whitespace."/>
+            <message key="ws.notPreceded"
+                     value="[space-between-keyword-parentheses] ''{0}'' is not preceded with whitespace."/>
+        </module>
+
+        <!-- [no-space-between-identifier-parentheses] -->
+        <module name="MethodParamPad">
+            <message key="line.previous"
+                     value="[no-space-between-identifier-parentheses] ''{0}'' should be on the previous line."/>
+            <message key="ws.preceded"
+                     value="[no-space-between-identifier-parentheses] ''{0}'' is preceded with whitespace."/>
+        </module>
+
+        <!-- [no-space-typecasting] -->
+        <module name="TypecastParenPad">
+            <property name="tokens" value="RPAREN,TYPECAST"/>
+            <message key="ws.followed"
+                     value="[no-space-typecasting] ''{0}'' is followed by whitespace."/>
+            <message key="ws.preceded"
+                     value="[no-space-typecasting] ''{0}'' is preceded with whitespace."/>
+        </module>
+
+        <!-- [generic-whitespace] -->
+        <module name="GenericWhitespace">
+            <message key="ws.followed"
+                     value="[generic-whitespace] ''{0}'' is followed by whitespace."/>
+            <message key="ws.preceded"
+                     value="[generic-whitespace] ''{0}'' is preceded with whitespace."/>
+            <message key="ws.illegalFollow"
+                     value="[generic-whitespace] ''{0}'' should followed by whitespace."/>
+            <message key="ws.notPreceded"
+                     value="[generic-whitespace] ''{0}'' is not preceded with whitespace."/>
+        </module>
+
+        <!-- [space-after-comma-semicolon] -->
+        <module name="WhitespaceAfter">
+            <property name="tokens" value="COMMA,SEMI"/>
+            <message key="ws.notFollowed"
+                     value="[space-after-comma-semicolon]: ''{0}'' is not followed by whitespace."/>
+        </module>
+        <module name="NoWhitespaceBefore">
+            <property name="tokens" value="COMMA,SEMI"/>
+            <message key="ws.preceded"
+                     value="[space-after-comma-semicolon] ''{0}'' is preceded with whitespace."/>
+        </module>
+
+        <!-- [space-around-colon] -->
+        <module name="WhitespaceAround">
+            <property name="tokens" value="COLON"/>
+            <property name="ignoreEnhancedForColon" value="false"/>
+            <message key="ws.notFollowed"
+                     value="[space-around-colon] ''{0}'' is not followed by whitespace."/>
+            <message key="ws.notPreceded"
+                     value="[space-around-colon] ''{0}'' is not preceded with whitespace."/>
+        </module>
+
+        <!-- [no-space-unary-operator] -->
+        <module name="NoWhitespaceBefore">
+            <property name="tokens" value="POST_INC, POST_DEC"/>
+            <message key="ws.preceded"
+                     value="[no-space-unary-operator] ''{0}'' is preceded with whitespace."/>
+        </module>
+        <module name="NoWhitespaceAfter">
+            <property name="tokens" value="INC, DEC, UNARY_MINUS, UNARY_PLUS, BNOT, LNOT"/>
+            <message key="ws.followed"
+                     value="[no-space-unary-operator] whitespace ''{0}'' is followed by whitespace."/>
+        </module>
+
+        <!-- [space-around-binary-ternary-operator] -->
+        <module name="WhitespaceAround">
+            <property name="tokens" value="ASSIGN, BAND, BAND_ASSIGN, BOR, BOR_ASSIGN, BSR, BSR_ASSIGN, BXOR, BXOR_ASSIGN, DIV,
+				 DIV_ASSIGN, EQUAL, GE, GT, LAND, LE, LOR, LT, MINUS, MINUS_ASSIGN, MOD, MOD_ASSIGN, NOT_EQUAL,
+				 PLUS, PLUS_ASSIGN, QUESTION, SL, SL_ASSIGN, SR, SR_ASSIGN, STAR, STAR_ASSIGN, TYPE_EXTENSION_AND"/>
+            <message key="ws.notFollowed"
+                     value="[space-around-binary-ternary-operator] ''{0}'' is not followed by whitespace."/>
+            <message key="ws.notPreceded"
+                     value="[space-around-binary-ternary-operator] ''{0}'' is not preceded with whitespace."/>
+        </module>
+
+        <!-- End of Whitespace chapter -->
+
+        <!--- Suppression -->
+        <module name="SuppressionCommentFilter">
+            <property name="offCommentFormat" value="@checkstyle:off"/>
+            <property name="onCommentFormat" value="@checkstyle:on"/>
+        </module>
+        <module name="SuppressWithNearbyCommentFilter">
+            <property name="commentFormat" value="@checkstyle:ignore"/>
+            <property name="checkFormat" value=".*"/>
+            <property name="influenceFormat" value="0"/>
+        </module>
+    </module>
+
+    <!--- Suppression -->
+    <module name="SuppressionFilter">
+        <property name="file" value="egov-checkstyle-suppressions.xml"/>
+        <property name="optional" value="true"/>
+    </module>
+
+    <!--- Exclude module-info.java -->
+    <module name="BeforeExecutionExclusionFileFilter">
+        <property name="fileNamePattern" value="module\-info\.java$"/>
+    </module>
+
+</module>

--- a/egov-checkstyle-suppressions.xml
+++ b/egov-checkstyle-suppressions.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<!DOCTYPE suppressions PUBLIC
+        "-//Puppy Crawl//DTD Suppressions 1.1//EN"
+        "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+<!--예시-->
+<!--<suppressions>-->
+<!--    <suppress files="UserController.java" checks=".*"/>-->
+<!--    <suppress files="UserService.java" checks=".*"/>-->
+<!--</suppressions>-->

--- a/egov-eclipse-formatter.xml
+++ b/egov-eclipse-formatter.xml
@@ -1,0 +1,363 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<profiles version="11">
+    <profile kind="CodeFormatterProfile" name="egov coding convention" version="1.2">
+
+        <!-- Start of Declarations chapter -->
+
+        <!-- [newline-after-annotation] -->
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_local_variable" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_member" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_parameter" value="insert"/>
+
+        <!-- End of Declarations chapter -->
+
+        <!-- Start of Indentation chapter -->
+
+        <!-- [indentation-tab] -->
+        <setting id="org.eclipse.jdt.core.formatter.tabulation.char" value="tab"/>
+
+        <!-- [4-spaces-tab] -->
+        <setting id="org.eclipse.jdt.core.formatter.tabulation.size" value="4"/>
+        <setting id="org.eclipse.jdt.core.formatter.indentation.size" value="4"/>
+
+        <!--[block-indentation] -->
+        <setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_annotation_declaration_header" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_enum_constant_header" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_enum_declaration_header" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_type_header" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_breaks_compare_to_cases" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_statements_compare_to_block" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_statements_compare_to_body" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_cases" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_switch" value="true"/>
+
+        <!-- End of Indentation chapter -->
+
+        <!-- Start of Braces chapter -->
+
+        <!--[braces-knr-style] -->
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_annotation_type_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_anonymous_type_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_array_initializer" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_block" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_block_in_case" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_constructor_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_enum_constant" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_enum_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_method_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_switch" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_type_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.format_guardian_clause_on_one_line" value="false"/>
+
+        <!-- [sub-flow-after-brace] -->
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_at_end_of_file_if_missing" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_catch_in_try_statement" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_else_in_if_statement" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_finally_in_try_statement" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_while_in_do_statement" value="do not insert"/>
+
+        <!-- [permit-concise-empty-block] -->
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_annotation_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_anonymous_type_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_block" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_enum_constant" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_enum_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_method_body" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_type_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_brackets_in_array_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_braces_in_array_initializer" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_brackets_in_array_allocation_expression" value="do not insert"/>
+
+        <!-- End of Braces chapter -->
+
+        <!-- Start of Line-wrapping chapter -->
+
+        <!-- [line-length-120] -->
+        <setting id="org.eclipse.jdt.core.formatter.lineSplit" value="120"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_enum_constant" value="120"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_constructor_declaration" value="120"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_method_declaration" value="120"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.line_length" value="120"/>
+
+        <!-- [indentation-after-line-wrapping] -->
+        <setting id="org.eclipse.jdt.core.formatter.continuation_indentation" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.continuation_indentation_for_array_initializer" value="1"/>
+
+        <!-- [line-wrapping-position] -->
+        <setting id="org.eclipse.jdt.core.formatter.join_wrapped_lines" value="false"/>
+        <!-- Respect custom line-wrapping. -->
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_binary_operator" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_selector_in_method_invocation" value="20"/>
+
+        <!-- End of Line-wrapping chapter -->
+
+        <!-- Start of Blank lines chapter -->
+        <!-- [blankline-after-package] -->
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_package" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_after_package" value="1"/>
+
+        <!-- [import-grouping] -->
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_between_import_groups" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_imports" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_after_imports" value="1"/>
+
+        <!-- [blankline-between-methods] -->
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_method" value="1"/>
+
+        <!-- End of Blank lines chapter -->
+
+        <!-- Start of Whitespace chapter -->
+
+        <!-- [no-trailing-spaces] -->
+        <setting id="org.eclipse.jdt.core.formatter.indent_empty_lines" value="false"/>
+
+        <!-- [space-after-bracket] -->
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_allocation_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_bracket_in_array_allocation_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_bracket_in_array_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_bracket_in_array_allocation_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_bracket_in_array_reference" value="do not insert"/>
+
+        <!-- [space-around-brace] -->
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_anonymous_type_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_array_initializer" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_block" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_constructor_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_constant" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_method_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_switch" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_type_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_brace_in_array_initializer" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_brace_in_block" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_brace_in_array_initializer" value="do not insert"/>
+
+        <!-- [space-between-keyword-parentheses] -->
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_synchronized" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_for" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_while" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_switch" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_catch" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_if" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_catch" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_for" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_if" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_switch" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_synchronized" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_while" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_catch" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_for" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_if" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_switch" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_synchronized" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_while" value="do not insert"/>
+
+        <!-- [no-space-between-identifier-parentheses] -->
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_constructor_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_invocation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_annotation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_annotation_type_member_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_enum_constant" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_constructor_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_invocation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_annotation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_enum_constant" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_constructor_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_invocation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_annotation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_enum_constant" value="do not insert"/>
+
+        <!--[no-space-typecasting] -->
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_cast" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_cast" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_paren_in_cast" value="do not insert"/>
+
+        <!-- [generic-whitespace] -->
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_type_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_type_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_type_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_type_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_type_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_type_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_arguments" value="do not insert"/>
+        <!-- ex) Util.<Integer, String>compare(l1, l2); -->
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_annotation_type_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_parameters" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_and_in_type_parameter" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_and_in_type_parameter" value="insert"/>
+
+        <!-- [space-after-comma-semicolon] -->
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon_in_for" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_semicolon_in_for" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_invocation_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_parameterized_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_multiple_local_declarations" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_enum_constant_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_multiple_field_declarations" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_for_increments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_type_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_superinterfaces" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_explicitconstructorcall_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_annotation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_declaration_throws" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_array_initializer" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_type_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_enum_declarations" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_declaration_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_allocation_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_constructor_declaration_throws" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_for_inits" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_constructor_declaration_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_annotation" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_type_arguments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_type_parameters" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_constant_arguments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_declarations" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_parameters" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_declaration_throws" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_for_increments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_explicitconstructorcall_arguments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_superinterfaces" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_declaration_parameters" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_for_inits" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_array_initializer" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_allocation_expression" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_throws" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_multiple_field_declarations" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_parameterized_type_reference" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_invocation_arguments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_multiple_local_declarations" value="insert"/>
+
+        <!-- [space-around-colon] -->
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_assert" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_case" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_conditional" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_default" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_for" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_labeled_statement" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_assert" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_case" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_conditional" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_for" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_labeled_statement" value="insert"/>
+
+        <!-- [space-around-binary-ternary-operator] -->
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_binary_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_binary_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_assignment_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_assignment_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_question_in_conditional" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_question_in_conditional" value="insert"/>
+
+        <!-- [no-space-unary-operator] -->
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_unary_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_unary_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_postfix_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_prefix_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_postfix_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_prefix_operator" value="do not insert"/>
+
+        <!-- End of Whitespace chapter -->
+
+
+        <!-- formatter on/off -->
+        <setting id="org.eclipse.jdt.core.formatter.disabling_tag" value="@formatter:off"/>
+        <setting id="org.eclipse.jdt.core.formatter.enabling_tag" value="@formatter:on"/>
+        <setting id="org.eclipse.jdt.core.formatter.use_on_off_tags" value="true"/>
+
+        <!-- Start of not madatory rules -->
+
+        <!-- comments -->
+        <setting id="org.eclipse.jdt.core.formatter.join_lines_in_comments" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_javadoc_comment" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_block_comments" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_header" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_html" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_javadoc_comments" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_line_comments" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_source_code" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.indent_parameter_description" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.indent_root_tags" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_before_root_tags" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_for_parameter" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.new_lines_at_block_boundaries" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.new_lines_at_javadoc_boundaries" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.never_indent_block_comments_on_first_column" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.never_indent_line_comments_on_first_column" value="false"/>
+
+        <!-- braces around array initializer -->
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_opening_brace_in_array_initializer" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_closing_brace_in_array_initializer" value="do not insert"/>
+
+        <!-- blank lines -->
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_field" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_first_class_body_declaration" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_member_type" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_new_chunk" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_between_type_declarations" value="1"/>
+
+        <!-- whitespace -->
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_annotation_type_member_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_constructor_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_enum_constant" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_invocation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_at_in_annotation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_at_in_annotation_type_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_ellipsis" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_question_in_wildcard" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_at_in_annotation_type_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_ellipsis" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_parenthesized_expression_in_return" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_parenthesized_expression_in_throw" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_question_in_wildcard" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_parenthesized_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_parenthesized_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_parenthesized_expression" value="do not insert"/>
+
+        <!-- Etc -->
+        <setting id="org.eclipse.jdt.core.formatter.keep_empty_array_initializer_on_one_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.align_type_members_on_columns" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_allocation_expression" value="20"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_annotation" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_explicit_constructor_call" value="20"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_method_invocation" value="20"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_qualified_allocation_expression" value="20"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_assignment" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_binary_expression" value="20"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_compact_if" value="20"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_conditional_expression" value="20"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_enum_constants" value="48"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_array_initializer" value="20"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_method_declaration" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_multiple_fields" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_constructor_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_method_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_superclass_in_type_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_enum_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_type_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_block_comment" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.compact_else_if" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.format_line_comment_starting_on_first_column" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_label" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_else_statement_on_same_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_imple_if_on_one_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_then_statement_on_same_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_at_beginning_of_method_body" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.number_of_empty_lines_to_preserve" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.put_empty_statement_on_new_line" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.use_tabs_only_for_leading_indentations" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_outer_expressions_when_nested" value="true"/>
+
+        <!-- End of not mandatory rules -->
+    </profile>
+</profiles>

--- a/egov-intellij-formatter.xml
+++ b/egov-intellij-formatter.xml
@@ -1,0 +1,62 @@
+<code_scheme name="egov-coding-convention-v1.2">
+    <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99" />
+    <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="1" />
+    <option name="IMPORT_LAYOUT_TABLE">
+        <value>
+            <emptyLine />
+            <package name="" withSubpackages="true" static="true" />
+            <emptyLine />
+            <package name="java" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="javax" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="org" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="net" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="com" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="com.nhncorp" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="com.navercorp" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="com.naver" withSubpackages="true" static="false" />
+            <emptyLine />
+        </value>
+    </option>
+    <option name="RIGHT_MARGIN" value="120" />
+    <option name="ENABLE_JAVADOC_FORMATTING" value="false" />
+    <option name="JD_KEEP_EMPTY_LINES" value="false" />
+    <option name="FORMATTER_TAGS_ENABLED" value="true" />
+    <XML>
+        <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
+    </XML>
+    <codeStyleSettings language="JAVA">
+        <option name="LINE_COMMENT_AT_FIRST_COLUMN" value="false" />
+        <option name="LINE_COMMENT_ADD_SPACE" value="true" />
+        <option name="KEEP_FIRST_COLUMN_COMMENT" value="false" />
+        <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false" />
+        <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1" />
+        <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
+        <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="1" />
+        <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
+        <option name="SPACE_AFTER_TYPE_CAST" value="false" />
+        <option name="SPACE_BEFORE_ARRAY_INITIALIZER_LBRACE" value="true" />
+        <option name="CALL_PARAMETERS_WRAP" value="1" />
+        <option name="METHOD_PARAMETERS_WRAP" value="1" />
+        <option name="EXTENDS_LIST_WRAP" value="1" />
+        <option name="METHOD_CALL_CHAIN_WRAP" value="5" />
+        <option name="THROWS_LIST_WRAP" value="5" />
+        <option name="EXTENDS_KEYWORD_WRAP" value="1" />
+        <option name="BINARY_OPERATION_WRAP" value="1" />
+        <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true" />
+        <option name="TERNARY_OPERATION_WRAP" value="1" />
+        <option name="ARRAY_INITIALIZER_WRAP" value="1" />
+        <indentOptions>
+            <option name="CONTINUATION_INDENT_SIZE" value="4" />
+            <option name="USE_TAB_CHARACTER" value="true" />
+        </indentOptions>
+    </codeStyleSettings>
+</code_scheme>

--- a/pom.xml
+++ b/pom.xml
@@ -657,6 +657,24 @@
                     <artifactId>maven-pmd-plugin</artifactId>
                     <version>3.12.0</version>
                 </plugin>
+                <!--Checkstyle 플러그인 설정-->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-checkstyle-plugin</artifactId>
+                    <version>3.1.1</version>
+                    <configuration>
+                        <configLocation>egov-checkstyle-rules.xml</configLocation>
+                        <sourceDirectories>${project.build.sourceDirectories}</sourceDirectories>
+                        <propertyExpansion>suppressionFile=./naver-checkstyle-suppressions.xml</propertyExpansion>
+                    </configuration>
+                    <dependencies>
+                        <dependency>
+                            <groupId>com.puppycrawl.tools</groupId>
+                            <artifactId>checkstyle</artifactId>
+                            <version>8.24</version>
+                        </dependency>
+                    </dependencies>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>

--- a/src/main/java/egovframework/com/cmm/context/EgovWebServletContextListener.java
+++ b/src/main/java/egovframework/com/cmm/context/EgovWebServletContextListener.java
@@ -11,7 +11,7 @@ import egovframework.com.cmm.service.EgovProperties;
 /**
  * EgovWebServletContextListener 클래스
  * <Notice>
- * 	    데이터베이스 설정을 spring.profiles.active 방식으로 처리
+ * 	    데이터베이스 설정을 egov.profiles.active 방식으로 처리
  * 		(공통컴포넌트 특성상 데이터베이스별 분리/개발,검증,운영서버로 분리 가능)
  * <Disclaimer>
  *		N/A
@@ -40,23 +40,23 @@ public class EgovWebServletContextListener implements ServletContextListener {
 
     @Override
 	public void contextInitialized(ServletContextEvent event){
-    	if(System.getProperty("spring.profiles.active") == null){
+    	if(System.getProperty("egov.profiles.active") == null){
     		setEgovProfileSetting();
     	}
     }
 
     @Override
 	public void contextDestroyed(ServletContextEvent event) {
-    	if(System.getProperty("spring.profiles.active") != null){
-    		System.clearProperty("spring.profiles.active");
+    	if(System.getProperty("egov.profiles.active") != null){
+    		System.clearProperty("egov.profiles.active");
     	}
     }
 
     public void setEgovProfileSetting(){
         try {
             LOGGER.debug("===========================Start EgovServletContextLoad START ===========");
-            System.setProperty("spring.profiles.active", EgovProperties.getProperty("Globals.DbType")+","+EgovProperties.getProperty("Globals.Auth"));
-            LOGGER.debug("Setting spring.profiles.active>"+System.getProperty("spring.profiles.active"));
+            System.setProperty("egov.profiles.active", EgovProperties.getProperty("Globals.DbType")+","+EgovProperties.getProperty("Globals.Auth"));
+            LOGGER.debug("Setting egov.profiles.active>"+System.getProperty("egov.profiles.active"));
             LOGGER.debug("===========================END   EgovServletContextLoad END ===========");
         //2017.03.03 	조성원 	시큐어코딩(ES)-오류 메시지를 통한 정보노출[CWE-209]
         } catch(IllegalArgumentException e) {

--- a/src/main/java/egovframework/com/cmm/service/EgovFileMngUtil.java
+++ b/src/main/java/egovframework/com/cmm/service/EgovFileMngUtil.java
@@ -35,22 +35,18 @@ import egovframework.com.cmm.util.EgovResourceCloseHelper;
 import org.egovframe.rte.fdl.idgnr.EgovIdGnrService;
 
 /**
+ * @author 공통 서비스 개발팀 이삼섭
+ * @version 1.0
  * @Class Name  : EgovFileMngUtil.java
  * @Description : 메시지 처리 관련 유틸리티
  * @Modification Information
- *
- *   수정일               수정자            수정내용
- *   ----------   --------   ---------------------------
- *   2009.02.13   이삼섭            최초 생성
- *   2011.08.09   서준식            utl.fcc패키지와 Dependency제거를 위해 getTimeStamp()메서드 추가
- *   2017.03.03   조성원            시큐어코딩(ES)-부적절한 예외 처리[CWE-253, CWE-440, CWE-754]
- *   2020.10.26   신용호            parseFileInf(List<MultipartFile> files ...) 추가
- *
- * @author 공통 서비스 개발팀 이삼섭
- * @since 2009. 02. 13
- * @version 1.0
+ * <p>
+ * 수정일               수정자            수정내용 ----------   --------   --------------------------- 2009.02.13   이삼섭
+ * 최초 생성 2011.08.09   서준식            utl.fcc패키지와 Dependency제거를 위해 getTimeStamp()메서드 추가 2017.03.03   조성원
+ * 시큐어코딩(ES)-부적절한 예외 처리[CWE-253, CWE-440, CWE-754] 2020.10.26   신용호            parseFileInf(List<MultipartFile> files
+ * ...) 추가
  * @see
- *
+ * @since 2009. 02. 13
  */
 @Component("EgovFileMngUtil")
 public class EgovFileMngUtil {
@@ -69,19 +65,20 @@ public class EgovFileMngUtil {
 	 * @return
 	 * @throws Exception
 	 */
-	public List<FileVO> parseFileInf(Map<String, MultipartFile> files, String KeyStr, int fileKeyParam, String atchFileId, String storePath) throws Exception {
+	public List<FileVO> parseFileInf(Map<String, MultipartFile> files, String KeyStr, int fileKeyParam,
+									 String atchFileId, String storePath) throws Exception {
 		int fileKey = fileKeyParam;
 
 		String storePathString = "";
 		String atchFileIdString = "";
 
-		if ("".equals(storePath) || storePath == null) {
+		if (storePath == null || "".equals(storePath)) {
 			storePathString = EgovProperties.getProperty("Globals.fileStorePath");
 		} else {
 			storePathString = EgovProperties.getProperty(storePath);
 		}
 
-		if ("".equals(atchFileId) || atchFileId == null) {
+		if (atchFileId == null || "".equals(atchFileId)) {
 			atchFileIdString = idgenService.getNextStringId();
 		} else {
 			atchFileIdString = atchFileId;
@@ -91,9 +88,9 @@ public class EgovFileMngUtil {
 
 		if (!saveFolder.exists() || saveFolder.isFile()) {
 			//2017.03.03 	조성원 	시큐어코딩(ES)-부적절한 예외 처리[CWE-253, CWE-440, CWE-754]
-			if (saveFolder.mkdirs()){
+			if (saveFolder.mkdirs()) {
 				LOGGER.debug("[file.mkdirs] saveFolder : Creation Success ");
-			}else{
+			} else {
 				LOGGER.error("[file.mkdirs] saveFolder : Creation Fail ");
 			}
 		}
@@ -154,19 +151,20 @@ public class EgovFileMngUtil {
 	 * @return
 	 * @throws Exception
 	 */
-	public List<FileVO> parseFileInf(List<MultipartFile> files, String KeyStr, int fileKeyParam, String atchFileId, String storePath) throws Exception {
+	public List<FileVO> parseFileInf(List<MultipartFile> files, String KeyStr, int fileKeyParam, String atchFileId,
+									 String storePath) throws Exception {
 		int fileKey = fileKeyParam;
 
 		String storePathString = "";
 		String atchFileIdString = "";
 
-		if ("".equals(storePath) || storePath == null) {
+		if (storePath == null || "".equals(storePath)) {
 			storePathString = EgovProperties.getProperty("Globals.fileStorePath");
 		} else {
 			storePathString = EgovProperties.getProperty(storePath);
 		}
 
-		if ("".equals(atchFileId) || atchFileId == null) {
+		if (atchFileId == null || "".equals(atchFileId)) {
 			atchFileIdString = idgenService.getNextStringId();
 		} else {
 			atchFileIdString = atchFileId;
@@ -176,9 +174,9 @@ public class EgovFileMngUtil {
 
 		if (!saveFolder.exists() || saveFolder.isFile()) {
 			//2017.03.03 	조성원 	시큐어코딩(ES)-부적절한 예외 처리[CWE-253, CWE-440, CWE-754]
-			if (saveFolder.mkdirs()){
+			if (saveFolder.mkdirs()) {
 				LOGGER.debug("[file.mkdirs] saveFolder : Creation Success ");
-			}else{
+			} else {
 				LOGGER.error("[file.mkdirs] saveFolder : Creation Fail ");
 			}
 		}
@@ -187,7 +185,7 @@ public class EgovFileMngUtil {
 		List<FileVO> result = new ArrayList<FileVO>();
 		FileVO fvo;
 
-		for (MultipartFile file : files ) {
+		for (MultipartFile file : files) {
 
 			String orginFileName = file.getOriginalFilename();
 
@@ -303,7 +301,8 @@ public class EgovFileMngUtil {
 		byte[] buffer = new byte[BUFF_SIZE]; //buffer size 2K.
 
 		response.setContentType("application/x-msdownload");
-		response.setHeader("Content-Disposition:", "attachment; filename=" + new String(orgFileName.getBytes(), "UTF-8"));
+		response.setHeader("Content-Disposition:",
+			"attachment; filename=" + new String(orgFileName.getBytes(), "UTF-8"));
 		response.setHeader("Content-Transfer-Encoding", "binary");
 		response.setHeader("Pragma", "no-cache");
 		response.setHeader("Expires", "0");
@@ -373,11 +372,11 @@ public class EgovFileMngUtil {
 			stream = file.getInputStream();
 			File cFile = new File(EgovWebUtil.filePathBlackList(stordFilePath));
 
-			if (!cFile.isDirectory()){
+			if (!cFile.isDirectory()) {
 				//2017.03.03 	조성원 	시큐어코딩(ES)-부적절한 예외 처리[CWE-253, CWE-440, CWE-754]
-				if (cFile.mkdirs()){
+				if (cFile.mkdirs()) {
 					LOGGER.debug("[file.mkdirs] saveFolder : Creation Success ");
-				}else{
+				} else {
 					LOGGER.error("[file.mkdirs] saveFolder : Creation Fail ");
 				}
 			}
@@ -399,7 +398,7 @@ public class EgovFileMngUtil {
 	 * 서버 파일에 대하여 다운로드를 처리한다.
 	 *
 	 * @param response
-	 * @param streFileNm 파일저장 경로가 포함된 형태
+	 * @param streFileNm  파일저장 경로가 포함된 형태
 	 * @param orignFileNm
 	 * @throws Exception
 	 */
@@ -496,8 +495,7 @@ public class EgovFileMngUtil {
 	}
 
 	/**
-	 * 공통 컴포넌트 utl.fcc 패키지와 Dependency제거를 위해 내부 메서드로 추가 정의함
-	 * 응용어플리케이션에서 고유값을 사용하기 위해 시스템에서17자리의TIMESTAMP값을 구하는 기능
+	 * 공통 컴포넌트 utl.fcc 패키지와 Dependency제거를 위해 내부 메서드로 추가 정의함 응용어플리케이션에서 고유값을 사용하기 위해 시스템에서17자리의TIMESTAMP값을 구하는 기능
 	 *
 	 * @param
 	 * @return Timestamp 값

--- a/src/main/java/egovframework/com/cmm/service/EgovProperties.java
+++ b/src/main/java/egovframework/com/cmm/service/EgovProperties.java
@@ -113,7 +113,7 @@ public class EgovProperties {
 		// key - value 형태로 된 배열 결과
 		ArrayList<Map<String, String>> keyList = new ArrayList<Map<String, String>>();
 
-		String src = property.replace('\\', File.separatorChar).replace('/', File.separatorChar);
+		String src = property.replace("\\", FILE_SEPARATOR).replace("/", FILE_SEPARATOR);
 
 		if (Files.exists(Paths.get(EgovWebUtil.filePathBlackList(src)))) { //2022.01 Potential Path Traversal
 			Properties props = loadPropertiesFromFile(src);

--- a/src/main/java/egovframework/com/cmm/service/Globals.java
+++ b/src/main/java/egovframework/com/cmm/service/Globals.java
@@ -56,4 +56,9 @@ public class Globals {
 	//SMS 정보 프로퍼티 위치
 	public static final String SMSDB_CONF_PATH = EgovProperties.getPathProperty("Globals.SmsDbConfPath");
 
+	//파일 업로드 가능 확장자들
+	public static final String FILE_UP_EXTS = EgovProperties.getProperty("Globals.fileUpload.Extensions");
+	//파일 업로드 최대 용량
+	public static final String FILE_UP_MAX_SIZE = EgovProperties.getProperty("Globals.fileUpload.maxSize");
+
 }

--- a/src/main/java/egovframework/com/cop/sms/service/impl/EgovSmsBasicServiceImpl.java
+++ b/src/main/java/egovframework/com/cop/sms/service/impl/EgovSmsBasicServiceImpl.java
@@ -76,14 +76,12 @@ public class EgovSmsBasicServiceImpl implements EgovSmsInfoService {
 		if (EgovProperties.class.getResource("") != null) {
 			String FILE_SEPARATOR = System.getProperty("file.separator");
 
-			String globalsPropertiesFile = EgovProperties.class.getResource("").getPath()
+			smeConfigPath = EgovProperties.class.getResource("").getPath()
 				+ FILE_SEPARATOR + ".." + FILE_SEPARATOR
 				+ ".." + FILE_SEPARATOR + ".." + FILE_SEPARATOR
 				+ FILE_SEPARATOR + "egovProps"
 				+ FILE_SEPARATOR + "conf"
 				+ FILE_SEPARATOR + "SMEConfig.properties";
-
-			smeConfigPath = globalsPropertiesFile;
 		}
 
 	}

--- a/src/main/java/egovframework/com/cop/sms/service/impl/EgovSmsBasicServiceImpl.java
+++ b/src/main/java/egovframework/com/cop/sms/service/impl/EgovSmsBasicServiceImpl.java
@@ -2,6 +2,7 @@ package egovframework.com.cop.sms.service.impl;
 
 //import java.io.BufferedInputStream;
 //import java.io.FileInputStream;
+
 import java.text.ParseException;
 import java.util.HashMap;
 import java.util.List;
@@ -19,12 +20,10 @@ import org.slf4j.LoggerFactory;
 
 /**
  * 문자메시지를 위한 서비스 구현 클래스 (프레임워크 비종속 버전)
- * @author 공통컴포넌트개발팀 한성곤
- * @since 2009.11.24
- * @version 1.0
- * @see
  *
- * <pre>
+ * @author 공통컴포넌트개발팀 한성곤
+ * @version 1.0
+ * @see <pre>
  * << 개정이력(Modification Information) >>
  *
  *   수정일      수정자           수정내용
@@ -32,261 +31,262 @@ import org.slf4j.LoggerFactory;
  *   2009.11.24  한성곤          최초 생성
  *
  * </pre>
+ * @since 2009.11.24
  */
 public class EgovSmsBasicServiceImpl implements EgovSmsInfoService {
-    private SmsBasicDAO smsDao = new SmsBasicDAO();
+	private SmsBasicDAO smsDao = new SmsBasicDAO();
 
-    private String smeConfigPath = null;
+	private String smeConfigPath = null;
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(EgovSmsBasicServiceImpl.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(EgovSmsBasicServiceImpl.class);
 
-    public EgovSmsBasicServiceImpl() {
-	//--------------------------------
-	// 속성 정보 얻기
-	// M-Gov에서 배포하는 SMEConfig.conf 파일을 절대경로로 지정하면 된다.
-	//--------------------------------
-	// //globals.properties를 활용한 방ㅣㄱ (공통모듈 사용)
-	//smeConfigPath = EgovProperties.getProperty("Globals.SMEConfigPath");
+	public EgovSmsBasicServiceImpl() {
+		//--------------------------------
+		// 속성 정보 얻기
+		// M-Gov에서 배포하는 SMEConfig.conf 파일을 절대경로로 지정하면 된다.
+		//--------------------------------
+		// //globals.properties를 활용한 방ㅣㄱ (공통모듈 사용)
+		//smeConfigPath = EgovProperties.getProperty("Globals.SMEConfigPath");
 
-	// //globals.properties를 직접 활용한 방식
-	//String globalsPropertiesFile = System.getProperty("user.home")
-	//	+ System.getProperty("file.separator") + "egovProps"
-	//	+ System.getProperty("file.separator") + "globals.properties";
-	//
-	//FileInputStream fis = null;
-	//
-	//try {
-	//    Properties props = new Properties();
-	//    fis  = new FileInputStream(globalsPropertiesFile);
-	//    props.load(new BufferedInputStream(fis));
-	//
-	//    smeConfigPath = props.getProperty("Globals.SMEConfigPath").trim();
-	//} catch(Exception ex) {
-	//    logger.error(ex);
-	//} finally {
-	//    try {
-	//	if (fis != null) {
-	//	    fis.close();
-	//	}
-	//    } catch (Exception ex) {
-	//	ex.printStackTrace();
-	//    }
-	//}
+		// //globals.properties를 직접 활용한 방식
+		//String globalsPropertiesFile = System.getProperty("user.home")
+		//	+ System.getProperty("file.separator") + "egovProps"
+		//	+ System.getProperty("file.separator") + "globals.properties";
+		//
+		//FileInputStream fis = null;
+		//
+		//try {
+		//    Properties props = new Properties();
+		//    fis  = new FileInputStream(globalsPropertiesFile);
+		//    props.load(new BufferedInputStream(fis));
+		//
+		//    smeConfigPath = props.getProperty("Globals.SMEConfigPath").trim();
+		//} catch(Exception ex) {
+		//    logger.error(ex);
+		//} finally {
+		//    try {
+		//	if (fis != null) {
+		//	    fis.close();
+		//	}
+		//    } catch (Exception ex) {
+		//	ex.printStackTrace();
+		//    }
+		//}
 
-		
-		if(EgovProperties.class.getResource("") != null) {
+		if (EgovProperties.class.getResource("") != null) {
+			String FILE_SEPARATOR = System.getProperty("file.separator");
+
 			String globalsPropertiesFile = EgovProperties.class.getResource("").getPath()
-			    	+ System.getProperty("file.separator") + ".." + System.getProperty("file.separator")
-			    	+ ".." + System.getProperty("file.separator") + ".." + System.getProperty("file.separator")
-					+ System.getProperty("file.separator") + "egovProps"
-					+ System.getProperty("file.separator") + "conf"
-					+ System.getProperty("file.separator") + "SMEConfig.properties";
-			
+				+ FILE_SEPARATOR + ".." + FILE_SEPARATOR
+				+ ".." + FILE_SEPARATOR + ".." + FILE_SEPARATOR
+				+ FILE_SEPARATOR + "egovProps"
+				+ FILE_SEPARATOR + "conf"
+				+ FILE_SEPARATOR + "SMEConfig.properties";
+
 			smeConfigPath = globalsPropertiesFile;
 		}
-		
-    }
 
-    private String getPhoneNumber(String number) {
-	String result = number;
-
-	if (number == null || number.trim().equals("")) {
-	    return "";
 	}
 
-	result = result.replace("-", "");
-	result = result.replace("(", "");
-	result = result.replace(")", "");
-	result = result.replace(" ", "");
+	private String getPhoneNumber(String number) {
+		String result = number;
 
-	return result;
-    }
-
-    private String formatPhoneNumber(String number) throws ParseException {
-	if (number == null || number.trim().equals("")) {
-	    return "";
-	}
-
-	StringBuffer buffer = new StringBuffer();
-
-
-	if (number.length() == 9) {	// 02-500-1234 형식
-	    buffer.append(number.substring(0, 2));
-	    buffer.append("-");
-	    buffer.append(number.substring(2, 2+3));
-	    buffer.append("-");
-	    buffer.append(number.substring(2+3, 2+3+4));
-
-	} else if (number.length() == 10) {
-	    if (number.startsWith("02")) {	// 02-5000-1234 형식
-		buffer.append(number.substring(0, 2));
-		buffer.append("-");
-		buffer.append(number.substring(2, 2 + 4));
-		buffer.append("-");
-		buffer.append(number.substring(2 + 4, 2 + 4 + 4));
-
-	    } else {				// 031-500-1234 형식
-		buffer.append(number.substring(0, 3));
-		buffer.append("-");
-		buffer.append(number.substring(3, 3 + 3));
-		buffer.append("-");
-		buffer.append(number.substring(3 + 3, 3 + 3 + 4));
-	    }
-
-	} else if (number.length() == 11) {	// 031-5000-1234 형식
-	    buffer.append(number.substring(0, 3));
-	    buffer.append("-");
-	    buffer.append(number.substring(3, 3+4));
-	    buffer.append("-");
-	    buffer.append(number.substring(3+4,3+4+4));
-
-	} else if (number.length() == 12) {	// 0505-5000-1234 형식
-	    buffer.append(number.substring(0, 4));
-	    buffer.append("-");
-	    buffer.append(number.substring(4, 4+4));
-	    buffer.append("-");
-	    buffer.append(number.substring(4+4, 4+4+4));
-
-	} else {
-	    return number;
-	}
-
-	return buffer.toString();
-    }
-
-    /**
-     * 문자메시지 목록을 조회 한다.
-     */
-    public Map<String, Object> selectSmsInfs(SmsVO searchVO) throws Exception {
-	List<SmsVO> result = smsDao.selectSmsInfs(searchVO);
-	int cnt = smsDao.selectSmsInfsCnt(searchVO);
-
-	// 전화번호 포맷 처리
-	for (int i = 0; i < result.size(); i++) {
-	    String phone = result.get(i).getTrnsmitTelno();
-	    result.get(i).setTrnsmitTelno(formatPhoneNumber(phone));
-	}
-
-	Map<String, Object> map = new HashMap<String, Object>();
-
-	map.put("resultList", result);
-	map.put("resultCnt", Integer.toString(cnt));
-
-	return map;
-    }
-
-    /**
-     * 문자메시지를 전송(등록)한다.
-     */
-    public void insertSmsInf(Sms sms) throws Exception {
-	HashMap<String, SmsRecptn> check = new HashMap<String, SmsRecptn>();
-
-	sms.setTrnsmitTelno(getPhoneNumber(sms.getTrnsmitTelno()));
-
-	//---------------------------------------
-	// 마스터 정보 등록
-	//---------------------------------------
-	String smsId = smsDao.insertSmsInf(sms);
-
-	//---------------------------------------
-	// 전송 요청 및 상세(수신자)정보 등록
-	//---------------------------------------
-	SmsRecptn smsRecptn = null;
-	if ( sms != null && sms.getRecptnTelno() != null) {
-	for (int i = 0; i < sms.getRecptnTelno().length; i++) {
-	    if (getPhoneNumber(sms.getRecptnTelno()[i]).equals("")) {
-		continue;
-	    }
-	    smsRecptn = new SmsRecptn();
-
-	    smsRecptn.setSmsId(smsId);
-	    smsRecptn.setRecptnTelno(getPhoneNumber(sms.getRecptnTelno()[i]));
-
-	    // 동일 전화번호면 SKIP
-	    if (check.containsKey(smsRecptn.getRecptnTelno())) {
-		continue;
-	    } else {
-		check.put(smsRecptn.getRecptnTelno(), smsRecptn);
-	    }
-
-	    //---------------------------------------
-	    // 실 전송 요청 저장
-	    //---------------------------------------
-	    SmsConnection smsConn = new SmsConnection();
-
-	    smsConn.setCallFrom(sms.getTrnsmitTelno());
-	    smsConn.setCallTo(smsRecptn.getRecptnTelno());
-	    smsConn.setCallBack(smsRecptn.getRecptnTelno());
-	    smsConn.setCallBackUrl("");
-	    smsConn.setText(sms.getTrnsmitCn());
-
-	    smsConn.setMessageId(smsId + "-" + smsRecptn.getRecptnTelno());
-
-	    // SMS 전송 요청
-	    EgovSmsInfoSender sender = null;
-	    SmsConnection result = null;
-	    try {
-		sender = new EgovSmsInfoSender(smeConfigPath);
-
-		sender.open();
-		result = sender.send(smsConn);
-	    } finally {
-		if (sender != null) {
-		    sender.close();
+		if (number == null || number.trim().equals("")) {
+			return "";
 		}
-	    }
-	    ////-------------------------------------
 
-	    // Sender의 전송 결과는 SMS G/W 처리 상의 결과만 리턴함
-	    // 이동통신사의 오류는 별도의 Receiver에서 수신 처리함
-	    // 수신 처리시 MessageId의 구성 형식(SMS_ID + "-" + 수신전화번호)를 통해 DB에 결과를 반영
+		result = result.replace("-", "");
+		result = result.replace("(", "");
+		result = result.replace(")", "");
+		result = result.replace(" ", "");
 
-	    if (result != null) {	// 2011.10.21 보안점검 후속조치
-	    	smsRecptn.setResultCode(Integer.toString(result.getResult()));
-	    	smsRecptn.setResultMssage(result.getResultMessage());
-	    }
-
-	    smsDao.insertSmsRecptnInf(smsRecptn);
-	} 
-	}
-    }
-
-    /**
-     * 문자메시지에 대한 상세정보를 조회한다.
-     */
-    public SmsVO selectSmsInf(SmsVO searchVO) throws Exception {
-	SmsVO vo = smsDao.selectSmsInf(searchVO);
-
-	// 전화번호 포맷 처리
-	vo.setTrnsmitTelno(formatPhoneNumber(vo.getTrnsmitTelno()));
-
-	SmsRecptn recptn = new SmsRecptn();
-
-	recptn.setSmsId(searchVO.getSmsId());
-
-	List<SmsRecptn> list = smsDao.selectSmsRecptnInfs(recptn);
-
-	// 전화번호 포맷 처리
-	for (int i = 0; i < list.size(); i++) {
-	    String phone = list.get(i).getRecptnTelno();
-	    list.get(i).setRecptnTelno(formatPhoneNumber(phone));
+		return result;
 	}
 
-	vo.setRecptn(list);
+	private String formatPhoneNumber(String number) throws ParseException {
+		if (number == null || number.trim().equals("")) {
+			return "";
+		}
 
-	return vo;
-    }
+		StringBuffer buffer = new StringBuffer();
 
-    /**
-     * 문자메시지 실 전송을 요청한다.
-     */
-    public SmsConnection sendRequsest(SmsConnection smsConn) throws Exception {
-	String callTo = smsConn.getCallTo();
-	String callFrom = smsConn.getCallFrom();
-	String callBack = smsConn.getCallBack();
-	String callBackUrl = smsConn.getCallBackUrl();
-	String text = smsConn.getText();
-	String messageId = smsConn.getMessageId();	// messageId 지정 필요
+		if (number.length() == 9) {    // 02-500-1234 형식
+			buffer.append(number.substring(0, 2));
+			buffer.append("-");
+			buffer.append(number.substring(2, 2 + 3));
+			buffer.append("-");
+			buffer.append(number.substring(2 + 3, 2 + 3 + 4));
+
+		} else if (number.length() == 10) {
+			if (number.startsWith("02")) {    // 02-5000-1234 형식
+				buffer.append(number.substring(0, 2));
+				buffer.append("-");
+				buffer.append(number.substring(2, 2 + 4));
+				buffer.append("-");
+				buffer.append(number.substring(2 + 4, 2 + 4 + 4));
+
+			} else {                // 031-500-1234 형식
+				buffer.append(number.substring(0, 3));
+				buffer.append("-");
+				buffer.append(number.substring(3, 3 + 3));
+				buffer.append("-");
+				buffer.append(number.substring(3 + 3, 3 + 3 + 4));
+			}
+
+		} else if (number.length() == 11) {    // 031-5000-1234 형식
+			buffer.append(number.substring(0, 3));
+			buffer.append("-");
+			buffer.append(number.substring(3, 3 + 4));
+			buffer.append("-");
+			buffer.append(number.substring(3 + 4, 3 + 4 + 4));
+
+		} else if (number.length() == 12) {    // 0505-5000-1234 형식
+			buffer.append(number.substring(0, 4));
+			buffer.append("-");
+			buffer.append(number.substring(4, 4 + 4));
+			buffer.append("-");
+			buffer.append(number.substring(4 + 4, 4 + 4 + 4));
+
+		} else {
+			return number;
+		}
+
+		return buffer.toString();
+	}
+
+	/**
+	 * 문자메시지 목록을 조회 한다.
+	 */
+	public Map<String, Object> selectSmsInfs(SmsVO searchVO) throws Exception {
+		List<SmsVO> result = smsDao.selectSmsInfs(searchVO);
+		int cnt = smsDao.selectSmsInfsCnt(searchVO);
+
+		// 전화번호 포맷 처리
+		for (int i = 0; i < result.size(); i++) {
+			String phone = result.get(i).getTrnsmitTelno();
+			result.get(i).setTrnsmitTelno(formatPhoneNumber(phone));
+		}
+
+		Map<String, Object> map = new HashMap<String, Object>();
+
+		map.put("resultList", result);
+		map.put("resultCnt", Integer.toString(cnt));
+
+		return map;
+	}
+
+	/**
+	 * 문자메시지를 전송(등록)한다.
+	 */
+	public void insertSmsInf(Sms sms) throws Exception {
+		HashMap<String, SmsRecptn> check = new HashMap<String, SmsRecptn>();
+
+		sms.setTrnsmitTelno(getPhoneNumber(sms.getTrnsmitTelno()));
+
+		//---------------------------------------
+		// 마스터 정보 등록
+		//---------------------------------------
+		String smsId = smsDao.insertSmsInf(sms);
+
+		//---------------------------------------
+		// 전송 요청 및 상세(수신자)정보 등록
+		//---------------------------------------
+		SmsRecptn smsRecptn = null;
+		if (sms != null && sms.getRecptnTelno() != null) {
+			for (int i = 0; i < sms.getRecptnTelno().length; i++) {
+				if (getPhoneNumber(sms.getRecptnTelno()[i]).equals("")) {
+					continue;
+				}
+				smsRecptn = new SmsRecptn();
+
+				smsRecptn.setSmsId(smsId);
+				smsRecptn.setRecptnTelno(getPhoneNumber(sms.getRecptnTelno()[i]));
+
+				// 동일 전화번호면 SKIP
+				if (check.containsKey(smsRecptn.getRecptnTelno())) {
+					continue;
+				} else {
+					check.put(smsRecptn.getRecptnTelno(), smsRecptn);
+				}
+
+				//---------------------------------------
+				// 실 전송 요청 저장
+				//---------------------------------------
+				SmsConnection smsConn = new SmsConnection();
+
+				smsConn.setCallFrom(sms.getTrnsmitTelno());
+				smsConn.setCallTo(smsRecptn.getRecptnTelno());
+				smsConn.setCallBack(smsRecptn.getRecptnTelno());
+				smsConn.setCallBackUrl("");
+				smsConn.setText(sms.getTrnsmitCn());
+
+				smsConn.setMessageId(smsId + "-" + smsRecptn.getRecptnTelno());
+
+				// SMS 전송 요청
+				EgovSmsInfoSender sender = null;
+				SmsConnection result = null;
+				try {
+					sender = new EgovSmsInfoSender(smeConfigPath);
+
+					sender.open();
+					result = sender.send(smsConn);
+				} finally {
+					if (sender != null) {
+						sender.close();
+					}
+				}
+				////-------------------------------------
+
+				// Sender의 전송 결과는 SMS G/W 처리 상의 결과만 리턴함
+				// 이동통신사의 오류는 별도의 Receiver에서 수신 처리함
+				// 수신 처리시 MessageId의 구성 형식(SMS_ID + "-" + 수신전화번호)를 통해 DB에 결과를 반영
+
+				if (result != null) {    // 2011.10.21 보안점검 후속조치
+					smsRecptn.setResultCode(Integer.toString(result.getResult()));
+					smsRecptn.setResultMssage(result.getResultMessage());
+				}
+
+				smsDao.insertSmsRecptnInf(smsRecptn);
+			}
+		}
+	}
+
+	/**
+	 * 문자메시지에 대한 상세정보를 조회한다.
+	 */
+	public SmsVO selectSmsInf(SmsVO searchVO) throws Exception {
+		SmsVO vo = smsDao.selectSmsInf(searchVO);
+
+		// 전화번호 포맷 처리
+		vo.setTrnsmitTelno(formatPhoneNumber(vo.getTrnsmitTelno()));
+
+		SmsRecptn recptn = new SmsRecptn();
+
+		recptn.setSmsId(searchVO.getSmsId());
+
+		List<SmsRecptn> list = smsDao.selectSmsRecptnInfs(recptn);
+
+		// 전화번호 포맷 처리
+		for (int i = 0; i < list.size(); i++) {
+			String phone = list.get(i).getRecptnTelno();
+			list.get(i).setRecptnTelno(formatPhoneNumber(phone));
+		}
+
+		vo.setRecptn(list);
+
+		return vo;
+	}
+
+	/**
+	 * 문자메시지 실 전송을 요청한다.
+	 */
+	public SmsConnection sendRequsest(SmsConnection smsConn) throws Exception {
+		String callTo = smsConn.getCallTo();
+		String callFrom = smsConn.getCallFrom();
+		String callBack = smsConn.getCallBack();
+		String callBackUrl = smsConn.getCallBackUrl();
+		String text = smsConn.getText();
+		String messageId = smsConn.getMessageId();    // messageId 지정 필요
 
 	/*
 	System.out.println("------------------------");
@@ -297,63 +297,63 @@ public class EgovSmsBasicServiceImpl implements EgovSmsInfoService {
 	System.out.println("text = " + text);
 	System.out.println("messageId = " + messageId);
 	*/
-	LOGGER.info("------------------------");
-	LOGGER.info("callTo = {}", callTo);
-	LOGGER.info("callFrom = {}", callFrom);
-	LOGGER.info("callBack = {}", callBack);
-	LOGGER.info("callBackUrl = {}", callBackUrl);
-	LOGGER.info("text = {}", text);
-	LOGGER.info("messageId = {}", messageId);
+		LOGGER.info("------------------------");
+		LOGGER.info("callTo = {}", callTo);
+		LOGGER.info("callFrom = {}", callFrom);
+		LOGGER.info("callBack = {}", callBack);
+		LOGGER.info("callBackUrl = {}", callBackUrl);
+		LOGGER.info("text = {}", text);
+		LOGGER.info("messageId = {}", messageId);
 
-	// SMS 전송 요청
-	EgovSmsInfoSender sender = null;
-	SmsConnection result = null;
-	try {
-	    sender = new EgovSmsInfoSender(smeConfigPath);
+		// SMS 전송 요청
+		EgovSmsInfoSender sender = null;
+		SmsConnection result = null;
+		try {
+			sender = new EgovSmsInfoSender(smeConfigPath);
 
-	    sender.open();
-	    result = sender.send(smsConn);
-	} finally {
-	    if (sender != null) {
-		sender.close();
-	    }
+			sender.open();
+			result = sender.send(smsConn);
+		} finally {
+			if (sender != null) {
+				sender.close();
+			}
+		}
+
+		// Sender의 전송 결과는 SMS G/W 처리 상의 결과만 리턴함
+		// 이동통신사의 오류는 별도의 Receiver에서 수신 처리함 (로그 기록)
+
+		if (result != null) {    // 2011.10.21 보안점검 후속조치
+			smsConn.setResult(result.getResult());
+			smsConn.setResultMessage(result.getResultMessage());
+		}
+
+		return smsConn;
 	}
 
-	// Sender의 전송 결과는 SMS G/W 처리 상의 결과만 리턴함
-	// 이동통신사의 오류는 별도의 Receiver에서 수신 처리함 (로그 기록)
+	/**
+	 * 여러 건의 문자메시지 실 전송을 요청한다.
+	 *
+	 * @param smsConn
+	 * @return
+	 * @throws Exception
+	 */
+	public SmsConnection[] sendRequsest(SmsConnection[] smsConn) throws Exception {
+		EgovSmsInfoSender sender = null;
 
-	if (result != null) {	// 2011.10.21 보안점검 후속조치
-		smsConn.setResult(result.getResult());
-		smsConn.setResultMessage(result.getResultMessage());
-	}
+		try {
+			sender = new EgovSmsInfoSender(smeConfigPath);
 
-	return smsConn;
-    }
+			sender.open();
 
-    /**
-     * 여러 건의 문자메시지 실 전송을 요청한다.
-     *
-     * @param smsConn
-     * @return
-     * @throws Exception
-     */
-    public SmsConnection[] sendRequsest(SmsConnection[] smsConn) throws Exception {
-	EgovSmsInfoSender sender = null;
-
-	try {
-	    sender = new EgovSmsInfoSender(smeConfigPath);
-
-	    sender.open();
-
-	    // SMS 전송 요청
-	    SmsConnection result = null;
-	    for (int i = 0; i < smsConn.length; i++) {
-		String callTo = smsConn[i].getCallTo();
-		String callFrom = smsConn[i].getCallFrom();
-		String callBack = smsConn[i].getCallBack();
-		String callBackUrl = smsConn[i].getCallBackUrl();
-		String text = smsConn[i].getText();
-		String messageId = smsConn[i].getMessageId();	// messageId 지정 필요
+			// SMS 전송 요청
+			SmsConnection result = null;
+			for (int i = 0; i < smsConn.length; i++) {
+				String callTo = smsConn[i].getCallTo();
+				String callFrom = smsConn[i].getCallFrom();
+				String callBack = smsConn[i].getCallBack();
+				String callBackUrl = smsConn[i].getCallBackUrl();
+				String text = smsConn[i].getText();
+				String messageId = smsConn[i].getMessageId();    // messageId 지정 필요
 
 		/*
 		System.out.println("------------------------");
@@ -364,30 +364,30 @@ public class EgovSmsBasicServiceImpl implements EgovSmsInfoService {
 		System.out.println("text =[" + i + "] = " + text);
 		System.out.println("messageId[" + i + "] = " + messageId);
 		*/
-		LOGGER.info("------------------------");
-		LOGGER.info("callTo[{}] = {}", i, callTo);
-		LOGGER.info("callFrom[{}] = {}", i, callFrom);
-		LOGGER.info("callBack[{}] = {}", i, callBack);
-		LOGGER.info("callBackUrl[{}] = {}", i, callBackUrl);
-		LOGGER.info("text =[{}] = {}", i, text);
-		LOGGER.info("messageId[{}] = {}", i, messageId);
+				LOGGER.info("------------------------");
+				LOGGER.info("callTo[{}] = {}", i, callTo);
+				LOGGER.info("callFrom[{}] = {}", i, callFrom);
+				LOGGER.info("callBack[{}] = {}", i, callBack);
+				LOGGER.info("callBackUrl[{}] = {}", i, callBackUrl);
+				LOGGER.info("text =[{}] = {}", i, text);
+				LOGGER.info("messageId[{}] = {}", i, messageId);
 
-		//smsConn[i] = sendRequsest(smsConn[i]);
-		result = sender.send(smsConn[i]);
+				//smsConn[i] = sendRequsest(smsConn[i]);
+				result = sender.send(smsConn[i]);
 
-		// Sender의 전송 결과는 SMS G/W 처리 상의 결과만 리턴함
-		// 이동통신사의 오류는 별도의 Receiver에서 수신 처리함 (로그 기록)
+				// Sender의 전송 결과는 SMS G/W 처리 상의 결과만 리턴함
+				// 이동통신사의 오류는 별도의 Receiver에서 수신 처리함 (로그 기록)
 
-		smsConn[i].setResult(result.getResult());
-		smsConn[i].setResultMessage(result.getResultMessage());
-	    }
+				smsConn[i].setResult(result.getResult());
+				smsConn[i].setResultMessage(result.getResultMessage());
+			}
 
-	} finally {
-	    if (sender != null) {
-		sender.close();
-	    }
+		} finally {
+			if (sender != null) {
+				sender.close();
+			}
+		}
+
+		return smsConn;
 	}
-
-	return smsConn;
-    }
 }

--- a/src/main/java/egovframework/com/uss/olh/faq/web/EgovFaqController.java
+++ b/src/main/java/egovframework/com/uss/olh/faq/web/EgovFaqController.java
@@ -1,5 +1,6 @@
 package egovframework.com.uss.olh.faq.web;
 
+import egovframework.com.cmm.service.Globals;
 import java.util.List;
 
 import javax.annotation.Resource;
@@ -54,7 +55,7 @@ import org.egovframe.rte.ptl.mvc.tags.ui.pagination.PaginationInfo;
 
 @Controller
 public class EgovFaqController {
-	
+
 	@Resource(name = "EgovFaqService")
 	private EgovFaqService egovFaqService;
 
@@ -76,7 +77,7 @@ public class EgovFaqController {
 	// Validation 관련
 	@Autowired
 	private DefaultBeanValidator beanValidator;
-	
+
 	/**
 	 * FAQ 목록을 조회한다.
 	 * @param searchVO
@@ -111,7 +112,7 @@ public class EgovFaqController {
 
 		return "egovframework/com/uss/olh/faq/EgovFaqList";
 	}
-	
+
 	/**
 	 * FAQ 목록에 대한 상세정보를 조회한다.
 	 * @param faqVO
@@ -129,7 +130,7 @@ public class EgovFaqController {
 
 		return "egovframework/com/uss/olh/faq/EgovFaqDetail";
 	}
-	
+
 	/**
 	 * FAQ를 등록하기 위한 전 처리
 	 * @param searchVO
@@ -141,10 +142,10 @@ public class EgovFaqController {
 	public String insertFaqView(@ModelAttribute("searchVO") FaqVO searchVO, Model model) throws Exception {
 
 		model.addAttribute("faqVO", new FaqVO());
-		
+
     	// 파일업로드 제한
-    	String whiteListFileUploadExtensions = EgovProperties.getProperty("Globals.fileUpload.Extensions");
-    	String fileUploadMaxSize = EgovProperties.getProperty("Globals.fileUpload.maxSize");
+    	String whiteListFileUploadExtensions = Globals.FILE_UP_EXTS;
+    	String fileUploadMaxSize = Globals.FILE_UP_MAX_SIZE;
 
         model.addAttribute("fileUploadExtensions", whiteListFileUploadExtensions);
         model.addAttribute("fileUploadMaxSize", fileUploadMaxSize);
@@ -152,7 +153,7 @@ public class EgovFaqController {
 		return "egovframework/com/uss/olh/faq/EgovFaqRegist";
 
 	}
-	
+
 	/**
 	 * FAQ를 등록한다.
 	 * @param multiRequest
@@ -199,7 +200,7 @@ public class EgovFaqController {
 
 		return "forward:/uss/olh/faq/selectFaqList.do";
 	}
-	
+
 	/**
 	 * FAQ를 수정하기 위한 전 처리
 	 * @param faqId
@@ -220,12 +221,12 @@ public class EgovFaqController {
 		model.addAttribute("faqVO", egovFaqService.selectFaqDetail(faqVO));
 
     	// 파일업로드 제한
-    	String whiteListFileUploadExtensions = EgovProperties.getProperty("Globals.fileUpload.Extensions");
-    	String fileUploadMaxSize = EgovProperties.getProperty("Globals.fileUpload.maxSize");
+    	String whiteListFileUploadExtensions = Globals.FILE_UP_EXTS;
+    	String fileUploadMaxSize = Globals.FILE_UP_MAX_SIZE;
 
         model.addAttribute("fileUploadExtensions", whiteListFileUploadExtensions);
         model.addAttribute("fileUploadMaxSize", fileUploadMaxSize);
-		
+
 		return "egovframework/com/uss/olh/faq/EgovFaqUpdt";
 	}
 
@@ -251,7 +252,7 @@ public class EgovFaqController {
 			return "egovframework/com/uss/olh/faq/EgovFaqUpdt";
 		}
 
-		
+
 		// 첨부파일 관련 ID 생성 start....
 		String atchFileId = faqVO.getAtchFileId();
 
@@ -307,5 +308,5 @@ public class EgovFaqController {
 
 		return "forward:/uss/olh/faq/selectFaqList.do";
 	}
-	
+
 }


### PR DESCRIPTION
## 1. README.md 파일 수정

표준프레임워크를 처음 접하는 사용자들을 위해 데모 구동 및 위키페이지를 함께 안내한다. 표준프레임워크 교육 없이 처음 공통컴포넌트를 구동시 DB 설정을 간과하여 당황해 하는 분들이 많은 것 같습니다. 이에 원키로 구동 될 수 있게 Hsql을 기본 DB로 제공하거나, 개발 DB에 관하여 설정 하는 부분을 안내 페이지에 추가하였습니다.


## 2. Documents 디렉터리 생성

1.번과 연관하여 개발자들의 진입장벽을 낮추는데 도움이 되리라 생각됩니다.
필수적인 문서는 소스와 함께 배포하여 사용자들의 진입 장벽을 낮추는데 도움이 될 것이라 생각합니다.
물론 표준프레임워크 교육과 홈페이지의 위키 가이드를 제공 하고는 있으나, 그 양이 방대할 뿐 더러 개별 사용자의 needs를 충족 시키기 힘든 부분들이 많은 것 같습니다.

이에 프로그램의 필수 안내 사항(기본 구동 방법, 필수 설정 사항)을 소스에 함께 배포 함으로써 처음 접하는 사용자들의 진입장벽을 낮추고, 프로그램을 유지 및 관리 하는 사용자들또한 관리 포인트를 낮춰 운영의 효율성을 증진을 기대 할 수 있습니다. 나머지 상세 기능의 안내등은 현재의 위키 가이드를 이용하도록 안내합니다.


## 3. 개발환경 컨벤션 설정

개발환경 컨벤션을 일괄 적용 할 수 있게 도와 줍니다. 

3-1. .editorconfig은 다양한 에디터와 IDE에서 공통적으로 지원하는 코드 스타일에 대한 설정 파일입니다.
3-2. .gitattributes은 Windows 형식인 CRLF가 섞이지 않도록 편집기와 GIT 설정 등을 확인합니다.
파일은 디렉토리별로 지정할 수 있으며, 전체 프로젝트에 적용한다면 최상위 디렉토리에 둡니다.다.
3-3. 코딩컨벤션 검사 도구의 설정 파일을 제공합니다. 
규칙을 검사하는 규칙 설정 파일(egov-checkstyle-rules.xml)을 제공합니다.
상세 설정 방법은 Docs/egov-coding-convention.md의 `4. IDE Formatter 적용`을 참고합니다.

## 4. spring.profiles.active -> egov.profiles.active 로 변경
spring에서 사용하는 환경설정(dev, test, prod)를 spring.profiles.active 통해 사용하고 있는바, 만약 같은 키를 사용시 기반이 되는 프레임워크의 프로퍼티 키 값과 혼동이 있을 수 것 같습니다. 이에 표준프레임워크 자체적으로 사용하는 System 프로퍼티를 따로 사용해야 할 것 같습니다. 이는 개발환경이나, 운영환경에서 해당 프로퍼티를 따로 사용하고 있는지 확인 후 적용이 필요 해 보입니다.


## 5. 기타 오류 수정 및 리팩토링

### 5-1. fileSeparator 사용 통일.
System.getProperties()는 System.setProperty(key, value)에 의해 Overriding 될 수 있으므로 FileSeparator 사용 방법을 통일.

시스템 요구 사항에 따라 , System.getProperty("file.separator"), java.io.File.separator, java.nio.file.FileSystems.getDefault().getSeparator() 중 선택하여 사용 할 수 있습니다.

### 5-2. 전역 변수 관리
잦은 호출이 일어나는 환경 변수는 메소드 호출 보다는 전역 상수로 관리하는 것이 비용이 줄어들 것으로 보입니다.

### 5-3. 기타 코드 스멜 및 오류 제거.