### PR TITLE
HTMLTagFilterTest.java assertThat 을 assertEquals 로 수정함

### DIFF
--- a/src/test/java/egovframework/com/filter/HTMLTagFilterTest.java
+++ b/src/test/java/egovframework/com/filter/HTMLTagFilterTest.java
@@ -19,11 +19,11 @@
 package egovframework.com.filter;
 
 import static org.junit.Assert.assertEquals;
-import static org.hamcrest.CoreMatchers.is;
-
 import java.util.Map;
 
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.web.filter.CorsFilter;
 
@@ -36,6 +36,8 @@ import egovframework.com.cmm.filter.HTMLTagFilterRequestWrapper;
  */
 public class HTMLTagFilterTest {
 
+	protected Logger egovLogger = LoggerFactory.getLogger(HTMLTagFilterTest.class);
+
 	HTMLTagFilter filter = new HTMLTagFilter();
 	MockHttpServletRequest request;
 	HTMLTagFilterRequestWrapper wrapper;
@@ -47,8 +49,8 @@ public class HTMLTagFilterTest {
 		request.addParameter("globalParameter", "<b>Text</b>");
 		wrapper = new HTMLTagFilterRequestWrapper(request);
 
-		System.out.println("testGetMethodGetParameter===> wrapper.getParameter(title) = "+wrapper.getParameter("title"));
-		System.out.println("testGetMethodGetParameter===> wrapper.getParameter(globalParameter) = "+wrapper.getParameter("globalParameter"));
+		egovLogger.debug("testGetMethodGetParameter===> wrapper.getParameter(title) = "+wrapper.getParameter("title"));
+		egovLogger.debug("testGetMethodGetParameter===> wrapper.getParameter(globalParameter) = "+wrapper.getParameter("globalParameter"));
 		assertEquals(wrapper.getParameter("title"), "&lt;b&gt;Text&lt;/b&gt;");
 		//assertEquals(wrapper.getParameter("globalParameter"), is("<b>Text</b>"));
 		assertEquals(wrapper.getParameter("globalParameter"), "&lt;b&gt;Text&lt;/b&gt;");
@@ -59,9 +61,9 @@ public class HTMLTagFilterTest {
 		request.addParameter("globalParameter", "<script>Text</script>");
 		wrapper = new HTMLTagFilterRequestWrapper(request);
 
-		System.out.println("testGetMethodGetParameter===> wrapper.getParameter(title) = "+wrapper.getParameter("title"));
-		System.out.println("testGetMethodGetParameter===> wrapper.getParameter(mode) = "+wrapper.getParameter("mode"));
-		System.out.println("testGetMethodGetParameter===> wrapper.getParameter(globalParameter) = "+wrapper.getParameter("globalParameter"));
+		egovLogger.debug("testGetMethodGetParameter===> wrapper.getParameter(title) = "+wrapper.getParameter("title"));
+		egovLogger.debug("testGetMethodGetParameter===> wrapper.getParameter(mode) = "+wrapper.getParameter("mode"));
+		egovLogger.debug("testGetMethodGetParameter===> wrapper.getParameter(globalParameter) = "+wrapper.getParameter("globalParameter"));
 		assertEquals(wrapper.getParameter("title"), "&lt;b&gt;Text&lt;/b&gt;");
 		assertEquals(wrapper.getParameter("mode"), "&lt;script&gt;Text&lt;/script&gt;");
 		assertEquals(wrapper.getParameter("globalParameter"), "&lt;script&gt;Text&lt;/script&gt;");
@@ -74,8 +76,8 @@ public class HTMLTagFilterTest {
 		request.addParameter("globalParameter", "<b>Text</b>");
 		wrapper = new HTMLTagFilterRequestWrapper(request);
 
-		System.out.println("testPostMethodGetParameter===> wrapper.getParameter(title) = "+wrapper.getParameter("title"));
-		System.out.println("testPostMethodGetParameter===> wrapper.getParameter(globalParameter) = "+wrapper.getParameter("globalParameter"));
+		egovLogger.debug("testPostMethodGetParameter===> wrapper.getParameter(title) = "+wrapper.getParameter("title"));
+		egovLogger.debug("testPostMethodGetParameter===> wrapper.getParameter(globalParameter) = "+wrapper.getParameter("globalParameter"));
 		assertEquals(wrapper.getParameter("title"), "&lt;b&gt;Text&lt;/b&gt;");
 		assertEquals(wrapper.getParameter("globalParameter"), "&lt;b&gt;Text&lt;/b&gt;");
 		//assertEquals(wrapper.getParameter("globalParameter"), is("<b>Text</b>"));
@@ -86,9 +88,9 @@ public class HTMLTagFilterTest {
 		request.addParameter("globalParameter", "<script>Text</script>");
 		wrapper = new HTMLTagFilterRequestWrapper(request);
 
-		System.out.println("testPostMethodGetParameter===> wrapper.getParameter(title) = "+wrapper.getParameter("title"));
-		System.out.println("testPostMethodGetParameter===> wrapper.getParameter(mode) = "+wrapper.getParameter("mode"));
-		System.out.println("testPostMethodGetParameter===> wrapper.getParameter(globalParameter) = "+wrapper.getParameter("globalParameter"));
+		egovLogger.debug("testPostMethodGetParameter===> wrapper.getParameter(title) = "+wrapper.getParameter("title"));
+		egovLogger.debug("testPostMethodGetParameter===> wrapper.getParameter(mode) = "+wrapper.getParameter("mode"));
+		egovLogger.debug("testPostMethodGetParameter===> wrapper.getParameter(globalParameter) = "+wrapper.getParameter("globalParameter"));
 		assertEquals(wrapper.getParameter("title"), "&lt;b&gt;Text&lt;/b&gt;");
 		assertEquals(wrapper.getParameter("mode"), "&lt;script&gt;Text&lt;/script&gt;");
 		assertEquals(wrapper.getParameter("globalParameter"), "&lt;script&gt;Text&lt;/script&gt;");
@@ -170,7 +172,7 @@ public class HTMLTagFilterTest {
 		assertEquals(values[1], "&lt;script&gt;Text2&lt;/script&gt;");
 
 		values = (String[])map.get("globalParameter");
-		System.out.println("===>>>"+values[0]);
+		egovLogger.debug("===>>>"+values[0]);
 		assertEquals(values[0], "&lt;script&gt;Text1&lt;/script&gt;");
 	}
 

--- a/src/test/java/egovframework/com/filter/HTMLTagFilterTest.java
+++ b/src/test/java/egovframework/com/filter/HTMLTagFilterTest.java
@@ -18,7 +18,7 @@
 
 package egovframework.com.filter;
 
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.hamcrest.CoreMatchers.is;
 
 import java.util.Map;
@@ -49,9 +49,9 @@ public class HTMLTagFilterTest {
 
 		System.out.println("testGetMethodGetParameter===> wrapper.getParameter(title) = "+wrapper.getParameter("title"));
 		System.out.println("testGetMethodGetParameter===> wrapper.getParameter(globalParameter) = "+wrapper.getParameter("globalParameter"));
-		assertThat(wrapper.getParameter("title"), is("&lt;b&gt;Text&lt;/b&gt;"));
-		//assertThat(wrapper.getParameter("globalParameter"), is("<b>Text</b>"));
-		assertThat(wrapper.getParameter("globalParameter"), is("&lt;b&gt;Text&lt;/b&gt;"));
+		assertEquals(wrapper.getParameter("title"), "&lt;b&gt;Text&lt;/b&gt;");
+		//assertEquals(wrapper.getParameter("globalParameter"), is("<b>Text</b>"));
+		assertEquals(wrapper.getParameter("globalParameter"), "&lt;b&gt;Text&lt;/b&gt;");
 
 		request = new MockHttpServletRequest("GET", "/url1.do");
 		request.addParameter("title", "<b>Text</b>");
@@ -62,9 +62,9 @@ public class HTMLTagFilterTest {
 		System.out.println("testGetMethodGetParameter===> wrapper.getParameter(title) = "+wrapper.getParameter("title"));
 		System.out.println("testGetMethodGetParameter===> wrapper.getParameter(mode) = "+wrapper.getParameter("mode"));
 		System.out.println("testGetMethodGetParameter===> wrapper.getParameter(globalParameter) = "+wrapper.getParameter("globalParameter"));
-		assertThat(wrapper.getParameter("title"), is("&lt;b&gt;Text&lt;/b&gt;"));
-		assertThat(wrapper.getParameter("mode"), is("&lt;script&gt;Text&lt;/script&gt;"));
-		assertThat(wrapper.getParameter("globalParameter"), is("&lt;script&gt;Text&lt;/script&gt;"));
+		assertEquals(wrapper.getParameter("title"), "&lt;b&gt;Text&lt;/b&gt;");
+		assertEquals(wrapper.getParameter("mode"), "&lt;script&gt;Text&lt;/script&gt;");
+		assertEquals(wrapper.getParameter("globalParameter"), "&lt;script&gt;Text&lt;/script&gt;");
 	}
 
 	@Test
@@ -76,9 +76,9 @@ public class HTMLTagFilterTest {
 
 		System.out.println("testPostMethodGetParameter===> wrapper.getParameter(title) = "+wrapper.getParameter("title"));
 		System.out.println("testPostMethodGetParameter===> wrapper.getParameter(globalParameter) = "+wrapper.getParameter("globalParameter"));
-		assertThat(wrapper.getParameter("title"), is("&lt;b&gt;Text&lt;/b&gt;"));
-		assertThat(wrapper.getParameter("globalParameter"), is("&lt;b&gt;Text&lt;/b&gt;"));
-		//assertThat(wrapper.getParameter("globalParameter"), is("<b>Text</b>"));
+		assertEquals(wrapper.getParameter("title"), "&lt;b&gt;Text&lt;/b&gt;");
+		assertEquals(wrapper.getParameter("globalParameter"), "&lt;b&gt;Text&lt;/b&gt;");
+		//assertEquals(wrapper.getParameter("globalParameter"), is("<b>Text</b>"));
 
 		request = new MockHttpServletRequest("POST", "/url1.do");
 		request.addParameter("title", "<b>Text</b>");
@@ -89,9 +89,9 @@ public class HTMLTagFilterTest {
 		System.out.println("testPostMethodGetParameter===> wrapper.getParameter(title) = "+wrapper.getParameter("title"));
 		System.out.println("testPostMethodGetParameter===> wrapper.getParameter(mode) = "+wrapper.getParameter("mode"));
 		System.out.println("testPostMethodGetParameter===> wrapper.getParameter(globalParameter) = "+wrapper.getParameter("globalParameter"));
-		assertThat(wrapper.getParameter("title"), is("&lt;b&gt;Text&lt;/b&gt;"));
-		assertThat(wrapper.getParameter("mode"), is("&lt;script&gt;Text&lt;/script&gt;"));
-		assertThat(wrapper.getParameter("globalParameter"), is("&lt;script&gt;Text&lt;/script&gt;"));
+		assertEquals(wrapper.getParameter("title"), "&lt;b&gt;Text&lt;/b&gt;");
+		assertEquals(wrapper.getParameter("mode"), "&lt;script&gt;Text&lt;/script&gt;");
+		assertEquals(wrapper.getParameter("globalParameter"), "&lt;script&gt;Text&lt;/script&gt;");
 	}
 
 	@Test
@@ -104,14 +104,14 @@ public class HTMLTagFilterTest {
 		wrapper = new HTMLTagFilterRequestWrapper(request);
 
 		String[] values = wrapper.getParameterValues("title");
-		assertThat(values[0], is("&lt;b&gt;Text1&lt;/b&gt;"));
-		assertThat(values[1], is("&lt;b&gt;Text2&lt;/b&gt;"));
+		assertEquals(values[0], "&lt;b&gt;Text1&lt;/b&gt;");
+		assertEquals(values[1], "&lt;b&gt;Text2&lt;/b&gt;");
 
 		values = wrapper.getParameterValues("globalParameter");
-		assertThat(values[0], is("&lt;b&gt;Text1&lt;/b&gt;"));
-		assertThat(values[1], is("&lt;b&gt;Text2&lt;/b&gt;"));
-		//assertThat(values[0], is("<b>Text1</b>"));
-		//assertThat(values[1], is("<b>Text2</b>"));
+		assertEquals(values[0], "&lt;b&gt;Text1&lt;/b&gt;");
+		assertEquals(values[1], "&lt;b&gt;Text2&lt;/b&gt;");
+		//assertEquals(values[0], is("<b>Text1</b>"));
+		//assertEquals(values[1], is("<b>Text2</b>"));
 
 		request = new MockHttpServletRequest("GET", "/url1.do");
 		request.addParameter("title", "<b>Text1</b>");
@@ -123,16 +123,16 @@ public class HTMLTagFilterTest {
 		wrapper = new HTMLTagFilterRequestWrapper(request);
 
 		values = wrapper.getParameterValues("title");
-		assertThat(values[0], is("&lt;b&gt;Text1&lt;/b&gt;"));
-		assertThat(values[1], is("&lt;b&gt;Text2&lt;/b&gt;"));
+		assertEquals(values[0], "&lt;b&gt;Text1&lt;/b&gt;");
+		assertEquals(values[1], "&lt;b&gt;Text2&lt;/b&gt;");
 
 		values = wrapper.getParameterValues("mode");
-		assertThat(values[0], is("&lt;script&gt;Text1&lt;/script&gt;"));
-		assertThat(values[1], is("&lt;script&gt;Text2&lt;/script&gt;"));
+		assertEquals(values[0], "&lt;script&gt;Text1&lt;/script&gt;");
+		assertEquals(values[1], "&lt;script&gt;Text2&lt;/script&gt;");
 
 		values = wrapper.getParameterValues("globalParameter");
-		assertThat(values[0], is("&lt;script&gt;Text1&lt;/script&gt;"));
-		assertThat(values[1], is("&lt;script&gt;Text2&lt;/script&gt;"));
+		assertEquals(values[0], "&lt;script&gt;Text1&lt;/script&gt;");
+		assertEquals(values[1], "&lt;script&gt;Text2&lt;/script&gt;");
 	}
 
 	@Test
@@ -145,12 +145,12 @@ public class HTMLTagFilterTest {
 
 		Map<String, String[]> map = wrapper.getParameterMap();
 		String[] values = (String[])map.get("title");
-		assertThat(values[0], is("&lt;b&gt;Text1&lt;/b&gt;"));
-		assertThat(values[1], is("&lt;b&gt;Text2&lt;/b&gt;"));
+		assertEquals(values[0], "&lt;b&gt;Text1&lt;/b&gt;");
+		assertEquals(values[1], "&lt;b&gt;Text2&lt;/b&gt;");
 
 		values = (String[])map.get("globalParameter");
-		assertThat(values[0], is("&lt;b&gt;Text1&lt;/b&gt;"));
-		//assertThat(values[0], is("<b>Text1</b>"));
+		assertEquals(values[0], "&lt;b&gt;Text1&lt;/b&gt;");
+		//assertEquals(values[0], is("<b>Text1</b>"));
 
 		request = new MockHttpServletRequest("GET", "/url1.do");
 		request.addParameter("title", "<b>Text1</b>");
@@ -162,16 +162,16 @@ public class HTMLTagFilterTest {
 
 		map = wrapper.getParameterMap();
 		values = (String[])map.get("title");
-		assertThat(values[0], is("&lt;b&gt;Text1&lt;/b&gt;"));
-		assertThat(values[1], is("&lt;b&gt;Text2&lt;/b&gt;"));
+		assertEquals(values[0], "&lt;b&gt;Text1&lt;/b&gt;");
+		assertEquals(values[1], "&lt;b&gt;Text2&lt;/b&gt;");
 
 		values = (String[])map.get("mode");
-		assertThat(values[0], is("&lt;script&gt;Text1&lt;/script&gt;"));
-		assertThat(values[1], is("&lt;script&gt;Text2&lt;/script&gt;"));
+		assertEquals(values[0], "&lt;script&gt;Text1&lt;/script&gt;");
+		assertEquals(values[1], "&lt;script&gt;Text2&lt;/script&gt;");
 
 		values = (String[])map.get("globalParameter");
 		System.out.println("===>>>"+values[0]);
-		assertThat(values[0], is("&lt;script&gt;Text1&lt;/script&gt;"));
+		assertEquals(values[0], "&lt;script&gt;Text1&lt;/script&gt;");
 	}
 
 	@Test
@@ -182,9 +182,9 @@ public class HTMLTagFilterTest {
 		request.addParameter("globalParameter", "<b>Text</b>");
 		wrapper = new HTMLTagFilterRequestWrapper(request);
 
-		assertThat(wrapper.getParameter("title"), is("&lt;b&gt;Text&lt;/b&gt;"));
-		assertThat(wrapper.getParameter("globalParameter"), is("&lt;b&gt;Text&lt;/b&gt;"));
-		//assertThat(wrapper.getParameter("globalParameter"), is("<b>Text</b>"));
+		assertEquals(wrapper.getParameter("title"), "&lt;b&gt;Text&lt;/b&gt;");
+		assertEquals(wrapper.getParameter("globalParameter"), "&lt;b&gt;Text&lt;/b&gt;");
+		//assertEquals(wrapper.getParameter("globalParameter"), is("<b>Text</b>"));
 
 		request = new MockHttpServletRequest("GET", "/test/url1.do");
 		request.setContextPath("/test");
@@ -193,8 +193,8 @@ public class HTMLTagFilterTest {
 		request.addParameter("globalParameter", "<script>Text</script>");
 		wrapper = new HTMLTagFilterRequestWrapper(request);
 
-		assertThat(wrapper.getParameter("title"), is("&lt;b&gt;Text&lt;/b&gt;"));
-		assertThat(wrapper.getParameter("mode"), is("&lt;script&gt;Text&lt;/script&gt;"));
-		assertThat(wrapper.getParameter("globalParameter"), is("&lt;script&gt;Text&lt;/script&gt;"));
+		assertEquals(wrapper.getParameter("title"), "&lt;b&gt;Text&lt;/b&gt;");
+		assertEquals(wrapper.getParameter("mode"), "&lt;script&gt;Text&lt;/script&gt;");
+		assertEquals(wrapper.getParameter("globalParameter"), "&lt;script&gt;Text&lt;/script&gt;");
 	}
 }


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

### HTMLTagFilterTest.java assertThat 을 assertEquals 로 수정함

The method assertThat(String, Matcher<? super String>) from the type Assert is deprecated
- Assert 유형의 assertThat(String, Matcher<? super String>) 메서드는 더 이상 사용되지 않습니다.
- HTMLTagFilterTest.java
- /egovframe-common-components/src/test/java/egovframework/com/filter
- line 52
- Java Problem

```java
//import static org.junit.Assert.assertThat;
import static org.junit.Assert.assertEquals;

//assertThat(wrapper.getParameter("title"), is("&lt;b&gt;Text&lt;/b&gt;"));
assertEquals(wrapper.getParameter("title"), "&lt;b&gt;Text&lt;/b&gt;");
```

System.out.println 을 egovLogger 로 수정함

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [x] JUnit 테스트 JUnit tests
- [] 수동 테스트 Manual testing

https://github.com/GSITM2023/egovframe-common-components/blob/2023/05/06a/src/test/java/egovframework/com/filter/HTMLTagFilterTest.java

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡쳐 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡쳐 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

https://youtu.be/oXewk2qshdo
