### PR TITLE
제네릭 타입 명시-디지털자산관리 - 지식정보관리-수정화면/수정 분기 고찰

### DIFF
--- a/src/main/java/egovframework/com/dam/mgm/web/EgovKnoManagementController.java
+++ b/src/main/java/egovframework/com/dam/mgm/web/EgovKnoManagementController.java
@@ -142,7 +142,7 @@ public class EgovKnoManagementController {
 	 * @param knoNm
 	 */
 	@GetMapping(value="/dam/mgm/EgovComDamManagementModify.do")
-	public String  updateKnoManagementView(@ModelAttribute("knoManagement") KnoManagement knoManagement
+	public String updateKnoManagementView(KnoManagement knoManagement
 			, ModelMap model
 			) throws Exception {
 
@@ -157,8 +157,7 @@ public class EgovKnoManagementController {
 		LoginVO loginVO = (LoginVO)EgovUserDetailsHelper.getAuthenticatedUser();
 
         knoManagement.setEmplyrId(loginVO.getUniqId());
-		knoManagement = knoManagementService.selectKnoManagement(knoManagement);
-		model.addAttribute("knoManagement", knoManagement);
+		model.addAttribute("resultKnoManagement", knoManagementService.selectKnoManagement(knoManagement));
 
 		LOGGER.debug("knoManagement>{}", knoManagement);
 		LOGGER.debug("knoManagement>{}", model.get("knoManagement"));
@@ -174,7 +173,7 @@ public class EgovKnoManagementController {
 	 * @param knoNm
 	 */
 	@PostMapping(value="/dam/mgm/EgovComDamManagementModify.do")
-	public String  updateKnoManagement(@ModelAttribute("knoManagement") KnoManagement knoManagement
+	public String  updateKnoManagement(KnoManagement knoManagement
 	        , BindingResult bindingResult
 	        , ModelMap model
 	        ) throws Exception {
@@ -192,8 +191,7 @@ public class EgovKnoManagementController {
         beanValidator.validate(knoManagement, bindingResult);
         if (bindingResult.hasErrors()){
             knoManagement.setEmplyrId(loginVO.getUniqId());
-            knoManagement = knoManagementService.selectKnoManagement(knoManagement);
-            model.addAttribute("knoManagement", knoManagement);
+            model.addAttribute("resultKnoManagement", knoManagementService.selectKnoManagement(knoManagement));
             return "egovframework/com/dam/mgm/EgovComDamManagementModify";
         }
         

--- a/src/main/java/egovframework/com/dam/mgm/web/EgovKnoManagementController.java
+++ b/src/main/java/egovframework/com/dam/mgm/web/EgovKnoManagementController.java
@@ -1,5 +1,7 @@
 package egovframework.com.dam.mgm.web;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 import javax.annotation.Resource;
@@ -22,6 +24,7 @@ import egovframework.com.dam.mgm.service.EgovKnoManagementService;
 import egovframework.com.dam.mgm.service.KnoManagement;
 import egovframework.com.dam.mgm.service.KnoManagementVO;
 
+import org.apache.commons.validator.GenericValidator;
 import org.egovframe.rte.fdl.property.EgovPropertyService;
 import org.egovframe.rte.psl.dataaccess.util.EgovMap;
 import org.egovframe.rte.ptl.mvc.tags.ui.pagination.PaginationInfo;
@@ -203,6 +206,9 @@ public class EgovKnoManagementController {
 
         beanValidator.validate(knoManagement, bindingResult);
         if (bindingResult.hasErrors()) {
+            if (GenericValidator.isDate(knoManagement.getJunkYmd(), "yyyyMMdd", true)) {
+                knoManagement.setJunkYmd(LocalDate.parse(knoManagement.getJunkYmd(), DateTimeFormatter.BASIC_ISO_DATE).format(DateTimeFormatter.ISO_LOCAL_DATE));
+            }
             updateKnoManagementViewInit(knoManagement, model);
             return "egovframework/com/dam/mgm/EgovComDamManagementModify";
         }

--- a/src/main/java/egovframework/com/dam/mgm/web/EgovKnoManagementController.java
+++ b/src/main/java/egovframework/com/dam/mgm/web/EgovKnoManagementController.java
@@ -154,51 +154,61 @@ public class EgovKnoManagementController {
 	    }
 
 		//로그인 객체 선언
-		LoginVO loginVO = (LoginVO)EgovUserDetailsHelper.getAuthenticatedUser();
-
-        knoManagement.setEmplyrId(loginVO.getUniqId());
-		model.addAttribute("resultKnoManagement", knoManagementService.selectKnoManagement(knoManagement));
-
-		LOGGER.debug("knoManagement>{}", knoManagement);
-		LOGGER.debug("knoManagement>{}", model.get("knoManagement"));
-
+		LoginVO loginVO = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();
+        if (loginVO != null) {
+            knoManagement.setEmplyrId(loginVO.getUniqId());
+        }
+        updateKnoManagementViewInit(knoManagement, model);
 		return "egovframework/com/dam/mgm/EgovComDamManagementModify";
 	}
 
-	/**
-	 * 기 등록 된 지식정보 정보를 수정 한다.
-	 * @param ManagementKnoNm - 지식정보 model
-	 * @return String - 리턴 Url
-	 *
-	 * @param knoNm
-	 */
-	@PostMapping(value="/dam/mgm/EgovComDamManagementModify.do")
-	public String  updateKnoManagement(KnoManagement knoManagement
-	        , BindingResult bindingResult
-	        , ModelMap model
-	        ) throws Exception {
-	    
-	    //Spring Security 사용자권한 처리
-	    Boolean isAuthenticated = EgovUserDetailsHelper.isAuthenticated();
-	    if (!isAuthenticated) {
-	        model.addAttribute("message", egovMessageSource.getMessage("fail.common.login"));
-	        return "redirect:/uat/uia/egovLoginUsr.do";
-	    }
-	    
-	    //로그인 객체 선언
-	    LoginVO loginVO = (LoginVO)EgovUserDetailsHelper.getAuthenticatedUser();
+    /**
+     * 기 등록 된 지식정보 정보를 수정 한다. 초기값
+     * 
+     * @param knoManagement
+     * @param model
+     * @throws Exception
+     */
+    private void updateKnoManagementViewInit(KnoManagement knoManagement, ModelMap model) throws Exception {
+        model.addAttribute("resultKnoManagement", knoManagementService.selectKnoManagement(knoManagement));
+
+        LOGGER.debug("knoManagement>{}", knoManagement);
+        LOGGER.debug("knoManagement>{}", model.get("knoManagement"));
+    }
+
+    /**
+     * 기 등록 된 지식정보 정보를 수정 한다.
+     * @param ManagementKnoNm - 지식정보 model
+     * @return String - 리턴 Url
+     *
+     * @param knoNm
+     */
+    @PostMapping(value = "/dam/mgm/EgovComDamManagementModify.do")
+    public String updateKnoManagement(KnoManagement knoManagement, BindingResult bindingResult, ModelMap model)
+            throws Exception {
+
+        // Spring Security 사용자권한 처리
+        Boolean isAuthenticated = EgovUserDetailsHelper.isAuthenticated();
+        if (!isAuthenticated) {
+            model.addAttribute("message", egovMessageSource.getMessage("fail.common.login"));
+            return "redirect:/uat/uia/egovLoginUsr.do";
+        }
+
+        // 로그인 객체 선언
+        LoginVO loginVO = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();
+        if (loginVO != null) {
+            knoManagement.setEmplyrId(loginVO.getUniqId());
+            knoManagement.setLastUpdusrId(loginVO.getUniqId());
+        }
 
         beanValidator.validate(knoManagement, bindingResult);
-        if (bindingResult.hasErrors()){
-            knoManagement.setEmplyrId(loginVO.getUniqId());
-            model.addAttribute("resultKnoManagement", knoManagementService.selectKnoManagement(knoManagement));
+        if (bindingResult.hasErrors()) {
+            updateKnoManagementViewInit(knoManagement, model);
             return "egovframework/com/dam/mgm/EgovComDamManagementModify";
         }
-        
-        knoManagement.setEmplyrId(loginVO.getUniqId());
-        knoManagement.setLastUpdusrId(loginVO.getUniqId());
+
         knoManagementService.updateKnoManagement(knoManagement);
         return "forward:/dam/mgm/EgovComDamManagementList.do";
-	}
+    }
 
 }

--- a/src/main/webapp/WEB-INF/jsp/egovframework/com/dam/mgm/EgovComDamManagementDetail.jsp
+++ b/src/main/webapp/WEB-INF/jsp/egovframework/com/dam/mgm/EgovComDamManagementDetail.jsp
@@ -47,6 +47,7 @@
 			varForm.action      = "<c:url value='/dam/mgm/EgovComDamManagementModify.do'/>";
 			varForm.knoId.value = "${result.knoId}";
 			//alert(varForm.knoId.value);	
+			varForm.method = 'get';
 			varForm.submit();
 		}
 		-->

--- a/src/main/webapp/WEB-INF/jsp/egovframework/com/dam/mgm/EgovComDamManagementModify.jsp
+++ b/src/main/webapp/WEB-INF/jsp/egovframework/com/dam/mgm/EgovComDamManagementModify.jsp
@@ -191,6 +191,7 @@
 				    <select name="knoAps" title="<spring:message code="comDamMgm.comDamManagementModify.knoAps"/>"><!-- 지식정제 선택 -->
 					    <option value="3" <c:if test="${knoManagement.knoAps == '3'}">selected</c:if> ><spring:message code="comDamMgm.comDamManagementModify.status.disposal"/></option><!-- 폐기 -->
 					</select>
+                    <form:errors path="knoAps" />
 				</td>
 			</tr>
 			<tr>

--- a/src/main/webapp/WEB-INF/jsp/egovframework/com/dam/mgm/EgovComDamManagementModify.jsp
+++ b/src/main/webapp/WEB-INF/jsp/egovframework/com/dam/mgm/EgovComDamManagementModify.jsp
@@ -118,44 +118,44 @@
 			<tr>
 				<th><spring:message code="comDamMgm.comDamManagementModify.orgnztNm"/> <span class="pilsu">*</span></th><!-- 조직명 -->
 				<td class="left">
-				    ${knoManagement.orgnztNm}
+				    ${resultKnoManagement.orgnztNm}
 				</td>
 			</tr>
 			<tr>
 				<th><spring:message code="comDamMgm.comDamManagementModify.knoTypeNm"/> <span class="pilsu">*</span></th><!-- 지식유형명 -->
 				<td class="left">
-				    ${knoManagement.knoTypeNm}
+				    ${resultKnoManagement.knoTypeNm}
 				</td>
 			</tr>
 			<tr>
 				<th><spring:message code="comDamMgm.comDamManagementModify.frstRegisterPnttm"/> <span class="pilsu">*</span></th><!-- 등록일자 -->
 				<td class="left">
-				    ${knoManagement.frstRegisterPnttm}
+				    ${resultKnoManagement.frstRegisterPnttm}
 				</td>
 			</tr>
 			<tr>
 				<th><spring:message code="comDamMgm.comDamManagementModify.userNm"/> <span class="pilsu">*</span></th><!-- 등록자명 -->
 				<td class="left">
-				    ${knoManagement.userNm}
+				    ${resultKnoManagement.userNm}
 				</td>
 			</tr>
 			<tr>
 				<th><spring:message code="comDamMgm.comDamManagementModify.knoNm"/> <span class="pilsu">*</span></th><!-- 지식명 -->
 				<td class="left">
-				    ${knoManagement.knoNm}
+				    ${resultKnoManagement.knoNm}
 				</td>
 			</tr>
 			<tr>
 				<th><spring:message code="comDamMgm.comDamManagementModify.knoCn"/> <span class="pilsu">*</span></th><!-- 지식내용 -->
 				<td class="left">
-				    <textarea name="knoCn" class="textarea" title="<spring:message code="comDamMgm.comDamManagementModify.knoCn"/>" cols="300" rows="5" style="width:450px;" readonly>${knoManagement.knoCn}</textarea><!-- 지식내용 -->
+				    <textarea name="knoCn" class="textarea" title="<spring:message code="comDamMgm.comDamManagementModify.knoCn"/>" cols="300" rows="5" style="width:450px;" readonly>${resultKnoManagement.knoCn}</textarea><!-- 지식내용 -->
 				</td>
 			</tr>
 			<tr>
 				<th><spring:message code="comDamMgm.comDamManagementModify.othbcAt"/> <span class="pilsu">*</span></th><!-- 공개여부 -->
 				<td class="left">
 				    <c:choose>
-					<c:when test="${knoManagement.othbcAt == 'Y'}">
+					<c:when test="${resultKnoManagement.othbcAt == 'Y'}">
 						<spring:message code="cop.public" />
 					</c:when>
 					<c:otherwise>
@@ -167,22 +167,22 @@
 			<tr>
 				<th><spring:message code="comDamMgm.comDamManagementModify.appYmd"/> <span class="pilsu">*</span></th><!-- 평가일자 -->
 				<td class="left">
-				    <c:if test="${knoManagement.appYmd == null}"><spring:message code="comDamMgm.comDamManagementModify.status.proceeding"/></c:if><!-- 진행중 -->
-		    		<c:if test="${knoManagement.appYmd != null}">${knoManagement.appYmd}</c:if>
+				    <c:if test="${resultKnoManagement.appYmd == null}"><spring:message code="comDamMgm.comDamManagementModify.status.proceeding"/></c:if><!-- 진행중 -->
+		    		<c:if test="${resultKnoManagement.appYmd != null}">${resultKnoManagement.appYmd}</c:if>
 				</td>
 			</tr>
 			<tr>
 				<th><spring:message code="comDamMgm.comDamManagementModify.speNm"/> <span class="pilsu">*</span></th><!-- 평가자명 -->
 				<td class="left">
-				    ${knoManagement.speNm}
+				    ${resultKnoManagement.speNm}
 				</td>
 			</tr>
 			<tr>
 				<th><spring:message code="comDamMgm.comDamManagementModify.knoAps"/> <span class="pilsu">*</span></th><!-- 평가결과 -->
 				<td class="left">
-				    <c:if test="${knoManagement.knoAps == null}"><spring:message code="comDamMgm.comDamManagementModify.status.evaluating"/></c:if><!-- 평가중 -->
-				    <c:if test="${knoManagement.knoAps == '1'}"><spring:message code="comDamMgm.comDamManagementModify.status.approved"/></c:if><!-- 승인 -->
-				    <c:if test="${knoManagement.knoAps == '2'}"><spring:message code="comDamMgm.comDamManagementModify.status.denied"/></c:if><!-- 반려 -->
+				    <c:if test="${resultKnoManagement.knoAps == null}"><spring:message code="comDamMgm.comDamManagementModify.status.evaluating"/></c:if><!-- 평가중 -->
+				    <c:if test="${resultKnoManagement.knoAps == '1'}"><spring:message code="comDamMgm.comDamManagementModify.status.approved"/></c:if><!-- 승인 -->
+				    <c:if test="${resultKnoManagement.knoAps == '2'}"><spring:message code="comDamMgm.comDamManagementModify.status.denied"/></c:if><!-- 반려 -->
 				</td>
 			</tr>
 			<tr>
@@ -202,12 +202,12 @@
 				</td>
 			</tr>
 			<!-- 첨부목록을 보여주기 위한 -->  
-			<c:if test="${knoManagement.atchFileId ne null && knoManagement.atchFileId ne ''}">
+			<c:if test="${resultKnoManagement.atchFileId ne null && resultKnoManagement.atchFileId ne ''}">
 			<tr>
 				<th><spring:message code="comDamMgm.comDamManagementModify.atchFileList"/></th><!-- 첨부파일 목록 -->
 				<td class="left">
 				    <c:import charEncoding="utf-8" url="/cmm/fms/selectFileInfs.do" >
-						<c:param name="param_atchFileId" value="${egovc:encrypt(knoManagement.atchFileId)}" />
+						<c:param name="param_atchFileId" value="${egovc:encrypt(resultKnoManagement.atchFileId)}" />
 					</c:import>
 				</td>
 			</tr>

--- a/src/main/webapp/WEB-INF/jsp/egovframework/com/dam/mgm/EgovComDamManagementModify.jsp
+++ b/src/main/webapp/WEB-INF/jsp/egovframework/com/dam/mgm/EgovComDamManagementModify.jsp
@@ -85,7 +85,7 @@
 				knoManagement.junkYmd.value = ls_junkYmd;
 			}
 			
-			if(confirm("<spring:message code="common.save.msg" />")){
+			if(confirm("<spring:message code="common.update.msg" />")){
 				if(!validateKnoManagement(form)){ 			
 					return;
 				}else{
@@ -217,7 +217,7 @@
 	
 		<!-- 하단 버튼 -->
 		<div class="btn">
-			<input class="s_submit" type="submit" value="<spring:message code="button.save" />" onclick="fn_egov_modify_KnoManagement(document.forms[0]); return false;" /><!-- 저장 -->
+			<input class="s_submit" type="submit" value="<spring:message code="button.update" />" onclick="fn_egov_modify_KnoManagement(document.forms[0]); return false;" /><!-- 저장 -->
 			<input class="s_submit" type="submit" value='<spring:message code="button.list" />' onclick="fn_egov_list_KnoManagement(); return false;" /><!-- 목록 -->
 		</div>
 		<div style="clear:both;"></div>


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

### 제네릭 타입 명시-디지털자산관리 - 지식정보관리-수정화면/수정 분기 고찰

post 메서드로 던지는 앞 단의 변동이 없어

수정 화면 및 처리 분기는 GetMapping과 PostMapping이 아닌

PostMapping 내의 bindingResult.hasErrors() 조건으로 분기 되고 있으므로

이에 대한 고찰이 필요해 보임

https://github.com/eGovFramework/egovframe-common-components/pull/139

1. 수정화면으로 form method 를 get 으로 수정
2. 수정화면에서 상세조회와 수정폼을 분리
3. 수정화면과 수정 유효성 검증에서 같이 사용하려고 '지식정보 상세 정보를 조회 한다.' 초기값 분리
4. 지식정제 <form:errors path="knoAps" /> 추가
5. 수정 유호성 검증에서 폐기일자 포맷 yyyy-MM-dd 맞춤
6. 저장을 수정으로 수정함

수정화면
- http://localhost:8080/egovframework-all-in-one/dam/mgm/EgovComDamManagementModify.do?knoId=DMID_000000000000001&knoCn=test+%EC%9D%B4%EB%B0%B1%ED%96%89+2023-06-10+%EC%A7%80%EC%8B%9D%EB%82%B4%EC%9A%A9&atchFileId=oO3rGEfD8twsMG5pYVeQOvXRVZDYkZMlAF88rDkQ48k%253D&fileSn=&fileListCnt=1

지식정보관리 목록

http://localhost:8080/egovframework-all-in-one/dam/mgm/EgovComDamManagementList.do

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [x] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡쳐 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡쳐 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

https://youtu.be/YUqTb1HgQI0
