### PR TITLE
TestBean.java 컨텍스트 닫음/LOGGER 사용/주석 제거

### DIFF
--- a/src/test/java/egovframework/com/bean/TestBean.java
+++ b/src/test/java/egovframework/com/bean/TestBean.java
@@ -7,43 +7,45 @@ import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 /**
  * XML 기반 빈설정에서 SpEL 표현식 사용하여 메소드 호출
+ * 
  * @author 표준프레임워크 신용호
  * @since 2019.01.03
  * @version 4.0
  * @see
- * <pre>
+ * 
+ *      <pre>
  *
  *  수정일              수정자          수정내용
  *  ----------  --------  ---------------------------
  *  2022.08.29  신용호          최초 생성
  *
- * </pre>
+ *      </pre>
  */
 
 public class TestBean {
 
-    /** 로그설정 */
+	/** 로그설정 */
 	private static final Logger LOGGER = LoggerFactory.getLogger(TestBean.class);
 	private static MyBean myBean;
 	private static MyBean myBean1;
-	
+
 	public static void main(String[] args) {
-    	
-    	ApplicationContext context = new ClassPathXmlApplicationContext("classpath:egovframework/spring/com/test-context-datetime.xml");
-    	//EgovEnvCryptoService cryptoService = (EgovEnvCryptoService)factory.getBean("egovEnvCryptoService");
-    	myBean = context.getBean(MyBean.class);
-    	System.out.println(myBean.getCurrentTimeMills());
-    	
-    	try {
+		ApplicationContext context = new ClassPathXmlApplicationContext(
+				"classpath:egovframework/spring/com/test-context-datetime.xml");
+
+		myBean = context.getBean(MyBean.class);
+		LOGGER.debug("currentTimeMills={}", myBean.getCurrentTimeMills());
+
+		try {
 			Thread.sleep(1000);
 		} catch (InterruptedException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
+			LOGGER.error("InterruptedException");
 		}
-    	
-    	myBean1 = context.getBean(MyBean.class);
-    	System.out.println(myBean1.getCurrentTimeMills());
 
+		myBean1 = context.getBean(MyBean.class);
+		LOGGER.debug("currentTimeMills={}", myBean1.getCurrentTimeMills());
+
+		((ClassPathXmlApplicationContext) context).close();
 	}
-	
+
 }


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

Resource leak: 'context' is never closed
- 리소스 누수: '컨텍스트'가 닫히지 않습니다.
- TestBean.java
- /egovframe-common-components/src/test/java/egovframework/com/bean
- line 32
- Java Problem

```java
((ClassPathXmlApplicationContext) context).close();
```

The value of the field TestBean.LOGGER is not used
- TestBean.LOGGER 필드의 값은 사용되지 않습니다.
- line 26

```java
LOGGER.debug("currentTimeMills={}", myBean.getCurrentTimeMills());
LOGGER.debug("currentTimeMills={}", myBean1.getCurrentTimeMills());
LOGGER.error("InterruptedException");
```

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [x] JUnit 테스트 JUnit tests
- [] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡쳐 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡쳐 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

https://youtu.be/98WEQmqpsxI
