### PR TITLE
제네릭 타입 명시: 설문조사 > 설문참여 등록

### DIFF
--- a/src/main/java/egovframework/com/uss/olp/qri/service/EgovQustnrRespondInfoService.java
+++ b/src/main/java/egovframework/com/uss/olp/qri/service/EgovQustnrRespondInfoService.java
@@ -3,6 +3,8 @@ package egovframework.com.uss.olp.qri.service;
 import java.util.List;
 import java.util.Map;
 
+import org.egovframe.rte.psl.dataaccess.util.EgovMap;
+
 import egovframework.com.cmm.ComDefaultVO;
 /**
  * 설문조사 Service Class 구현
@@ -55,12 +57,14 @@ public interface EgovQustnrRespondInfoService {
 	public Map<?, ?> selectQustnrRespondInfoManageEmplyrinfo(Map<?, ?> map) throws Exception;
 
     /**
-	 * 설문정보를 조회한다.
-	 * @param map - 조회할 정보가 담긴 map
-	 * @return List
-	 * @throws Exception
-	 */
-	public List<?> selectQustnrRespondInfoManageComtnqestnrinfo(Map<?, ?> map) throws Exception;
+     * 설문정보를 조회한다.
+     *
+     * @param map - 조회할 정보가 담긴 map
+     * @return List
+     * @throws Exception
+     */
+    public List<EgovMap> selectQustnrRespondInfoManageComtnqestnrinfo(Map<?, ?> map) throws Exception;
+
     /**
 	 * 문항정보를 조회한다.
 	 * @param map - 조회할 정보가 담긴 map

--- a/src/main/java/egovframework/com/uss/olp/qri/service/impl/EgovQustnrRespondInfoServiceImpl.java
+++ b/src/main/java/egovframework/com/uss/olp/qri/service/impl/EgovQustnrRespondInfoServiceImpl.java
@@ -3,16 +3,16 @@ package egovframework.com.uss.olp.qri.service.impl;
 import java.util.List;
 import java.util.Map;
 
-import egovframework.com.cmm.ComDefaultVO;
-import egovframework.com.uss.olp.qri.service.EgovQustnrRespondInfoService;
-import egovframework.com.uss.olp.qri.service.QustnrRespondInfoVO;
+import javax.annotation.Resource;
 
 import org.egovframe.rte.fdl.cmmn.EgovAbstractServiceImpl;
 import org.egovframe.rte.fdl.idgnr.EgovIdGnrService;
-
-import javax.annotation.Resource;
-
+import org.egovframe.rte.psl.dataaccess.util.EgovMap;
 import org.springframework.stereotype.Service;
+
+import egovframework.com.cmm.ComDefaultVO;
+import egovframework.com.uss.olp.qri.service.EgovQustnrRespondInfoService;
+import egovframework.com.uss.olp.qri.service.QustnrRespondInfoVO;
 /**
  * 설문조사 ServiceImpl Class 구현
  * @author 공통서비스 장동한
@@ -84,15 +84,17 @@ public class EgovQustnrRespondInfoServiceImpl extends EgovAbstractServiceImpl im
 	}
 
     /**
-	 * 설문정보를 조회한다.
-	 * @param map - 조회할 정보가 담긴 map
-	 * @return List
-	 * @throws Exception
-	 */
-	@Override
-	public List<?> selectQustnrRespondInfoManageComtnqestnrinfo(Map<?, ?> map) throws Exception{
-		return dao.selectQustnrRespondInfoManageComtnqestnrinfo(map);
-	}
+     * 설문정보를 조회한다.
+     *
+     * @param map - 조회할 정보가 담긴 map
+     * @return List
+     * @throws Exception
+     */
+    @Override
+    public List<EgovMap> selectQustnrRespondInfoManageComtnqestnrinfo(Map<?, ?> map) throws Exception {
+        return dao.selectQustnrRespondInfoManageComtnqestnrinfo(map);
+    }
+
     /**
 	 * 문항정보를 조회한다.
 	 * @param map - 조회할 정보가 담긴 map
@@ -202,7 +204,7 @@ public class EgovQustnrRespondInfoServiceImpl extends EgovAbstractServiceImpl im
 	public void deleteQustnrRespondInfo(QustnrRespondInfoVO qustnrRespondInfoVO) throws Exception{
 		dao.deleteQustnrRespondInfo(qustnrRespondInfoVO);
 	}
-	
+
     /**
 	 * 설문템플릿을 조회한다.
 	 * @param map - 조회할 정보가 담긴 map

--- a/src/main/java/egovframework/com/uss/olp/qri/service/impl/QustnrRespondInfoDao.java
+++ b/src/main/java/egovframework/com/uss/olp/qri/service/impl/QustnrRespondInfoDao.java
@@ -3,11 +3,12 @@ package egovframework.com.uss.olp.qri.service.impl;
 import java.util.List;
 import java.util.Map;
 
+import org.egovframe.rte.psl.dataaccess.util.EgovMap;
+import org.springframework.stereotype.Repository;
+
 import egovframework.com.cmm.ComDefaultVO;
 import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.uss.olp.qri.service.QustnrRespondInfoVO;
-
-import org.springframework.stereotype.Repository;
 /**
  * 설문조사 Dao Class 구현
  * @author 공통서비스 장동한
@@ -69,14 +70,16 @@ public class QustnrRespondInfoDao extends EgovComAbstractDAO {
 	}
 
     /**
-	 * 설문정보를 조회한다.
-	 * @param map - 조회할 정보가 담긴 map
-	 * @return List
-	 * @throws Exception
-	 */
-	public List<?> selectQustnrRespondInfoManageComtnqestnrinfo(Map<?, ?> map) throws Exception{
-		return selectList("QustnrRespondInfo.selectQustnrRespondInfoManageComtnqestnrinfo", map);
-	}
+     * 설문정보를 조회한다.
+     *
+     * @param map - 조회할 정보가 담긴 map
+     * @return List
+     * @throws Exception
+     */
+    public List<EgovMap> selectQustnrRespondInfoManageComtnqestnrinfo(Map<?, ?> map) throws Exception {
+        return selectList("QustnrRespondInfo.selectQustnrRespondInfoManageComtnqestnrinfo", map);
+    }
+
     /**
 	 * 문항정보를 조회한다.
 	 * @param map - 조회할 정보가 담긴 map
@@ -170,7 +173,7 @@ public class QustnrRespondInfoDao extends EgovComAbstractDAO {
 	public void deleteQustnrRespondInfo(QustnrRespondInfoVO qustnrRespondInfoVO) throws Exception{
 		insert("QustnrRespondInfo.deleteQustnrRespondInfo", qustnrRespondInfoVO);
 	}
-	
+
     /**
 	 * 설문템플릿 화이트리스트를 조회한다.
 	 * @param map - 조회할 정보가 담긴 map


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

### 제네릭 타입 명시: 설문조사 > 설문참여 등록
- `List<?>` 을 `List<EgovMap>` 로 수정
```java
qri
service
impl
EgovQustnrRespondInfoServiceImpl.java (10 matches)
51: public List<?> selectQustnrTmplatManage(Map<?, ?> map) throws Exception{
QustnrRespondInfoDao.java (10 matches)
38: public List<?> selectQustnrTmplatManage(Map<?, ?> map) throws Exception{
EgovQustnrRespondInfoService.java (10 matches)
33: public List<?> selectQustnrTmplatManage(Map<?, ?> map) throws Exception;
```
설문조사(설문참여)를 등록한다.
- http://localhost:8080/egovframework-all-in-one/uss/olp/qnn/EgovQustnrRespondInfoManageRegist.do

설문템플릿을 적용한다.
- http://localhost:8080/egovframework-all-in-one/uss/olp/qri/template/template.do

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [X] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡쳐 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡쳐 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

설문조사(설문등록)를 등록한다.
- http://localhost:8080/egovframework-all-in-one/uss/olp/qnn/EgovQustnrRespondInfoManageRegist.do
웹브라우저 화면
![image](https://github.com/eGovFramework/egovframe-common-components/assets/21186414/22ea9de9-e761-4dd4-aa09-1d903b0065ed)
디버깅화면에서 결괏값 확인
![image](https://github.com/eGovFramework/egovframe-common-components/assets/21186414/c6585b1b-bd52-4016-9559-84d6298b2ae7)

설문템플릿을 적용한다.
- http://localhost:8080/egovframework-all-in-one/uss/olp/qri/template/template.do
웹브라우저 화면
![image](https://github.com/eGovFramework/egovframe-common-components/assets/21186414/22ea9de9-e761-4dd4-aa09-1d903b0065ed)
디버깅화면에서 결괏값 확인
![image](https://github.com/eGovFramework/egovframe-common-components/assets/21186414/ae085a90-1b3a-4591-86cd-a76223a9f443)
