### PR TITLE
GS ITM - 2023 전자정부 표준프레임워크 컨트리뷰션 참가 - 공통컴포넌트 Java Problem 버그수정 Bug fixes

### DIFF
--- a/src/main/java/egovframework/com/cmm/util/EgovMybatisUtil.java
+++ b/src/main/java/egovframework/com/cmm/util/EgovMybatisUtil.java
@@ -39,7 +39,7 @@ public class EgovMybatisUtil {
 	 * @exception IllegalArgumentException
 	 */
 	public static boolean isEmpty(Object o) {
-
+		logger.debug("o={}", o);
 		if(o == null) return true;
 		
 		if(o instanceof String) {
@@ -47,7 +47,7 @@ public class EgovMybatisUtil {
 				return true;
 			}
 		} else if(o instanceof Collection) {
-			if(((Collection)o).isEmpty()){
+			if(((Collection<?>)o).isEmpty()){
 			return true;
 			}
 		} else if(o.getClass().isArray()) {
@@ -55,7 +55,7 @@ public class EgovMybatisUtil {
 			return true;
 			}
 		} else if(o instanceof Map) {
-			if(((Map)o).isEmpty()){
+			if(((Map<?, ?>)o).isEmpty()){
 			return true;
 			}
 		}else {

--- a/src/main/java/egovframework/com/cop/sms/service/impl/SmsBasicDBUtil.java
+++ b/src/main/java/egovframework/com/cop/sms/service/impl/SmsBasicDBUtil.java
@@ -5,6 +5,7 @@ import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.time.Duration;
 
 import org.apache.commons.dbcp2.BasicDataSource;
 import org.apache.commons.dbcp2.DataSourceConnectionFactory;
@@ -89,9 +90,9 @@ public class SmsBasicDBUtil {
 		//커넥션이 유효한지 확인
 		poolableConnectionFactory.setValidationQuery(" SELECT 1 FROM DUAL ");
 		//커넥션 풀의 설정 정보를 생성
-		GenericObjectPoolConfig poolConfig = new GenericObjectPoolConfig();
+		GenericObjectPoolConfig<PoolableConnection> poolConfig = new GenericObjectPoolConfig<>();
 		//유효 커넥션 검사 주기
-		poolConfig.setTimeBetweenEvictionRunsMillis(1000L * 60L * 1L);
+		poolConfig.setTimeBetweenEvictionRuns(Duration.ofMillis(1000L * 60L * 1L));
 		//풀에 있는 커넥션이 유효한지 검사 유무 설정
 		poolConfig.setTestWhileIdle(true);
 		//기본값  : false /true 일 경우 validationQuery 를 매번 수행한다.

--- a/src/test/java/egovframework/com/cmm/util/EgovMybatisUtilTest.java
+++ b/src/test/java/egovframework/com/cmm/util/EgovMybatisUtilTest.java
@@ -1,0 +1,71 @@
+package egovframework.com.cmm.util;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class EgovMybatisUtilTest {
+
+	protected Logger egovLogger = LoggerFactory.getLogger(EgovMybatisUtilTest.class);
+
+	@Test
+	public void test_a10_isEmpty_Collection_null() {
+		List<String> o = null;
+		boolean isEmpty = EgovMybatisUtil.isEmpty(o);
+		egovLogger.debug("isEmpty={}", isEmpty);
+		assertEquals(isEmpty, true);
+	}
+
+	@Test
+	public void test_a20_isEmpty_Collection_true() {
+		List<String> o = new ArrayList<String>();
+		boolean isEmpty = EgovMybatisUtil.isEmpty(o);
+		egovLogger.debug("isEmpty={}", isEmpty);
+		assertEquals(isEmpty, true);
+	}
+
+	@Test
+	public void test_a30_isEmpty_Collection_false() {
+		List<String> o = new ArrayList<String>();
+		o.add("test 이백행 2023-05-01");
+		boolean isEmpty = EgovMybatisUtil.isEmpty(o);
+		egovLogger.debug("isEmpty={}", isEmpty);
+		assertEquals(isEmpty, false);
+	}
+
+	@Test
+	public void test_b10_isEmpty_Map_null() {
+		Map<String, Object> o = null;
+		boolean isEmpty = EgovMybatisUtil.isEmpty(o);
+		egovLogger.debug("isEmpty={}", isEmpty);
+		assertEquals(isEmpty, true);
+	}
+
+	@Test
+	public void test_b20_isEmpty_Map_true() {
+		Map<String, Object> o = new HashMap<>();
+		boolean isEmpty = EgovMybatisUtil.isEmpty(o);
+		egovLogger.debug("isEmpty={}", isEmpty);
+		assertEquals(isEmpty, true);
+	}
+
+	@Test
+	public void test_b30_isEmpty_Map_false() {
+		Map<String, Object> o = new HashMap<>();
+		o.put("test", "test 이백행 2023-05-01");
+		boolean isEmpty = EgovMybatisUtil.isEmpty(o);
+		egovLogger.debug("isEmpty={}", isEmpty);
+		assertEquals(isEmpty, false);
+	}
+
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

### 2023-05-02 SmsBasicDBUtil.java Java Problem 버그수정 Bug fixes

GenericObjectPoolConfig is a raw type. References to generic type GenericObjectPoolConfig<T> should be parameterized
- GenericObjectPoolConfig는 원시 유형입니다. 제네릭 형식 GenericObjectPoolConfig<T>에 대한 참조는 매개 변수화되어야 합니다.

Type safety: The expression of type GenericObjectPoolConfig needs unchecked conversion to conform to GenericObjectPoolConfig<PoolableConnection>
- 형식 안전성: GenericObjectPoolConfig 형식의 식은 GenericObjectPoolConfig<PoolableConnection>을 준수하기 위해 확인되지 않은 변환이 필요합니다.

```java
// GenericObjectPoolConfig poolConfig = new GenericObjectPoolConfig();
GenericObjectPoolConfig<PoolableConnection> poolConfig = new GenericObjectPoolConfig<>();
```

The method setTimeBetweenEvictionRunsMillis(long) from the type BaseObjectPoolConfig is deprecated
- BaseObjectPoolConfig 유형의 setTimeBetweenEvictionRunsMillis(long) 메서드는 더 이상 사용되지 않습니다.

```java
// poolConfig.setTimeBetweenEvictionRunsMillis(1000L * 60L * 1L);
poolConfig.setTimeBetweenEvictionRuns(Duration.ofMillis(1000L * 60L * 1L));
```

### 2023-05-01 EgovMybatisUtil.java Java Problem 버그수정 Bug fixes

Collection is a raw type. References to generic type Collection<E> should be parameterized
- 컬렉션은 원시 유형입니다. 제네릭 형식 Collection<E>에 대한 참조는 매개 변수화되어야 합니다.

```java
// if(((Collection)o).isEmpty()){
if(((Collection<?>)o).isEmpty()){
```

Map is a raw type. References to generic type Map<K,V> should be parameterized
- 지도는 원시 유형입니다. 일반 유형 Map<K,V>에 대한 참조는 매개변수화되어야 합니다.

```java
//if(((Map)o).isEmpty()){
if(((Map<?, ?>)o).isEmpty()){
```

The value of the field EgovMybatisUtil.logger is not used
- EgovMybatisUtil.logger 필드의 값은 사용되지 않습니다.

```java
logger.debug("o={}", o); // 추가
```

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [x] JUnit 테스트 JUnit tests
- [] 수동 테스트 Manual testing

2023-05-01 EgovMybatisUtil.java Java Problem 버그수정 Bug fixes
- https://github.com/GSITM2023/egovframe-common-components/blob/contribution/src/test/java/egovframework/com/cmm/util/EgovMybatisUtilTest.java

Duration 클래스 jdk 1.8 이상 작동되는지 테스트함
- https://github.com/GSITM2023/egovframe-common-components/commit/078a7b8e29935991a423045ad196ba952c3b3748

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡쳐 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡쳐 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

Duration 클래스 jdk 1.8 이상 작동되는지 테스트함
- https://youtu.be/cEBAM_n_gm4
