### PR TITLE
310. 문자메시지 시큐어코딩 Exception 제거

### DIFF
--- a/src/main/java/egovframework/com/cop/sms/service/EgovSmsInfoService.java
+++ b/src/main/java/egovframework/com/cop/sms/service/EgovSmsInfoService.java
@@ -4,60 +4,58 @@ import java.util.Map;
 
 /**
  * 문자메시지를 위한 서비스 인터페이스 클래스
+ * 
  * @author 공통컴포넌트개발팀 한성곤
  * @since 2009.06.18
  * @version 1.0
  * @see
  *
- * <pre>
+ *      <pre>
  * << 개정이력(Modification Information) >>
  *   
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.06.18  한성곤          최초 생성
+ *   2024.08.27  이백행          컨트리뷰션 시큐어코딩 Exception 제거
  *
- * </pre>
+ *      </pre>
  */
 public interface EgovSmsInfoService {
-    /**
-     * 문자메시지 목록을 조회 한다.
-     * 
-     * @param SmsVO
-     */
-    public Map<String, Object> selectSmsInfs(SmsVO searchVO) throws Exception;
-    
-    /**
-     * 문자메시지를 전송(등록)한다.
-     * 
-     * @param sms
-     * @throws Exception
-     */
-    public void insertSmsInf(Sms sms) throws Exception;
-    
-    /**
-     * 문자메시지에 대한 상세정보를 조회한다.
-     * 
-     * @param searchVO
-     * @return
-     * @throws Exception
-     */
-    public SmsVO selectSmsInf(SmsVO searchVO) throws Exception;
-    
-    /**
-     * 문자메시지 실 전송을 요청한다.
-     * 
-     * @param smsConn
-     * @return
-     * @throws Exception
-     */
-    public SmsConnection sendRequsest(SmsConnection smsConn) throws Exception;
-    
-    /**
-     * 여러 건의 문자메시지 실 전송을 요청한다.
-     * 
-     * @param smsConn
-     * @return
-     * @throws Exception
-     */
-    public SmsConnection[] sendRequsest(SmsConnection[] smsConn) throws Exception;
+	/**
+	 * 문자메시지 목록을 조회 한다.
+	 * 
+	 * @param SmsVO
+	 */
+	public Map<String, Object> selectSmsInfs(SmsVO searchVO);
+
+	/**
+	 * 문자메시지를 전송(등록)한다.
+	 * 
+	 * @param sms
+	 */
+	public void insertSmsInf(Sms sms) throws Exception;
+
+	/**
+	 * 문자메시지에 대한 상세정보를 조회한다.
+	 * 
+	 * @param searchVO
+	 * @return
+	 */
+	public SmsVO selectSmsInf(SmsVO searchVO);
+
+	/**
+	 * 문자메시지 실 전송을 요청한다.
+	 * 
+	 * @param smsConn
+	 * @return
+	 */
+	public SmsConnection sendRequsest(SmsConnection smsConn);
+
+	/**
+	 * 여러 건의 문자메시지 실 전송을 요청한다.
+	 * 
+	 * @param smsConn
+	 * @return
+	 */
+	public SmsConnection[] sendRequsest(SmsConnection[] smsConn);
 }

--- a/src/main/java/egovframework/com/cop/sms/service/impl/EgovSmsBasicReceiver.java
+++ b/src/main/java/egovframework/com/cop/sms/service/impl/EgovSmsBasicReceiver.java
@@ -1,7 +1,5 @@
 package egovframework.com.cop.sms.service.impl;
 
-import java.io.IOException;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -20,21 +18,23 @@ import x3.client.smeapi.impl.SMELogger;
 
 /**
  * 문자메시지 연동 결과 수신 처리를 위한 클래스 (프레임워크 비종속 버전)
+ * 
  * @author 공통컴포넌트개발팀 한성곤
  * @since 2009.11.24
  * @version 1.0
  * @see
  *
- * <pre>
+ *      <pre>
  * << 개정이력(Modification Information) >>
  *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.11.24  한성곤          최초 생성
- *   2011.10.10	 이기하			 보안점검 후속초치(디버거코드 주석처리)
- *   2017.03.07    조성원 	시큐어코딩(ES)-부적절한 예외 처리[CWE-253, CWE-440, CWE-754]
+ *   2011.10.10  이기하          보안점검 후속초치(디버거코드 주석처리)
+ *   2017.03.07  조성원          시큐어코딩(ES)-부적절한 예외 처리[CWE-253, CWE-440, CWE-754]
+ *   2024.08.27  이백행          컨트리뷰션 시큐어코딩 Exception 제거
  *
- * </pre>
+ *      </pre>
  */
 public class EgovSmsBasicReceiver implements SMEListener {
 	private SmsBasicDAO smsDao = new SmsBasicDAO();
@@ -146,109 +146,112 @@ public class EgovSmsBasicReceiver implements SMEListener {
 			if (msg.isConnected()) {
 				SMEReport rpt = msg;
 				String msgId = rpt.getMessageId();
-				int nRes = rpt.getResult(); 						// 결과코드
-				String doneTime = rpt.getDeliverTime();	// 이동통신사 결과처리시간-단말기에 전달된 시간(이동통신사 생성)
-				String netCode = rpt.getDestination();		// 이동통신사 정보
+				int nRes = rpt.getResult(); // 결과코드
+				String doneTime = rpt.getDeliverTime(); // 이동통신사 결과처리시간-단말기에 전달된 시간(이동통신사 생성)
+				String netCode = rpt.getDestination(); // 이동통신사 정보
 
-				//System.out.println("Receiver Number is :" + ((SMEReportImpl)rpt).receiver.activeCount()); // 주석처리
+				// System.out.println("Receiver Number is :" +
+				// ((SMEReportImpl)rpt).receiver.activeCount()); // 주석처리
 
 				String resultMsg = "";
 
 				switch (nRes) {
-					case 0:
-						resultMsg = "";
-						break;
-					case 4001:
-						resultMsg = "잘못된 전화번호; 착신 이통사를 결정할 수 없음";
-						break;
-					case 4002:
-						resultMsg = "MessageID 중복";
-						break;
-					case 4005:
-						resultMsg = "스팸 메시지로 처리 거부됨";
-						break;
-					case 4006:
-						resultMsg = "스팸 콜백번호로 처리 거부됨";
-						break;
-					case 5000:
-						resultMsg = "SMG Server 내부 에러 (인증실패,연결실패)";
-						break;
-					case 5050:
-						resultMsg = "착신 이통사 연동 실패";
-						break;
-					case 6000:
-						resultMsg = "이통사 시스템 장애";
-						break;
-					case 6001:
-						resultMsg = "이통사 메시지 형식 오류";
-						break;
-					case 6002:
-						resultMsg = "이통사 착신번호 인증 에러";
-						break;
-					case 6003:
-						resultMsg = "이통사 스팸 메시지로 처리 거부됨";
-						break;
-					case 6004:
-						resultMsg = "이통사 순간 전송량 제한 초과";
-						break;
-					case 6005:
-						resultMsg = "이통사 월 전송량 제한 초과";
-						break;
-					case 6006:
-						resultMsg = "이통사 Resource 제한에 의한 전송 제어";
-						break;
-					case 6007:
-						resultMsg = "이통사 Resource full";
-						break;
-					case 6008:
-						resultMsg = "이통사 번호이동 시스템 장애";
-						break;
-					case 6009:
-						resultMsg = "이통사 메시지 타입 오류";
-						break;
-					case 6010:
-						resultMsg = "이통사 전송 실패";
-						break;
-					case 6011:
-						resultMsg = "이통사 메시지 전송불가(단말기에서 착신 거부)";
-						break;
-					case 6012:
-						resultMsg = "이통사 전송 실패(무선망단)";
-						break;
-					case 6013:
-						resultMsg = "이통사 전송 실패(무선망 -> 단말기단)";
-						break;
-					case 6014:
-						resultMsg = "이통사 수신 단말기 형식 오류";
-						break;
-					case 6015:
-						resultMsg = "이통사 Unknown Error";
-						break;
-					case 7000:
-						resultMsg = "수신 단말기 전원꺼짐";
-						break;
-					case 7001:
-						resultMsg = "수신 단말기 메시지 버퍼 풀";
-						break;
-					case 7002:
-						resultMsg = "수신 단말기 음영지역";
-						break;
-					case 7003:
-						resultMsg = "수신 단말기 메시지 삭제됨";
-						break;
-					default:
-						resultMsg = "알 수 없는 오류 발생";
+				case 0:
+					resultMsg = "";
+					break;
+				case 4001:
+					resultMsg = "잘못된 전화번호; 착신 이통사를 결정할 수 없음";
+					break;
+				case 4002:
+					resultMsg = "MessageID 중복";
+					break;
+				case 4005:
+					resultMsg = "스팸 메시지로 처리 거부됨";
+					break;
+				case 4006:
+					resultMsg = "스팸 콜백번호로 처리 거부됨";
+					break;
+				case 5000:
+					resultMsg = "SMG Server 내부 에러 (인증실패,연결실패)";
+					break;
+				case 5050:
+					resultMsg = "착신 이통사 연동 실패";
+					break;
+				case 6000:
+					resultMsg = "이통사 시스템 장애";
+					break;
+				case 6001:
+					resultMsg = "이통사 메시지 형식 오류";
+					break;
+				case 6002:
+					resultMsg = "이통사 착신번호 인증 에러";
+					break;
+				case 6003:
+					resultMsg = "이통사 스팸 메시지로 처리 거부됨";
+					break;
+				case 6004:
+					resultMsg = "이통사 순간 전송량 제한 초과";
+					break;
+				case 6005:
+					resultMsg = "이통사 월 전송량 제한 초과";
+					break;
+				case 6006:
+					resultMsg = "이통사 Resource 제한에 의한 전송 제어";
+					break;
+				case 6007:
+					resultMsg = "이통사 Resource full";
+					break;
+				case 6008:
+					resultMsg = "이통사 번호이동 시스템 장애";
+					break;
+				case 6009:
+					resultMsg = "이통사 메시지 타입 오류";
+					break;
+				case 6010:
+					resultMsg = "이통사 전송 실패";
+					break;
+				case 6011:
+					resultMsg = "이통사 메시지 전송불가(단말기에서 착신 거부)";
+					break;
+				case 6012:
+					resultMsg = "이통사 전송 실패(무선망단)";
+					break;
+				case 6013:
+					resultMsg = "이통사 전송 실패(무선망 -> 단말기단)";
+					break;
+				case 6014:
+					resultMsg = "이통사 수신 단말기 형식 오류";
+					break;
+				case 6015:
+					resultMsg = "이통사 Unknown Error";
+					break;
+				case 7000:
+					resultMsg = "수신 단말기 전원꺼짐";
+					break;
+				case 7001:
+					resultMsg = "수신 단말기 메시지 버퍼 풀";
+					break;
+				case 7002:
+					resultMsg = "수신 단말기 음영지역";
+					break;
+				case 7003:
+					resultMsg = "수신 단말기 메시지 삭제됨";
+					break;
+				default:
+					resultMsg = "알 수 없는 오류 발생";
 				}
 
 				if (nRes != SMEMessage.RESULT_SUCCESS) {
-					// System.out.println("SMSMessage (msgId = " + msgId + ") report = " + rpt.getResult());
+					// System.out.println("SMSMessage (msgId = " + msgId + ") report = " +
+					// rpt.getResult());
 					LOGGER.info("MessageId   : {}", msgId);
 					LOGGER.info("Result      : {}", nRes);
 					LOGGER.info("Result Msg. : {}", resultMsg);
 					LOGGER.info("Done Time   : {}", doneTime);
 					LOGGER.info("Net Code    : {}", netCode);
 				} else {
-					// System.out.println("SMEMessage (msgId = " + msgId + ") report = " + rpt.getResult());
+					// System.out.println("SMEMessage (msgId = " + msgId + ") report = " +
+					// rpt.getResult());
 					LOGGER.info("MessageId   : {}", msgId);
 					LOGGER.info("Result      : {}", nRes);
 					LOGGER.info("Result Msg. : {}", resultMsg);
@@ -260,22 +263,14 @@ public class EgovSmsBasicReceiver implements SMEListener {
 				if (smeConfigPath != null) {
 					SmsRecptn recptn = new SmsRecptn();
 
-					recptn.setSmsId(msgId.substring(0, 20)); 			// SMS_ID + "-" + 수신전화번호
-					recptn.setRecptnTelno(msgId.substring(21)); 	// "-" 제외
+					recptn.setSmsId(msgId.substring(0, 20)); // SMS_ID + "-" + 수신전화번호
+					recptn.setRecptnTelno(msgId.substring(21)); // "-" 제외
 
 					recptn.setResultCode(Integer.toString(nRes));
 					recptn.setResultMssage(resultMsg);
 
-					try {
-						smsDao.updateSmsRecptnInf(recptn);
-					//2017.02.08 	이정은 	시큐어코딩(ES)-부적절한 예외 처리[CWE-253, CWE-440, CWE-754]
-					} catch (IOException ex) {
-//						LOGGER.error("Exception: {}", ex.getClass().getName());
-//						LOGGER.error("Exception  Message: {}", ex.getMessage());
-						LOGGER.error("[IOException] : Connection Close");
-					} catch (Exception ex) {
-						LOGGER.error("["+ ex.getClass() +"] Connection Close : ", ex.getMessage());
-					}
+					smsDao.updateSmsRecptnInf(recptn);
+					// 2017.02.08 이정은 시큐어코딩(ES)-부적절한 예외 처리[CWE-253, CWE-440, CWE-754]
 				}
 			} else {
 				LOGGER.debug("SMEReceiver Disconnected!!");
@@ -290,58 +285,37 @@ public class EgovSmsBasicReceiver implements SMEListener {
 	 * @param args
 	 */
 	// 2022.01. Exit methods should not be called 처리 - 예제이므로 주석 처리
-	/*	public static void mainExample(String[] args) {
-			if (args.length < 1) {
-				LOGGER.error("SMEConfig.conf file full path needed.");
-				LOGGER.error("ex) java [JVM Options] [className] /home/egovframe/conf/SMEConfig.conf");
-				System.exit(-1);
-			}
-
-			EgovSmsBasicReceiver receiver = new EgovSmsBasicReceiver();
-
-			try {
-				try {
-					SMEConfig.configSet(args[0]);
-					receiver.readPropertyFile();
-
-				} catch (Exception ex) {
-	//				LOGGER.error("DEBUG: {}", ex.getMessage());
-					//2017.03.07 	조성원 	시큐어코딩(ES)-부적절한 예외 처리[CWE-253, CWE-440, CWE-754]
-					LOGGER.error("["+ ex.getClass() +"] : Connection Close ", ex.getMessage());
-					return;
-				}
-
-				// 결과 수신을 위해서 리포트 세션을 접속한다.
-				// 프로그램 시작시 최초 한번만 해준다.
-				receiver.open();
-
-				long startTimestamp = System.currentTimeMillis();
-				long nowTimestamp = 0;
-				long limitTimeInterval = (60)*60*1000; //60분간으로 제한
-
-				// 데몬이 종료안되도록 10초씩 쉬면서 루프를 돌렸습니다.
-				// 실제 사용 목적에 맞게끔 고쳐주시면 됩니다.
-				while (true) {
-					// 연결을 유지해야하는데 서버측에서 세션을 끊어버리거나
-					// 네트워크 간섭 또는 장애 상황으로 연결이 끊겼을 경우 재접속할 수 있도록 처리
-					//if (receiver.isConnected == false) {
-					if (!receiver.isConnected) { // recommended by PMD
-						receiver.close();
-						Thread.sleep(10000);
-						receiver.open();
-					}
-
-					Thread.sleep(10000);
-					nowTimestamp = System.currentTimeMillis();
-					if ( (nowTimestamp - startTimestamp) > limitTimeInterval) break;
-				}
-
-			} catch (SMEException ex) {
-				LOGGER.error("DEBUG: {}", ex.getMessage());
-			} catch (InterruptedException ie) {
-				EgovBasicLogger.ignore("InterruptedException", ie);
-			} finally {
-				receiver.close();
-			}
-		}*/
+	/*
+	 * public static void mainExample(String[] args) { if (args.length < 1) {
+	 * LOGGER.error("SMEConfig.conf file full path needed."); LOGGER.
+	 * error("ex) java [JVM Options] [className] /home/egovframe/conf/SMEConfig.conf"
+	 * ); System.exit(-1); }
+	 * 
+	 * EgovSmsBasicReceiver receiver = new EgovSmsBasicReceiver();
+	 * 
+	 * try { try { SMEConfig.configSet(args[0]); receiver.readPropertyFile();
+	 * 
+	 * } catch (Exception ex) { // LOGGER.error("DEBUG: {}", ex.getMessage());
+	 * //2017.03.07 조성원 시큐어코딩(ES)-부적절한 예외 처리[CWE-253, CWE-440, CWE-754]
+	 * LOGGER.error("["+ ex.getClass() +"] : Connection Close ", ex.getMessage());
+	 * return; }
+	 * 
+	 * // 결과 수신을 위해서 리포트 세션을 접속한다. // 프로그램 시작시 최초 한번만 해준다. receiver.open();
+	 * 
+	 * long startTimestamp = System.currentTimeMillis(); long nowTimestamp = 0; long
+	 * limitTimeInterval = (60)*60*1000; //60분간으로 제한
+	 * 
+	 * // 데몬이 종료안되도록 10초씩 쉬면서 루프를 돌렸습니다. // 실제 사용 목적에 맞게끔 고쳐주시면 됩니다. while (true) {
+	 * // 연결을 유지해야하는데 서버측에서 세션을 끊어버리거나 // 네트워크 간섭 또는 장애 상황으로 연결이 끊겼을 경우 재접속할 수 있도록
+	 * 처리 //if (receiver.isConnected == false) { if (!receiver.isConnected) { //
+	 * recommended by PMD receiver.close(); Thread.sleep(10000); receiver.open(); }
+	 * 
+	 * Thread.sleep(10000); nowTimestamp = System.currentTimeMillis(); if (
+	 * (nowTimestamp - startTimestamp) > limitTimeInterval) break; }
+	 * 
+	 * } catch (SMEException ex) { LOGGER.error("DEBUG: {}", ex.getMessage()); }
+	 * catch (InterruptedException ie) {
+	 * EgovBasicLogger.ignore("InterruptedException", ie); } finally {
+	 * receiver.close(); } }
+	 */
 }

--- a/src/main/java/egovframework/com/cop/sms/service/impl/EgovSmsBasicServiceImpl.java
+++ b/src/main/java/egovframework/com/cop/sms/service/impl/EgovSmsBasicServiceImpl.java
@@ -1,11 +1,11 @@
 package egovframework.com.cop.sms.service.impl;
 
-//import java.io.BufferedInputStream;
-//import java.io.FileInputStream;
-import java.text.ParseException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import egovframework.com.cmm.service.EgovProperties;
 import egovframework.com.cop.sms.service.EgovSmsInfoService;
@@ -14,22 +14,23 @@ import egovframework.com.cop.sms.service.SmsConnection;
 import egovframework.com.cop.sms.service.SmsRecptn;
 import egovframework.com.cop.sms.service.SmsVO;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /**
  * 문자메시지를 위한 서비스 구현 클래스 (프레임워크 비종속 버전)
  *
  * @author 공통컴포넌트개발팀 한성곤
  * @version 1.0
- * @see <pre>
+ * @see
+ * 
+ *      <pre>
  * << 개정이력(Modification Information) >>
  *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.11.24  한성곤          최초 생성
+ *   2024.08.27  이백행          컨트리뷰션 시큐어코딩 Exception 제거
  *
- * </pre>
+ *      </pre>
+ * 
  * @since 2009.11.24
  */
 public class EgovSmsBasicServiceImpl implements EgovSmsInfoService {
@@ -40,47 +41,44 @@ public class EgovSmsBasicServiceImpl implements EgovSmsInfoService {
 	private static final Logger LOGGER = LoggerFactory.getLogger(EgovSmsBasicServiceImpl.class);
 
 	public EgovSmsBasicServiceImpl() {
-		//--------------------------------
+		// --------------------------------
 		// 속성 정보 얻기
 		// M-Gov에서 배포하는 SMEConfig.conf 파일을 절대경로로 지정하면 된다.
-		//--------------------------------
+		// --------------------------------
 		// //globals.properties를 활용한 방식 (공통모듈 사용)
-		//smeConfigPath = EgovProperties.getProperty("Globals.SMEConfigPath");
+		// smeConfigPath = EgovProperties.getProperty("Globals.SMEConfigPath");
 
 		// //globals.properties를 직접 활용한 방식
-		//String globalsPropertiesFile = System.getProperty("user.home")
-		//	+ System.getProperty("file.separator") + "egovProps"
-		//	+ System.getProperty("file.separator") + "globals.properties";
+		// String globalsPropertiesFile = System.getProperty("user.home")
+		// + System.getProperty("file.separator") + "egovProps"
+		// + System.getProperty("file.separator") + "globals.properties";
 		//
-		//FileInputStream fis = null;
+		// FileInputStream fis = null;
 		//
-		//try {
-		//    Properties props = new Properties();
-		//    fis  = new FileInputStream(globalsPropertiesFile);
-		//    props.load(new BufferedInputStream(fis));
+		// try {
+		// Properties props = new Properties();
+		// fis = new FileInputStream(globalsPropertiesFile);
+		// props.load(new BufferedInputStream(fis));
 		//
-		//    smeConfigPath = props.getProperty("Globals.SMEConfigPath").trim();
-		//} catch(Exception ex) {
-		//    logger.error(ex);
-		//} finally {
-		//    try {
-		//	if (fis != null) {
-		//	    fis.close();
-		//	}
-		//    } catch (Exception ex) {
-		//	ex.printStackTrace();
-		//    }
-		//}
+		// smeConfigPath = props.getProperty("Globals.SMEConfigPath").trim();
+		// } catch(Exception ex) {
+		// logger.error(ex);
+		// } finally {
+		// try {
+		// if (fis != null) {
+		// fis.close();
+		// }
+		// } catch (Exception ex) {
+		// ex.printStackTrace();
+		// }
+		// }
 
 		if (EgovProperties.class.getResource("") != null) {
 			String FILE_SEPARATOR = System.getProperty("file.separator");
 
-			smeConfigPath = EgovProperties.class.getResource("").getPath()
-				+ FILE_SEPARATOR + ".." + FILE_SEPARATOR
-				+ ".." + FILE_SEPARATOR + ".." + FILE_SEPARATOR
-				+ FILE_SEPARATOR + "egovProps"
-				+ FILE_SEPARATOR + "conf"
-				+ FILE_SEPARATOR + "SMEConfig.properties";
+			smeConfigPath = EgovProperties.class.getResource("").getPath() + FILE_SEPARATOR + ".." + FILE_SEPARATOR
+					+ ".." + FILE_SEPARATOR + ".." + FILE_SEPARATOR + FILE_SEPARATOR + "egovProps" + FILE_SEPARATOR
+					+ "conf" + FILE_SEPARATOR + "SMEConfig.properties";
 		}
 
 	}
@@ -100,14 +98,14 @@ public class EgovSmsBasicServiceImpl implements EgovSmsInfoService {
 		return result;
 	}
 
-	private String formatPhoneNumber(String number) throws ParseException {
+	private String formatPhoneNumber(String number) {
 		if (number == null || number.trim().equals("")) {
 			return "";
 		}
 
 		StringBuffer buffer = new StringBuffer();
 
-		if (number.length() == 9) {    // 02-500-1234 형식
+		if (number.length() == 9) { // 02-500-1234 형식
 			buffer.append(number.substring(0, 2));
 			buffer.append("-");
 			buffer.append(number.substring(2, 2 + 3));
@@ -115,14 +113,14 @@ public class EgovSmsBasicServiceImpl implements EgovSmsInfoService {
 			buffer.append(number.substring(2 + 3, 2 + 3 + 4));
 
 		} else if (number.length() == 10) {
-			if (number.startsWith("02")) {    // 02-5000-1234 형식
+			if (number.startsWith("02")) { // 02-5000-1234 형식
 				buffer.append(number.substring(0, 2));
 				buffer.append("-");
 				buffer.append(number.substring(2, 2 + 4));
 				buffer.append("-");
 				buffer.append(number.substring(2 + 4, 2 + 4 + 4));
 
-			} else {                // 031-500-1234 형식
+			} else { // 031-500-1234 형식
 				buffer.append(number.substring(0, 3));
 				buffer.append("-");
 				buffer.append(number.substring(3, 3 + 3));
@@ -130,14 +128,14 @@ public class EgovSmsBasicServiceImpl implements EgovSmsInfoService {
 				buffer.append(number.substring(3 + 3, 3 + 3 + 4));
 			}
 
-		} else if (number.length() == 11) {    // 031-5000-1234 형식
+		} else if (number.length() == 11) { // 031-5000-1234 형식
 			buffer.append(number.substring(0, 3));
 			buffer.append("-");
 			buffer.append(number.substring(3, 3 + 4));
 			buffer.append("-");
 			buffer.append(number.substring(3 + 4, 3 + 4 + 4));
 
-		} else if (number.length() == 12) {    // 0505-5000-1234 형식
+		} else if (number.length() == 12) { // 0505-5000-1234 형식
 			buffer.append(number.substring(0, 4));
 			buffer.append("-");
 			buffer.append(number.substring(4, 4 + 4));
@@ -154,7 +152,8 @@ public class EgovSmsBasicServiceImpl implements EgovSmsInfoService {
 	/**
 	 * 문자메시지 목록을 조회 한다.
 	 */
-	public Map<String, Object> selectSmsInfs(SmsVO searchVO) throws Exception {
+	@Override
+	public Map<String, Object> selectSmsInfs(SmsVO searchVO) {
 		List<SmsVO> result = smsDao.selectSmsInfs(searchVO);
 		int cnt = smsDao.selectSmsInfsCnt(searchVO);
 
@@ -175,19 +174,20 @@ public class EgovSmsBasicServiceImpl implements EgovSmsInfoService {
 	/**
 	 * 문자메시지를 전송(등록)한다.
 	 */
-	public void insertSmsInf(Sms sms) throws Exception {
+	@Override
+	public void insertSmsInf(Sms sms) {
 		HashMap<String, SmsRecptn> check = new HashMap<String, SmsRecptn>();
 
 		sms.setTrnsmitTelno(getPhoneNumber(sms.getTrnsmitTelno()));
 
-		//---------------------------------------
+		// ---------------------------------------
 		// 마스터 정보 등록
-		//---------------------------------------
+		// ---------------------------------------
 		String smsId = smsDao.insertSmsInf(sms);
 
-		//---------------------------------------
+		// ---------------------------------------
 		// 전송 요청 및 상세(수신자)정보 등록
-		//---------------------------------------
+		// ---------------------------------------
 		SmsRecptn smsRecptn = null;
 		if (sms != null && sms.getRecptnTelno() != null) {
 			for (int i = 0; i < sms.getRecptnTelno().length; i++) {
@@ -206,9 +206,9 @@ public class EgovSmsBasicServiceImpl implements EgovSmsInfoService {
 					check.put(smsRecptn.getRecptnTelno(), smsRecptn);
 				}
 
-				//---------------------------------------
+				// ---------------------------------------
 				// 실 전송 요청 저장
-				//---------------------------------------
+				// ---------------------------------------
 				SmsConnection smsConn = new SmsConnection();
 
 				smsConn.setCallFrom(sms.getTrnsmitTelno());
@@ -232,13 +232,13 @@ public class EgovSmsBasicServiceImpl implements EgovSmsInfoService {
 						sender.close();
 					}
 				}
-				////-------------------------------------
+				//// -------------------------------------
 
 				// Sender의 전송 결과는 SMS G/W 처리 상의 결과만 리턴함
 				// 이동통신사의 오류는 별도의 Receiver에서 수신 처리함
 				// 수신 처리시 MessageId의 구성 형식(SMS_ID + "-" + 수신전화번호)를 통해 DB에 결과를 반영
 
-				if (result != null) {    // 2011.10.21 보안점검 후속조치
+				if (result != null) { // 2011.10.21 보안점검 후속조치
 					smsRecptn.setResultCode(Integer.toString(result.getResult()));
 					smsRecptn.setResultMssage(result.getResultMessage());
 				}
@@ -251,7 +251,8 @@ public class EgovSmsBasicServiceImpl implements EgovSmsInfoService {
 	/**
 	 * 문자메시지에 대한 상세정보를 조회한다.
 	 */
-	public SmsVO selectSmsInf(SmsVO searchVO) throws Exception {
+	@Override
+	public SmsVO selectSmsInf(SmsVO searchVO) {
 		SmsVO vo = smsDao.selectSmsInf(searchVO);
 
 		// 전화번호 포맷 처리
@@ -277,23 +278,23 @@ public class EgovSmsBasicServiceImpl implements EgovSmsInfoService {
 	/**
 	 * 문자메시지 실 전송을 요청한다.
 	 */
-	public SmsConnection sendRequsest(SmsConnection smsConn) throws Exception {
+	@Override
+	public SmsConnection sendRequsest(SmsConnection smsConn) {
 		String callTo = smsConn.getCallTo();
 		String callFrom = smsConn.getCallFrom();
 		String callBack = smsConn.getCallBack();
 		String callBackUrl = smsConn.getCallBackUrl();
 		String text = smsConn.getText();
-		String messageId = smsConn.getMessageId();    // messageId 지정 필요
+		String messageId = smsConn.getMessageId(); // messageId 지정 필요
 
-	/*
-	System.out.println("------------------------");
-	System.out.println("callTo = " + callTo);
-	System.out.println("callFrom = " + callFrom);
-	System.out.println("callBack = " + callBack);
-	System.out.println("callBackUrl = " + callBackUrl);
-	System.out.println("text = " + text);
-	System.out.println("messageId = " + messageId);
-	*/
+		/*
+		 * System.out.println("------------------------");
+		 * System.out.println("callTo = " + callTo); System.out.println("callFrom = " +
+		 * callFrom); System.out.println("callBack = " + callBack);
+		 * System.out.println("callBackUrl = " + callBackUrl);
+		 * System.out.println("text = " + text); System.out.println("messageId = " +
+		 * messageId);
+		 */
 		LOGGER.info("------------------------");
 		LOGGER.info("callTo = {}", callTo);
 		LOGGER.info("callFrom = {}", callFrom);
@@ -319,7 +320,7 @@ public class EgovSmsBasicServiceImpl implements EgovSmsInfoService {
 		// Sender의 전송 결과는 SMS G/W 처리 상의 결과만 리턴함
 		// 이동통신사의 오류는 별도의 Receiver에서 수신 처리함 (로그 기록)
 
-		if (result != null) {    // 2011.10.21 보안점검 후속조치
+		if (result != null) { // 2011.10.21 보안점검 후속조치
 			smsConn.setResult(result.getResult());
 			smsConn.setResultMessage(result.getResultMessage());
 		}
@@ -331,10 +332,10 @@ public class EgovSmsBasicServiceImpl implements EgovSmsInfoService {
 	 * 여러 건의 문자메시지 실 전송을 요청한다.
 	 *
 	 * @param smsConn
-	 * @return
-	 * @throws Exception
+	 * @return @
 	 */
-	public SmsConnection[] sendRequsest(SmsConnection[] smsConn) throws Exception {
+	@Override
+	public SmsConnection[] sendRequsest(SmsConnection[] smsConn) {
 		EgovSmsInfoSender sender = null;
 
 		try {
@@ -350,17 +351,16 @@ public class EgovSmsBasicServiceImpl implements EgovSmsInfoService {
 				String callBack = smsConn[i].getCallBack();
 				String callBackUrl = smsConn[i].getCallBackUrl();
 				String text = smsConn[i].getText();
-				String messageId = smsConn[i].getMessageId();    // messageId 지정 필요
+				String messageId = smsConn[i].getMessageId(); // messageId 지정 필요
 
-		/*
-		System.out.println("------------------------");
-		System.out.println("callTo[" + i + "] = " + callTo);
-		System.out.println("callFrom[" + i + "] = " + callFrom);
-		System.out.println("callBack[" + i + "] = " + callBack);
-		System.out.println("callBackUrl[" + i + "] = " + callBackUrl);
-		System.out.println("text =[" + i + "] = " + text);
-		System.out.println("messageId[" + i + "] = " + messageId);
-		*/
+				/*
+				 * System.out.println("------------------------"); System.out.println("callTo["
+				 * + i + "] = " + callTo); System.out.println("callFrom[" + i + "] = " +
+				 * callFrom); System.out.println("callBack[" + i + "] = " + callBack);
+				 * System.out.println("callBackUrl[" + i + "] = " + callBackUrl);
+				 * System.out.println("text =[" + i + "] = " + text);
+				 * System.out.println("messageId[" + i + "] = " + messageId);
+				 */
 				LOGGER.info("------------------------");
 				LOGGER.info("callTo[{}] = {}", i, callTo);
 				LOGGER.info("callFrom[{}] = {}", i, callFrom);
@@ -369,7 +369,7 @@ public class EgovSmsBasicServiceImpl implements EgovSmsInfoService {
 				LOGGER.info("text =[{}] = {}", i, text);
 				LOGGER.info("messageId[{}] = {}", i, messageId);
 
-				//smsConn[i] = sendRequsest(smsConn[i]);
+				// smsConn[i] = sendRequsest(smsConn[i]);
 				result = sender.send(smsConn[i]);
 
 				// Sender의 전송 결과는 SMS G/W 처리 상의 결과만 리턴함

--- a/src/main/java/egovframework/com/cop/sms/service/impl/EgovSmsInfoSender.java
+++ b/src/main/java/egovframework/com/cop/sms/service/impl/EgovSmsInfoSender.java
@@ -1,10 +1,10 @@
 package egovframework.com.cop.sms.service.impl;
 
-import egovframework.com.cop.sms.service.SmsConnection;
-
+import org.egovframe.rte.fdl.cmmn.exception.BaseRuntimeException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import egovframework.com.cop.sms.service.SmsConnection;
 import x3.client.smeapi.SMEConnection;
 import x3.client.smeapi.SMEConnectionFactory;
 import x3.client.smeapi.SMEException;
@@ -18,196 +18,200 @@ import x3.client.smeapi.impl.SMELogger;
 
 /**
  * 문자메시지 연동 처리를 위한 클래스
+ * 
  * @author 공통컴포넌트개발팀 한성곤
  * @since 2009.08.05
  * @version 1.0
  * @see
  *
- * <pre>
+ *      <pre>
  * << 개정이력(Modification Information) >>
  *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.08.05  한성곤          최초 생성
+ *   2024.08.27  이백행          컨트리뷰션 시큐어코딩 Exception 제거
  *
- * </pre>
+ *      </pre>
  */
 public class EgovSmsInfoSender {
-    /** SMS 서버 URL */
-    private final String connString;	// ex) sme://000.000.000.000:20000
-    /** SMS 연계 ID */
-    private final String smsId;
-    /** SMS 연계 password */
-    private final String smsPwd;
+	/** SMS 서버 URL */
+	private final String connString; // ex) sme://000.000.000.000:20000
+	/** SMS 연계 ID */
+	private final String smsId;
+	/** SMS 연계 password */
+	private final String smsPwd;
 
-    /** SMS G/W Connection Factory */
-    private SMEConnectionFactory factSender = null;
-    /** SMS G/W Connection */
-    private SMEConnection connSender = null;
-    /** SMS G/W Session */
-    private SMESession sessSender = null;
-    /** SMS G/W Sender */
-    private SMESender sender = null;
+	/** SMS G/W Connection Factory */
+	private SMEConnectionFactory factSender = null;
+	/** SMS G/W Connection */
+	private SMEConnection connSender = null;
+	/** SMS G/W Session */
+	private SMESession sessSender = null;
+	/** SMS G/W Sender */
+	private SMESender sender = null;
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(EgovSmsInfoSender.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(EgovSmsInfoSender.class);
 
-    /**
-     * SMS 연계를 위한 생성자.
-     * SMEConfig 설정파일로부터 필요한 연결 정보 및 로그 관련 정보를 얻는다.
-     *
-     * @param configFile
-     * @throws Exception
-     */
-    public EgovSmsInfoSender(String configFile) throws Exception {
-	SMEConfig.configSet(configFile);
+	/**
+	 * SMS 연계를 위한 생성자. SMEConfig 설정파일로부터 필요한 연결 정보 및 로그 관련 정보를 얻는다.
+	 *
+	 * @param configFile
+	 */
+	public EgovSmsInfoSender(String configFile) {
+		try {
+			SMEConfig.configSet(configFile);
+		} catch (Exception e) {
+			throw new BaseRuntimeException("Exception: configSet", e);
+		}
 
-	connString = SMEConfig.getSmsUrl();
-	smsId = SMEConfig.getSmsId();
-	smsPwd = SMEConfig.getSmsPwd();
+		connString = SMEConfig.getSmsUrl();
+		smsId = SMEConfig.getSmsId();
+		smsPwd = SMEConfig.getSmsPwd();
 
-	String tmp = null;
+		String tmp = null;
 
-	tmp = SMEConfig.getLogLevel();
-	if (tmp != null && !tmp.equals("")) {
-		SMELogger.setLogLevel(tmp);
+		tmp = SMEConfig.getLogLevel();
+		if (tmp != null && !tmp.equals("")) {
+			SMELogger.setLogLevel(tmp);
+		}
+
+		tmp = SMEConfig.getLogLayout();
+		if (tmp != null && !tmp.equals("")) {
+			SMELogger.setLogLayout(tmp);
+		}
+
+		tmp = SMEConfig.getLogPath();
+		if (tmp != null && !tmp.equals("")) {
+			SMELogger.setLogPath(tmp);
+		}
+
+		SMELogger.setUseConsoleLogger(SMEConfig.getUseConsoleLogger());
+		SMELogger.setUseFileLogger(SMEConfig.getUseFileLogger());
 	}
 
-	tmp = SMEConfig.getLogLayout();
-	if (tmp != null && !tmp.equals("")) {
-		SMELogger.setLogLayout(tmp);
+	/**
+	 * SMS 연결을 위한 Connection 및 Session 생성한다. 발송건이 있을 경우만 open()을 호출하고 close()를 호출하여
+	 * 종료한다. 만약 DB 와 연동시 select로 데이타 검출시 데이타가 없으면 open()을 호출하지 않는다. (중요!!! 꼭 데이타가 있을
+	 * 경우만 open() 을 하여 접속)
+	 */
+	public void open() {
+		try {
+			this.factSender = new SMEConnectionFactoryImpl(connString);
+			this.connSender = factSender.createConnection(smsId, smsPwd); // 아이디와 패스워드입니다.
+			this.sessSender = connSender.createSession();
+			this.sender = sessSender.createSender();
+		} catch (SMEException e) {
+			throw new BaseRuntimeException("SMEException: SMEConnectionFactoryImpl", e);
+		}
+
+		// 현재 발송한 호에 대해서 리포트 수신을 위해서는 true 로 설정해야 리포트 수신을 할 수 있다.
+		// 만약 false 로 세팅하고 발송을 하면 현재 발송한 호에 대해서는 결과수신을 할 수 없다.
+		// 리포트가 필요없는 기관에서는 아래 디폴트값인 false를 유지한다.
+		// false로 설정을 하면 보내는 메시지에 대해서 결과를 수신할 수 없습니다.
+		// [2008-08-25] 리포트 수신 필수조건으로 변경
+		// 리포트는 필수 수신입니다.
+		this.sessSender.setReceiverCreated(true);
+		this.connSender.start();
 	}
 
-	tmp = SMEConfig.getLogPath();
-	if (tmp != null && !tmp.equals("")) {
-		SMELogger.setLogPath(tmp);
+	/**
+	 * SMS를 전송한다.
+	 *
+	 * @param smsConn
+	 * @return
+	 */
+	public SmsConnection send(SmsConnection smsConn) {
+		SMERequest request = null;
+
+		try {
+			request = sessSender.createRequest();
+			// destination
+			request.setTo(smsConn.getCallTo()); // 수신번호
+			// origination
+			request.setFrom(smsConn.getCallFrom()); // 발신번호
+			// callback
+			request.setCallback(smsConn.getCallBack()); // 회신번호(콜백번호)
+
+			// callbackurl
+			// 무선인터넷 주소 휴대전화 인터넷 (WAP) 페이지 접속용 URL
+			// 단문자메세지 외의 별도 과금이 되므로 WAP 페이지가 있는 기관에서만 사용
+			// 해당 URL 접속시 수신자에게 과금이 되므로 주의.
+			request.setCallbackURL(smsConn.getCallBackUrl()); // CallbackURL은 선택사항 입니다.
+
+			// message (메세지내용)
+			request.setText(smsConn.getText());
+
+			// serial *MUST* be unique number in single SME.
+			// 반드시 메시지 발송시 연속되는 일련번호 형식을 띈 고유값이어야 함
+			// SMS G/W로 전송누적 일련번호
+			// 예) 'TestMessage-000000' 숫자 또는 문자 + 숫자로 조합 가능 ( 40 byte )
+			// 예) '200808251259590001'
+			request.setMessageId(smsConn.getMessageId()); // 일련번호 고유값
+
+			sender = sessSender.createSender();
+			SMEResponse res = sender.send(request);
+			int nRes = res.getResult();
+
+			smsConn.setResult(nRes);
+			// smsConn.setResultMessage("");
+
+			switch (nRes) {
+			case 0:
+				smsConn.setResultMessage("");
+				break;
+			case 3000:
+				smsConn.setResultMessage("착발신 번호 포맷 오류 또는 부재");
+				break;
+			case 3001:
+				smsConn.setResultMessage("콜백번호 포맷 오류");
+				break;
+			case 3002:
+				smsConn.setResultMessage("MessageID 포맷 오류 또는 부재");
+				break;
+			case 3003:
+				smsConn.setResultMessage("Text 및 Callback URL 포맷 오류");
+				break;
+			case 4005:
+				smsConn.setResultMessage("SMG Server 스팸 메시지로 처리 거부됨");
+				break;
+			case 5000:
+				smsConn.setResultMessage("SMG Server 내부 에러 (인증실패,연결실패)");
+				break;
+			default:
+				smsConn.setResultMessage("알 수 없는 오류 발생");
+			}
+
+		} catch (SMEException ex) {
+			throw new BaseRuntimeException("SMEException: SMEConnectionFactoryImpl", ex);
+		}
+
+		return smsConn;
 	}
 
-	SMELogger.setUseConsoleLogger(SMEConfig.getUseConsoleLogger());
-	SMELogger.setUseFileLogger(SMEConfig.getUseFileLogger());
-    }
+	/**
+	 * SMS 연결을 위한 Connection 및 Session 해제한다. 메시지 처리 전송후 반드시 종료해야 한다.
+	 */
+	public void close() {
+		try {
+			if (sender != null)
+				sender.close();
+		} catch (SMEException ignore) {
+			LOGGER.debug(ignore.getMessage());
+		}
 
-    /**
-     * SMS 연결을 위한 Connection 및 Session 생성한다.
-     * 발송건이 있을 경우만 open()을 호출하고 close()를 호출하여 종료한다.
-     * 만약 DB 와 연동시 select로 데이타 검출시 데이타가 없으면
-     * open()을 호출하지 않는다. (중요!!! 꼭 데이타가 있을 경우만 open() 을 하여 접속)
-     *
-     * @throws SMEException
-     */
-    public void open() throws SMEException {
-	this.factSender = new SMEConnectionFactoryImpl(connString);
-	this.connSender = factSender.createConnection(smsId, smsPwd); // 아이디와 패스워드입니다.
-	this.sessSender = connSender.createSession();
-	this.sender = sessSender.createSender();
+		try {
+			if (sessSender != null)
+				sessSender.close();
+		} catch (SMEException ignore) {
+			LOGGER.debug(ignore.getMessage());
+		}
 
-	// 현재 발송한 호에 대해서 리포트 수신을 위해서는 true 로 설정해야  리포트 수신을 할 수 있다.
-	// 만약 false 로 세팅하고 발송을 하면 현재 발송한 호에 대해서는 결과수신을 할 수 없다.
-	// 리포트가 필요없는 기관에서는 아래 디폴트값인 false를 유지한다.
-	// false로 설정을 하면 보내는 메시지에 대해서 결과를 수신할 수 없습니다.
-	// [2008-08-25] 리포트 수신 필수조건으로 변경
-	// 리포트는 필수 수신입니다.
-	this.sessSender.setReceiverCreated(true);
-	this.connSender.start();
-    }
-
-    /**
-     * SMS를 전송한다.
-     *
-     * @param smsConn
-     * @return
-     */
-    public SmsConnection send(SmsConnection smsConn) throws SMEException {
-	SMERequest request = null;
-
-	try {
-	    request = sessSender.createRequest();
-	    // destination
-	    request.setTo(smsConn.getCallTo()); //수신번호
-	    // origination
-	    request.setFrom(smsConn.getCallFrom()); //발신번호
-	    // callback
-	    request.setCallback(smsConn.getCallBack()); //회신번호(콜백번호)
-
-	    // callbackurl
-	    // 무선인터넷 주소  휴대전화 인터넷 (WAP) 페이지 접속용 URL
-	    // 단문자메세지 외의 별도 과금이 되므로 WAP 페이지가 있는 기관에서만 사용
-	    // 해당 URL 접속시 수신자에게 과금이 되므로 주의.
-	    request.setCallbackURL(smsConn.getCallBackUrl()); //CallbackURL은 선택사항 입니다.
-
-	    // message (메세지내용)
-	    request.setText(smsConn.getText());
-
-	    // serial *MUST* be unique number in single SME.
-	    // 반드시 메시지 발송시 연속되는 일련번호 형식을 띈 고유값이어야 함
-	    // SMS G/W로 전송누적 일련번호
-	    // 예) 'TestMessage-000000' 숫자 또는 문자 + 숫자로 조합 가능 ( 40 byte )
-	    // 예) '200808251259590001'
-	    request.setMessageId(smsConn.getMessageId()); //일련번호 고유값
-
-	    sender = sessSender.createSender();
-	    SMEResponse res = sender.send(request);
-	    int nRes = res.getResult();
-
-	    smsConn.setResult(nRes);
-	    //smsConn.setResultMessage("");
-
-	    switch (nRes) {
-	    case 0:
-		smsConn.setResultMessage("");
-		break;
-	    case 3000:
-		smsConn.setResultMessage("착발신 번호 포맷 오류 또는 부재");
-		break;
-	    case 3001:
-		smsConn.setResultMessage("콜백번호 포맷 오류");
-		break;
-	    case 3002:
-		smsConn.setResultMessage("MessageID 포맷 오류 또는 부재");
-		break;
-	    case 3003:
-		smsConn.setResultMessage("Text 및 Callback URL 포맷 오류");
-		break;
-	    case 4005:
-		smsConn.setResultMessage("SMG Server 스팸 메시지로 처리 거부됨");
-		break;
-	    case 5000:
-		smsConn.setResultMessage("SMG Server 내부 에러 (인증실패,연결실패)");
-		break;
-	    default:
-		smsConn.setResultMessage("알 수 없는 오류 발생");
-	    }
-
-	} catch (SMEException ex) {
-	    throw ex;
+		try {
+			if (connSender != null)
+				connSender.close();
+		} catch (SMEException ignore) {
+			LOGGER.debug(ignore.getMessage());
+		}
 	}
-
-	return smsConn;
-    }
-
-    /**
-     * SMS 연결을 위한 Connection 및 Session 해제한다.
-     * 메시지 처리 전송후 반드시 종료해야 한다.
-     */
-    public void close() {
-	try {
-	    if (sender != null)
-		sender.close();
-	} catch (SMEException ignore) {
-		LOGGER.debug(ignore.getMessage());
-	}
-
-	try {
-	    if (sessSender != null)
-		sessSender.close();
-	} catch (SMEException ignore) {
-		LOGGER.debug(ignore.getMessage());
-	}
-
-	try {
-	    if (connSender != null)
-		connSender.close();
-	} catch (SMEException ignore) {
-		LOGGER.debug(ignore.getMessage());
-	}
-    }
 }

--- a/src/main/java/egovframework/com/cop/sms/service/impl/EgovSmsInfoServiceImpl.java
+++ b/src/main/java/egovframework/com/cop/sms/service/impl/EgovSmsInfoServiceImpl.java
@@ -1,9 +1,18 @@
 package egovframework.com.cop.sms.service.impl;
 
-import java.text.ParseException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.Resource;
+
+import org.egovframe.rte.fdl.cmmn.EgovAbstractServiceImpl;
+import org.egovframe.rte.fdl.cmmn.exception.FdlException;
+import org.egovframe.rte.fdl.idgnr.EgovIdGnrService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
 
 import egovframework.com.cmm.service.EgovProperties;
 import egovframework.com.cop.sms.service.EgovSmsInfoService;
@@ -12,161 +21,161 @@ import egovframework.com.cop.sms.service.SmsConnection;
 import egovframework.com.cop.sms.service.SmsRecptn;
 import egovframework.com.cop.sms.service.SmsVO;
 
-import org.egovframe.rte.fdl.cmmn.EgovAbstractServiceImpl;
-import org.egovframe.rte.fdl.idgnr.EgovIdGnrService;
-
-import javax.annotation.PostConstruct;
-import javax.annotation.Resource;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.stereotype.Service;
-
 /**
  * 문자메시지를 위한 서비스 구현 클래스
+ * 
  * @author 공통컴포넌트개발팀 한성곤
  * @since 2009.06.18
  * @version 1.0
  * @see
  *
- * <pre>
+ *      <pre>
  * << 개정이력(Modification Information) >>
  *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.06.18  한성곤          최초 생성
+ *   2024.08.27  이백행          컨트리뷰션 시큐어코딩 Exception 제거
  *
- * </pre>
+ *      </pre>
  */
 @Service("EgovSmsInfoService")
 public class EgovSmsInfoServiceImpl extends EgovAbstractServiceImpl implements EgovSmsInfoService {
-    @Resource(name="SmsDAO")
-    private SmsDAO smsDao;
+	@Resource(name = "SmsDAO")
+	private SmsDAO smsDao;
 
-    @Resource(name="egovSmsIdGnrService")
-    private EgovIdGnrService idgenService;
+	@Resource(name = "egovSmsIdGnrService")
+	private EgovIdGnrService idgenService;
 
-    private String smeConfigPath = null;
+	private String smeConfigPath = null;
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(EgovSmsInfoServiceImpl.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(EgovSmsInfoServiceImpl.class);
 
-    @PostConstruct
-    public void init() {
-	//--------------------------------
-	// 속성 정보 얻기
-	//--------------------------------
-    	this.smeConfigPath = EgovProperties.getPathProperty("Globals.SMEConfigPath");
-    }
-
-    private String getPhoneNumber(String number) {
-	String result = number;
-
-	if (number == null || number.trim().equals("")) {
-	    return "";
+	@PostConstruct
+	public void init() {
+		// --------------------------------
+		// 속성 정보 얻기
+		// --------------------------------
+		this.smeConfigPath = EgovProperties.getPathProperty("Globals.SMEConfigPath");
 	}
 
-	result = result.replace("-", "");
-	result = result.replace("(", "");
-	result = result.replace(")", "");
-	result = result.replace(" ", "");
+	private String getPhoneNumber(String number) {
+		String result = number;
 
-	return result;
-    }
+		if (number == null || number.trim().equals("")) {
+			return "";
+		}
 
-    private String formatPhoneNumber(String number) throws ParseException {
-	if (number == null || number.trim().equals("")) {
-	    return "";
+		result = result.replace("-", "");
+		result = result.replace("(", "");
+		result = result.replace(")", "");
+		result = result.replace(" ", "");
+
+		return result;
 	}
 
-	StringBuffer buffer = new StringBuffer();
+	private String formatPhoneNumber(String number) {
+		if (number == null || number.trim().equals("")) {
+			return "";
+		}
 
+		StringBuffer buffer = new StringBuffer();
 
-	if (number.length() == 9) {	// 02-500-1234 형식
-	    buffer.append(number.substring(0, 2));
-	    buffer.append("-");
-	    buffer.append(number.substring(2, 2+3));
-	    buffer.append("-");
-	    buffer.append(number.substring(2+3, 2+3+4));
+		if (number.length() == 9) { // 02-500-1234 형식
+			buffer.append(number.substring(0, 2));
+			buffer.append("-");
+			buffer.append(number.substring(2, 2 + 3));
+			buffer.append("-");
+			buffer.append(number.substring(2 + 3, 2 + 3 + 4));
 
-	} else if (number.length() == 10) {
-	    if (number.startsWith("02")) {	// 02-5000-1234 형식
-		buffer.append(number.substring(0, 2));
-		buffer.append("-");
-		buffer.append(number.substring(2, 2 + 4));
-		buffer.append("-");
-		buffer.append(number.substring(2 + 4, 2 + 4 + 4));
+		} else if (number.length() == 10) {
+			if (number.startsWith("02")) { // 02-5000-1234 형식
+				buffer.append(number.substring(0, 2));
+				buffer.append("-");
+				buffer.append(number.substring(2, 2 + 4));
+				buffer.append("-");
+				buffer.append(number.substring(2 + 4, 2 + 4 + 4));
 
-	    } else {				// 031-500-1234 형식
-		buffer.append(number.substring(0, 3));
-		buffer.append("-");
-		buffer.append(number.substring(3, 3 + 3));
-		buffer.append("-");
-		buffer.append(number.substring(3 + 3, 3 + 3 + 4));
-	    }
+			} else { // 031-500-1234 형식
+				buffer.append(number.substring(0, 3));
+				buffer.append("-");
+				buffer.append(number.substring(3, 3 + 3));
+				buffer.append("-");
+				buffer.append(number.substring(3 + 3, 3 + 3 + 4));
+			}
 
-	} else if (number.length() == 11) {	// 031-5000-1234 형식
-	    buffer.append(number.substring(0, 3));
-	    buffer.append("-");
-	    buffer.append(number.substring(3, 3+4));
-	    buffer.append("-");
-	    buffer.append(number.substring(3+4,3+4+4));
+		} else if (number.length() == 11) { // 031-5000-1234 형식
+			buffer.append(number.substring(0, 3));
+			buffer.append("-");
+			buffer.append(number.substring(3, 3 + 4));
+			buffer.append("-");
+			buffer.append(number.substring(3 + 4, 3 + 4 + 4));
 
-	} else if (number.length() == 12) {	// 0505-5000-1234 형식
-	    buffer.append(number.substring(0, 4));
-	    buffer.append("-");
-	    buffer.append(number.substring(4, 4+4));
-	    buffer.append("-");
-	    buffer.append(number.substring(4+4, 4+4+4));
+		} else if (number.length() == 12) { // 0505-5000-1234 형식
+			buffer.append(number.substring(0, 4));
+			buffer.append("-");
+			buffer.append(number.substring(4, 4 + 4));
+			buffer.append("-");
+			buffer.append(number.substring(4 + 4, 4 + 4 + 4));
 
-	} else {
-	    return number;
+		} else {
+			return number;
+		}
+
+		return buffer.toString();
 	}
 
-	return buffer.toString();
-    }
+	/**
+	 * 문자메시지 목록을 조회 한다.
+	 */
+	@Override
+	public Map<String, Object> selectSmsInfs(SmsVO searchVO) {
+		List<SmsVO> result = smsDao.selectSmsInfs(searchVO);
+		int cnt = smsDao.selectSmsInfsCnt(searchVO);
 
-    /**
-     * 문자메시지 목록을 조회 한다.
-     */
-    public Map<String, Object> selectSmsInfs(SmsVO searchVO) throws Exception {
-	List<SmsVO> result = smsDao.selectSmsInfs(searchVO);
-	int cnt = smsDao.selectSmsInfsCnt(searchVO);
+		// 전화번호 포맷 처리
+		for (int i = 0; i < result.size(); i++) {
+			String phone = result.get(i).getTrnsmitTelno();
+			result.get(i).setTrnsmitTelno(formatPhoneNumber(phone));
+		}
 
-	// 전화번호 포맷 처리
-	for (int i = 0; i < result.size(); i++) {
-	    String phone = result.get(i).getTrnsmitTelno();
-	    result.get(i).setTrnsmitTelno(formatPhoneNumber(phone));
+		Map<String, Object> map = new HashMap<String, Object>();
+
+		map.put("resultList", result);
+		map.put("resultCnt", Integer.toString(cnt));
+
+		return map;
 	}
 
-	Map<String, Object> map = new HashMap<String, Object>();
+	/**
+	 * 문자메시지를 전송(등록)한다.
+	 * 
+	 * @throws Exception
+	 */
+	@Override
+	public void insertSmsInf(Sms sms) throws Exception {
+		HashMap<String, SmsRecptn> check = new HashMap<String, SmsRecptn>();
 
-	map.put("resultList", result);
-	map.put("resultCnt", Integer.toString(cnt));
+		String smsId;
+		try {
+			smsId = idgenService.getNextStringId();
+		} catch (FdlException e) {
+			throw processException("fail.common.msg", e);
+		}
 
-	return map;
-    }
+		sms.setSmsId(smsId);
 
-    /**
-     * 문자메시지를 전송(등록)한다.
-     */
-    public void insertSmsInf(Sms sms) throws Exception {
-	HashMap<String, SmsRecptn> check = new HashMap<String, SmsRecptn>();
+		sms.setTrnsmitTelno(getPhoneNumber(sms.getTrnsmitTelno()));
 
-	String smsId = idgenService.getNextStringId();
+		// ---------------------------------------
+		// 마스터 정보 등록
+		// ---------------------------------------
+		smsDao.insertSmsInf(sms);
 
-	sms.setSmsId(smsId);
-
-	sms.setTrnsmitTelno(getPhoneNumber(sms.getTrnsmitTelno()));
-
-	//---------------------------------------
-	// 마스터 정보 등록
-	//---------------------------------------
-	smsDao.insertSmsInf(sms);
-
-	//---------------------------------------
-	// 전송 요청 및 상세(수신자)정보 등록
-	//---------------------------------------
-	SmsRecptn smsRecptn = null;
+		// ---------------------------------------
+		// 전송 요청 및 상세(수신자)정보 등록
+		// ---------------------------------------
+		SmsRecptn smsRecptn = null;
 		if (sms != null && sms.getRecptnTelno() != null) {
 			for (int i = 0; i < sms.getRecptnTelno().length; i++) {
 				if (getPhoneNumber(sms.getRecptnTelno()[i]).equals("")) {
@@ -175,8 +184,7 @@ public class EgovSmsInfoServiceImpl extends EgovAbstractServiceImpl implements E
 				smsRecptn = new SmsRecptn();
 
 				smsRecptn.setSmsId(smsId);
-				smsRecptn
-						.setRecptnTelno(getPhoneNumber(sms.getRecptnTelno()[i]));
+				smsRecptn.setRecptnTelno(getPhoneNumber(sms.getRecptnTelno()[i]));
 
 				// 동일 전화번호면 SKIP
 				if (check.containsKey(smsRecptn.getRecptnTelno())) {
@@ -219,8 +227,7 @@ public class EgovSmsInfoServiceImpl extends EgovAbstractServiceImpl implements E
 
 				// 2011.10.21 보안점검 후속조치
 				if (result != null) {
-					smsRecptn
-							.setResultCode(Integer.toString(result.getResult()));
+					smsRecptn.setResultCode(Integer.toString(result.getResult()));
 					smsRecptn.setResultMssage(result.getResultMessage());
 				}
 				smsDao.insertSmsRecptnInf(smsRecptn);
@@ -228,124 +235,126 @@ public class EgovSmsInfoServiceImpl extends EgovAbstractServiceImpl implements E
 		}
 	}
 
-    /**
-     * 문자메시지에 대한 상세정보를 조회한다.
-     */
-    public SmsVO selectSmsInf(SmsVO searchVO) throws Exception {
-	SmsVO vo = smsDao.selectSmsInf(searchVO);
+	/**
+	 * 문자메시지에 대한 상세정보를 조회한다.
+	 */
+	@Override
+	public SmsVO selectSmsInf(SmsVO searchVO) {
+		SmsVO vo = smsDao.selectSmsInf(searchVO);
 
-	// 전화번호 포맷 처리
-	vo.setTrnsmitTelno(formatPhoneNumber(vo.getTrnsmitTelno()));
+		// 전화번호 포맷 처리
+		vo.setTrnsmitTelno(formatPhoneNumber(vo.getTrnsmitTelno()));
 
-	SmsRecptn recptn = new SmsRecptn();
+		SmsRecptn recptn = new SmsRecptn();
 
-	recptn.setSmsId(searchVO.getSmsId());
+		recptn.setSmsId(searchVO.getSmsId());
 
-	List<SmsRecptn> list = smsDao.selectSmsRecptnInfs(recptn);
+		List<SmsRecptn> list = smsDao.selectSmsRecptnInfs(recptn);
 
-	// 전화번호 포맷 처리
-	for (int i = 0; i < list.size(); i++) {
-	    String phone = list.get(i).getRecptnTelno();
-	    list.get(i).setRecptnTelno(formatPhoneNumber(phone));
+		// 전화번호 포맷 처리
+		for (int i = 0; i < list.size(); i++) {
+			String phone = list.get(i).getRecptnTelno();
+			list.get(i).setRecptnTelno(formatPhoneNumber(phone));
+		}
+
+		vo.setRecptn(list);
+
+		return vo;
 	}
 
-	vo.setRecptn(list);
-
-	return vo;
-    }
-
-    /**
-     * 문자메시지 실 전송을 요청한다.
-     */
-    public SmsConnection sendRequsest(SmsConnection smsConn) throws Exception {
-	String callTo = smsConn.getCallTo();
-	String callFrom = smsConn.getCallFrom();
-	String callBack = smsConn.getCallBack();
-	String callBackUrl = smsConn.getCallBackUrl();
-	String text = smsConn.getText();
-	String messageId = smsConn.getMessageId();	// messageId 지정 필요
-
-	LOGGER.info("------------------------");
-	LOGGER.info("callTo = {}", callTo);
-	LOGGER.info("callFrom = {}", callFrom);
-	LOGGER.info("callBack = {}", callBack);
-	LOGGER.info("callBackUrl = {}", callBackUrl);
-	LOGGER.info("text = {}", text);
-	LOGGER.info("messageId = {}", messageId);
-
-	// SMS 전송 요청
-	EgovSmsInfoSender sender = null;
-	SmsConnection result = null;
-	try {
-	    sender = new EgovSmsInfoSender(smeConfigPath);
-
-	    sender.open();
-	    result = sender.send(smsConn);
-	} finally {
-	    if (sender != null) {
-		sender.close();
-	    }
-	}
-
-	// Sender의 전송 결과는 SMS G/W 처리 상의 결과만 리턴함
-	// 이동통신사의 오류는 별도의 Receiver에서 수신 처리함 (로그 기록)
-
-	if (result != null) {  // 2011.10.21 보안점검 후속조치
-		smsConn.setResult(result.getResult());
-		smsConn.setResultMessage(result.getResultMessage());
-	}
-	return smsConn;
-    }
-
-    /**
-     * 여러 건의 문자메시지 실 전송을 요청한다.
-     *
-     * @param smsConn
-     * @return
-     * @throws Exception
-     */
-    public SmsConnection[] sendRequsest(SmsConnection[] smsConn) throws Exception {
-	EgovSmsInfoSender sender = null;
-
-	try {
-	    sender = new EgovSmsInfoSender(smeConfigPath);
-
-	    sender.open();
-
-	    // SMS 전송 요청
-	    SmsConnection result = null;
-	    for (int i = 0; i < smsConn.length; i++) {
-		String callTo = smsConn[i].getCallTo();
-		String callFrom = smsConn[i].getCallFrom();
-		String callBack = smsConn[i].getCallBack();
-		String callBackUrl = smsConn[i].getCallBackUrl();
-		String text = smsConn[i].getText();
-		String messageId = smsConn[i].getMessageId();	// messageId 지정 필요
+	/**
+	 * 문자메시지 실 전송을 요청한다.
+	 */
+	@Override
+	public SmsConnection sendRequsest(SmsConnection smsConn) {
+		String callTo = smsConn.getCallTo();
+		String callFrom = smsConn.getCallFrom();
+		String callBack = smsConn.getCallBack();
+		String callBackUrl = smsConn.getCallBackUrl();
+		String text = smsConn.getText();
+		String messageId = smsConn.getMessageId(); // messageId 지정 필요
 
 		LOGGER.info("------------------------");
-		LOGGER.info("callTo[{}] = {}", i, callTo);
-		LOGGER.info("callFrom[{}] = {}", i, callFrom);
-		LOGGER.info("callBack[{}] = {}", i, callBack);
-		LOGGER.info("callBackUrl[{}] = {}", i, callBackUrl);
-		LOGGER.info("text =[{}] = {}", i, text);
-		LOGGER.info("messageId[{}] = {}", i, messageId);
+		LOGGER.info("callTo = {}", callTo);
+		LOGGER.info("callFrom = {}", callFrom);
+		LOGGER.info("callBack = {}", callBack);
+		LOGGER.info("callBackUrl = {}", callBackUrl);
+		LOGGER.info("text = {}", text);
+		LOGGER.info("messageId = {}", messageId);
 
-		//smsConn[i] = sendRequsest(smsConn[i]);
-		result = sender.send(smsConn[i]);
+		// SMS 전송 요청
+		EgovSmsInfoSender sender = null;
+		SmsConnection result = null;
+		try {
+			sender = new EgovSmsInfoSender(smeConfigPath);
+
+			sender.open();
+			result = sender.send(smsConn);
+		} finally {
+			if (sender != null) {
+				sender.close();
+			}
+		}
 
 		// Sender의 전송 결과는 SMS G/W 처리 상의 결과만 리턴함
 		// 이동통신사의 오류는 별도의 Receiver에서 수신 처리함 (로그 기록)
 
-		smsConn[i].setResult(result.getResult());
-		smsConn[i].setResultMessage(result.getResultMessage());
-	    }
-
-	} finally {
-	    if (sender != null) {
-		sender.close();
-	    }
+		if (result != null) { // 2011.10.21 보안점검 후속조치
+			smsConn.setResult(result.getResult());
+			smsConn.setResultMessage(result.getResultMessage());
+		}
+		return smsConn;
 	}
 
-	return smsConn;
-    }
+	/**
+	 * 여러 건의 문자메시지 실 전송을 요청한다.
+	 *
+	 * @param smsConn
+	 * @return
+	 */
+	@Override
+	public SmsConnection[] sendRequsest(SmsConnection[] smsConn) {
+		EgovSmsInfoSender sender = null;
+
+		try {
+			sender = new EgovSmsInfoSender(smeConfigPath);
+
+			sender.open();
+
+			// SMS 전송 요청
+			SmsConnection result = null;
+			for (int i = 0; i < smsConn.length; i++) {
+				String callTo = smsConn[i].getCallTo();
+				String callFrom = smsConn[i].getCallFrom();
+				String callBack = smsConn[i].getCallBack();
+				String callBackUrl = smsConn[i].getCallBackUrl();
+				String text = smsConn[i].getText();
+				String messageId = smsConn[i].getMessageId(); // messageId 지정 필요
+
+				LOGGER.info("------------------------");
+				LOGGER.info("callTo[{}] = {}", i, callTo);
+				LOGGER.info("callFrom[{}] = {}", i, callFrom);
+				LOGGER.info("callBack[{}] = {}", i, callBack);
+				LOGGER.info("callBackUrl[{}] = {}", i, callBackUrl);
+				LOGGER.info("text =[{}] = {}", i, text);
+				LOGGER.info("messageId[{}] = {}", i, messageId);
+
+				// smsConn[i] = sendRequsest(smsConn[i]);
+				result = sender.send(smsConn[i]);
+
+				// Sender의 전송 결과는 SMS G/W 처리 상의 결과만 리턴함
+				// 이동통신사의 오류는 별도의 Receiver에서 수신 처리함 (로그 기록)
+
+				smsConn[i].setResult(result.getResult());
+				smsConn[i].setResultMessage(result.getResultMessage());
+			}
+
+		} finally {
+			if (sender != null) {
+				sender.close();
+			}
+		}
+
+		return smsConn;
+	}
 }

--- a/src/main/java/egovframework/com/cop/sms/service/impl/SmsBasicDAO.java
+++ b/src/main/java/egovframework/com/cop/sms/service/impl/SmsBasicDAO.java
@@ -7,25 +7,29 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.egovframe.rte.fdl.cmmn.exception.BaseRuntimeException;
+
 import egovframework.com.cop.sms.service.Sms;
 import egovframework.com.cop.sms.service.SmsRecptn;
 import egovframework.com.cop.sms.service.SmsVO;
 
 /**
  * 문자메시지를 위한 데이터 접근 클래스 (프레임워크 비종속 버전)
+ * 
  * @author 공통컴포넌트개발팀 한성곤
  * @since 2009.11.24
  * @version 1.0
  * @see
  *
- * <pre>
+ *      <pre>
  * << 개정이력(Modification Information) >>
  *   
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.11.24  한성곤          최초 생성
+ *   2024.08.27  이백행          컨트리뷰션 시큐어코딩 Exception 제거
  *
- * </pre>
+ *      </pre>
  */
 public class SmsBasicDAO {
 	/**
@@ -33,10 +37,10 @@ public class SmsBasicDAO {
 	 * 
 	 * @param SmsVO
 	 */
-	public List<SmsVO> selectSmsInfs(SmsVO vo) throws Exception {
+	public List<SmsVO> selectSmsInfs(SmsVO vo) {
 		List<SmsVO> list = new ArrayList<SmsVO>();
 
-		//variables
+		// variables
 		Connection conn = null;
 		PreparedStatement pstmt = null;
 		ResultSet rs = null;
@@ -54,7 +58,8 @@ public class SmsBasicDAO {
 
 			if ("0".equals(vo.getSearchCnd())) {
 				if (!"".equals(vo.getSearchWrd())) {
-					buffer.append("  AND a.SMS_ID in (SELECT SMS_ID FROM COMTNSMSRECPTN WHERE RECPTN_TELNO LIKE CONCAT ('%', ?,'%'))\n");
+					buffer.append(
+							"  AND a.SMS_ID in (SELECT SMS_ID FROM COMTNSMSRECPTN WHERE RECPTN_TELNO LIKE CONCAT ('%', ?,'%'))\n");
 				}
 			} else if ("1".equals(vo.getSearchCnd())) {
 				buffer.append("  AND a.TRNSMIS_CN LIKE CONCAT ('%', #searchWrd#,'%')\n");
@@ -65,25 +70,23 @@ public class SmsBasicDAO {
 
 			// for Oracle
 			/*
-			buffer.append("SELECT * FROM ( SELECT rownum rn, TB.* FROM (\n");
-			buffer.append("SELECT\n");
-			buffer.append("  a.SMS_ID, a.TRNSMIS_TELNO, a.TRNSMIS_CN,\n");
-			buffer.append("  (SELECT COUNT(*) FROM COMTNSMSRECPTN s WHERE s.SMS_ID = a.SMS_ID) as RECPTN_CNT,\n");
-			buffer.append("  TO_CHAR(a.FRST_REGIST_PNTTM, 'YYYY-MM-DD HH24:MI:SS') as FRST_REGIST_PNTTM\n");
-			buffer.append("FROM COMTNSMS a\n");
-			buffer.append("WHERE 1=1\n");
-
-			if ("0".equals(vo.getSearchCnd())) {
-			if (!"".equals(vo.getSearchWrd())) {
-			    buffer.append("  AND a.SMS_ID in (SELECT SMS_ID FROM COMTNSMSRECPTN WHERE RECPTN_TELNO LIKE '%' || ? || '%')\n");
-			}
-			} else if ("1".equals(vo.getSearchCnd())) {
-			buffer.append("  AND a.TRNSMIS_CN LIKE '%' || ? || '%'\n");
-			}
-
-			buffer.append("ORDER BY a.FRST_REGIST_PNTTM DESC\n");
-			buffer.append(") TB ) WHERE rn BETWEEN ? + 1 AND ? + ?");
-			*/
+			 * buffer.append("SELECT * FROM ( SELECT rownum rn, TB.* FROM (\n");
+			 * buffer.append("SELECT\n");
+			 * buffer.append("  a.SMS_ID, a.TRNSMIS_TELNO, a.TRNSMIS_CN,\n"); buffer.
+			 * append("  (SELECT COUNT(*) FROM COMTNSMSRECPTN s WHERE s.SMS_ID = a.SMS_ID) as RECPTN_CNT,\n"
+			 * ); buffer.
+			 * append("  TO_CHAR(a.FRST_REGIST_PNTTM, 'YYYY-MM-DD HH24:MI:SS') as FRST_REGIST_PNTTM\n"
+			 * ); buffer.append("FROM COMTNSMS a\n"); buffer.append("WHERE 1=1\n");
+			 * 
+			 * if ("0".equals(vo.getSearchCnd())) { if (!"".equals(vo.getSearchWrd())) {
+			 * buffer.
+			 * append("  AND a.SMS_ID in (SELECT SMS_ID FROM COMTNSMSRECPTN WHERE RECPTN_TELNO LIKE '%' || ? || '%')\n"
+			 * ); } } else if ("1".equals(vo.getSearchCnd())) {
+			 * buffer.append("  AND a.TRNSMIS_CN LIKE '%' || ? || '%'\n"); }
+			 * 
+			 * buffer.append("ORDER BY a.FRST_REGIST_PNTTM DESC\n");
+			 * buffer.append(") TB ) WHERE rn BETWEEN ? + 1 AND ? + ?");
+			 */
 
 			conn = SmsBasicDBUtil.getConnection();
 
@@ -105,10 +108,9 @@ public class SmsBasicDAO {
 
 			// for Oracle
 			/*
-			pstmt.setInt(++index, vo.getFirstIndex());
-			pstmt.setInt(++index, vo.getFirstIndex());
-			pstmt.setInt(++index, vo.getRecordCountPerPage());
-			*/
+			 * pstmt.setInt(++index, vo.getFirstIndex()); pstmt.setInt(++index,
+			 * vo.getFirstIndex()); pstmt.setInt(++index, vo.getRecordCountPerPage());
+			 */
 
 			rs = pstmt.executeQuery();
 
@@ -127,7 +129,8 @@ public class SmsBasicDAO {
 			}
 
 			return list;
-
+		} catch (SQLException e) {
+			throw new BaseRuntimeException("SQLException: selectSmsInfs", e);
 		} finally {
 			SmsBasicDBUtil.close(rs, pstmt, conn);
 		}
@@ -138,10 +141,9 @@ public class SmsBasicDAO {
 	 * 
 	 * @param SmsVO
 	 * @return
-	 * @throws Exception
 	 */
-	public int selectSmsInfsCnt(SmsVO vo) throws Exception {
-		//variables
+	public int selectSmsInfsCnt(SmsVO vo) {
+		// variables
 		Connection conn = null;
 		PreparedStatement pstmt = null;
 		ResultSet rs = null;
@@ -157,7 +159,8 @@ public class SmsBasicDAO {
 
 			if ("0".equals(vo.getSearchCnd())) {
 				if (!"".equals(vo.getSearchWrd())) {
-					buffer.append("  AND a.SMS_ID in (SELECT SMS_ID FROM COMTNSMSRECPTN WHERE RECPTN_TELNO LIKE CONCAT ('%', ?,'%'))\n");
+					buffer.append(
+							"  AND a.SMS_ID in (SELECT SMS_ID FROM COMTNSMSRECPTN WHERE RECPTN_TELNO LIKE CONCAT ('%', ?,'%'))\n");
 				}
 			} else if ("1".equals(vo.getSearchCnd())) {
 				buffer.append("  AND a.TRNSMIS_CN LIKE CONCAT ('%', #searchWrd#,'%')\n");
@@ -165,19 +168,15 @@ public class SmsBasicDAO {
 
 			// for Oracle
 			/*
-			buffer.append("SELECT\n");
-			buffer.append("  COUNT(a.SMS_ID) as cnt\n");
-			buffer.append("FROM COMTNSMS a\n");
-			buffer.append("WHERE 1=1\n");
-
-			if ("0".equals(vo.getSearchCnd())) {
-			if (!"".equals(vo.getSearchWrd())) {
-			    buffer.append("  AND a.SMS_ID in (SELECT SMS_ID FROM COMTNSMSRECPTN WHERE RECPTN_TELNO LIKE '%' || ? || '%')\n");
-			}
-			} else if ("1".equals(vo.getSearchCnd())) {
-			buffer.append("  AND a.TRNSMIS_CN LIKE '%' || ? || '%'\n");
-			}
-			*/
+			 * buffer.append("SELECT\n"); buffer.append("  COUNT(a.SMS_ID) as cnt\n");
+			 * buffer.append("FROM COMTNSMS a\n"); buffer.append("WHERE 1=1\n");
+			 * 
+			 * if ("0".equals(vo.getSearchCnd())) { if (!"".equals(vo.getSearchWrd())) {
+			 * buffer.
+			 * append("  AND a.SMS_ID in (SELECT SMS_ID FROM COMTNSMSRECPTN WHERE RECPTN_TELNO LIKE '%' || ? || '%')\n"
+			 * ); } } else if ("1".equals(vo.getSearchCnd())) {
+			 * buffer.append("  AND a.TRNSMIS_CN LIKE '%' || ? || '%'\n"); }
+			 */
 
 			conn = SmsBasicDBUtil.getConnection();
 
@@ -200,7 +199,8 @@ public class SmsBasicDAO {
 			}
 
 			return 0;
-
+		} catch (SQLException e) {
+			throw new BaseRuntimeException("SQLException: selectSmsInfsCnt", e);
 		} finally {
 			SmsBasicDBUtil.close(rs, pstmt, conn);
 		}
@@ -211,12 +211,11 @@ public class SmsBasicDAO {
 	 * 
 	 * @param notification
 	 * @return
-	 * @throws Exception
 	 */
-	public String insertSmsInf(Sms sms) throws Exception {
+	public String insertSmsInf(Sms sms) {
 		String smsId = null;
 
-		//variables
+		// variables
 		Connection conn = null;
 		PreparedStatement pstmt = null;
 
@@ -232,12 +231,11 @@ public class SmsBasicDAO {
 
 			// for Oracle
 			/*
-			buffer.append("INSERT INTO COMTNSMS\n");
-			buffer.append("  (SMS_ID, TRNSMIS_TELNO, TRNSMIS_CN,\n");
-			buffer.append("   FRST_REGISTER_ID, FRST_REGIST_PNTTM )\n");
-			buffer.append("VALUES\n");
-			buffer.append("(?, ?, ?, ?, SYSDATE)");
-			*/
+			 * buffer.append("INSERT INTO COMTNSMS\n");
+			 * buffer.append("  (SMS_ID, TRNSMIS_TELNO, TRNSMIS_CN,\n");
+			 * buffer.append("   FRST_REGISTER_ID, FRST_REGIST_PNTTM )\n");
+			 * buffer.append("VALUES\n"); buffer.append("(?, ?, ?, ?, SYSDATE)");
+			 */
 
 			conn = SmsBasicDBUtil.getConnection();
 
@@ -259,17 +257,15 @@ public class SmsBasicDAO {
 			conn.commit();
 
 			return smsId;
-		} catch (SQLException ex) {//KISA 보안약점 조치 (2018-10-29, 윤창원)
+		} catch (SQLException ex) {// KISA 보안약점 조치 (2018-10-29, 윤창원)
 			if (conn != null) {
-				conn.rollback();
+				try {
+					conn.rollback();
+				} catch (SQLException e) {
+					throw new BaseRuntimeException("SQLException: rollback", ex);
+				}
 			}
-			throw ex;
-		} catch (Exception ex) {
-			if (conn != null) {
-				conn.rollback();
-			}
-			throw ex;
-
+			throw new BaseRuntimeException("SQLException: insertSmsInf", ex);
 		} finally {
 			SmsBasicDBUtil.close(null, pstmt, conn);
 		}
@@ -277,11 +273,11 @@ public class SmsBasicDAO {
 
 	/**
 	 * 문자메시지 수신정보 및 결과 정보를 등록한다.
+	 * 
 	 * @param smsRecptn
-	 * @throws Exception
 	 */
-	public void insertSmsRecptnInf(SmsRecptn smsRecptn) throws Exception {
-		//variables
+	public void insertSmsRecptnInf(SmsRecptn smsRecptn) {
+		// variables
 		Connection conn = null;
 		PreparedStatement pstmt = null;
 
@@ -306,7 +302,8 @@ public class SmsBasicDAO {
 			pstmt.setString(++index, smsRecptn.getResultMssage());
 
 			pstmt.executeUpdate();
-
+		} catch (SQLException e) {
+			throw new BaseRuntimeException("SQLException: insertSmsRecptnInf", e);
 		} finally {
 			SmsBasicDBUtil.close(null, pstmt, conn);
 		}
@@ -318,10 +315,10 @@ public class SmsBasicDAO {
 	 * @param searchVO
 	 * @return
 	 */
-	public SmsVO selectSmsInf(SmsVO searchVO) throws Exception {
+	public SmsVO selectSmsInf(SmsVO searchVO) {
 		SmsVO smsVO = new SmsVO();
 
-		//variables
+		// variables
 		Connection conn = null;
 		PreparedStatement pstmt = null;
 		ResultSet rs = null;
@@ -341,15 +338,16 @@ public class SmsBasicDAO {
 
 			// for Oracle
 			/*
-			buffer.append("SELECT\n");
-			buffer.append("  a.SMS_ID, a.TRNSMIS_TELNO, a.TRNSMIS_CN,\n");
-			buffer.append("  a.FRST_REGISTER_ID, b.USER_NM as FRST_REGISTER_NM,\n");
-			buffer.append("  TO_CHAR(a.FRST_REGIST_PNTTM, 'YYYY-MM-DD') as FRST_REGIST_PNTTM\n");
-			buffer.append("FROM COMTNSMS a\n");
-			buffer.append("LEFT OUTER JOIN COMVNUSERMASTER b\n");
-			buffer.append("  ON a.FRST_REGISTER_ID = b.ESNTL_ID\n");
-			buffer.append("WHERE a.SMS_ID = ?\n");
-			*/
+			 * buffer.append("SELECT\n");
+			 * buffer.append("  a.SMS_ID, a.TRNSMIS_TELNO, a.TRNSMIS_CN,\n");
+			 * buffer.append("  a.FRST_REGISTER_ID, b.USER_NM as FRST_REGISTER_NM,\n");
+			 * buffer.
+			 * append("  TO_CHAR(a.FRST_REGIST_PNTTM, 'YYYY-MM-DD') as FRST_REGIST_PNTTM\n"
+			 * ); buffer.append("FROM COMTNSMS a\n");
+			 * buffer.append("LEFT OUTER JOIN COMVNUSERMASTER b\n");
+			 * buffer.append("  ON a.FRST_REGISTER_ID = b.ESNTL_ID\n");
+			 * buffer.append("WHERE a.SMS_ID = ?\n");
+			 */
 
 			conn = SmsBasicDBUtil.getConnection();
 
@@ -369,7 +367,8 @@ public class SmsBasicDAO {
 			}
 
 			return smsVO;
-
+		} catch (SQLException e) {
+			throw new BaseRuntimeException("SQLException: selectSmsInf", e);
 		} finally {
 			SmsBasicDBUtil.close(rs, pstmt, conn);
 		}
@@ -380,10 +379,10 @@ public class SmsBasicDAO {
 	 * 
 	 * @param SmsRecptn
 	 */
-	public List<SmsRecptn> selectSmsRecptnInfs(SmsRecptn vo) throws Exception {
+	public List<SmsRecptn> selectSmsRecptnInfs(SmsRecptn vo) {
 		List<SmsRecptn> list = new ArrayList<SmsRecptn>();
 
-		//variables
+		// variables
 		Connection conn = null;
 		PreparedStatement pstmt = null;
 		ResultSet rs = null;
@@ -421,22 +420,21 @@ public class SmsBasicDAO {
 			}
 
 			return list;
-
+		} catch (SQLException e) {
+			throw new BaseRuntimeException("SQLException: selectSmsRecptnInfs", e);
 		} finally {
 			SmsBasicDBUtil.close(rs, pstmt, conn);
 		}
 	}
 
 	/**
-	 * 문자메시지 전송 결과 수신을 처리한다.
-	 * EgovSmsInfoReceiver(Schedule job)에 의해 호출된다.
+	 * 문자메시지 전송 결과 수신을 처리한다. EgovSmsInfoReceiver(Schedule job)에 의해 호출된다.
 	 * 
 	 * @param smsRecptn
 	 * @return
-	 * @throws Exception
 	 */
-	public void updateSmsRecptnInf(SmsRecptn smsRecptn) throws Exception {
-		//variables
+	public void updateSmsRecptnInf(SmsRecptn smsRecptn) {
+		// variables
 		Connection conn = null;
 		PreparedStatement pstmt = null;
 
@@ -462,21 +460,20 @@ public class SmsBasicDAO {
 			pstmt.setString(++index, smsRecptn.getRecptnTelno());
 
 			pstmt.executeUpdate();
-
+		} catch (SQLException e) {
+			throw new BaseRuntimeException("SQLException: updateSmsRecptnInf", e);
 		} finally {
 			SmsBasicDBUtil.close(null, pstmt, conn);
 		}
 	}
 
 	/**
-	 * ID 처리.
-	 * transaction 처리를 위해 Connection을 파라미터로 넘겨받음
+	 * ID 처리. transaction 처리를 위해 Connection을 파라미터로 넘겨받음
 	 * 
 	 * @return
-	 * @throws Exception
 	 */
-	protected String getNextId(Connection conn) throws Exception {
-		//variables
+	protected String getNextId(Connection conn) {
+		// variables
 		PreparedStatement pstmt = null;
 		ResultSet rs = null;
 
@@ -484,14 +481,16 @@ public class SmsBasicDAO {
 
 		try {
 			// for mySql
-			buffer.append("SELECT CONCAT('SMSID_', LPAD(IFNULL(MAX(SUBSTR(SMS_ID, 7, 14)), 0) + 1, 14, '0')) as SMS_ID from COMTNSMS\n");
+			buffer.append(
+					"SELECT CONCAT('SMSID_', LPAD(IFNULL(MAX(SUBSTR(SMS_ID, 7, 14)), 0) + 1, 14, '0')) as SMS_ID from COMTNSMS\n");
 			buffer.append("WHERE SMS_ID LIKE 'SMSID_%'");
 
 			// for Oracle
 			/*
-			buffer.append("SELECT CONCAT('SMSID_', LPAD(IFNULL(MAX(SUBSTR(SMS_ID, 7, 14)), 0) + 1, 14, '0')) as SMS_ID from COMTNSMS\n");
-			buffer.append("WHERE SMS_ID LIKE 'SMSID_%'");
-			*/
+			 * buffer.
+			 * append("SELECT CONCAT('SMSID_', LPAD(IFNULL(MAX(SUBSTR(SMS_ID, 7, 14)), 0) + 1, 14, '0')) as SMS_ID from COMTNSMS\n"
+			 * ); buffer.append("WHERE SMS_ID LIKE 'SMSID_%'");
+			 */
 
 			pstmt = conn.prepareStatement(buffer.toString());
 
@@ -502,7 +501,8 @@ public class SmsBasicDAO {
 			}
 
 			return null;
-
+		} catch (SQLException e) {
+			throw new BaseRuntimeException("SQLException: getNextId", e);
 		} finally {
 			SmsBasicDBUtil.close(rs, pstmt, null);
 		}

--- a/src/main/java/egovframework/com/cop/sms/service/impl/SmsBasicDBUtil.java
+++ b/src/main/java/egovframework/com/cop/sms/service/impl/SmsBasicDBUtil.java
@@ -13,6 +13,7 @@ import org.apache.commons.dbcp2.PoolableConnection;
 import org.apache.commons.dbcp2.PoolableConnectionFactory;
 import org.apache.commons.pool2.impl.GenericObjectPool;
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
+import org.egovframe.rte.fdl.cmmn.exception.BaseRuntimeException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -20,25 +21,25 @@ import egovframework.com.cmm.service.EgovProperties;
 import egovframework.com.cmm.service.Globals;
 
 /**
- * 문자메시지를 위한 DB Util 클래스 (프레임워크 비종속 버전)
- * Apache commons의 DBCP를 활용한 예로 각 프로젝트에 맞게 수정 필요
- * (EX : DataSource 사용 등)
+ * 문자메시지를 위한 DB Util 클래스 (프레임워크 비종속 버전) Apache commons의 DBCP를 활용한 예로 각 프로젝트에 맞게
+ * 수정 필요 (EX : DataSource 사용 등)
  *
  * @author 공통컴포넌트개발팀 한성곤
  * @since 2009.11.24
  * @version 1.0
  * @see
  *
- * <pre>
+ *      <pre>
  * << 개정이력(Modification Information) >>
  *
  *  수정일                수정자           수정내용
  *  ----------   --------   ---------------------------
- *  2009.11.24   한성곤            최초 생성
- *  2017-02-13   이정은            시큐어코딩(ES) - 시큐어코딩 부적절한 예외 처리[CWE-253, CWE-440, CWE-754]
- *  2020-07-01   신용호            DBCP2 관련 변경사항 적용
+ *   2009.11.24  한성곤          최초 생성
+ *   2017.02.13  이정은          시큐어코딩(ES) - 시큐어코딩 부적절한 예외 처리[CWE-253, CWE-440, CWE-754]
+ *   2020.07.01  신용호          DBCP2 관련 변경사항 적용
+ *   2024.08.27  이백행          컨트리뷰션 시큐어코딩 Exception 제거
  *
- * </pre>
+ *      </pre>
  */
 public class SmsBasicDBUtil {
 	/** Driver load 여부 */
@@ -61,7 +62,8 @@ public class SmsBasicDBUtil {
 	/** 사용되지 않고 pool에 유지할 최소한의 커넥션 개수 */
 	private static final int MIN_IDLE = 5;
 	// 최대 커넥션이 20이고 maxIdle이 10인경우
-	// DB요청이 유휴상태가 되면 20개까지 생성된 커넥션풀은 10개까지 유휴커넥션으로 줄어들수 있다. (10~20개까지 커넥션풀의 개수가 생성및 반납을 반복한다.)
+	// DB요청이 유휴상태가 되면 20개까지 생성된 커넥션풀은 10개까지 유휴커넥션으로 줄어들수 있다. (10~20개까지 커넥션풀의 개수가 생성및
+	// 반납을 반복한다.)
 	// 이후 최소 IDLE까지 줄어들수 있다.
 	/** 커넥션 timeout */
 	private static final int MAX_WAIT_MILLIS = 20000;
@@ -77,36 +79,36 @@ public class SmsBasicDBUtil {
 	 * Connection Pool 생성.
 	 *
 	 * @param alias
-	 * @param bds
-	 * @throws Exception
+	 * @param bds   @
 	 */
 	protected static void createPools(String alias, BasicDataSource bds) {
-		
+
 		DataSourceConnectionFactory factory = new DataSourceConnectionFactory(bds);
 		PoolableConnectionFactory poolableConnectionFactory;
 
 		poolableConnectionFactory = new PoolableConnectionFactory(factory, null);
 
-		//커넥션이 유효한지 확인
+		// 커넥션이 유효한지 확인
 		poolableConnectionFactory.setValidationQuery(" SELECT 1 FROM DUAL ");
-		//커넥션 풀의 설정 정보를 생성
+		// 커넥션 풀의 설정 정보를 생성
 		GenericObjectPoolConfig<PoolableConnection> poolConfig = new GenericObjectPoolConfig<>();
-		//유효 커넥션 검사 주기
+		// 유효 커넥션 검사 주기
 		poolConfig.setTimeBetweenEvictionRuns(Duration.ofMillis(1000L * 60L * 1L));
-		//풀에 있는 커넥션이 유효한지 검사 유무 설정
+		// 풀에 있는 커넥션이 유효한지 검사 유무 설정
 		poolConfig.setTestWhileIdle(true);
-		//기본값  : false /true 일 경우 validationQuery 를 매번 수행한다.
+		// 기본값 : false /true 일 경우 validationQuery 를 매번 수행한다.
 		poolConfig.setTestOnBorrow(false);
-		//커넥션 최소개수 설정
+		// 커넥션 최소개수 설정
 		poolConfig.setMinIdle(bds.getMinIdle());
-		//반납직후 커넥션 최소개수 설정
+		// 반납직후 커넥션 최소개수 설정
 		poolConfig.setMaxIdle(bds.getMaxIdle());
-		//커넥션 최대 개수 설정
+		// 커넥션 최대 개수 설정
 		poolConfig.setMaxTotal(bds.getMaxTotal());
-		GenericObjectPool<PoolableConnection> connectionPool = new GenericObjectPool<PoolableConnection>(poolableConnectionFactory,poolConfig);
-		//PoolableConnectionFactory 커넥션 풀 연결
+		GenericObjectPool<PoolableConnection> connectionPool = new GenericObjectPool<PoolableConnection>(
+				poolableConnectionFactory, poolConfig);
+		// PoolableConnectionFactory 커넥션 풀 연결
 		poolableConnectionFactory.setPool(connectionPool);
-		
+
 		LOGGER.info("Pool : {}", poolableConnectionFactory.getClass().getName());
 
 	}
@@ -130,12 +132,17 @@ public class SmsBasicDBUtil {
 		LOGGER.info("Initialized pool : {}", JDBC_ALIAS);
 	}
 
-	public static Connection getConnection() throws Exception {
+	public static Connection getConnection() {
 		if (!isDriverLoaded) {
 			loadDriver();
 		}
 
-		Connection connection = DriverManager.getConnection("jdbc:apache:commons:dbcp:" + JDBC_ALIAS);
+		Connection connection;
+		try {
+			connection = DriverManager.getConnection("jdbc:apache:commons:dbcp:" + JDBC_ALIAS);
+		} catch (SQLException e) {
+			throw new BaseRuntimeException("SQLException: getConnection", e);
+		}
 		return connection;
 	}
 
@@ -143,21 +150,21 @@ public class SmsBasicDBUtil {
 		if (rs != null)
 			try {
 				rs.close();
-			//2017.02.08 	이정은 	시큐어코딩(ES)-부적절한 예외 처리[CWE-253, CWE-440, CWE-754]
+				// 2017.02.08 이정은 시큐어코딩(ES)-부적절한 예외 처리[CWE-253, CWE-440, CWE-754]
 			} catch (SQLException ignore) {
 				LOGGER.error("[SQLExceptionException] : database access error occurs");
 			}
 		if (stmt != null)
 			try {
 				stmt.close();
-			//2017.02.08 	이정은 	시큐어코딩(ES)-부적절한 예외 처리[CWE-253, CWE-440, CWE-754]
+				// 2017.02.08 이정은 시큐어코딩(ES)-부적절한 예외 처리[CWE-253, CWE-440, CWE-754]
 			} catch (SQLException ignore) {
 				LOGGER.error("[SQLExceptionException] : database access error occurs");
 			}
 		if (conn != null)
 			try {
 				conn.close();
-			//2017.02.08 	이정은 	시큐어코딩(ES)-부적절한 예외 처리[CWE-253, CWE-440, CWE-754]
+				// 2017.02.08 이정은 시큐어코딩(ES)-부적절한 예외 처리[CWE-253, CWE-440, CWE-754]
 			} catch (SQLException ignore) {
 				LOGGER.error("[SQLExceptionException] : database access error occurs");
 			}

--- a/src/main/java/egovframework/com/cop/sms/web/EgovSmsInfoController.java
+++ b/src/main/java/egovframework/com/cop/sms/web/EgovSmsInfoController.java
@@ -4,6 +4,8 @@ import java.util.Map;
 
 import javax.annotation.Resource;
 
+import org.egovframe.rte.fdl.property.EgovPropertyService;
+import org.egovframe.rte.ptl.mvc.tags.ui.pagination.PaginationInfo;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
@@ -21,25 +23,25 @@ import egovframework.com.cop.sms.service.EgovSmsInfoService;
 import egovframework.com.cop.sms.service.Sms;
 import egovframework.com.cop.sms.service.SmsVO;
 import egovframework.com.utl.fcc.service.EgovStringUtil;
-import org.egovframe.rte.fdl.property.EgovPropertyService;
-import org.egovframe.rte.ptl.mvc.tags.ui.pagination.PaginationInfo;
 
 /**
  * 문자메시지 서비스 컨트롤러 클래스
+ * 
  * @author 공통컴포넌트개발팀 한성곤
  * @since 2009.06.18
  * @version 1.0
  * @see
  *
- * <pre>
+ *      <pre>
  * << 개정이력(Modification Information) >>
  *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
- *   2009.06.18 한성곤          최초 생성
- *   2011.8.26	정진오			IncludedInfo annotation 추가
+ *   2009.06.18  한성곤          최초 생성
+ *   2011.08.26  정진오          IncludedInfo annotation 추가
+ *   2024.08.27  이백행          컨트리뷰션 시큐어코딩 Exception 제거
  *
- * </pre>
+ *      </pre>
  */
 
 @Controller
@@ -57,7 +59,8 @@ public class EgovSmsInfoController {
 	@Autowired
 	private DefaultBeanValidator beanValidator;
 
-	//private static final Logger LOGGER = LoggerFactory.getLogger(EgovSmsInfoController.class);
+	// private static final Logger LOGGER =
+	// LoggerFactory.getLogger(EgovSmsInfoController.class);
 
 	/**
 	 * 문자메시지 목록을 조회한다.
@@ -65,18 +68,17 @@ public class EgovSmsInfoController {
 	 * @param smsVO
 	 * @param model
 	 * @return
-	 * @throws Exception
 	 */
 	@IncludedInfo(name = "문자메시지", order = 310, gid = 40)
 	@RequestMapping("/cop/sms/selectSmsList.do")
-	public String selectSmsList(@ModelAttribute("searchVO") SmsVO smsVO, ModelMap model) throws Exception {
+	public String selectSmsList(@ModelAttribute("searchVO") SmsVO smsVO, ModelMap model) {
 		LoginVO user = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();
-   	 	// KISA 보안취약점 조치 (2018-12-10, 신용호)
-        Boolean isAuthenticated = EgovUserDetailsHelper.isAuthenticated();
+		// KISA 보안취약점 조치 (2018-12-10, 신용호)
+		Boolean isAuthenticated = EgovUserDetailsHelper.isAuthenticated();
 
-        if(!isAuthenticated) {
-            return "redirect:/uat/uia/egovLoginUsr.do";
-        }
+		if (!isAuthenticated) {
+			return "redirect:/uat/uia/egovLoginUsr.do";
+		}
 
 		smsVO.setUniqId(user == null ? "" : EgovStringUtil.isNullToString(user.getUniqId()));
 
@@ -111,10 +113,9 @@ public class EgovSmsInfoController {
 	 * @param smsVO
 	 * @param model
 	 * @return
-	 * @throws Exception
 	 */
 	@RequestMapping("/cop/sms/addSms.do")
-	public String addSms(@ModelAttribute("searchVO") SmsVO smsVO, ModelMap model) throws Exception {
+	public String addSms(@ModelAttribute("searchVO") SmsVO smsVO, ModelMap model) {
 
 		Sms sms = new Sms();
 
@@ -135,8 +136,8 @@ public class EgovSmsInfoController {
 	 * @throws Exception
 	 */
 	@RequestMapping("/cop/sms/insertSms.do")
-	public String insertSms(@ModelAttribute("searchVO") SmsVO smsVO, @ModelAttribute("sms") Sms sms, BindingResult bindingResult, SessionStatus status, ModelMap model)
-			throws Exception {
+	public String insertSms(@ModelAttribute("searchVO") SmsVO smsVO, @ModelAttribute("sms") Sms sms,
+			BindingResult bindingResult, SessionStatus status, ModelMap model) throws Exception {
 
 		LoginVO user = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();
 		Boolean isAuthenticated = EgovUserDetailsHelper.isAuthenticated();
@@ -148,11 +149,9 @@ public class EgovSmsInfoController {
 
 		// 서버 점검 추가
 		/*
-		if (true) {
-		    model.addAttribute("msg", "서버와의 연결이 정상적이지 않습니다.");
-		    return "egovframework/com/cop/sms/EgovSmsInfoRegist";
-		}
-		*/
+		 * if (true) { model.addAttribute("msg", "서버와의 연결이 정상적이지 않습니다."); return
+		 * "egovframework/com/cop/sms/EgovSmsInfoRegist"; }
+		 */
 
 		if (isAuthenticated) {
 			sms.setFrstRegisterId(user == null ? "" : EgovStringUtil.isNullToString(user.getUniqId()));
@@ -169,17 +168,16 @@ public class EgovSmsInfoController {
 	 * @param smsVO
 	 * @param model
 	 * @return
-	 * @throws Exception
 	 */
 	@RequestMapping("/cop/sms/selectSms.do")
-	public String selectSms(@ModelAttribute("searchVO") SmsVO smsVO, ModelMap model) throws Exception {
+	public String selectSms(@ModelAttribute("searchVO") SmsVO smsVO, ModelMap model) {
 		LoginVO user = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();
-   	 	// KISA 보안취약점 조치 (2018-12-10, 신용호)
-        Boolean isAuthenticated = EgovUserDetailsHelper.isAuthenticated();
+		// KISA 보안취약점 조치 (2018-12-10, 신용호)
+		Boolean isAuthenticated = EgovUserDetailsHelper.isAuthenticated();
 
-        if(!isAuthenticated) {
-            return "redirect:/uat/uia/egovLoginUsr.do";
-        }
+		if (!isAuthenticated) {
+			return "redirect:/uat/uia/egovLoginUsr.do";
+		}
 
 		SmsVO vo = smsInfoService.selectSmsInf(smsVO);
 


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

## 310. 문자메시지 시큐어코딩 Exception 제거

크롬 링크 주소 복사
```
http://localhost:8080/egovframework-all-in-one/cop/sms/selectSmsList.do
```

검색(Search)
```
/cop/sms/selectSmsList.do
```

새 브랜치:
```
2024/pmd/EgovSmsInfoController
```

310. 문자메시지 시큐어코딩 Exception 제거
- `@throws Exception/throws Exception/throws ParseException/throws SMEException/catch (Exception` 제거
- ` *   2024.08.27  이백행          컨트리뷰션 시큐어코딩 Exception 제거` 개정이력 수정
- Source > Format

```java
throw new BaseRuntimeException("SQLException: getConnection", e);
throw new BaseRuntimeException("Exception: configSet", e);
throw new BaseRuntimeException("SMEException: SMEConnectionFactoryImpl", e);
throw new BaseRuntimeException("SQLException: selectSmsInfsCnt", e);
throw new BaseRuntimeException("SQLException: insertSmsInf", ex);
throw processException("fail.common.msg", e);
```

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [x] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

https://youtu.be/ic7FsLG8oTg
