### PR TITLE
버그수정: 권한그룹관리 목록 검색어 조회

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/egovframework/com/sec/rgm/EgovAuthorGroupManage.jsp
+++ b/src/main/webapp/WEB-INF/jsp/egovframework/com/sec/rgm/EgovAuthorGroupManage.jsp
@@ -227,7 +227,7 @@ function press() {
 			</li>
 			<!-- 검색키워드 및 조회버튼 -->
 			<li>
-				<input class="s_input" name="searchKeyword" type="text"  size="35" title="<spring:message code="title.search" /> <spring:message code="input.input" />" value='<c:out value="${searchVO.searchKeyword}"/>'  maxlength="155" >
+				<input class="s_input" name="searchKeyword" type="text"  size="35" title="<spring:message code="title.search" /> <spring:message code="input.input" />" value='<c:out value="${authorGroupVO.searchKeyword}"/>'  maxlength="155" >
 
 				<input type="button" class="s_btn" onClick="fncSelectAuthorGroupPop()" value="<spring:message code="comCopSecRgm.btn.groupInquire" />" title="<spring:message code="comCopSecRgm.btn.groupInquire" /> <spring:message code="input.button" />" /><!-- 그룹조회팝업 -->
 				<input type="button" class="s_btn" onClick="fncSelectAuthorGroupList('1')" value="<spring:message code="button.inquire" />" title="<spring:message code="button.inquire" /> <spring:message code="input.button" />" /><!-- 조회 -->

--- a/src/main/webapp/WEB-INF/jsp/egovframework/com/sec/rgm/EgovAuthorGroupManage.jsp
+++ b/src/main/webapp/WEB-INF/jsp/egovframework/com/sec/rgm/EgovAuthorGroupManage.jsp
@@ -227,7 +227,7 @@ function press() {
 			</li>
 			<!-- 검색키워드 및 조회버튼 -->
 			<li>
-				<input class="s_input" name="searchKeyword" type="text"  size="35" title="<spring:message code="title.search" /> <spring:message code="input.input" />" value='<c:out value="${authorManageVO.searchKeyword}"/>'  maxlength="155" >
+				<input class="s_input" name="searchKeyword" type="text"  size="35" title="<spring:message code="title.search" /> <spring:message code="input.input" />" value='<c:out value="${authorGroupVO.searchKeyword}"/>'  maxlength="155" >
 
 				<input type="button" class="s_btn" onClick="fncSelectAuthorGroupPop()" value="<spring:message code="comCopSecRgm.btn.groupInquire" />" title="<spring:message code="comCopSecRgm.btn.groupInquire" /> <spring:message code="input.button" />" /><!-- 그룹조회팝업 -->
 				<input type="button" class="s_btn" onClick="fncSelectAuthorGroupList('1')" value="<spring:message code="button.inquire" />" title="<spring:message code="button.inquire" /> <spring:message code="input.button" />" /><!-- 조회 -->

--- a/src/main/webapp/WEB-INF/jsp/egovframework/com/sec/rgm/EgovAuthorGroupManage.jsp
+++ b/src/main/webapp/WEB-INF/jsp/egovframework/com/sec/rgm/EgovAuthorGroupManage.jsp
@@ -227,7 +227,7 @@ function press() {
 			</li>
 			<!-- 검색키워드 및 조회버튼 -->
 			<li>
-				<input class="s_input" name="searchKeyword" type="text"  size="35" title="<spring:message code="title.search" /> <spring:message code="input.input" />" value='<c:out value="${authorGroupVO.searchKeyword}"/>'  maxlength="155" >
+				<input class="s_input" name="searchKeyword" type="text"  size="35" title="<spring:message code="title.search" /> <spring:message code="input.input" />" value='<c:out value="${authorManageVO.searchKeyword}"/>'  maxlength="155" >
 
 				<input type="button" class="s_btn" onClick="fncSelectAuthorGroupPop()" value="<spring:message code="comCopSecRgm.btn.groupInquire" />" title="<spring:message code="comCopSecRgm.btn.groupInquire" /> <spring:message code="input.button" />" /><!-- 그룹조회팝업 -->
 				<input type="button" class="s_btn" onClick="fncSelectAuthorGroupList('1')" value="<spring:message code="button.inquire" />" title="<spring:message code="button.inquire" /> <spring:message code="input.button" />" /><!-- 조회 -->


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

### 버그수정: 권한그룹관리 목록 검색어 조회

권한그룹관리 목록 화면에서 검색어 입력 후 조회 버튼 클릭하면 검색어가 출력되지 않음

- `searchVO.searchKeyword` 를 `authorManageVO.searchKeyword` 로 수정

권한그룹관리 목록
- 70. 권한그룹관리
- http://localhost:8080/egovframework-all-in-one/sec/rgm/EgovAuthorGroupList.do

권한 그룹 관리
- https://www.egovframe.go.kr/wiki/doku.php?id=egovframework:com:v4.1:sec:%EA%B6%8C%ED%95%9C%EA%B7%B8%EB%A3%B9%EA%B4%80%EB%A6%AC

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [x] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡쳐 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡쳐 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

테스트 전
![image](https://github.com/eGovFramework/egovframe-common-components/assets/20558160/630c6f04-643d-4483-9764-c298dcf2ce08)

테스트 후
![image](https://github.com/eGovFramework/egovframe-common-components/assets/20558160/c8a0f8ed-010a-443e-8e92-4214228278f9)
