### PR TITLE
제네릭 타입 명시: 등록된 회의실관리의 상세정보를 조회한다.

### DIFF
--- a/src/main/java/egovframework/com/uss/ion/mtg/web/EgovMtgPlaceManageController.java
+++ b/src/main/java/egovframework/com/uss/ion/mtg/web/EgovMtgPlaceManageController.java
@@ -22,6 +22,7 @@ import egovframework.com.cmm.ComDefaultCodeVO;
 import egovframework.com.cmm.EgovMessageSource;
 import egovframework.com.cmm.LoginVO;
 import egovframework.com.cmm.annotation.IncludedInfo;
+import egovframework.com.cmm.service.CmmnDetailCode;
 import egovframework.com.cmm.service.EgovCmmUseService;
 import egovframework.com.cmm.service.EgovFileMngService;
 import egovframework.com.cmm.service.EgovFileMngUtil;
@@ -139,7 +140,7 @@ public class EgovMtgPlaceManageController {
     	String sCmd = commandMap.get("cmd") == null ? "" : (String)commandMap.get("cmd"); // 상세정보 구분
     	ComDefaultCodeVO vo = new ComDefaultCodeVO();
 		vo.setCodeId("COM070");
-        List<?> lcSeCodeList = cmmUseService.selectCmmCodeDetail(vo);
+        List<CmmnDetailCode> lcSeCodeList = cmmUseService.selectCmmCodeDetail(vo);
                 
         model.addAttribute("lcSeCode",          lcSeCodeList);
     	model.addAttribute("mtgPlaceManage",  egovMtgPlaceManageService.selectMtgPlaceManage(mtgPlaceManageVO));
@@ -163,7 +164,7 @@ public class EgovMtgPlaceManageController {
 
     	ComDefaultCodeVO vo = new ComDefaultCodeVO();
 		vo.setCodeId("COM070");
-        List<?> lcSeCodeList = cmmUseService.selectCmmCodeDetail(vo);
+        List<CmmnDetailCode> lcSeCodeList = cmmUseService.selectCmmCodeDetail(vo);
 
         model.addAttribute("lcSeCode",        lcSeCodeList);
 


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

### 제네릭 타입 명시: 등록된 회의실관리의 상세정보를 조회한다.

- `List<?>` 을 `List<CmmnDetailCode>` 로 수정

```java
mtg
web
EgovMtgPlaceManageController.java (2 matches)
142: List<?> lcSeCodeList = cmmUseService.selectCmmCodeDetail(vo);
166: List<?> lcSeCodeList = cmmUseService.selectCmmCodeDetail(vo);
```

### 등록된 회의실관리의 상세정보를 조회한다.
```java
EgovMtgPlaceManageController.java (2 matches)
142: List<?> lcSeCodeList = cmmUseService.selectCmmCodeDetail(vo);
```
http://localhost:8080/egovframework-all-in-one/uss/ion/mtg/selectMtgPlaceManage.do

### 회의실관리 등록 화면으로 이동한다.
```java
EgovMtgPlaceManageController.java (2 matches)
166: List<?> lcSeCodeList = cmmUseService.selectCmmCodeDetail(vo);
```
http://localhost:8080/egovframework-all-in-one/uss/ion/mtg/insertViewMtgPlace.do

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [x] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡쳐 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡쳐 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

https://youtu.be/wNamgEKxzf8
