### PR TITLE
제네릭 타입 명시: 응답자관리

### DIFF
--- a/src/main/java/egovframework/com/uss/olp/qrm/web/EgovQustnrRespondManageController.java
+++ b/src/main/java/egovframework/com/uss/olp/qrm/web/EgovQustnrRespondManageController.java
@@ -5,6 +5,9 @@ import java.util.Map;
 
 import javax.annotation.Resource;
 
+import org.egovframe.rte.fdl.property.EgovPropertyService;
+import org.egovframe.rte.psl.dataaccess.util.EgovMap;
+import org.egovframe.rte.ptl.mvc.tags.ui.pagination.PaginationInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,14 +24,12 @@ import egovframework.com.cmm.ComDefaultVO;
 import egovframework.com.cmm.EgovMessageSource;
 import egovframework.com.cmm.LoginVO;
 import egovframework.com.cmm.annotation.IncludedInfo;
+import egovframework.com.cmm.service.CmmnDetailCode;
 import egovframework.com.cmm.service.EgovCmmUseService;
 import egovframework.com.cmm.util.EgovUserDetailsHelper;
 import egovframework.com.uss.olp.qrm.service.EgovQustnrRespondManageService;
 import egovframework.com.uss.olp.qrm.service.QustnrRespondManageVO;
 import egovframework.com.utl.fcc.service.EgovStringUtil;
-import org.egovframe.rte.fdl.property.EgovPropertyService;
-import org.egovframe.rte.psl.dataaccess.util.EgovMap;
-import org.egovframe.rte.ptl.mvc.tags.ui.pagination.PaginationInfo;
 /**
  * 설문응답자관리 Controller Class 구현
  * @author 공통서비스 장동한
@@ -39,10 +40,10 @@ import org.egovframe.rte.ptl.mvc.tags.ui.pagination.PaginationInfo;
  * <pre>
  * << 개정이력(Modification Information) >>
  *
- *   수정일      수정자           수정내용
- *  -------    --------    ---------------------------
- *   2009.03.20  장동한          최초 생성
- *   2011.8.26	정진오			IncludedInfo annotation 추가
+ *   수정일          수정자       수정내용
+ *  -----------    --------    ---------------------------
+ *   2009.03.20     장동한       최초 생성
+ *   2011.08.26     정진오       IncludedInfo annotation 추가
  *
  * </pre>
  */
@@ -50,250 +51,229 @@ import org.egovframe.rte.ptl.mvc.tags.ui.pagination.PaginationInfo;
 @Controller
 public class EgovQustnrRespondManageController {
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(EgovQustnrRespondManageController.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(EgovQustnrRespondManageController.class);
 
-	@Autowired
-	private DefaultBeanValidator beanValidator;
+    @Autowired
+    private DefaultBeanValidator beanValidator;
 
-	/** EgovMessageSource */
-    @Resource(name="egovMessageSource")
+    /** EgovMessageSource */
+    @Resource(name = "egovMessageSource")
     EgovMessageSource egovMessageSource;
 
-	@Resource(name = "egovQustnrRespondManageService")
-	private EgovQustnrRespondManageService egovQustnrRespondManageService;
+    @Resource(name = "egovQustnrRespondManageService")
+    private EgovQustnrRespondManageService egovQustnrRespondManageService;
 
     /** EgovPropertyService */
     @Resource(name = "propertiesService")
     protected EgovPropertyService propertiesService;
 
-	@Resource(name="EgovCmmUseService")
-	private EgovCmmUseService cmmUseService;
+    @Resource(name = "EgovCmmUseService")
+    private EgovCmmUseService cmmUseService;
 
-	/**
-	 * 응답자정보 목록을 조회한다.
-	 * @param searchVO
-	 * @param commandMap
-	 * @param qustnrRespondManageVO
-	 * @param model
-	 * @return "egovframework/com/uss/olp/qrm/EgovQustnrRespondManageList"
-	 * @throws Exception
-	 */
-	@IncludedInfo(name="응답자관리",  order = 620 ,gid = 50)
-	@RequestMapping(value="/uss/olp/qrm/EgovQustnrRespondManageList.do")
-	public String egovQustnrRespondManageList(
-			@ModelAttribute("searchVO") ComDefaultVO searchVO,
-			@RequestParam Map<?, ?> commandMap,
-			QustnrRespondManageVO qustnrRespondManageVO,
-    		ModelMap model)
-    throws Exception {
+    /**
+     * 응답자정보 목록을 조회한다.
+     *
+     * @param searchVO
+     * @param commandMap
+     * @param qustnrRespondManageVO
+     * @param model
+     * @return "egovframework/com/uss/olp/qrm/EgovQustnrRespondManageList"
+     * @throws Exception
+     */
+    @IncludedInfo(name = "응답자관리", order = 620, gid = 50)
+    @RequestMapping(value = "/uss/olp/qrm/EgovQustnrRespondManageList.do")
+    public String egovQustnrRespondManageList(@ModelAttribute("searchVO") ComDefaultVO searchVO, @RequestParam Map<?, ?> commandMap, QustnrRespondManageVO qustnrRespondManageVO, ModelMap model) throws Exception {
 
-		String sSearchMode = commandMap.get("searchMode") == null ? "" : (String)commandMap.get("searchMode");
+        String sSearchMode = commandMap.get("searchMode") == null ? "" : (String) commandMap.get("searchMode");
 
-		//설문지정보에서 넘어오면 자동검색 설정
-		if(sSearchMode.equals("Y")){
-			searchVO.setSearchCondition("QESTNR_ID");
-			searchVO.setSearchKeyword(qustnrRespondManageVO.getQestnrId());
-		}
+        // 설문지정보에서 넘어오면 자동검색 설정
+        if (sSearchMode.equals("Y")) {
+            searchVO.setSearchCondition("QESTNR_ID");
+            searchVO.setSearchKeyword(qustnrRespondManageVO.getQestnrId());
+        }
 
-    	/** EgovPropertyService.sample */
-    	searchVO.setPageUnit(propertiesService.getInt("pageUnit"));
-    	searchVO.setPageSize(propertiesService.getInt("pageSize"));
+        /** EgovPropertyService.sample */
+        searchVO.setPageUnit(propertiesService.getInt("pageUnit"));
+        searchVO.setPageSize(propertiesService.getInt("pageSize"));
 
-    	/** pageing */
-    	PaginationInfo paginationInfo = new PaginationInfo();
-	    	
-    	paginationInfo.setCurrentPageNo(searchVO.getPageIndex());
-		paginationInfo.setRecordCountPerPage(searchVO.getPageUnit());
-		paginationInfo.setPageSize(searchVO.getPageSize());
+        /** pageing */
+        PaginationInfo paginationInfo = new PaginationInfo();
 
-		searchVO.setFirstIndex(paginationInfo.getFirstRecordIndex());
-		searchVO.setLastIndex(paginationInfo.getLastRecordIndex());
-		searchVO.setRecordCountPerPage(paginationInfo.getRecordCountPerPage());
+        paginationInfo.setCurrentPageNo(searchVO.getPageIndex());
+        paginationInfo.setRecordCountPerPage(searchVO.getPageUnit());
+        paginationInfo.setPageSize(searchVO.getPageSize());
+
+        searchVO.setFirstIndex(paginationInfo.getFirstRecordIndex());
+        searchVO.setLastIndex(paginationInfo.getLastRecordIndex());
+        searchVO.setRecordCountPerPage(paginationInfo.getRecordCountPerPage());
 
         List<EgovMap> sampleList = egovQustnrRespondManageService.selectQustnrRespondManageList(searchVO);
         model.addAttribute("resultList", sampleList);
 
-        model.addAttribute("searchKeyword", commandMap.get("searchKeyword") == null ? "" : (String)commandMap.get("searchKeyword"));
-        model.addAttribute("searchCondition", commandMap.get("searchCondition") == null ? "" : (String)commandMap.get("searchCondition"));
+        model.addAttribute("searchKeyword", commandMap.get("searchKeyword") == null ? "" : (String) commandMap.get("searchKeyword"));
+        model.addAttribute("searchCondition", commandMap.get("searchCondition") == null ? "" : (String) commandMap.get("searchCondition"));
 
         int totCnt = egovQustnrRespondManageService.selectQustnrRespondManageListCnt(searchVO);
-		paginationInfo.setTotalRecordCount(totCnt);
+        paginationInfo.setTotalRecordCount(totCnt);
         model.addAttribute("paginationInfo", paginationInfo);
 
-		return "egovframework/com/uss/olp/qrm/EgovQustnrRespondManageList";
-	}
+        return "egovframework/com/uss/olp/qrm/EgovQustnrRespondManageList";
+    }
 
-	/**
-	 * 응답자정보 목록을 상세조회 조회한다.
-	 * @param searchVO
-	 * @param qustnrRespondManageVO
-	 * @param commandMap
-	 * @param model
-	 * @return "egovframework/com/uss/olp/qrm/EgovQustnrRespondManageDetail"
-	 * @throws Exception
-	 */
-	@RequestMapping(value="/uss/olp/qrm/EgovQustnrRespondManageDetail.do")
-	public String egovQustnrRespondManageDetail(
-			@ModelAttribute("searchVO") ComDefaultVO searchVO,
-			QustnrRespondManageVO qustnrRespondManageVO,
-			@RequestParam Map<?, ?> commandMap,
-    		ModelMap model)
-    throws Exception {
+    /**
+     * 응답자정보 목록을 상세조회 조회한다.
+     *
+     * @param searchVO
+     * @param qustnrRespondManageVO
+     * @param commandMap
+     * @param model
+     * @return "egovframework/com/uss/olp/qrm/EgovQustnrRespondManageDetail"
+     * @throws Exception
+     */
+    @RequestMapping(value = "/uss/olp/qrm/EgovQustnrRespondManageDetail.do")
+    public String egovQustnrRespondManageDetail(@ModelAttribute("searchVO") ComDefaultVO searchVO, QustnrRespondManageVO qustnrRespondManageVO, @RequestParam Map<?, ?> commandMap, ModelMap model) throws Exception {
 
-		String sLocationUrl = "egovframework/com/uss/olp/qrm/EgovQustnrRespondManageDetail";
+        String sLocationUrl = "egovframework/com/uss/olp/qrm/EgovQustnrRespondManageDetail";
 
-		String sCmd = commandMap.get("cmd") == null ? "" : (String)commandMap.get("cmd");
+        String sCmd = commandMap.get("cmd") == null ? "" : (String) commandMap.get("cmd");
 
-		if(sCmd.equals("del")){
-			egovQustnrRespondManageService.deleteQustnrRespondManage(qustnrRespondManageVO);
-			sLocationUrl = "redirect:/uss/olp/qrm/EgovQustnrRespondManageList.do";
-		}else{
-	     	//성별코드조회
-	    	ComDefaultCodeVO voComCode = new ComDefaultCodeVO();
-	    	voComCode.setCodeId("COM014");
-	    	List<?> listComCode = cmmUseService.selectCmmCodeDetail(voComCode);
-	    	model.addAttribute("comCode014", listComCode);
+        if (sCmd.equals("del")) {
+            egovQustnrRespondManageService.deleteQustnrRespondManage(qustnrRespondManageVO);
+            sLocationUrl = "redirect:/uss/olp/qrm/EgovQustnrRespondManageList.do";
+        } else {
+            // 성별코드조회
+            ComDefaultCodeVO voComCode = new ComDefaultCodeVO();
+            voComCode.setCodeId("COM014");
+            List<CmmnDetailCode> listComCode = cmmUseService.selectCmmCodeDetail(voComCode);
+            model.addAttribute("comCode014", listComCode);
 
-	    	//직업코드조회
-	    	voComCode.setCodeId("COM034");
-	    	listComCode = cmmUseService.selectCmmCodeDetail(voComCode);
-	    	model.addAttribute("comCode034", listComCode);
+            // 직업코드조회
+            voComCode.setCodeId("COM034");
+            listComCode = cmmUseService.selectCmmCodeDetail(voComCode);
+            model.addAttribute("comCode034", listComCode);
 
-	        List<EgovMap> sampleList = egovQustnrRespondManageService.selectQustnrRespondManageDetail(qustnrRespondManageVO);
-	        model.addAttribute("resultList", sampleList);
-		}
-
-		return sLocationUrl;
-	}
-
-	/**
-	 * 응답자정보를 수정한다.
-	 * @param searchVO
-	 * @param commandMap
-	 * @param qustnrRespondManageVO
-	 * @param bindingResult
-	 * @param model
-	 * @return "egovframework/com/uss/olp/qrm/EgovQustnrRespondManageModify"
-	 * @throws Exception
-	 */
-	@RequestMapping(value="/uss/olp/qrm/EgovQustnrRespondManageModify.do")
-	public String qustnrRespondManageModify(
-			@ModelAttribute("searchVO") ComDefaultVO searchVO,
-			@RequestParam Map<?, ?> commandMap,
-			@ModelAttribute("qustnrRespondManageVO") QustnrRespondManageVO qustnrRespondManageVO,
-			BindingResult bindingResult,
-    		ModelMap model)
-    throws Exception {
-
-    	// 0. Spring Security 사용자권한 처리
-    	Boolean isAuthenticated = EgovUserDetailsHelper.isAuthenticated();
-    	if(!isAuthenticated) {
-    		model.addAttribute("message", egovMessageSource.getMessage("fail.common.login"));
-        	return "redirect:/uat/uia/egovLoginUsr.do";
-    	}
-
-		//로그인 객체 선언
-		LoginVO loginVO = (LoginVO)EgovUserDetailsHelper.getAuthenticatedUser();
-
-		String sLocationUrl = "egovframework/com/uss/olp/qrm/EgovQustnrRespondManageModify";
-
-		String sCmd = commandMap.get("cmd") == null ? "" : (String)commandMap.get("cmd");
-
-     	//성별코드조회
-    	ComDefaultCodeVO voComCode = new ComDefaultCodeVO();
-    	voComCode.setCodeId("COM014");
-    	List<?> listComCode = cmmUseService.selectCmmCodeDetail(voComCode);
-    	model.addAttribute("comCode014", listComCode);
-
-    	//직업코드조회
-    	voComCode.setCodeId("COM034");
-    	listComCode = cmmUseService.selectCmmCodeDetail(voComCode);
-    	model.addAttribute("comCode034", listComCode);
-
-        if(sCmd.equals("save")){
-    		//서버  validate 체크
-            beanValidator.validate(qustnrRespondManageVO, bindingResult);
-    		if(bindingResult.hasErrors()){
-
-    			return sLocationUrl;
-    		}
-    		//아이디 설정
-    		qustnrRespondManageVO.setFrstRegisterId(loginVO == null ? "" : EgovStringUtil.isNullToString(loginVO.getUniqId()));
-    		qustnrRespondManageVO.setLastUpdusrId(loginVO == null ? "" : EgovStringUtil.isNullToString(loginVO.getUniqId()));
-
-        	egovQustnrRespondManageService.updateQustnrRespondManage(qustnrRespondManageVO);
-        	sLocationUrl = "redirect:/uss/olp/qrm/EgovQustnrRespondManageList.do";
-		}else{
-	        List<?> sampleList = egovQustnrRespondManageService.selectQustnrRespondManageDetail(qustnrRespondManageVO);
-	        model.addAttribute("resultList", sampleList);
-		}
-
-		return sLocationUrl;
-	}
-
-	/**
-	 * 응답자정보를 등록한다.
-	 * @param searchVO
-	 * @param commandMap
-	 * @param qustnrRespondManageVO
-	 * @param bindingResult
-	 * @param model
-	 * @return "egovframework/com/uss/olp/qrm/EgovQustnrRespondManageRegist"
-	 * @throws Exception
-	 */
-	@RequestMapping(value="/uss/olp/qrm/EgovQustnrRespondManageRegist.do")
-	public String qustnrRespondManageRegist(
-			@ModelAttribute("searchVO") ComDefaultVO searchVO,
-			@RequestParam Map<?, ?> commandMap,
-			@ModelAttribute("qustnrRespondManageVO") QustnrRespondManageVO qustnrRespondManageVO,
-			BindingResult bindingResult,
-    		ModelMap model)
-    throws Exception {
-
-    	// 0. Spring Security 사용자권한 처리
-    	Boolean isAuthenticated = EgovUserDetailsHelper.isAuthenticated();
-    	if(!isAuthenticated) {
-    		model.addAttribute("message", egovMessageSource.getMessage("fail.common.login"));
-        	return "redirect:/uat/uia/egovLoginUsr.do";
-    	}
-
-		//로그인 객체 선언
-		LoginVO loginVO = (LoginVO)EgovUserDetailsHelper.getAuthenticatedUser();
-
-		String sLocationUrl = "egovframework/com/uss/olp/qrm/EgovQustnrRespondManageRegist";
-
-		String sCmd = commandMap.get("cmd") == null ? "" : (String)commandMap.get("cmd");
-		LOGGER.info("cmd => {}", sCmd);
-
-     	//성별코드조회
-    	ComDefaultCodeVO voComCode = new ComDefaultCodeVO();
-    	voComCode.setCodeId("COM014");
-    	List<?> listComCode = cmmUseService.selectCmmCodeDetail(voComCode);
-    	model.addAttribute("comCode014", listComCode);
-
-    	//직업코드조회
-    	voComCode.setCodeId("COM034");
-    	listComCode = cmmUseService.selectCmmCodeDetail(voComCode);
-    	model.addAttribute("comCode034", listComCode);
-
-        if(sCmd.equals("save")){
-    		//서버  validate 체크
-            beanValidator.validate(qustnrRespondManageVO, bindingResult);
-    		if(bindingResult.hasErrors()){
-
-    			return sLocationUrl;
-    		}
-    		//아이디 설정
-    		qustnrRespondManageVO.setFrstRegisterId(loginVO == null ? "" : EgovStringUtil.isNullToString(loginVO.getUniqId()));
-    		qustnrRespondManageVO.setLastUpdusrId(loginVO == null ? "" : EgovStringUtil.isNullToString(loginVO.getUniqId()));
-
-        	egovQustnrRespondManageService.insertQustnrRespondManage(qustnrRespondManageVO);
-        	sLocationUrl = "redirect:/uss/olp/qrm/EgovQustnrRespondManageList.do";
+            List<EgovMap> resultList = egovQustnrRespondManageService.selectQustnrRespondManageDetail(qustnrRespondManageVO);
+            model.addAttribute("resultList", resultList);
         }
 
-		return sLocationUrl;
-	}
+        return sLocationUrl;
+    }
 
+    /**
+     * 응답자정보를 수정한다.
+     *
+     * @param searchVO
+     * @param commandMap
+     * @param qustnrRespondManageVO
+     * @param bindingResult
+     * @param model
+     * @return "egovframework/com/uss/olp/qrm/EgovQustnrRespondManageModify"
+     * @throws Exception
+     */
+    @RequestMapping(value = "/uss/olp/qrm/EgovQustnrRespondManageModify.do")
+    public String qustnrRespondManageModify(@ModelAttribute("searchVO") ComDefaultVO searchVO, @RequestParam Map<?, ?> commandMap, @ModelAttribute("qustnrRespondManageVO") QustnrRespondManageVO qustnrRespondManageVO, BindingResult bindingResult, ModelMap model) throws Exception {
+
+        // 0. Spring Security 사용자권한 처리
+        Boolean isAuthenticated = EgovUserDetailsHelper.isAuthenticated();
+        if (!isAuthenticated) {
+            model.addAttribute("message", egovMessageSource.getMessage("fail.common.login"));
+            return "redirect:/uat/uia/egovLoginUsr.do";
+        }
+
+        // 로그인 객체 선언
+        LoginVO loginVO = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();
+
+        String sLocationUrl = "egovframework/com/uss/olp/qrm/EgovQustnrRespondManageModify";
+
+        String sCmd = commandMap.get("cmd") == null ? "" : (String) commandMap.get("cmd");
+
+        // 성별코드조회
+        ComDefaultCodeVO voComCode = new ComDefaultCodeVO();
+        voComCode.setCodeId("COM014");
+        List<CmmnDetailCode> listComCode = cmmUseService.selectCmmCodeDetail(voComCode);
+        model.addAttribute("comCode014", listComCode);
+
+        // 직업코드조회
+        voComCode.setCodeId("COM034");
+        listComCode = cmmUseService.selectCmmCodeDetail(voComCode);
+        model.addAttribute("comCode034", listComCode);
+
+        if (sCmd.equals("save")) {
+            // 서버 validate 체크
+            beanValidator.validate(qustnrRespondManageVO, bindingResult);
+            if (bindingResult.hasErrors()) {
+
+                return sLocationUrl;
+            }
+            // 아이디 설정
+            qustnrRespondManageVO.setFrstRegisterId(loginVO == null ? "" : EgovStringUtil.isNullToString(loginVO.getUniqId()));
+            qustnrRespondManageVO.setLastUpdusrId(loginVO == null ? "" : EgovStringUtil.isNullToString(loginVO.getUniqId()));
+
+            egovQustnrRespondManageService.updateQustnrRespondManage(qustnrRespondManageVO);
+            sLocationUrl = "redirect:/uss/olp/qrm/EgovQustnrRespondManageList.do";
+        } else {
+            List<EgovMap> resultList = egovQustnrRespondManageService.selectQustnrRespondManageDetail(qustnrRespondManageVO);
+            model.addAttribute("resultList", resultList);
+        }
+
+        return sLocationUrl;
+    }
+
+    /**
+     * 응답자정보를 등록한다.
+     *
+     * @param searchVO
+     * @param commandMap
+     * @param qustnrRespondManageVO
+     * @param bindingResult
+     * @param model
+     * @return "egovframework/com/uss/olp/qrm/EgovQustnrRespondManageRegist"
+     * @throws Exception
+     */
+    @RequestMapping(value = "/uss/olp/qrm/EgovQustnrRespondManageRegist.do")
+    public String qustnrRespondManageRegist(@ModelAttribute("searchVO") ComDefaultVO searchVO, @RequestParam Map<?, ?> commandMap, @ModelAttribute("qustnrRespondManageVO") QustnrRespondManageVO qustnrRespondManageVO, BindingResult bindingResult, ModelMap model) throws Exception {
+
+        // 0. Spring Security 사용자권한 처리
+        Boolean isAuthenticated = EgovUserDetailsHelper.isAuthenticated();
+        if (!isAuthenticated) {
+            model.addAttribute("message", egovMessageSource.getMessage("fail.common.login"));
+            return "redirect:/uat/uia/egovLoginUsr.do";
+        }
+
+        // 로그인 객체 선언
+        LoginVO loginVO = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();
+
+        String sLocationUrl = "egovframework/com/uss/olp/qrm/EgovQustnrRespondManageRegist";
+
+        String sCmd = commandMap.get("cmd") == null ? "" : (String) commandMap.get("cmd");
+        LOGGER.info("cmd => {}", sCmd);
+
+        // 성별코드조회
+        ComDefaultCodeVO voComCode = new ComDefaultCodeVO();
+        voComCode.setCodeId("COM014");
+        List<CmmnDetailCode> listComCode = cmmUseService.selectCmmCodeDetail(voComCode);
+        model.addAttribute("comCode014", listComCode);
+
+        // 직업코드조회
+        voComCode.setCodeId("COM034");
+        listComCode = cmmUseService.selectCmmCodeDetail(voComCode);
+        model.addAttribute("comCode034", listComCode);
+
+        if (sCmd.equals("save")) {
+            // 서버 validate 체크
+            beanValidator.validate(qustnrRespondManageVO, bindingResult);
+            if (bindingResult.hasErrors()) {
+
+                return sLocationUrl;
+            }
+            // 아이디 설정
+            qustnrRespondManageVO.setFrstRegisterId(loginVO == null ? "" : EgovStringUtil.isNullToString(loginVO.getUniqId()));
+            qustnrRespondManageVO.setLastUpdusrId(loginVO == null ? "" : EgovStringUtil.isNullToString(loginVO.getUniqId()));
+
+            egovQustnrRespondManageService.insertQustnrRespondManage(qustnrRespondManageVO);
+            sLocationUrl = "redirect:/uss/olp/qrm/EgovQustnrRespondManageList.do";
+        }
+
+        return sLocationUrl;
+    }
 }
-
-


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

### 제네릭 타입 명시: 응답자관리

- `List<?>` 을 `List<CmmnDetailCode>` 로 수정
- `List<?>` 을 `List<EgovMap>` 로 수정

```java
qrm
web
EgovQustnrRespondManageController.java (4 matches)
154: List<?> listComCode = cmmUseService.selectCmmCodeDetail(voComCode);
205: List<?> listComCode = cmmUseService.selectCmmCodeDetail(voComCode);
227: List<?> sampleList = egovQustnrRespondManageService.selectQustnrRespondManageDetail(qustnrRespondManageVO);
271: List<?> listComCode = cmmUseService.selectCmmCodeDetail(voComCode);
```

### 응답자정보 목록을 상세조회 조회한다.
```java
EgovQustnrRespondManageController.java (4 matches)
154: List<?> listComCode = cmmUseService.selectCmmCodeDetail(voComCode);
```
http://localhost:8080/egovframework-all-in-one/uss/olp/qrm/EgovQustnrRespondManageDetail.do

### 응답자정보를 수정한다.
```java
EgovQustnrRespondManageController.java (4 matches)
205: List<?> listComCode = cmmUseService.selectCmmCodeDetail(voComCode);
227: List<?> sampleList = egovQustnrRespondManageService.selectQustnrRespondManageDetail(qustnrRespondManageVO);
```
http://localhost:8080/egovframework-all-in-one/uss/olp/qrm/EgovQustnrRespondManageModify.do

### 응답자정보를 등록한다.
```java
EgovQustnrRespondManageController.java (4 matches)
271: List<?> listComCode = cmmUseService.selectCmmCodeDetail(voComCode);
```
http://localhost:8080/egovframework-all-in-one/uss/olp/qrm/EgovQustnrRespondManageRegist.do

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [X] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡쳐 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡쳐 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

응답자정보 목록을 상세조회 조회한다.
- http://localhost:8080/egovframework-all-in-one/uss/olp/qrm/EgovQustnrRespondManageDetail.do
- 웹브라우저 화면
![image](https://github.com/eGovFramework/egovframe-common-components/assets/21186414/ebde24a9-353d-4738-95b1-f6b2d695005a)
- 디버깅화면에서 결괏값 확인
![image](https://github.com/eGovFramework/egovframe-common-components/assets/21186414/36d08a89-d982-4830-8ad7-bf7035560443)

응답자정보를 수정한다.
- http://localhost:8080/egovframework-all-in-one/uss/olp/qrm/EgovQustnrRespondManageModify.do
- 웹브라우저 화면
![image](https://github.com/eGovFramework/egovframe-common-components/assets/21186414/e627bf21-941e-47e2-802a-eacd78ccce29)
- 디버깅화면에서 결괏값 확인
![image](https://github.com/eGovFramework/egovframe-common-components/assets/21186414/d87f21dd-d30e-4091-afb7-7c08f9f0d6a3)
![image](https://github.com/eGovFramework/egovframe-common-components/assets/21186414/841fad21-cf14-4c87-875f-3afe058f39f9)

응답자정보를 등록한다.
- http://localhost:8080/egovframework-all-in-one/uss/olp/qrm/EgovQustnrRespondManageRegist.do
- 웹브라우저 화면
![image](https://github.com/eGovFramework/egovframe-common-components/assets/21186414/1e766817-2e57-4dc0-9234-ae488ba38da8)
- 디버깅화면에서 결괏값 확인
![image](https://github.com/eGovFramework/egovframe-common-components/assets/21186414/1115eb93-21d8-43b7-8619-937ca00a6105)
