### PR TITLE
[add] jsp 파일 오류 수정(610. 설문템플릿관리-등록일자 안나오는 오류)

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/egovframework/com/uss/olp/qtm/EgovQustnrTmplatManageList.jsp
+++ b/src/main/webapp/WEB-INF/jsp/egovframework/com/uss/olp/qtm/EgovQustnrTmplatManageList.jsp
@@ -166,7 +166,7 @@ function fn_egov_search_QustnrTmplatManage(){
 		<!-- 작성자명 -->
 		<td class="lt_text3">${resultInfo.frstRegisterNm}</td>
 		<!-- 등록일자 -->
-		<td class="lt_text3">${fn:substring(resultInfo.frstRegisterPnttm, 0, 10)}</td>
+		<td class="lt_text3">${fn:substring(resultInfo.frstRegistPnttm, 0, 10)}</td>
 	  </tr>	  
 	</c:forEach>	
 	</tbody>


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

[610. 설문템플릿관리] 부분을 조회했을 때 '등록일자'가 나오지 않는 문제가 발생하였으며, jsp 내 값을 잘못 설정한 것으로 확인되어 아래와 같이 변경하였습니다.

`resultInfo.frstRegisterPnttm` -> `resultInfo.frstRegistPnttm`

- 수정한 파일: `src/main/webapp/WEB-INF/jsp/egovframework/com/uss/olp/qmc/EgovQustnrManageList.jsp`

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [x] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [X] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡쳐 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡쳐 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

[테스트 전]
<img width="969" alt="스크린샷 2023-08-09 오후 9 51 42" src="https://github.com/eGovFramework/egovframe-common-components/assets/91789496/f318b741-6971-4342-8b61-708d77e27aed">

[테스트 후]
<img width="978" alt="스크린샷 2023-08-09 오후 9 52 10" src="https://github.com/eGovFramework/egovframe-common-components/assets/91789496/17a57e75-0085-4012-84e4-6d907bed5dc6">