### PR TITLE
EgovFileSysMntrngServiceImpl.java 에서 java.nio.file.FileStore#getUsableSpace() 사용함

### DIFF
--- a/src/main/java/egovframework/com/utl/sys/fsm/service/impl/EgovFileSysMntrngServiceImpl.java
+++ b/src/main/java/egovframework/com/utl/sys/fsm/service/impl/EgovFileSysMntrngServiceImpl.java
@@ -1,4 +1,9 @@
 package egovframework.com.utl.sys.fsm.service.impl;
+import java.io.IOException;
+import java.nio.file.FileStore;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -108,8 +113,17 @@ public class EgovFileSysMntrngServiceImpl extends EgovAbstractServiceImpl implem
 	 * @param fileSysMntrng
 	 */
 	public int selectFileSysMg(FileSysMntrng fileSysMntrng) throws Exception{
-		FileSystemUtils.freeSpaceKb("");
-		return 0;
+		Path path = Paths.get("");
+		FileStore fs = null;
+		long usableSpaceBytes = 0;
+		try {
+			fs = Files.getFileStore(path);
+			usableSpaceBytes = fs.getUsableSpace();
+		} catch (IOException e) {
+			egovLogger.error("IOException");
+		}
+		long usableSpaceKb = usableSpaceBytes / 1024;
+		return (int) usableSpaceKb;
 	}
 	
 	/**

--- a/src/test/java/egovframework/com/utl/sys/fsm/service/impl/EgovFileSysMntrngServiceImpl_테스트.java
+++ b/src/test/java/egovframework/com/utl/sys/fsm/service/impl/EgovFileSysMntrngServiceImpl_테스트.java
@@ -1,0 +1,53 @@
+package egovframework.com.utl.sys.fsm.service.impl;
+
+import java.io.IOException;
+import java.nio.file.FileStore;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.apache.commons.io.FileSystemUtils;
+import org.apache.commons.io.FileUtils;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@SuppressWarnings("deprecation")
+public class EgovFileSysMntrngServiceImpl_테스트 {
+
+	protected Logger egovLogger = LoggerFactory.getLogger(EgovFileSysMntrngServiceImpl_테스트.class);
+
+	@Test
+	public void test() {
+		// freeSpaceKb
+		long freeSpaceKb = 0;
+		try {
+			freeSpaceKb = FileSystemUtils.freeSpaceKb("");
+		} catch (IOException e) {
+			egovLogger.error("IOException");
+		}
+
+		long freeSpaceBytes = freeSpaceKb * 1024;
+
+		egovLogger.debug("freeSpaceBytes={}", freeSpaceBytes);
+		egovLogger.debug("freeSpaceKb={}", freeSpaceKb);
+		egovLogger.debug("freeSpaceMb={}", FileUtils.byteCountToDisplaySize(freeSpaceBytes));
+
+		// getUsableSpace
+		Path path = Paths.get("");
+		FileStore fs = null;
+		long usableSpaceBytes = 0;
+		try {
+			fs = Files.getFileStore(path);
+			usableSpaceBytes = fs.getUsableSpace();
+		} catch (IOException e) {
+			egovLogger.error("IOException");
+		}
+		long usableSpaceKb = usableSpaceBytes / 1024;
+
+		egovLogger.debug("usableSpaceBytes={}", usableSpaceBytes);
+		egovLogger.debug("usableSpaceKb={}", usableSpaceKb);
+		egovLogger.debug("usableSpaceMb={}", FileUtils.byteCountToDisplaySize(usableSpaceBytes));
+	}
+
+}


### PR DESCRIPTION
…eSpace() 사용함

## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

### EgovFileSysMntrngServiceImpl.java 에서 java.nio.file.FileStore#getUsableSpace() 사용함

The method freeSpaceKb(String) from the type FileSystemUtils is deprecated
- FileSystemUtils 유형의 freeSpaceKb(String) 메서드는 더 이상 사용되지 않습니다.
- EgovFileSysMntrngServiceImpl.java
- /egovframe-common-components/src/main/java/egovframework/com/utl/sys/fsm/service/impl
- line 111
- Java Problem

@deprecated As of 2.6 deprecated without replacement. Please use {@link java.nio.file.FileStore#getUsableSpace()}.

@deprecated 2.6부터 대체 없이 사용되지 않습니다. {@link java.nio.file.FileStore#getUsableSpace()}를 사용하십시오.

사용 가능한 공간 얻기

```java
//		FileSystemUtils.freeSpaceKb("");
//		return 0;
		Path path = Paths.get("");
		FileStore fs = null;
		long usableSpaceBytes = 0;
		try {
			fs = Files.getFileStore(path);
			usableSpaceBytes = fs.getUsableSpace();
		} catch (IOException e) {
			egovLogger.error("IOException");
		}
		long usableSpaceKb = usableSpaceBytes / 1024;
		return (int) usableSpaceKb; // TODO long에서 int로 형 변환 예외 처리해야 함
```

```
freeSpaceBytes=160471506944
freeSpaceKb=156710456
freeSpaceMb=149 GB

usableSpaceBytes=160471506944
usableSpaceKb=156710456
usableSpaceMb=149 GB
```

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [x] JUnit 테스트 JUnit tests
- [] 수동 테스트 Manual testing

https://github.com/GSITM2023/egovframe-common-components/blob/2023/05/10/src/test/java/egovframework/com/utl/sys/fsm/service/impl/EgovFileSysMntrngServiceImpl_%ED%85%8C%EC%8A%A4%ED%8A%B8.java

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡쳐 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡쳐 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

https://youtu.be/RnHsxfBCJ70
