### PR TITLE
제네릭 타입 명시: 백업작업정보목록을  조회한다.

### DIFF
--- a/src/main/java/egovframework/com/sym/sym/bak/service/BackupScheduler.java
+++ b/src/main/java/egovframework/com/sym/sym/bak/service/BackupScheduler.java
@@ -168,42 +168,41 @@ public class BackupScheduler {
 		}
 	}
 
-	/**
-	 * 클래스 초기화메소드.
-	 * 배치스케줄테이블을 읽어서 Quartz 스케줄러를 초기화한다.
-	 *
-	 */
-	public void init() throws Exception {
-		BackupOpert searchVO = new BackupOpert();
-		// 모니터링 대상 검색 조건 초기화
-		searchVO.setPageIndex(1);
-		searchVO.setFirstIndex(0);
-		searchVO.setRecordCountPerPage(RECORD_COUNT_PER_PAGE);
+    /**
+     * 클래스 초기화메소드. 배치스케줄테이블을 읽어서 Quartz 스케줄러를 초기화한다.
+     *
+     */
+    public void init() throws Exception {
+        BackupOpert searchVO = new BackupOpert();
+        // 모니터링 대상 검색 조건 초기화
+        searchVO.setPageIndex(1);
+        searchVO.setFirstIndex(0);
+        searchVO.setRecordCountPerPage(RECORD_COUNT_PER_PAGE);
         // 모니터링 대상 정보 읽어들이기~~~
-		List<BackupOpert> targetList = egovBackupOpertService.selectBackupOpertList(searchVO);
-		LOGGER.debug("조회조건 {}", searchVO);
-		LOGGER.debug("Result 건수 : {}", targetList.size());
+        List<BackupOpert> targetList = egovBackupOpertService.selectBackupOpertList(searchVO);
+        LOGGER.debug("조회조건 {}", searchVO);
+        LOGGER.debug("Result 건수 : {}", targetList.size());
 
-		// 스케줄러 생성하기
-		SchedulerFactory schedFact = new org.quartz.impl.StdSchedulerFactory();
-		sched = schedFact.getScheduler();
+        // 스케줄러 생성하기
+        SchedulerFactory schedFact = new org.quartz.impl.StdSchedulerFactory();
+        sched = schedFact.getScheduler();
 
         // Set up the listener
-		BackupJobListener listener = new BackupJobListener();
+        BackupJobListener listener = new BackupJobListener();
 
         listener.setEgovBackupOpertService(egovBackupOpertService);
         listener.setIdgenService(idgenService);
 
         sched.getListenerManager().addJobListener(listener);
 
-		// 스케줄러에 Job, Trigger 등록하기
-		for (BackupOpert target : targetList) {
-			LOGGER.debug("Data : {}", target);
+        // 스케줄러에 Job, Trigger 등록하기
+        for (BackupOpert target : targetList) {
+            LOGGER.debug("Data : {}", target);
 
-			insertBackupOpert(target);
-		}
-		sched.start();
-	}
+            insertBackupOpert(target);
+        }
+        sched.start();
+    }
 
 	/**
 	 * 클래스 destroy메소드.

--- a/src/main/java/egovframework/com/sym/sym/bak/service/BackupScheduler.java
+++ b/src/main/java/egovframework/com/sym/sym/bak/service/BackupScheduler.java
@@ -173,16 +173,14 @@ public class BackupScheduler {
 	 * 배치스케줄테이블을 읽어서 Quartz 스케줄러를 초기화한다.
 	 *
 	 */
-	@SuppressWarnings("unchecked")
 	public void init() throws Exception {
-		// 모니터링 대상 정보 읽어들이기~~~
-		List<BackupOpert> targetList = null;
 		BackupOpert searchVO = new BackupOpert();
 		// 모니터링 대상 검색 조건 초기화
 		searchVO.setPageIndex(1);
 		searchVO.setFirstIndex(0);
 		searchVO.setRecordCountPerPage(RECORD_COUNT_PER_PAGE);
-		targetList = (List<BackupOpert>) egovBackupOpertService.selectBackupOpertList(searchVO);
+        // 모니터링 대상 정보 읽어들이기~~~
+		List<BackupOpert> targetList = egovBackupOpertService.selectBackupOpertList(searchVO);
 		LOGGER.debug("조회조건 {}", searchVO);
 		LOGGER.debug("Result 건수 : {}", targetList.size());
 
@@ -199,9 +197,7 @@ public class BackupScheduler {
         sched.getListenerManager().addJobListener(listener);
 
 		// 스케줄러에 Job, Trigger 등록하기
-        BackupOpert target = null;
-		for (int i = 0; i < targetList.size(); i++) {
-			target = targetList.get(i);
+		for (BackupOpert target : targetList) {
 			LOGGER.debug("Data : {}", target);
 
 			insertBackupOpert(target);

--- a/src/main/java/egovframework/com/sym/sym/bak/service/EgovBackupOpertService.java
+++ b/src/main/java/egovframework/com/sym/sym/bak/service/EgovBackupOpertService.java
@@ -45,14 +45,15 @@ public interface EgovBackupOpertService {
 	 */
 	public BackupOpert selectBackupOpert(BackupOpert backupOpert) throws Exception;
 
-	/**
-	 * 백업작업 목록을 조회한다.
-	 * @return 백업작업목록
-	 *
-	 * @param searchVO    조회조건VO
-	 * @exception Exception Exception
-	 */
-	public List<BackupOpert> selectBackupOpertList(BackupOpert searchVO) throws Exception;
+    /**
+     * 백업작업 목록을 조회한다.
+     * 
+     * @return 백업작업목록
+     *
+     * @param searchVO 조회조건VO
+     * @exception Exception Exception
+     */
+    public List<BackupOpert> selectBackupOpertList(BackupOpert searchVO) throws Exception;
 
 	/**
 	 * 백업작업 목록 전체 건수를(을) 조회한다.

--- a/src/main/java/egovframework/com/sym/sym/bak/service/EgovBackupOpertService.java
+++ b/src/main/java/egovframework/com/sym/sym/bak/service/EgovBackupOpertService.java
@@ -52,7 +52,7 @@ public interface EgovBackupOpertService {
 	 * @param searchVO    조회조건VO
 	 * @exception Exception Exception
 	 */
-	public List<?> selectBackupOpertList(BackupOpert searchVO) throws Exception;
+	public List<BackupOpert> selectBackupOpertList(BackupOpert searchVO) throws Exception;
 
 	/**
 	 * 백업작업 목록 전체 건수를(을) 조회한다.

--- a/src/main/java/egovframework/com/sym/sym/bak/service/impl/BackupOpertDao.java
+++ b/src/main/java/egovframework/com/sym/sym/bak/service/impl/BackupOpertDao.java
@@ -99,15 +99,10 @@ public class BackupOpertDao extends EgovComAbstractDAO {
 	  throws Exception{
 		List<BackupOpert> resultList = selectList("BackupOpertDao.selectBackupOpertList", searchVO);
 
-		for (int i = 0; i < resultList.size(); i++) {
-			BackupOpert result = (BackupOpert) resultList.get(i);
+		for (BackupOpert result : resultList) {
 			// 스케줄요일정보를 가져온다.
 			List<BackupSchdulDfk> dfkSeList = selectList("BackupOpertDao.selectBackupSchdulDfkList", result.getBackupOpertId());
-			String [] dfkSes = new String [dfkSeList.size()];
-			for (int j = 0; j < dfkSeList.size(); j++) {
-				dfkSes[j] = dfkSeList.get(j).getExecutSchdulDfkSe();
-			}
-			result.setExecutSchdulDfkSes(dfkSes);
+			result.setExecutSchdulDfkSes(dfkSeList.stream().map(BackupSchdulDfk::getExecutSchdulDfkSe).toArray(String[]::new));
 			// 화면표시용 실행스케줄 속성을 만든다.
 			result.makeExecutSchdul(dfkSeList);
 		}

--- a/src/main/java/egovframework/com/sym/sym/bak/service/impl/BackupOpertDao.java
+++ b/src/main/java/egovframework/com/sym/sym/bak/service/impl/BackupOpertDao.java
@@ -88,26 +88,28 @@ public class BackupOpertDao extends EgovComAbstractDAO {
 		return result ;
 	}
 
-	/**
-	 * 백업작업정보목록을  조회한다.
-	 * @return 백업작업목록
-	 *
-	 * @param searchVO    조회조건이 저장된 VO
-	 * @exception Exception Exception
-	 */
-	public List<BackupOpert> selectBackupOpertList(BackupOpert searchVO)
-	  throws Exception{
-		List<BackupOpert> resultList = selectList("BackupOpertDao.selectBackupOpertList", searchVO);
+    /**
+     * 백업작업정보목록을 조회한다.
+     * 
+     * @return 백업작업목록
+     *
+     * @param searchVO 조회조건이 저장된 VO
+     * @exception Exception Exception
+     */
+    public List<BackupOpert> selectBackupOpertList(BackupOpert searchVO) throws Exception {
+        List<BackupOpert> resultList = selectList("BackupOpertDao.selectBackupOpertList", searchVO);
 
-		for (BackupOpert result : resultList) {
-			// 스케줄요일정보를 가져온다.
-			List<BackupSchdulDfk> dfkSeList = selectList("BackupOpertDao.selectBackupSchdulDfkList", result.getBackupOpertId());
-			result.setExecutSchdulDfkSes(dfkSeList.stream().map(BackupSchdulDfk::getExecutSchdulDfkSe).toArray(String[]::new));
-			// 화면표시용 실행스케줄 속성을 만든다.
-			result.makeExecutSchdul(dfkSeList);
-		}
-		return resultList;
-	}
+        for (BackupOpert result : resultList) {
+            // 스케줄요일정보를 가져온다.
+            List<BackupSchdulDfk> dfkSeList = selectList("BackupOpertDao.selectBackupSchdulDfkList",
+                    result.getBackupOpertId());
+            result.setExecutSchdulDfkSes(
+                    dfkSeList.stream().map(BackupSchdulDfk::getExecutSchdulDfkSe).toArray(String[]::new));
+            // 화면표시용 실행스케줄 속성을 만든다.
+            result.makeExecutSchdul(dfkSeList);
+        }
+        return resultList;
+    }
 
 	/**
 	 * 백업작업 목록 전체 건수를(을) 조회한다.

--- a/src/main/java/egovframework/com/sym/sym/bak/service/impl/BackupOpertDao.java
+++ b/src/main/java/egovframework/com/sym/sym/bak/service/impl/BackupOpertDao.java
@@ -95,9 +95,9 @@ public class BackupOpertDao extends EgovComAbstractDAO {
 	 * @param searchVO    조회조건이 저장된 VO
 	 * @exception Exception Exception
 	 */
-	public List<?> selectBackupOpertList(BackupOpert searchVO)
+	public List<BackupOpert> selectBackupOpertList(BackupOpert searchVO)
 	  throws Exception{
-		List<?> resultList = selectList("BackupOpertDao.selectBackupOpertList", searchVO);
+		List<BackupOpert> resultList = selectList("BackupOpertDao.selectBackupOpertList", searchVO);
 
 		for (int i = 0; i < resultList.size(); i++) {
 			BackupOpert result = (BackupOpert) resultList.get(i);

--- a/src/main/java/egovframework/com/sym/sym/bak/service/impl/EgovBackupOpertServiceImpl.java
+++ b/src/main/java/egovframework/com/sym/sym/bak/service/impl/EgovBackupOpertServiceImpl.java
@@ -85,9 +85,9 @@ public class EgovBackupOpertServiceImpl extends EgovAbstractServiceImpl implemen
 	 * @exception Exception Exception
 	 */
 	@Override
-	public List<?> selectBackupOpertList(BackupOpert searchVO)
+	public List<BackupOpert> selectBackupOpertList(BackupOpert searchVO)
 	  throws Exception{
-		List<?> result = backupOpertDao.selectBackupOpertList(searchVO);
+		List<BackupOpert> result = backupOpertDao.selectBackupOpertList(searchVO);
 		return result;
 	}
 

--- a/src/main/java/egovframework/com/sym/sym/bak/service/impl/EgovBackupOpertServiceImpl.java
+++ b/src/main/java/egovframework/com/sym/sym/bak/service/impl/EgovBackupOpertServiceImpl.java
@@ -77,18 +77,18 @@ public class EgovBackupOpertServiceImpl extends EgovAbstractServiceImpl implemen
 		return backupOpertDao.selectBackupOpert(backupOpert);
 	}
 
-	/**
-	 * 백업작업의 목록을 조회 한다.
-	 * @return 백업작업목록
-	 *
-	 * @param searchVO 	조회정보가 담긴 VO
-	 * @exception Exception Exception
-	 */
-	@Override
-	public List<BackupOpert> selectBackupOpertList(BackupOpert searchVO)
-	  throws Exception{
-	    return backupOpertDao.selectBackupOpertList(searchVO);
-	}
+    /**
+     * 백업작업의 목록을 조회 한다.
+     * 
+     * @return 백업작업목록
+     *
+     * @param searchVO 조회정보가 담긴 VO
+     * @exception Exception Exception
+     */
+    @Override
+    public List<BackupOpert> selectBackupOpertList(BackupOpert searchVO) throws Exception {
+        return backupOpertDao.selectBackupOpertList(searchVO);
+    }
 
 	/**
 	 * 백업작업 목록 전체 건수를(을) 조회한다.

--- a/src/main/java/egovframework/com/sym/sym/bak/service/impl/EgovBackupOpertServiceImpl.java
+++ b/src/main/java/egovframework/com/sym/sym/bak/service/impl/EgovBackupOpertServiceImpl.java
@@ -87,8 +87,7 @@ public class EgovBackupOpertServiceImpl extends EgovAbstractServiceImpl implemen
 	@Override
 	public List<BackupOpert> selectBackupOpertList(BackupOpert searchVO)
 	  throws Exception{
-		List<BackupOpert> result = backupOpertDao.selectBackupOpertList(searchVO);
-		return result;
+	    return backupOpertDao.selectBackupOpertList(searchVO);
 	}
 
 	/**

--- a/src/main/java/egovframework/com/sym/sym/bak/web/EgovBackupOpertController.java
+++ b/src/main/java/egovframework/com/sym/sym/bak/web/EgovBackupOpertController.java
@@ -227,7 +227,6 @@ public class EgovBackupOpertController {
 	 * @param model		ModelMap
 	 * @exception Exception Exception
 	 */
-	@SuppressWarnings("unchecked")
 	@IncludedInfo(name="백업관리", order = 1150 ,gid = 60)
 	@RequestMapping("/sym/sym/bak/getBackupOpertList.do")
 	public String selectBackupOpertList(@ModelAttribute("searchVO")BackupOpert searchVO, ModelMap model)
@@ -244,13 +243,12 @@ public class EgovBackupOpertController {
 		searchVO.setLastIndex(paginationInfo.getLastRecordIndex());
 		searchVO.setRecordCountPerPage(paginationInfo.getRecordCountPerPage());
 
-		List<BackupOpert> resultList = (List<BackupOpert>) egovBackupOpertService.selectBackupOpertList(searchVO);
+		List<BackupOpert> resultList = egovBackupOpertService.selectBackupOpertList(searchVO);
 		int totCnt = egovBackupOpertService.selectBackupOpertListCnt(searchVO);
 
 		paginationInfo.setTotalRecordCount(totCnt);
 
 		model.addAttribute("resultList", resultList);
-		model.addAttribute("resultCnt", totCnt);
 		model.addAttribute("paginationInfo", paginationInfo);
 
 		return "egovframework/com/sym/sym/bak/EgovBackupOpertList";

--- a/src/main/java/egovframework/com/sym/sym/bak/web/EgovBackupOpertController.java
+++ b/src/main/java/egovframework/com/sym/sym/bak/web/EgovBackupOpertController.java
@@ -219,40 +219,41 @@ public class EgovBackupOpertController {
         return "egovframework/com/sym/sym/bak/EgovBackupOpertUpdt";
 	}
 
-	/**
-	 * 백업작업 목록을 조회한다.
-	 * @return 리턴URL
-	 *
-	 * @param searchVO 목록조회조건VO
-	 * @param model		ModelMap
-	 * @exception Exception Exception
-	 */
-	@IncludedInfo(name="백업관리", order = 1150 ,gid = 60)
-	@RequestMapping("/sym/sym/bak/getBackupOpertList.do")
-	public String selectBackupOpertList(@ModelAttribute("searchVO")BackupOpert searchVO, ModelMap model)
-	  throws Exception{
-		searchVO.setPageUnit(propertyService.getInt("pageUnit"));
-		searchVO.setPageSize(propertyService.getInt("pageSize"));
+    /**
+     * 백업작업 목록을 조회한다.
+     * 
+     * @return 리턴URL
+     *
+     * @param searchVO 목록조회조건VO
+     * @param model    ModelMap
+     * @exception Exception Exception
+     */
+    @IncludedInfo(name = "백업관리", order = 1150, gid = 60)
+    @RequestMapping("/sym/sym/bak/getBackupOpertList.do")
+    public String selectBackupOpertList(@ModelAttribute("searchVO") BackupOpert searchVO, ModelMap model)
+            throws Exception {
+        searchVO.setPageUnit(propertyService.getInt("pageUnit"));
+        searchVO.setPageSize(propertyService.getInt("pageSize"));
 
-		PaginationInfo paginationInfo = new PaginationInfo();
-		paginationInfo.setCurrentPageNo(searchVO.getPageIndex());
-		paginationInfo.setRecordCountPerPage(searchVO.getPageUnit());
-		paginationInfo.setPageSize(searchVO.getPageSize());
+        PaginationInfo paginationInfo = new PaginationInfo();
+        paginationInfo.setCurrentPageNo(searchVO.getPageIndex());
+        paginationInfo.setRecordCountPerPage(searchVO.getPageUnit());
+        paginationInfo.setPageSize(searchVO.getPageSize());
 
-		searchVO.setFirstIndex(paginationInfo.getFirstRecordIndex());
-		searchVO.setLastIndex(paginationInfo.getLastRecordIndex());
-		searchVO.setRecordCountPerPage(paginationInfo.getRecordCountPerPage());
+        searchVO.setFirstIndex(paginationInfo.getFirstRecordIndex());
+        searchVO.setLastIndex(paginationInfo.getLastRecordIndex());
+        searchVO.setRecordCountPerPage(paginationInfo.getRecordCountPerPage());
 
-		List<BackupOpert> resultList = egovBackupOpertService.selectBackupOpertList(searchVO);
-		int totCnt = egovBackupOpertService.selectBackupOpertListCnt(searchVO);
+        List<BackupOpert> resultList = egovBackupOpertService.selectBackupOpertList(searchVO);
+        int totCnt = egovBackupOpertService.selectBackupOpertListCnt(searchVO);
 
-		paginationInfo.setTotalRecordCount(totCnt);
+        paginationInfo.setTotalRecordCount(totCnt);
 
-		model.addAttribute("resultList", resultList);
-		model.addAttribute("paginationInfo", paginationInfo);
+        model.addAttribute("resultList", resultList);
+        model.addAttribute("paginationInfo", paginationInfo);
 
-		return "egovframework/com/sym/sym/bak/EgovBackupOpertList";
-	}
+        return "egovframework/com/sym/sym/bak/EgovBackupOpertList";
+    }
 
 	/**
 	 * 백업작업을 수정한다.


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

### 제네릭 타입 명시: 백업작업정보목록을  조회한다.

- `List<?>` 을 `List<BackupOpert>` 로 수정
- 코드 정리
  - `for (int i = 0; i < resultList.size(); i++) {` 을 `for (BackupOpert result : resultList) {` 로 수정
  - `for (int i = 0; i < targetList.size(); i++) {` 을 `for (BackupOpert target : targetList) {` 로 수정
  - result.setExecutSchdulDfkSes stream 으로 수정
  - `List<?> result = ` 제거하고 바로 return
  - `@SuppressWarnings("unchecked")` 제거
  - `(List<BackupOpert>) ` 제거
  - `model.addAttribute("resultCnt", totCnt);` 사용하지 않아 제거
- Source > Format 탭을 공백으로 로 수정

selectBackupOpertList

백업작업정보목록을  조회한다.

```java
sym
bak
service
impl
BackupOpertDao.java (2 matches)
98: public List<?> selectBackupOpertList(BackupOpert searchVO)  
100: List<?> resultList = selectList("BackupOpertDao.selectBackupOpertList", searchVO);  
BackupResultDao.java
69: public List<?> selectBackupResultList(BackupResult searchVO)  
EgovBackupOpertServiceImpl.java (2 matches)
88: public List<?> selectBackupOpertList(BackupOpert searchVO)  
90: List<?> result = backupOpertDao.selectBackupOpertList(searchVO);  
EgovBackupResultServiceImpl.java (2 matches)
70: public List<?> selectBackupResultList(BackupResult searchVO)  
72: List<?> result = dao.selectBackupResultList(searchVO);  
EgovBackupOpertService.java
55: public List<?> selectBackupOpertList(BackupOpert searchVO) throws Exception;  
EgovBackupResultService.java
47: public List<?> selectBackupResultList(BackupResult searchVO) throws Exception;  
```

```java
			String [] dfkSes = new String [dfkSeList.size()];
			for (int j = 0; j < dfkSeList.size(); j++) {
				dfkSes[j] = dfkSeList.get(j).getExecutSchdulDfkSe();
			}
			result.setExecutSchdulDfkSes(dfkSes);
```
를

```java
result.setExecutSchdulDfkSes(dfkSeList.stream().map(BackupSchdulDfk::getExecutSchdulDfkSe).toArray(String[]::new));
```
로 수정

# 파일 동기화 컴포넌트에서 사용할 파일 업로드 경로(경로 설정은 반드시 절대경로를 사용해야함, 경로 뒤에 /를 붙여 주어야함.)

Globals.SynchrnServerPath = C:/egovframework/upload/Synch/

백업작업 등록
- 백업작업명: test 이백행 2023-08-01 백업작업명
- 백업원본디렉토리: src1
- 백업저장디렉토리: target1
- 실행주기: 매주 요일 전체 선택

백업작업 목록을 조회한다.
- 백업관리
- http://localhost:8080/egovframework-all-in-one/sym/sym/bak/getBackupOpertList.do

시스템관리 - 백업관리
- https://www.egovframe.go.kr/wiki/doku.php?id=egovframework:com:v4.1:sym:%EB%B0%B1%EC%97%85%EA%B4%80%EB%A6%AC

```sql
select
	A.BACKUP_OPERT_ID,
	A.EXECUT_SCHDUL_DFK_SE,
	B.CODE_NM EXECUT_SCHDUL_DFK_SE_NM
from
	COMTNBACKUPSCHDULDFK 
A,
	COMTCCMMNDETAILCODE B
where
	A.BACKUP_OPERT_ID = 'BAK00000000000000001'
	and A.EXECUT_SCHDUL_DFK_SE = B.CODE
	and B.CODE_ID = 'COM074'
;
```

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [x] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡쳐 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡쳐 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

https://youtu.be/0mReB7l9szs

https://github.com/GSITM2023/egovframe-common-components/commit/8a5cbc9c13f067acfc49ae28b296f1794fc29cbd

https://github.com/GSITM2023/egovframe-common-components/commit/ed4986c3a9bf24ec1b23cd009c44db5f55f00caf

https://github.com/GSITM2023/egovframe-common-components/commit/b2972cd7848c5df3bd6240bc1b222ac2095a0847
