### PR TITLE
EgovWhiteList.java checkNew 메서드 추가

### DIFF
--- a/src/test/java/egovframework/com/cmm/service/EgovWhiteList.java
+++ b/src/test/java/egovframework/com/cmm/service/EgovWhiteList.java
@@ -21,6 +21,38 @@ public class EgovWhiteList {
 	final static  String FILE_SEPARATOR = System.getProperty("file.separator");
 	public static final String RELATIVE_PATH_PREFIX = EgovProperties.RELATIVE_PATH_PREFIX;
 
+	public static boolean checkNew(String keyword) {
+		
+		String fName = EgovProperties.getProperty("Globals.linkWhitelistFile");
+		if ( fName == null || "".equals(fName) ) {
+			throw new RuntimeException("Globals.linkWhitelistFile is not defined!");
+		}
+		return checkNew(keyword, fName);
+	}
+	
+	public static boolean checkNew(String keyword, String whiteListFile) {
+		
+		String filePath = RELATIVE_PATH_PREFIX+"egovProps"+FILE_SEPARATOR+whiteListFile;
+
+		List<String> whiteList = loadWhiteListNew(EgovWebUtil.filePathBlackList(filePath));
+		if ( whiteList == null ) return false;
+		
+		for (String whiteListData : whiteList) {
+			
+			if ( whiteListData != null ) {
+				if ( !whiteListData.trim().equals("") ) {
+					if ("#".equals(whiteListData.substring(0,1))) {
+						// 주석으로 인식 - Pass
+					} else {
+						if (whiteListData.equals(keyword)) return true;
+					}
+				}
+			}
+		}
+		
+		return false;
+	}
+
 	public static boolean check(String keyword) {
 		
 		String fName = EgovProperties.getProperty("Globals.linkWhitelistFile");
@@ -33,7 +65,7 @@ public class EgovWhiteList {
 	public static boolean check(String keyword, String whiteListFile) {
 		
 		String filePath = RELATIVE_PATH_PREFIX+"egovProps"+FILE_SEPARATOR+whiteListFile;
-
+		
 		List<String> whiteList = loadWhiteList(EgovWebUtil.filePathBlackList(filePath));
 		if ( whiteList == null ) return false;
 		

--- a/src/test/java/egovframework/com/cmm/service/TestLoadFile.java
+++ b/src/test/java/egovframework/com/cmm/service/TestLoadFile.java
@@ -24,6 +24,9 @@ public class TestLoadFile {
 		
 		boolean result = EgovWhiteList.check("/egovframework/com/main_bottom");
 		egovLogger.debug("===>>> result = "+result);
+
+		boolean resultNew = EgovWhiteList.checkNew("/egovframework/com/main_bottom");
+		egovLogger.debug("===>>> resultNew = "+resultNew);
 		
 		egovLogger.debug(">>> "+EgovProperties.class.getResource(".").getPath());
 		

--- a/src/test/java/egovframework/com/cmm/service/TestWhiteListLink.java
+++ b/src/test/java/egovframework/com/cmm/service/TestWhiteListLink.java
@@ -3,7 +3,6 @@ package egovframework.com.cmm.service;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import org.egovframe.rte.fdl.cmmn.EgovAbstractServiceImpl;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,6 +47,9 @@ public class TestWhiteListLink {
 		boolean resultTrue = EgovWhiteList.check(link);
 		egovLogger.debug("===>>> result = "+resultTrue);
 
+		boolean resultTrueNew = EgovWhiteList.checkNew(link);
+		egovLogger.debug("===>>> resultNew = "+resultTrueNew);
+
 		assertTrue(resultTrue);
 		
 	}
@@ -60,6 +62,9 @@ public class TestWhiteListLink {
 		
 		boolean resultFalse = EgovWhiteList.check(link);
 		egovLogger.debug("===>>> result = "+resultFalse);
+
+		boolean resultFalseNew = EgovWhiteList.checkNew(link);
+		egovLogger.debug("===>>> resultNew = "+resultFalseNew);
 		
 		assertFalse(resultFalse);
 	}
@@ -73,6 +78,9 @@ public class TestWhiteListLink {
 
 		boolean resultFalse = EgovWhiteList.check(link);
 		egovLogger.debug("===>>> result = "+resultFalse);
+
+		boolean resultFalseNew = EgovWhiteList.checkNew(link);
+		egovLogger.debug("===>>> resultNew = "+resultFalseNew);
 		
 		assertFalse(resultFalse);
 	}


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

### EgovWhiteList.java checkNew 메서드 추가

EgovWhiteList.java 에서
checkNew 메서드를 추가했습니다.
loadWhiteListNew(String) 메서드는 로컬에서 사용되지 않기 때문에.

The method loadWhiteListNew(String) from the type EgovWhiteList is never used locally
- EgovWhiteList 유형의 loadWhiteListNew(String) 메서드는 로컬에서 사용되지 않습니다.
- EgovWhiteList.java
- /egovframe-common-components/src/test/java/egovframework/com/cmm/service
- line 58
- Java Problem

/egovframe-common-components/src/test/java/egovframework/com/cmm/service/TestLoadFile.java

/egovframe-common-components/src/test/java/egovframework/com/cmm/service/TestWhiteListLink.java

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [x] JUnit 테스트 JUnit tests
- [] 수동 테스트 Manual testing

https://github.com/GSITM2023/egovframe-common-components/blob/2023/05/17/src/test/java/egovframework/com/cmm/service/TestLoadFile.java

https://github.com/GSITM2023/egovframe-common-components/blob/2023/05/17/src/test/java/egovframework/com/cmm/service/TestWhiteListLink.java

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡쳐 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡쳐 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

https://youtu.be/oz4tQou8l3A
