### PR TITLE
PasswordValidationTest.java deprecated method 주석함

### DIFF
--- a/src/test/java/egovframework/com/uss/umt/validation/PasswordValidationTest.java
+++ b/src/test/java/egovframework/com/uss/umt/validation/PasswordValidationTest.java
@@ -53,11 +53,15 @@ public class PasswordValidationTest {
 		String[] ok = { "abcdefgh", "12345678", "#!@#^#$#@" };
 		
 		for (int i = 0; i < notOk.length; i++) {
-			assertFalse(RteGenericValidator.checkCharacterType(notOk[i]));
+//			assertFalse(RteGenericValidator.checkCharacterType(notOk[i]));
+			assertFalse(RteGenericValidator.isMoreThan2CharTypeComb(notOk[i]));
+			assertFalse(RteGenericValidator.isMoreThan3CharTypeComb(notOk[i]));
 		}
 		
 		for (int i = 0; i < ok.length; i++) {
-			assertTrue(RteGenericValidator.checkCharacterType(ok[i]));
+//			assertTrue(RteGenericValidator.checkCharacterType(ok[i]));
+			assertFalse(RteGenericValidator.isMoreThan2CharTypeComb(ok[i]));
+			assertFalse(RteGenericValidator.isMoreThan3CharTypeComb(ok[i]));
 		}
 	}
 	
@@ -67,11 +71,15 @@ public class PasswordValidationTest {
 		String[] ok = { "abcaabbee", };
 		
 		for (int i = 0; i < notOk.length; i++) {
-			assertFalse(RteGenericValidator.checkSeries(notOk[i]));
+//			assertFalse(RteGenericValidator.checkSeries(notOk[i]));
+			assertTrue(RteGenericValidator.isSeriesCharacter(notOk[i]));
+			assertFalse(RteGenericValidator.isRepeatCharacter(notOk[i]));
 		}
 		
 		for (int i = 0; i < ok.length; i++) {
-			assertTrue(RteGenericValidator.checkSeries(ok[i]));
+//			assertTrue(RteGenericValidator.checkSeries(ok[i]));
+			assertTrue(RteGenericValidator.isSeriesCharacter(ok[i]));
+			assertFalse(RteGenericValidator.isRepeatCharacter(ok[i]));
 		}
 	}
 	
@@ -81,11 +89,15 @@ public class PasswordValidationTest {
 		String[] ok = { "aaatesta", };
 		
 		for (int i = 0; i < notOk.length; i++) {
-			assertFalse(RteGenericValidator.checkSeries(notOk[i]));
+//			assertFalse(RteGenericValidator.checkSeries(notOk[i]));
+			assertFalse(RteGenericValidator.isSeriesCharacter(notOk[i]));
+			assertTrue(RteGenericValidator.isRepeatCharacter(notOk[i]));
 		}
 		
 		for (int i = 0; i < ok.length; i++) {
-			assertTrue(RteGenericValidator.checkSeries(ok[i]));
+//			assertTrue(RteGenericValidator.checkSeries(ok[i]));
+			assertFalse(RteGenericValidator.isSeriesCharacter(ok[i]));
+			assertTrue(RteGenericValidator.isRepeatCharacter(ok[i]));
 		}
 	}
 	


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

### PasswordValidationTest.java deprecated method 주석함

deprecated 안 된 패스워드 점검 method 추가함
- checkCharacterType
  - isMoreThan2CharTypeComb
  - isMoreThan3CharTypeComb
- checkSeries
  - isSeriesCharacter
  - isRepeatCharacter

The method checkCharacterType(String) from the type RteGenericValidator is deprecated
- RteGenericValidator 유형의 checkCharacterType(String) 메서드는 더 이상 사용되지 않습니다.
- PasswordValidationTest.java
- /egovframe-common-components/src/test/java/egovframework/com/uss/umt/validation
- line 56
- Java Problem

```java
//assertFalse(RteGenericValidator.checkCharacterType(notOk[i]));
assertFalse(RteGenericValidator.isMoreThan2CharTypeComb(notOk[i]));
assertFalse(RteGenericValidator.isMoreThan3CharTypeComb(notOk[i]));
```

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [x] JUnit 테스트 JUnit tests
- [] 수동 테스트 Manual testing

https://github.com/GSITM2023/egovframe-common-components/blob/contribution/src/test/java/egovframework/com/uss/umt/validation/PasswordValidationTest.java

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡쳐 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡쳐 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

https://youtu.be/eBv5HPMsTUU
