### PR TITLE
EgovAtchFileIdPropertyEditor.java 에서 encode(String s, String enc) 메서드를 사용함

### DIFF
--- a/src/main/java/egovframework/com/cmm/web/EgovAtchFileIdPropertyEditor.java
+++ b/src/main/java/egovframework/com/cmm/web/EgovAtchFileIdPropertyEditor.java
@@ -2,6 +2,7 @@ package egovframework.com.cmm.web;
 
 import java.beans.PropertyEditorSupport;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -15,7 +16,7 @@ class EgovAtchFileIdPropertyEditor extends PropertyEditorSupport {
 		String decryptText = "";
 		if (text != null && !"".equals(text) ) {
 			try {
-				String encText = URLEncoder.encode(text);
+				String encText = URLEncoder.encode(text, StandardCharsets.UTF_8.name());
 				decryptText = EgovFileMngController.decrypt(encText);
 			} catch (Exception e) {
 				LOGGER.debug(e.getMessage());

--- a/src/test/java/egovframework/com/cmm/web/EgovAtchFileIdPropertyEditorTest.java
+++ b/src/test/java/egovframework/com/cmm/web/EgovAtchFileIdPropertyEditorTest.java
@@ -1,0 +1,37 @@
+package egovframework.com.cmm.web;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class EgovAtchFileIdPropertyEditorTest {
+
+	protected Logger egovLogger = LoggerFactory.getLogger(EgovAtchFileIdPropertyEditorTest.class);
+
+	@Test
+	public void test() {
+		String text = "test 이백행 2023-05-09";
+
+		String enc = StandardCharsets.UTF_8.name();
+
+		egovLogger.debug("enc={}", enc);
+
+		String encText = null;
+		try {
+			encText = URLEncoder.encode(text, enc);
+		} catch (UnsupportedEncodingException e) {
+			egovLogger.error("UnsupportedEncodingException");
+		}
+
+		egovLogger.debug("encText={}", encText);
+
+		assertEquals("test+%EC%9D%B4%EB%B0%B1%ED%96%89+2023-05-09", encText);
+	}
+
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.


### EgovAtchFileIdPropertyEditor.java 에서 encode(String s, String enc) 메서드를 사용함

The method encode(String) from the type URLEncoder is deprecated
- URLEncoder 유형의 encode(String) 메서드는 더 이상 사용되지 않습니다.
- EgovAtchFileIdPropertyEditor.java
- /egovframe-common-components/src/main/java/egovframework/com/cmm/web
- line 18
- Java Problem

```java
//String encText = URLEncoder.encode(text);
String encText = URLEncoder.encode(text, StandardCharsets.UTF_8.name());
```

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [x] JUnit 테스트 JUnit tests
- [] 수동 테스트 Manual testing

https://github.com/GSITM2023/egovframe-common-components/blob/2023/05/09/src/test/java/egovframework/com/cmm/web/EgovAtchFileIdPropertyEditorTest.java

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡쳐 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡쳐 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

https://youtu.be/2SOBEsLcmeA
