### PR TITLE
TestCopyDate.java 에서 Date.setYear 를 Calendar.set 으로 대체

### DIFF
--- a/src/test/java/egovframework/code/security/copyobj/TestCopyDate.java
+++ b/src/test/java/egovframework/code/security/copyobj/TestCopyDate.java
@@ -1,5 +1,6 @@
 package egovframework.code.security.copyobj;
 
+import java.util.Calendar;
 import java.util.Date;
 
 import org.slf4j.Logger;
@@ -13,8 +14,10 @@ public class TestCopyDate {
 		
 		Date d = new Date();
 		Date copyDate = (Date)d.clone();
-		d.setYear(2021-1900);
-		LOGGER.debug("Org Date.year = "+(d.getYear()+1900));
+		Calendar calendar = Calendar.getInstance();
+		calendar.set(Calendar.YEAR, 2021);
+		d = calendar.getTime();
+		LOGGER.debug("Org Date.year = "+(calendar.get(Calendar.YEAR)));
 		LOGGER.debug("Org Date = "+d);
 		LOGGER.debug("Org Date = "+d.hashCode());
 		LOGGER.debug("Destination Date = "+copyDate);


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

### TestCopyDate.java 에서 Date.setYear 를 Calendar.set 으로 대체

The method getYear() from the type Date is deprecated
- Date 유형의 getYear() 메서드는 더 이상 사용되지 않습니다.
- TestCopyDate.java
- /egovframe-common-components/src/test/java/egovframework/code/security/copyobj
- line 17
- Java Problem

Deprecated.  As of JDK version 1.1,replaced by Calendar.set(Calendar.YEAR, year + 1900).

더 이상 사용되지 않습니다. JDK 버전 1.1부터는 Calendar.set(Calendar.YEAR, year + 1900)으로 대체되었습니다.

```java
//d.setYear(2021-1900);
//LOGGER.debug("Org Date.year = "+(d.getYear()+1900));
Calendar calendar = Calendar.getInstance();
calendar.set(Calendar.YEAR, 2021);
d = calendar.getTime();
LOGGER.debug("Org Date.year = "+(calendar.get(Calendar.YEAR)));
```

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [x] JUnit 테스트 JUnit tests
- [] 수동 테스트 Manual testing

https://github.com/GSITM2023/egovframe-common-components/blob/2023/05/11/src/test/java/egovframework/code/security/copyobj/TestCopyDate.java

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡쳐 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡쳐 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

https://youtu.be/8mp2ajqyrVE
