### PR TITLE
쿼리문 오류 수정(520. 도움말)

### DIFF
--- a/src/main/resources/egovframework/mapper/com/uss/olh/hpc/EgovHpcm_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olh/hpc/EgovHpcm_SQL_maria.xml
@@ -44,7 +44,7 @@
 				A.HPCM_ID,
 				A.HPCM_SE_CODE,
 				B.CODE_NM HPCM_SE_CODE_NM,
-				A.HPCM_DFN 						HPCM_DF,
+				A.HPCM_DFN,
 				HPCM_DC,
 				DATE_FORMAT(A.FRST_REGIST_PNTTM,'%Y-%m-%d') FRST_REGIST_PNTTM,
 				A.FRST_REGISTER_ID,
@@ -56,10 +56,10 @@
 			WHERE	1=1   			
 							
 			<if test="searchCnd == 0">AND
-				b.CODE_NM LIKE CONCAT('%', #{searchWrd}, '%')
+				B.CODE_NM LIKE CONCAT('%', #{searchWrd}, '%')
 			</if>
 			<if test="searchCnd == 1">AND
-				a.HPCM_DFN LIKE CONCAT('%', #{searchWrd}, '%')
+				A.HPCM_DFN LIKE CONCAT('%', #{searchWrd}, '%')
 			</if>
 			ORDER BY HPCM_ID DESC			
 			LIMIT  #{recordCountPerPage} OFFSET #{firstIndex}	
@@ -74,10 +74,10 @@
 			WHERE 	1=1
 					
 			<if test="searchCnd == 0">AND
-				b.CODE_NM LIKE CONCAT('%', #{searchWrd}, '%')
+				B.CODE_NM LIKE CONCAT('%', #{searchWrd}, '%')
 			</if>
 			<if test="searchCnd == 1">AND
-				a.HPCM_DFN LIKE CONCAT('%', #{searchWrd}, '%')
+				A.HPCM_DFN LIKE CONCAT('%', #{searchWrd}, '%')
 			</if>
 	</select>
 	

--- a/src/main/resources/egovframework/mapper/com/uss/olh/hpc/EgovHpcm_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olh/hpc/EgovHpcm_SQL_mysql.xml
@@ -56,10 +56,10 @@
 			WHERE	1=1   			
 							
 			<if test="searchCnd == 0">AND
-				b.CODE_NM LIKE CONCAT('%', #{searchWrd}, '%')
+				B.CODE_NM LIKE CONCAT('%', #{searchWrd}, '%')
 			</if>
 			<if test="searchCnd == 1">AND
-				a.HPCM_DFN LIKE CONCAT('%', #{searchWrd}, '%')
+				A.HPCM_DFN LIKE CONCAT('%', #{searchWrd}, '%')
 			</if>
 			ORDER BY HPCM_ID DESC			
 			LIMIT  #{recordCountPerPage} OFFSET #{firstIndex}	
@@ -74,10 +74,10 @@
 			WHERE 	1=1
 					
 			<if test="searchCnd == 0">AND
-				b.CODE_NM LIKE CONCAT('%', #{searchWrd}, '%')
+				B.CODE_NM LIKE CONCAT('%', #{searchWrd}, '%')
 			</if>
 			<if test="searchCnd == 1">AND
-				a.HPCM_DFN LIKE CONCAT('%', #{searchWrd}, '%')
+				A.HPCM_DFN LIKE CONCAT('%', #{searchWrd}, '%')
 			</if>
 	</select>
 	

--- a/src/main/resources/egovframework/mapper/com/uss/olh/hpc/EgovHpcm_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olh/hpc/EgovHpcm_SQL_postgres.xml
@@ -56,10 +56,10 @@
 			WHERE	1=1   			
 							
 			<if test="searchCnd == 0">AND
-				b.CODE_NM LIKE CONCAT('%', #{searchWrd}, '%')
+				B.CODE_NM LIKE CONCAT('%', #{searchWrd}, '%')
 			</if>
 			<if test="searchCnd == 1">AND
-				a.HPCM_DFN LIKE CONCAT('%', #{searchWrd}, '%')
+				A.HPCM_DFN LIKE CONCAT('%', #{searchWrd}, '%')
 			</if>
 			ORDER BY HPCM_ID DESC			
 			LIMIT  #{recordCountPerPage} OFFSET #{firstIndex}	
@@ -74,10 +74,10 @@
 			WHERE 	1=1
 					
 			<if test="searchCnd == 0">AND
-				b.CODE_NM LIKE CONCAT('%', #{searchWrd}, '%')
+				B.CODE_NM LIKE CONCAT('%', #{searchWrd}, '%')
 			</if>
 			<if test="searchCnd == 1">AND
-				a.HPCM_DFN LIKE CONCAT('%', #{searchWrd}, '%')
+				A.HPCM_DFN LIKE CONCAT('%', #{searchWrd}, '%')
 			</if>
 	</select>
 	


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

[520. 도움말] 부분을 조회했을 때 '데이터 처리 중 오류가 발생하였습니다!' 오류가 발생하였으며,

쿼리문의 오류로 확인되어 쿼리문 수정을 하였습니다.

mariaDB를 사용해서 테스트를 했었어서,

`src/main/resources/egovframework/mapper/com/uss/olh/hpc/EgovHpcm_SQL_maria.xml`와

`src/main/resources/egovframework/mapper/com/uss/olh/hpc/EgovHpcm_SQL_mysql.xml`,

`src/main/resources/egovframework/mapper/com/uss/olh/hpc/EgovHpcm_SQL_postgres.xml` 파일 부분

`b.CODE_NM -> b.CODE_NM`

`a.HPCM_DFN -> A.HPCM_DFN` 로 변경하였습니다.

cf) mysql, postgres 쿼리문도 동일한 쿼리문 오류로 보여 동일하게 수정하였습니다.

또한, mariaDB 같은 경우, 47번째 쿼리문에 HPCM_DF 별칭을 붙임으로써 '도움말 정의' 부분이 나타나지 않아 HPCM_DF 별칭을 삭제해주었습니다. 

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [x] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [X] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡쳐 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡쳐 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

[테스트 전]
1. 쿼리문 오류
<img width="1170" alt="스크린샷 2023-07-15 오후 3 20 33" src="https://github.com/eGovFramework/egovframe-common-components/assets/91789496/8c881ece-e57c-42df-8a06-68d195ce0baf">


2. 별칭 오류
<img width="1087" alt="스크린샷 2023-07-15 오후 4 22 35" src="https://github.com/eGovFramework/egovframe-common-components/assets/91789496/b677a2e1-8062-4eb7-a71c-9f136de05de6">

[테스트 후]
1. 쿼리문 오류
<img width="1158" alt="스크린샷 2023-07-15 오후 3 31 47" src="https://github.com/eGovFramework/egovframe-common-components/assets/91789496/b6c49424-15cf-4fc0-8c24-ce1b6945f583">


2. 별칭 오류
<img width="1261" alt="스크린샷 2023-07-15 오후 4 44 35" src="https://github.com/eGovFramework/egovframe-common-components/assets/91789496/b140fb86-92db-461e-8981-1d947e3598be">
