### PR TITLE
[기능개선] 1300. 공휴일관리(달력) - 등록/수정 화면과 처리 로직 분리, 백엔드 필수값 검증 적용

### DIFF
--- a/src/main/java/egovframework/com/sym/cal/service/Restde.java
+++ b/src/main/java/egovframework/com/sym/cal/service/Restde.java
@@ -1,5 +1,6 @@
 package egovframework.com.sym.cal.service;
 
+import javax.validation.constraints.NotEmpty;
 import java.io.Serializable;
 
 /**
@@ -30,21 +31,25 @@ public class Restde implements Serializable {
     /*
      * 휴일일자
      */
+	@NotEmpty(message = "휴일일자{common.required.msg}")
     private String restdeDe       = "";
 
     /*
      * 휴일명
      */
+	@NotEmpty(message = "휴일명{common.required.msg}")
     private String restdeNm       = "";
 
     /*
      * 휴일설명
      */
+	@NotEmpty(message = "휴일설명{common.required.msg}")
     private String restdeDc       = "";
 
     /*
      * 휴일구분
      */
+	@NotEmpty(message = "휴일구분{common.required.msg}")
     private String restdeSe       = "";
 
     /*
@@ -400,5 +405,19 @@ public class Restde implements Serializable {
 		this.lastDayMonth = lastDayMonth;
 	}
 
+	/**
+	 * restdeDe 값을 "yyyy-mm-dd" 형식으로 반환한다.
+	 * @return
+	 */
+	public String getFormattedRestdeDe() {
+		if (restdeDe != null && restdeDe.length() == 8 && restdeDe.matches("\\d{8}")) {
+			String year = restdeDe.substring(0, 4);
+			String month = restdeDe.substring(4, 6);
+			String day = restdeDe.substring(6, 8);
+			return year + "-" + month + "-" + day;
+		} else {
+			return restdeDe;
+		}
+	}
 
 }

--- a/src/main/java/egovframework/com/sym/cal/web/EgovCalRestdeManageController.java
+++ b/src/main/java/egovframework/com/sym/cal/web/EgovCalRestdeManageController.java
@@ -26,10 +26,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.ObjectError;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.*;
 import org.springmodules.validation.commons.DefaultBeanValidator;
 
 /**
@@ -1393,7 +1390,7 @@ public class EgovCalRestdeManageController {
 	 * @return "egovframework/com/sym/cal/EgovRestdeRegist"
 	 * @throws Exception
 	 */
-	@RequestMapping(value = "/sym/cal/EgovRestdeRegist.do", method = RequestMethod.GET)
+	@GetMapping("/sym/cal/EgovRestdeRegist.do")
 	public String insertRestde(@ModelAttribute("loginVO") LoginVO loginVO
 			, ModelMap model
 	) throws Exception {
@@ -1415,7 +1412,7 @@ public class EgovCalRestdeManageController {
 	 * @return
 	 * @throws Exception
 	 */
-	@RequestMapping(value = "/sym/cal/EgovRestdeRegist.do", method = RequestMethod.POST)
+	@PostMapping(value = "/sym/cal/EgovRestdeRegist.do")
 	public String insertRestde(@ModelAttribute("loginVO") LoginVO loginVO
 			, @ModelAttribute("restde") Restde restde
 			, BindingResult bindingResult
@@ -1505,7 +1502,7 @@ public class EgovCalRestdeManageController {
 	 * @return "egovframework/com/sym/cal/EgovRestdeModify"
 	 * @throws Exception
 	 */
-	@RequestMapping(value = "/sym/cal/EgovRestdeModify.do", method = RequestMethod.GET)
+	@GetMapping("/sym/cal/EgovRestdeModify.do")
 	public String updateRestde(@ModelAttribute("loginVO") LoginVO loginVO
 			, @ModelAttribute("restde") Restde restde
 			, ModelMap model
@@ -1532,7 +1529,7 @@ public class EgovCalRestdeManageController {
 	 * @return
 	 * @throws Exception
 	 */
-	@RequestMapping(value = "/sym/cal/EgovRestdeModify.do", method = RequestMethod.POST)
+	@PostMapping("/sym/cal/EgovRestdeModify.do")
 	public String updateRestde(@ModelAttribute("loginVO") LoginVO loginVO
 			, @ModelAttribute("restde") Restde restde
 			, BindingResult bindingResult

--- a/src/main/java/egovframework/com/sym/cal/web/EgovCalRestdeManageController.java
+++ b/src/main/java/egovframework/com/sym/cal/web/EgovCalRestdeManageController.java
@@ -1390,7 +1390,7 @@ public class EgovCalRestdeManageController {
 	 * @return "egovframework/com/sym/cal/EgovRestdeRegist"
 	 * @throws Exception
 	 */
-	@GetMapping("/sym/cal/EgovRestdeRegist.do")
+	@GetMapping("/sym/cal/EgovRestdeRegistView.do")
 	public String insertRestde(@ModelAttribute("loginVO") LoginVO loginVO
 			, ModelMap model
 	) throws Exception {
@@ -1502,7 +1502,7 @@ public class EgovCalRestdeManageController {
 	 * @return "egovframework/com/sym/cal/EgovRestdeModify"
 	 * @throws Exception
 	 */
-	@GetMapping("/sym/cal/EgovRestdeModify.do")
+	@GetMapping("/sym/cal/EgovRestdeModifyView.do")
 	public String updateRestde(@ModelAttribute("loginVO") LoginVO loginVO
 			, @ModelAttribute("restde") Restde restde
 			, ModelMap model

--- a/src/main/webapp/WEB-INF/jsp/egovframework/com/sym/cal/EgovRestdeDetail.jsp
+++ b/src/main/webapp/WEB-INF/jsp/egovframework/com/sym/cal/EgovRestdeDetail.jsp
@@ -42,7 +42,7 @@ function fn_egov_list_Restde(){
  ******************************************************** */
 function fn_egov_modify_Restde(){
 	var varForm				 = document.all["Form"];
-	varForm.action           = "<c:url value='/sym/cal/EgovRestdeModify.do'/>";
+	varForm.action           = "<c:url value='/sym/cal/EgovRestdeModifyView.do'/>";
 	varForm.restdeNo.value   = "${result.restdeNo}";
 	varForm.method = "get";
 	varForm.submit();

--- a/src/main/webapp/WEB-INF/jsp/egovframework/com/sym/cal/EgovRestdeDetail.jsp
+++ b/src/main/webapp/WEB-INF/jsp/egovframework/com/sym/cal/EgovRestdeDetail.jsp
@@ -44,6 +44,7 @@ function fn_egov_modify_Restde(){
 	var varForm				 = document.all["Form"];
 	varForm.action           = "<c:url value='/sym/cal/EgovRestdeModify.do'/>";
 	varForm.restdeNo.value   = "${result.restdeNo}";
+	varForm.method = "get";
 	varForm.submit();
 }
 /* ********************************************************

--- a/src/main/webapp/WEB-INF/jsp/egovframework/com/sym/cal/EgovRestdeList.jsp
+++ b/src/main/webapp/WEB-INF/jsp/egovframework/com/sym/cal/EgovRestdeList.jsp
@@ -51,7 +51,7 @@ function fn_egov_search_Restde(){
  * 등록 처리 함수
  ******************************************************** */
 function fn_egov_regist_Restde(){
-	location.href = "<c:url value='/sym/cal/EgovRestdeRegist.do' />";
+	location.href = "<c:url value='/sym/cal/EgovRestdeRegistView.do' />";
 }
 /* ********************************************************
  * 상세회면 처리 함수

--- a/src/main/webapp/WEB-INF/jsp/egovframework/com/sym/cal/EgovRestdeModify.jsp
+++ b/src/main/webapp/WEB-INF/jsp/egovframework/com/sym/cal/EgovRestdeModify.jsp
@@ -45,10 +45,10 @@ function fn_egov_list_Restde(){
  * 저장처리화면
  ******************************************************** */
 function fn_egov_regist_Restde(form){
-	if(confirm("<spring:message code='common.save.msg'/>")){
-		if(!validateRestde(form)){
-			return;
-		}else{
+	if (confirm("<spring:message code='common.save.msg'/>")) {
+		if (!validateRestde(form)) {
+		 	return;
+		} else {
 			form.submit();
 		}
 	}
@@ -59,7 +59,7 @@ function fn_egov_regist_Restde(form){
 <body>
 <noscript class="noScriptTitle"><spring:message code="common.noScriptTitle.msg" /></noscript>
 
-<form:form modelAttribute="restde" name="restde" method="post">
+<form:form modelAttribute="restde" name="restde" method="post" action="/sym/cal/EgovRestdeModify.do">
 <input name="cmd" type="hidden" value="Modify">
 <form:hidden path="restdeNo"/>
 <form:hidden path="restdeDe"/>

--- a/src/main/webapp/WEB-INF/jsp/egovframework/com/sym/cal/EgovRestdeRegist.jsp
+++ b/src/main/webapp/WEB-INF/jsp/egovframework/com/sym/cal/EgovRestdeRegist.jsp
@@ -46,10 +46,10 @@ function fn_egov_list_Restde(){
  * 저장처리화면
  ******************************************************** */
  function fn_egov_regist_Restde(form){
-	if(confirm("<spring:message code='common.save.msg' />")){
-		if(!validateRestde(form)){
+	if (confirm("<spring:message code='common.save.msg' />")) {
+		if (!validateRestde(form)) {
 			return;
-		}else{
+		} else {
 			form.submit();
 		}
 	}
@@ -75,30 +75,30 @@ function fn_egov_list_Restde(){
 		<tr>
 			<th><spring:message code="sym.cal.restDay" /> <span class="pilsu">*</span></th><!-- 휴일일자 -->
 			<td class="left">
-			    <input type="hidden" name="cal_url" value="<c:url value='/sym/cal/EgovNormalCalPopup.do'/>" />
-		    	<form:hidden path="restdeDe" />
-				<input name="vrestdeDe" type="text" value=""  maxlength="10" readonly="readonly" onclick="fn_egov_NormalCalendar(document.restde, document.restde.restdeDe, document.restde.vrestdeDe);" title="<spring:message code="sym.cal.restDay" />(새창)" style="width:70px"/>
+				<input type="hidden" name="cal_url" value="<c:url value='/sym/cal/EgovNormalCalPopup.do'/>" />
+				<form:hidden path="restdeDe" />
+				<input name="vrestdeDe" type="text" value="${restde.formattedRestdeDe}"  maxlength="10" readonly="readonly" onclick="fn_egov_NormalCalendar(document.restde, document.restde.restdeDe, document.restde.vrestdeDe);" title="<spring:message code="sym.cal.restDay" />(새창)" style="width:70px"/>
 				<a href="#noscript" onclick="fn_egov_NormalCalendar(document.restde, document.restde.restdeDe, document.restde.vrestdeDe); return false;"><img src="<c:url value='/images/egovframework/com/cmm/icon/bu_icon_carlendar.gif' />" alt="달력창팝업버튼이미지"/></a>
 			</td>
 		</tr>
 		<tr>
 			<th><spring:message code="sym.cal.restName" /> <span class="pilsu">*</span></th><!-- 휴일명 -->
 			<td class="left">
-			    <form:input  path="restdeNm" size="50" maxlength="50" title="<spring:message code='sym.cal.restName' />"/>
-      			<form:errors path="restdeNm"/>
+				<form:input  path="restdeNm" size="50" maxlength="50" title="<spring:message code='sym.cal.restName' />"/>
+				<form:errors path="restdeNm"/>
 			</td>
 		</tr>
 		<tr>
 			<th><spring:message code="sym.cal.restDetail" /> <span class="pilsu">*</span></th><!-- 휴일설명 -->
 			<td class="left">
-			    <form:textarea path="restdeDc" rows="3" cols="60" title="<spring:message code='sym.cal.restDetail' />"/>
-      			<form:errors   path="restdeDc"/>
+				<form:textarea path="restdeDc" rows="3" cols="60" title="<spring:message code='sym.cal.restDetail' />"/>
+				<form:errors   path="restdeDc"/>
 			</td>
 		</tr>
 		<tr>
 			<th><spring:message code="sym.cal.restCategory" /> <span class="pilsu">*</span></th>
 			<td class="left">
-			    <form:select path="restdeSeCode" title="<spring:message code='sym.cal.restCategory' />">
+				<form:select path="restdeSeCode" title="<spring:message code='sym.cal.restCategory' />">
 				<form:options items="${restdeCode}" itemValue="code" itemLabel="codeNm" />
 				</form:select>
 			</td>

--- a/src/main/webapp/WEB-INF/jsp/egovframework/com/sym/cal/EgovRestdeRegist.jsp
+++ b/src/main/webapp/WEB-INF/jsp/egovframework/com/sym/cal/EgovRestdeRegist.jsp
@@ -60,7 +60,7 @@ function fn_egov_list_Restde(){
 <body>
 <noscript class="noScriptTitle"><spring:message code="common.noScriptTitle.msg" /></noscript>
 
-<form:form modelAttribute="restde" name="restde" method="post">
+<form:form modelAttribute="restde" name="restde" method="post" action="/sym/cal/EgovRestdeRegist.do">
 
 <div class="wTableFrm">
 	<!-- 타이틀 -->

--- a/src/test/java/egovframework/com/sym/cal/service/RestdeTest.java
+++ b/src/test/java/egovframework/com/sym/cal/service/RestdeTest.java
@@ -1,0 +1,87 @@
+package egovframework.com.sym.cal.service;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class RestdeTest {
+
+	@Test
+	public void test_getFormattedRestdeDe_validDate() {
+		// Given
+		Restde restde = new Restde();
+		restde.setRestdeDe("20240831"); // 올바른 8자리 날짜 입력
+
+		// When
+		String formattedDate = restde.getFormattedRestdeDe();
+
+		// Then
+		assertEquals("2024-08-31", formattedDate); // 예상되는 출력
+	}
+
+	@Test
+	public void test_getFormattedRestdeDe_nullValue() {
+		// Given
+		Restde restde = new Restde();
+		restde.setRestdeDe(null); // null 입력
+
+		// When
+		String formattedDate = restde.getFormattedRestdeDe();
+
+		// Then
+		assertEquals(null, formattedDate); // null 반환
+	}
+
+	@Test
+	public void test_getFormattedRestdeDe_emptyValue() {
+		// Given
+		Restde restde = new Restde();
+		restde.setRestdeDe(""); // 빈 문자열 입력
+
+		// When
+		String formattedDate = restde.getFormattedRestdeDe();
+
+		// Then
+		assertEquals("", formattedDate); // 빈 문자열 반환
+	}
+
+	@Test
+	public void test_getFormattedRestdeDe_invalidLength() {
+		// Given
+		Restde restde = new Restde();
+		restde.setRestdeDe("202408"); // 잘못된 길이의 입력
+
+		// When
+		String formattedDate = restde.getFormattedRestdeDe();
+
+		// Then
+		assertEquals("202408", formattedDate); // 원래 문자열 반환
+	}
+
+	@Test
+	public void test_getFormattedRestdeDe_nonNumericValue() {
+		// Given
+		Restde restde = new Restde();
+		restde.setRestdeDe("abcd1234"); // 숫자가 아닌 문자가 포함된 입력
+
+		// When
+		String formattedDate = restde.getFormattedRestdeDe();
+
+		// Then
+		assertEquals("abcd1234", formattedDate); // 원래 문자열 반환
+	}
+
+	@Test
+	public void test_getFormattedRestdeDe_partialNonNumericValue() {
+		// Given
+		Restde restde = new Restde();
+		restde.setRestdeDe("2024abcd"); // 부분적으로 숫자가 아닌 문자가 포함된 입력
+
+		// When
+		String formattedDate = restde.getFormattedRestdeDe();
+
+		// Then
+		assertEquals("2024abcd", formattedDate); // 원래 문자열 반환
+	}
+
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [ ] 버그수정 Bug fixes
- [X] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

1. `EgovCalRestdeManageController` 의 화면/처리 메서드 분리
- 화면을 보여주기 위한 처리와 데이터 등록 처리를 하나의 메서드에서 담당하고 있어 하나의 메서드가 하나의 역할을 할 수 있도록 분리하였습니다.
  - 등록
    - 화면 : `/sym/cal/EgovRestdeRegistView.do`
    - 처리 : `/sym/cal/EgovRestdeRegist.do`
  - 수정
    - 화면 : `/sym/cal/EgovRestdeModifyView.do`
    - 처리 : `/sym/cal/EgovRestdeModify.do`
2. 위 사유 (하나의 메서드에서 화면과 처리를 함께함)로 인해 bindingResult가 작동하지 않는 점을 개선했습니다.
- bindingResult 처리를 위해 `Restde` class에 validation annotation을 추가
3. validation 실패 시 사용자가 작성 화면으로 돌아갈 때 원래 작성중이던 값의 세팅을 위한 method 추가
- `Restde` class에 `getFormattedRestdeDe` 메서드 추가
  - 화면에서 날짜 정보를 불러올 때 formatting 된 값을 반환하여 spring form에 binding하기 위함
- `getFormattedRestdeDe`  메서드에 대한 테스트 클래스 `RestdeTest` 추가



## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [x] JUnit 테스트 JUnit tests
- [x] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [X] Chrome
- [X] Firefox
- [X] Edge
- [X] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

### 추가한 메서드 junit test
![image](https://github.com/user-attachments/assets/91fab8d8-9022-46af-a09c-8edba6438643)

### 등록

https://github.com/user-attachments/assets/1d63511e-ed51-47d8-b250-a5a4d3b35fb1


### 수정

https://github.com/user-attachments/assets/aa6762c8-ace9-46e1-bf15-f8cf1e64f068


### 삭제

https://github.com/user-attachments/assets/efc7538e-02fd-4e59-b4df-a5457816bb14


### 검색

https://github.com/user-attachments/assets/74bda38f-c778-4910-86d9-10c2538fe821


### validation
- 스크립트에서 validation이 실패한 경우 서버 validation 메시지가 binding


https://github.com/user-attachments/assets/3bec61a0-37cb-4625-9708-5f4c66b658e1








