### PR TITLE
로컬 변수 inputFile의 값이 사용되지 않아 주석

### DIFF
--- a/src/test/java/egovframework/com/utl/sim/TestPdfConverter2.java
+++ b/src/test/java/egovframework/com/utl/sim/TestPdfConverter2.java
@@ -1,6 +1,6 @@
 package egovframework.com.utl.sim;
 
-import java.io.File;
+//import java.io.File;
 
 /*
 import org.jodconverter.JodConverter;
@@ -36,10 +36,9 @@ import org.jodconverter.office.OfficeUtils;
 public class TestPdfConverter2 {
 
 	public static void main(String[] args) {
-		// TODO Auto-generated method stub
 
-		File inputFile = new File("C:/egovframework/test1.xls");
-		File outputFile = new File("C:/egovframework/result1.pdf");
+//		File inputFile = new File("C:/egovframework/test1.xls");
+//		File outputFile = new File("C:/egovframework/result1.pdf");
 
 		// Create an office manager using the default configuration.
 		// The default port is 2002. Note that when an office manager
@@ -58,7 +57,6 @@ public class TestPdfConverter2 {
 		             .to(outputFile)
 		             .execute();
 		} catch (OfficeException e) {
-			// TODO Auto-generated catch block
 			e.printStackTrace();
 		} finally {
 		    // Stop the office process


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

### 로컬 변수 inputFile의 값이 사용되지 않아 주석

TestPdfConverter2.java 에서

inputFile 주석했습니다.

로컬 변수 inputFile의 값이 사용되지 않기 때문에.

// TODO Auto-generated catch block 제거

The value of the local variable inputFile is not used
- 로컬 변수 inputFile의 값이 사용되지 않습니다.
- TestPdfConverter2.java
- /egovframe-common-components/src/test/java/egovframework/com/utl/sim
- line 41
- Java Problem

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [] JUnit 테스트 JUnit tests
- [] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡쳐 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡쳐 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

https://youtu.be/XKOocd5EIiU
