### PR TITLE
1000. 우편번호 관리 - 등록/수정 화면과 처리 로직 분리, 백엔드 필수값 검증 적용

### DIFF
--- a/src/main/java/egovframework/com/sym/cal/service/Restde.java
+++ b/src/main/java/egovframework/com/sym/cal/service/Restde.java
@@ -1,5 +1,6 @@
 package egovframework.com.sym.cal.service;
 
+import javax.validation.constraints.NotEmpty;
 import java.io.Serializable;
 
 /**
@@ -30,21 +31,25 @@ public class Restde implements Serializable {
     /*
      * 휴일일자
      */
+	@NotEmpty(message = "휴일일자{common.required.msg}")
     private String restdeDe       = "";
 
     /*
      * 휴일명
      */
+	@NotEmpty(message = "휴일명{common.required.msg}")
     private String restdeNm       = "";
 
     /*
      * 휴일설명
      */
+	@NotEmpty(message = "휴일설명{common.required.msg}")
     private String restdeDc       = "";
 
     /*
      * 휴일구분
      */
+	@NotEmpty(message = "휴일구분{common.required.msg}")
     private String restdeSe       = "";
 
     /*
@@ -400,5 +405,19 @@ public class Restde implements Serializable {
 		this.lastDayMonth = lastDayMonth;
 	}
 
+	/**
+	 * restdeDe 값을 "yyyy-mm-dd" 형식으로 반환한다.
+	 * @return
+	 */
+	public String getFormattedRestdeDe() {
+		if (restdeDe != null && restdeDe.length() == 8 && restdeDe.matches("\\d{8}")) {
+			String year = restdeDe.substring(0, 4);
+			String month = restdeDe.substring(4, 6);
+			String day = restdeDe.substring(6, 8);
+			return year + "-" + month + "-" + day;
+		} else {
+			return restdeDe;
+		}
+	}
 
 }

--- a/src/main/java/egovframework/com/sym/cal/web/EgovCalRestdeManageController.java
+++ b/src/main/java/egovframework/com/sym/cal/web/EgovCalRestdeManageController.java
@@ -26,10 +26,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.ObjectError;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.*;
 import org.springmodules.validation.commons.DefaultBeanValidator;
 
 /**
@@ -1393,7 +1390,7 @@ public class EgovCalRestdeManageController {
 	 * @return "egovframework/com/sym/cal/EgovRestdeRegist"
 	 * @throws Exception
 	 */
-	@RequestMapping(value = "/sym/cal/EgovRestdeRegist.do", method = RequestMethod.GET)
+	@GetMapping("/sym/cal/EgovRestdeRegist.do")
 	public String insertRestde(@ModelAttribute("loginVO") LoginVO loginVO
 			, ModelMap model
 	) throws Exception {
@@ -1415,7 +1412,7 @@ public class EgovCalRestdeManageController {
 	 * @return
 	 * @throws Exception
 	 */
-	@RequestMapping(value = "/sym/cal/EgovRestdeRegist.do", method = RequestMethod.POST)
+	@PostMapping(value = "/sym/cal/EgovRestdeRegist.do")
 	public String insertRestde(@ModelAttribute("loginVO") LoginVO loginVO
 			, @ModelAttribute("restde") Restde restde
 			, BindingResult bindingResult
@@ -1505,7 +1502,7 @@ public class EgovCalRestdeManageController {
 	 * @return "egovframework/com/sym/cal/EgovRestdeModify"
 	 * @throws Exception
 	 */
-	@RequestMapping(value = "/sym/cal/EgovRestdeModify.do", method = RequestMethod.GET)
+	@GetMapping("/sym/cal/EgovRestdeModify.do")
 	public String updateRestde(@ModelAttribute("loginVO") LoginVO loginVO
 			, @ModelAttribute("restde") Restde restde
 			, ModelMap model
@@ -1532,7 +1529,7 @@ public class EgovCalRestdeManageController {
 	 * @return
 	 * @throws Exception
 	 */
-	@RequestMapping(value = "/sym/cal/EgovRestdeModify.do", method = RequestMethod.POST)
+	@PostMapping("/sym/cal/EgovRestdeModify.do")
 	public String updateRestde(@ModelAttribute("loginVO") LoginVO loginVO
 			, @ModelAttribute("restde") Restde restde
 			, BindingResult bindingResult

--- a/src/main/java/egovframework/com/sym/cal/web/EgovCalRestdeManageController.java
+++ b/src/main/java/egovframework/com/sym/cal/web/EgovCalRestdeManageController.java
@@ -1390,7 +1390,7 @@ public class EgovCalRestdeManageController {
 	 * @return "egovframework/com/sym/cal/EgovRestdeRegist"
 	 * @throws Exception
 	 */
-	@GetMapping("/sym/cal/EgovRestdeRegist.do")
+	@GetMapping("/sym/cal/EgovRestdeRegistView.do")
 	public String insertRestde(@ModelAttribute("loginVO") LoginVO loginVO
 			, ModelMap model
 	) throws Exception {
@@ -1502,7 +1502,7 @@ public class EgovCalRestdeManageController {
 	 * @return "egovframework/com/sym/cal/EgovRestdeModify"
 	 * @throws Exception
 	 */
-	@GetMapping("/sym/cal/EgovRestdeModify.do")
+	@GetMapping("/sym/cal/EgovRestdeModifyView.do")
 	public String updateRestde(@ModelAttribute("loginVO") LoginVO loginVO
 			, @ModelAttribute("restde") Restde restde
 			, ModelMap model

--- a/src/main/java/egovframework/com/sym/ccm/zip/service/EgovCcmRdnmadZipManageService.java
+++ b/src/main/java/egovframework/com/sym/ccm/zip/service/EgovCcmRdnmadZipManageService.java
@@ -43,7 +43,7 @@ public interface EgovCcmRdnmadZipManageService {
 	 * @param zip
 	 * @throws Exception
 	 */
-	void insertZip(Zip zip) throws Exception;
+	void insertZip(Zip zip);
 
 	/**
 	 * 우편번호 엑셀파일을 등록한다.

--- a/src/main/java/egovframework/com/sym/ccm/zip/service/EgovCcmZipManageService.java
+++ b/src/main/java/egovframework/com/sym/ccm/zip/service/EgovCcmZipManageService.java
@@ -43,7 +43,7 @@ public interface EgovCcmZipManageService {
 	 * @param zip
 	 * @throws Exception
 	 */
-	void insertZip(Zip zip) throws Exception;
+	void insertZip(Zip zip);
 
 	/**
 	 * 우편번호 엑셀파일을 등록한다.

--- a/src/main/java/egovframework/com/sym/ccm/zip/service/Zip.java
+++ b/src/main/java/egovframework/com/sym/ccm/zip/service/Zip.java
@@ -1,5 +1,6 @@
 package egovframework.com.sym.ccm.zip.service;
 
+import javax.validation.constraints.NotEmpty;
 import java.io.Serializable;
 
 /**
@@ -26,6 +27,7 @@ public class Zip implements Serializable {
 	/*
 	 * 우편번호
 	 */
+	@NotEmpty(message = "우편번호{common.required.msg}")
     private String zip            = "";
 
     /*
@@ -36,16 +38,19 @@ public class Zip implements Serializable {
     /*
      * 시도명
      */
+    @NotEmpty(message = "시도명{common.required.msg}")
 	private String ctprvnNm       = "";
 
 	/*
 	 * 시군구명
 	 */
+	@NotEmpty(message = "시군구명{common.required.msg}")
     private String signguNm       = "";
 
     /*
      * 읍면동명
      */
+    @NotEmpty(message = "읍면동명{common.required.msg}")
     private String emdNm          = "";
 
     /*

--- a/src/main/java/egovframework/com/sym/ccm/zip/service/impl/EgovCcmRdnmadZipServiceImpl.java
+++ b/src/main/java/egovframework/com/sym/ccm/zip/service/impl/EgovCcmRdnmadZipServiceImpl.java
@@ -62,7 +62,7 @@ public class EgovCcmRdnmadZipServiceImpl extends EgovAbstractServiceImpl impleme
 	 * 우편번호를 등록한다.
 	 */
 	@Override
-	public void insertZip(Zip zip) throws Exception {
+	public void insertZip(Zip zip) {
 		rdnmadZipDAO.insertZip(zip);
 	}
 

--- a/src/main/java/egovframework/com/sym/ccm/zip/service/impl/EgovCcmZipManageServiceImpl.java
+++ b/src/main/java/egovframework/com/sym/ccm/zip/service/impl/EgovCcmZipManageServiceImpl.java
@@ -63,7 +63,7 @@ public class EgovCcmZipManageServiceImpl extends EgovAbstractServiceImpl impleme
 	 * 우편번호를 등록한다.
 	 */
 	@Override
-	public void insertZip(Zip zip) throws Exception {
+	public void insertZip(Zip zip) {
     	zipManageDAO.insertZip(zip);
 	}
 

--- a/src/main/java/egovframework/com/sym/ccm/zip/service/impl/RdnmadZipDAO.java
+++ b/src/main/java/egovframework/com/sym/ccm/zip/service/impl/RdnmadZipDAO.java
@@ -51,7 +51,7 @@ public class RdnmadZipDAO extends EgovComAbstractDAO {
 	 * @param zip
 	 * @throws Exception
 	 */
-	public void insertZip(Zip zip) throws Exception {
+	public void insertZip(Zip zip) {
         insert("RdnmadZipDAO.insertZip", zip);
 	}
 

--- a/src/main/java/egovframework/com/sym/ccm/zip/service/impl/ZipManageDAO.java
+++ b/src/main/java/egovframework/com/sym/ccm/zip/service/impl/ZipManageDAO.java
@@ -51,7 +51,7 @@ public class ZipManageDAO extends EgovComAbstractDAO {
 	 * @param zip
 	 * @throws Exception
 	 */
-	public void insertZip(Zip zip) throws Exception {
+	public void insertZip(Zip zip) {
         insert("ZipManageDAO.insertZip", zip);
 	}
 

--- a/src/main/java/egovframework/com/sym/ccm/zip/web/EgovCcmZipManageController.java
+++ b/src/main/java/egovframework/com/sym/ccm/zip/web/EgovCcmZipManageController.java
@@ -18,9 +18,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.ui.ModelMap;
 import org.springframework.validation.BindingResult;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.multipart.MultipartHttpServletRequest;
 import org.springframework.web.util.WebUtils;
@@ -53,12 +51,13 @@ import org.egovframe.rte.ptl.mvc.tags.ui.pagination.PaginationInfo;
  *
  *  수정일               수정자            수정내용
  *  ----------   --------   ---------------------------
- *  2009.04.01   이중호            최초 생성
- *  2011.08.26   정진오            IncludedInfo annotation 추가
- *  2011.10.07   이기하            보안취약점 수정(파일 업로드시 엑셀파일만 가능하도록 추가)
- *  2011.11.21   이기하            도로명주소 추가(rdnmadZip)
- *  2021.02.16   신용호            WebUtils.getNativeRequest(request,MultipartHttpServletRequest.class);
- *  2022.11.11   김혜준			   시큐어코딩 처리
+ *  2009.04.01   이중호         최초 생성
+ *  2011.08.26   정진오         IncludedInfo annotation 추가
+ *  2011.10.07   이기하         보안취약점 수정(파일 업로드시 엑셀파일만 가능하도록 추가)
+ *  2011.11.21   이기하         도로명주소 추가(rdnmadZip)
+ *  2021.02.16   신용호         WebUtils.getNativeRequest(request,MultipartHttpServletRequest.class);
+ *  2022.11.11   김혜준         시큐어코딩 처리
+ *  2024.08.31   권태성         등록 & 수정의 화면과 데이터를 처리하는 method 분리, validation 적용
  *
  * </pre>
  */
@@ -162,44 +161,65 @@ public class EgovCcmZipManageController {
 	}
 
 	/**
-	 * 우편번호를 등록한다.
+	 * 우편번호 등록 화면
+	 * @param loginVO
+	 * @param zip
+	 * @param model
+	 * @return "egovframework/com/sym/ccm/zip/EgovCcmZipRegist"
+	 */
+	@RequestMapping(value = "/sym/ccm/zip/EgovCcmZipRegistView.do")
+	public String insertZip(@ModelAttribute("loginVO") LoginVO loginVO
+						, @ModelAttribute("zip") Zip zip
+						, ZipVO searchVO
+						, ModelMap model) {
+		model.addAttribute("searchList", searchVO.getSearchList());
+		model.addAttribute("isRoadAddr", ("2".equals(searchVO.getSearchList()))); // true : 도로명주소등록, false : 일반주소등록
+		return "egovframework/com/sym/ccm/zip/EgovCcmZipRegist";
+	}
+
+	/**
+	 * 우편번호를 등록 한다.
 	 * @param loginVO
 	 * @param zip
 	 * @param bindingResult
+	 * @param searchVO
 	 * @param model
-	 * @return "egovframework/com/sym/ccm/zip/EgovCcmZipRegist"
+	 * @return
 	 * @throws Exception
 	 */
 	@RequestMapping(value = "/sym/ccm/zip/EgovCcmZipRegist.do")
-	public String insertZip(@ModelAttribute("loginVO") LoginVO loginVO, @ModelAttribute("zip") Zip zip, ZipVO searchVO,
-		BindingResult bindingResult, ModelMap model)
-		throws Exception {
-
+	public String insertZip(@ModelAttribute("loginVO") LoginVO loginVO
+						, @ModelAttribute("zip") Zip zip
+						, BindingResult bindingResult
+						, ZipVO searchVO
+						, ModelMap model) {
 		model.addAttribute("searchList", searchVO.getSearchList());
 
-		if (zip.getZip() == null || zip.getZip().equals("")) {
+		boolean isRoadAddr = ("2".equals(searchVO.getSearchList()));
 
+		beanValidator.validate(zip, bindingResult);
+		if (!isRoadAddr && bindingResult.hasErrors()) {
+			model.addAttribute("errorMessage", bindingResult.getAllErrors());
+			model.addAttribute("zip", zip);
 			return "egovframework/com/sym/ccm/zip/EgovCcmZipRegist";
 		}
-
-		if (searchVO.getSearchList().equals("1")) {
+		/* 2024-08-31 권태성 - 기존 코드에서 도로명주소 일 때 validate를 주석 처리해두어 주석을 유지함
+		else {
 			beanValidator.validate(zip, bindingResult);
-			if (bindingResult.hasErrors()) {
-				return "egovframework/com/sym/ccm/zip/EgovCcmZipRegist";
-			}
-
-			zip.setFrstRegisterId(loginVO.getUniqId());
-			zipManageService.insertZip(zip);
-		} else {
-			/*beanValidator.validate(zip, bindingResult);
 			if (bindingResult.hasErrors()){
 				return "egovframework/com/sym/ccm/zip/EgovCcmZipRegist";
-			}*/
-
-			zip.setFrstRegisterId(loginVO.getUniqId());
-			rdnmadZipService.insertZip(zip);
+			}
 		}
-		return "forward:/sym/ccm/zip/EgovCcmZipList.do";
+		*/
+
+		zip.setFrstRegisterId(loginVO.getUniqId());
+		if (isRoadAddr) {
+			rdnmadZipService.insertZip(zip);
+		} else {
+			zipManageService.insertZip(zip);
+		}
+
+		return "redirect:/sym/ccm/zip/EgovCcmZipList.do";
 	}
 
 	/**
@@ -341,54 +361,74 @@ public class EgovCcmZipManageController {
 	}
 
 	/**
-	 * 우편번호를 수정한다.
+	 * 우편번호 수정화면
 	 * @param loginVO
 	 * @param zip
-	 * @param bindingResult
-	 * @param commandMap
 	 * @param model
 	 * @return "egovframework/com/sym/ccm/zip/EgovCcmZipModify"
 	 * @throws Exception
 	 */
-	@RequestMapping(value = "/sym/ccm/zip/EgovCcmZipModify.do")
-	public String updateZip(@ModelAttribute("loginVO") LoginVO loginVO, @ModelAttribute("zip") Zip zip, ZipVO searchVO,
-		BindingResult bindingResult, @RequestParam Map<String, Object> commandMap,
-		ModelMap model) throws Exception {
-		String sCmd = commandMap.get("cmd") == null ? "" : (String)commandMap.get("cmd");
+	@RequestMapping(value = "/sym/ccm/zip/EgovCcmZipModifyView.do")
+	public String updateZip(@ModelAttribute("loginVO") LoginVO loginVO
+						, @ModelAttribute("zip") Zip zip
+						, ZipVO searchVO
+						, ModelMap model) throws Exception {
 		model.addAttribute("searchList", searchVO.getSearchList());
-		if (sCmd.equals("")) {
-			if (searchVO.getSearchList().equals("1")) {
-				Zip vo = zipManageService.selectZipDetail(zip);
-				model.addAttribute("zip", vo);
-			} else {
-				Zip vo = rdnmadZipService.selectZipDetail(zip);
-				model.addAttribute("zip", vo);
-			}
-			return "egovframework/com/sym/ccm/zip/EgovCcmZipModify";
-		} else if (sCmd.equals("Modify")) {
-			if (searchVO.getSearchList().equals("1")) {
-				beanValidator.validate(zip, bindingResult);
-				if (bindingResult.hasErrors()) {
-					return "egovframework/com/sym/ccm/zip/EgovCcmZipModify";
-				}
-
-				zip.setLastUpdusrId(loginVO.getUniqId());
-				zipManageService.updateZip(zip);
-			} else {
-				/*beanValidator.validate(zip, bindingResult);
-				if (bindingResult.hasErrors()){
-					return "egovframework/com/sym/ccm/zip/EgovCcmZipModify";
-				}*/
-
-				zip.setLastUpdusrId(loginVO.getUniqId());
-				rdnmadZipService.updateZip(zip);
-			}
-
-			return "forward:/sym/ccm/zip/EgovCcmZipList.do";
+		boolean isRoadAddr = ("2".equals(searchVO.getSearchList()));
+		Zip vo = null;
+		if (isRoadAddr) {
+			vo = rdnmadZipService.selectZipDetail(zip);
 		} else {
-			return "forward:/sym/ccm/zip/EgovCcmZipList.do";
+			vo = zipManageService.selectZipDetail(zip);
 		}
+		model.addAttribute("zip", vo);
+		model.addAttribute("isRoadAddr", isRoadAddr);
+		return "egovframework/com/sym/ccm/zip/EgovCcmZipModify";
 	}
+
+	/**
+	 * 우편번호를 수정한다.
+	 * @param loginVO
+	 * @param zip
+	 * @param bindingResult
+	 * @param searchVO
+	 * @param model
+	 * @return
+	 * @throws Exception
+	 */
+	@RequestMapping(value = "/sym/ccm/zip/EgovCcmZipModify.do")
+	public String updateZip(@ModelAttribute("loginVO") LoginVO loginVO
+						, @ModelAttribute("zip") Zip zip
+						, BindingResult bindingResult
+						, ZipVO searchVO
+						, ModelMap model) throws Exception {
+		if (zip.getSn() == 0) {
+			return "redirect:/sym/ccm/zip/EgovCcmZipList.do";
+		}
+		boolean isRoadAddr = ("2".equals(searchVO.getSearchList()));
+		beanValidator.validate(zip, bindingResult);
+		if (!isRoadAddr && bindingResult.hasErrors()) {
+			model.addAttribute("searchList", searchVO.getSearchList());
+			return "egovframework/com/sym/ccm/zip/EgovCcmZipModify";
+		}
+		/* 2024-08-31 권태성 - 기존 코드에서 도로명주소 일 때 validate를 주석 처리해두어 주석을 유지함
+		else {
+			beanValidator.validate(zip, bindingResult);
+			if (bindingResult.hasErrors()){
+				return "egovframework/com/sym/ccm/zip/EgovCcmZipModify";
+			}
+		}
+		*/
+
+		zip.setLastUpdusrId(loginVO.getUniqId());
+		if (isRoadAddr) {
+			rdnmadZipService.updateZip(zip);
+		} else {
+			zipManageService.updateZip(zip);
+		}
+		return "redirect:/sym/ccm/zip/EgovCcmZipList.do";
+	}
+
 
 	/**
 	 * 주소정보연계 팝업을 위한 입력 페이지를 호출한다.

--- a/src/main/webapp/WEB-INF/jsp/egovframework/com/sym/cal/EgovRestdeDetail.jsp
+++ b/src/main/webapp/WEB-INF/jsp/egovframework/com/sym/cal/EgovRestdeDetail.jsp
@@ -42,7 +42,7 @@ function fn_egov_list_Restde(){
  ******************************************************** */
 function fn_egov_modify_Restde(){
 	var varForm				 = document.all["Form"];
-	varForm.action           = "<c:url value='/sym/cal/EgovRestdeModify.do'/>";
+	varForm.action           = "<c:url value='/sym/cal/EgovRestdeModifyView.do'/>";
 	varForm.restdeNo.value   = "${result.restdeNo}";
 	varForm.method = "get";
 	varForm.submit();

--- a/src/main/webapp/WEB-INF/jsp/egovframework/com/sym/cal/EgovRestdeDetail.jsp
+++ b/src/main/webapp/WEB-INF/jsp/egovframework/com/sym/cal/EgovRestdeDetail.jsp
@@ -44,6 +44,7 @@ function fn_egov_modify_Restde(){
 	var varForm				 = document.all["Form"];
 	varForm.action           = "<c:url value='/sym/cal/EgovRestdeModify.do'/>";
 	varForm.restdeNo.value   = "${result.restdeNo}";
+	varForm.method = "get";
 	varForm.submit();
 }
 /* ********************************************************

--- a/src/main/webapp/WEB-INF/jsp/egovframework/com/sym/cal/EgovRestdeList.jsp
+++ b/src/main/webapp/WEB-INF/jsp/egovframework/com/sym/cal/EgovRestdeList.jsp
@@ -51,7 +51,7 @@ function fn_egov_search_Restde(){
  * 등록 처리 함수
  ******************************************************** */
 function fn_egov_regist_Restde(){
-	location.href = "<c:url value='/sym/cal/EgovRestdeRegist.do' />";
+	location.href = "<c:url value='/sym/cal/EgovRestdeRegistView.do' />";
 }
 /* ********************************************************
  * 상세회면 처리 함수

--- a/src/main/webapp/WEB-INF/jsp/egovframework/com/sym/cal/EgovRestdeModify.jsp
+++ b/src/main/webapp/WEB-INF/jsp/egovframework/com/sym/cal/EgovRestdeModify.jsp
@@ -45,10 +45,10 @@ function fn_egov_list_Restde(){
  * 저장처리화면
  ******************************************************** */
 function fn_egov_regist_Restde(form){
-	if(confirm("<spring:message code='common.save.msg'/>")){
-		if(!validateRestde(form)){
-			return;
-		}else{
+	if (confirm("<spring:message code='common.save.msg'/>")) {
+		if (!validateRestde(form)) {
+		 	return;
+		} else {
 			form.submit();
 		}
 	}
@@ -59,7 +59,7 @@ function fn_egov_regist_Restde(form){
 <body>
 <noscript class="noScriptTitle"><spring:message code="common.noScriptTitle.msg" /></noscript>
 
-<form:form modelAttribute="restde" name="restde" method="post">
+<form:form modelAttribute="restde" name="restde" method="post" action="/sym/cal/EgovRestdeModify.do">
 <input name="cmd" type="hidden" value="Modify">
 <form:hidden path="restdeNo"/>
 <form:hidden path="restdeDe"/>

--- a/src/main/webapp/WEB-INF/jsp/egovframework/com/sym/cal/EgovRestdeRegist.jsp
+++ b/src/main/webapp/WEB-INF/jsp/egovframework/com/sym/cal/EgovRestdeRegist.jsp
@@ -46,10 +46,10 @@ function fn_egov_list_Restde(){
  * 저장처리화면
  ******************************************************** */
  function fn_egov_regist_Restde(form){
-	if(confirm("<spring:message code='common.save.msg' />")){
-		if(!validateRestde(form)){
+	if (confirm("<spring:message code='common.save.msg' />")) {
+		if (!validateRestde(form)) {
 			return;
-		}else{
+		} else {
 			form.submit();
 		}
 	}
@@ -75,30 +75,30 @@ function fn_egov_list_Restde(){
 		<tr>
 			<th><spring:message code="sym.cal.restDay" /> <span class="pilsu">*</span></th><!-- 휴일일자 -->
 			<td class="left">
-			    <input type="hidden" name="cal_url" value="<c:url value='/sym/cal/EgovNormalCalPopup.do'/>" />
-		    	<form:hidden path="restdeDe" />
-				<input name="vrestdeDe" type="text" value=""  maxlength="10" readonly="readonly" onclick="fn_egov_NormalCalendar(document.restde, document.restde.restdeDe, document.restde.vrestdeDe);" title="<spring:message code="sym.cal.restDay" />(새창)" style="width:70px"/>
+				<input type="hidden" name="cal_url" value="<c:url value='/sym/cal/EgovNormalCalPopup.do'/>" />
+				<form:hidden path="restdeDe" />
+				<input name="vrestdeDe" type="text" value="${restde.formattedRestdeDe}"  maxlength="10" readonly="readonly" onclick="fn_egov_NormalCalendar(document.restde, document.restde.restdeDe, document.restde.vrestdeDe);" title="<spring:message code="sym.cal.restDay" />(새창)" style="width:70px"/>
 				<a href="#noscript" onclick="fn_egov_NormalCalendar(document.restde, document.restde.restdeDe, document.restde.vrestdeDe); return false;"><img src="<c:url value='/images/egovframework/com/cmm/icon/bu_icon_carlendar.gif' />" alt="달력창팝업버튼이미지"/></a>
 			</td>
 		</tr>
 		<tr>
 			<th><spring:message code="sym.cal.restName" /> <span class="pilsu">*</span></th><!-- 휴일명 -->
 			<td class="left">
-			    <form:input  path="restdeNm" size="50" maxlength="50" title="<spring:message code='sym.cal.restName' />"/>
-      			<form:errors path="restdeNm"/>
+				<form:input  path="restdeNm" size="50" maxlength="50" title="<spring:message code='sym.cal.restName' />"/>
+				<form:errors path="restdeNm"/>
 			</td>
 		</tr>
 		<tr>
 			<th><spring:message code="sym.cal.restDetail" /> <span class="pilsu">*</span></th><!-- 휴일설명 -->
 			<td class="left">
-			    <form:textarea path="restdeDc" rows="3" cols="60" title="<spring:message code='sym.cal.restDetail' />"/>
-      			<form:errors   path="restdeDc"/>
+				<form:textarea path="restdeDc" rows="3" cols="60" title="<spring:message code='sym.cal.restDetail' />"/>
+				<form:errors   path="restdeDc"/>
 			</td>
 		</tr>
 		<tr>
 			<th><spring:message code="sym.cal.restCategory" /> <span class="pilsu">*</span></th>
 			<td class="left">
-			    <form:select path="restdeSeCode" title="<spring:message code='sym.cal.restCategory' />">
+				<form:select path="restdeSeCode" title="<spring:message code='sym.cal.restCategory' />">
 				<form:options items="${restdeCode}" itemValue="code" itemLabel="codeNm" />
 				</form:select>
 			</td>

--- a/src/main/webapp/WEB-INF/jsp/egovframework/com/sym/cal/EgovRestdeRegist.jsp
+++ b/src/main/webapp/WEB-INF/jsp/egovframework/com/sym/cal/EgovRestdeRegist.jsp
@@ -60,7 +60,7 @@ function fn_egov_list_Restde(){
 <body>
 <noscript class="noScriptTitle"><spring:message code="common.noScriptTitle.msg" /></noscript>
 
-<form:form modelAttribute="restde" name="restde" method="post">
+<form:form modelAttribute="restde" name="restde" method="post" action="/sym/cal/EgovRestdeRegist.do">
 
 <div class="wTableFrm">
 	<!-- 타이틀 -->

--- a/src/main/webapp/WEB-INF/jsp/egovframework/com/sym/ccm/zip/EgovCcmZipDetail.jsp
+++ b/src/main/webapp/WEB-INF/jsp/egovframework/com/sym/ccm/zip/EgovCcmZipDetail.jsp
@@ -40,7 +40,7 @@ function fn_egov_list_Zip(){
  ******************************************************** */
 function fn_egov_modify_Zip(){
 	var varForm				 = document.getElementById("Form");
-	varForm.action           = "<c:url value='/sym/ccm/zip/EgovCcmZipModify.do'/>";
+	varForm.action           = "<c:url value='/sym/ccm/zip/EgovCcmZipModifyView.do'/>";
 	if (${searchList} == "1") {
 		varForm.zip.value        = "${result.zip}";
 		varForm.sn.value         = "${result.sn}";

--- a/src/main/webapp/WEB-INF/jsp/egovframework/com/sym/ccm/zip/EgovCcmZipList.jsp
+++ b/src/main/webapp/WEB-INF/jsp/egovframework/com/sym/ccm/zip/EgovCcmZipList.jsp
@@ -55,9 +55,9 @@ function fn_egov_search_Zip(){
  * 등록 처리 함수
  ******************************************************** */
 function fn_egov_regist_Zip(no){
-//	location.href = "<c:url value='/sym/ccm/zip/EgovCcmZipRegist.do'/>";
+//	location.href = "<c:url value='/sym/ccm/zip/EgovCcmZipRegistView.do'/>";
 	var varForm	   			 = document.getElementById("Form");
-	varForm.action 			 = "<c:url value='/sym/ccm/zip/EgovCcmZipRegist.do'/>";
+	varForm.action 			 = "<c:url value='/sym/ccm/zip/EgovCcmZipRegistView.do'/>";
 	varForm.searchList.value = no;
 	varForm.submit();
 }

--- a/src/main/webapp/WEB-INF/jsp/egovframework/com/sym/ccm/zip/EgovCcmZipModify.jsp
+++ b/src/main/webapp/WEB-INF/jsp/egovframework/com/sym/ccm/zip/EgovCcmZipModify.jsp
@@ -56,7 +56,7 @@ function fn_egov_modify_Zip(form){
 </script>
 </head>
 <body>
-<form:form modelAttribute="zip" name="zip" method="post">
+<form:form modelAttribute="zip" name="zip" method="post" action="/sym/ccm/zip/EgovCcmZipModify.do">
 <input name="cmd" type="hidden" value="Modify">
 	<form:hidden path="zip"/>
 	<form:hidden path="sn"/>
@@ -91,7 +91,7 @@ function fn_egov_modify_Zip(form){
 	  <tr>
 	    <th class="ic_none" width="20%" height="23" scope="row" nowrap><spring:message code="comSymCcmZip.zipVO.zip"/> <span class="pilsu">*</span></th> <!-- 우편번호 -->          
 	    <td>
-	    	<c:out value='${fn:substring(zip.zip, 0,3)}'/>-<c:out value='${fn:substring(zip.zip, 3,6)}'/>
+	    	<c:out value='${zip.zip}'/>
 	    </td>
 	  </tr> 
 	  <tr> 
@@ -138,7 +138,7 @@ function fn_egov_modify_Zip(form){
 	  </tr>
 	  <tr>
 	    <th class="ic_none" width="20%" height="23" scope="row" nowrap><spring:message code="comSymCcmZip.zipVO.ctprvnNm"/> <span class="pilsu">*</span></th> <!-- 시도명 -->
-	    <td><c:out value='${zip.ctprvnNm}'/>}</td>
+	    <td><c:out value='${zip.ctprvnNm}'/></td>
 	  </tr>
 	  <tr>
 	    <th class="ic_none" width="20%" height="23" scope="row" nowrap><spring:message code="comSymCcmZip.zipVO.signguNm"/> <span class="pilsu">*</span></th> <!-- 시군구명 -->

--- a/src/main/webapp/WEB-INF/jsp/egovframework/com/sym/ccm/zip/EgovCcmZipRegist.jsp
+++ b/src/main/webapp/WEB-INF/jsp/egovframework/com/sym/ccm/zip/EgovCcmZipRegist.jsp
@@ -46,11 +46,11 @@ function fn_egov_list_Zip(){
  ******************************************************** */
 function fn_egov_regist_Zip(form){
 	if(confirm("<spring:message code='common.save.msg'/>")){
-		if(!validateZip(form)){
-			return;
-		}else{
+//		if(!validateZip(form)){
+//			return;
+//		}else{
 			form.submit();
-		}
+//		}
 	}
 }
 /* ********************************************************
@@ -80,17 +80,17 @@ function jusoCallBack(zipNo,rnMgtSn,siNm,sggNm,roadFullAddr,buldMnnm,buldSlno,bd
 </head>
 <body>
 <noscript class="noScriptTitle"><spring:message code="common.noScriptTitle.msg"/></noscript>
-<form:form modelAttribute="zip" name="zip" method="post">
+<form:form modelAttribute="zip" name="zip" method="post" action="/sym/ccm/zip/EgovCcmZipRegist.do">
 <div class="note">
 
 <!-- 상단 타이틀  영역 -->
   <h1>
   <c:set var="titleZip"><spring:message code="comSymCcmZip.zipVO.zipCreate"/></c:set>
   <c:set var="titleRdmn"><spring:message code="comSymCcmZip.zipVO.rdmnCreate"/></c:set>
-  <c:if test="${searchList == '1'}">
+  <c:if test="${!isRoadAddr}">
    <img src="<c:url value='/images/egovframework/com/cmm/icon/tit_icon.gif' />" width="16" height="16" hspace="3" style="vertical-align: middle" alt="제목아이콘이미지">&nbsp;${titleZip }</h1></td>
   </c:if>
-  <c:if test="${searchList == '2'}">
+  <c:if test="${isRoadAddr}">
    <img src="<c:url value='/images/egovframework/com/cmm/icon/tit_icon.gif' />" width="16" height="16" hspace="3" style="vertical-align: middle" alt="제목아이콘이미지">&nbsp;${titleRdmn }</h1></td>
   </c:if>
 
@@ -102,7 +102,7 @@ function jusoCallBack(zipNo,rnMgtSn,siNm,sggNm,roadFullAddr,buldMnnm,buldSlno,bd
 	<col style="width: 20%;"><col style="width: ;">
 </colgroup>
 <tbody>
-  <c:if test="${searchList == '1'}">
+  <c:if test="${!isRoadAddr}">
   	  <!-- 우편번호  -->
 	  <c:set var="title"><spring:message code="comSymCcmZip.zipVO.zip"/></c:set>
 	  <tr>
@@ -160,7 +160,7 @@ function jusoCallBack(zipNo,rnMgtSn,siNm,sggNm,roadFullAddr,buldMnnm,buldSlno,bd
 	  <input type=hidden name="rdmnCode" id="rdmnCode" value="0"/>
 	  <input type=hidden name="rdmn" id="rdmn" value="0"/>
   </c:if>
-  <c:if test="${searchList == '2'}">
+  <c:if test="${isRoadAddr}">
   	  <!-- 우편번호  -->
 	  <c:set var="title"><spring:message code="comSymCcmZip.zipVO.zip"/></c:set>
 	  <c:set var="address"><spring:message code="comSymCcmZip.zipVO.rdmnSearch"/></c:set>

--- a/src/test/java/egovframework/com/sym/cal/service/RestdeTest.java
+++ b/src/test/java/egovframework/com/sym/cal/service/RestdeTest.java
@@ -1,0 +1,87 @@
+package egovframework.com.sym.cal.service;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class RestdeTest {
+
+	@Test
+	public void test_getFormattedRestdeDe_validDate() {
+		// Given
+		Restde restde = new Restde();
+		restde.setRestdeDe("20240831"); // 올바른 8자리 날짜 입력
+
+		// When
+		String formattedDate = restde.getFormattedRestdeDe();
+
+		// Then
+		assertEquals("2024-08-31", formattedDate); // 예상되는 출력
+	}
+
+	@Test
+	public void test_getFormattedRestdeDe_nullValue() {
+		// Given
+		Restde restde = new Restde();
+		restde.setRestdeDe(null); // null 입력
+
+		// When
+		String formattedDate = restde.getFormattedRestdeDe();
+
+		// Then
+		assertEquals(null, formattedDate); // null 반환
+	}
+
+	@Test
+	public void test_getFormattedRestdeDe_emptyValue() {
+		// Given
+		Restde restde = new Restde();
+		restde.setRestdeDe(""); // 빈 문자열 입력
+
+		// When
+		String formattedDate = restde.getFormattedRestdeDe();
+
+		// Then
+		assertEquals("", formattedDate); // 빈 문자열 반환
+	}
+
+	@Test
+	public void test_getFormattedRestdeDe_invalidLength() {
+		// Given
+		Restde restde = new Restde();
+		restde.setRestdeDe("202408"); // 잘못된 길이의 입력
+
+		// When
+		String formattedDate = restde.getFormattedRestdeDe();
+
+		// Then
+		assertEquals("202408", formattedDate); // 원래 문자열 반환
+	}
+
+	@Test
+	public void test_getFormattedRestdeDe_nonNumericValue() {
+		// Given
+		Restde restde = new Restde();
+		restde.setRestdeDe("abcd1234"); // 숫자가 아닌 문자가 포함된 입력
+
+		// When
+		String formattedDate = restde.getFormattedRestdeDe();
+
+		// Then
+		assertEquals("abcd1234", formattedDate); // 원래 문자열 반환
+	}
+
+	@Test
+	public void test_getFormattedRestdeDe_partialNonNumericValue() {
+		// Given
+		Restde restde = new Restde();
+		restde.setRestdeDe("2024abcd"); // 부분적으로 숫자가 아닌 문자가 포함된 입력
+
+		// When
+		String formattedDate = restde.getFormattedRestdeDe();
+
+		// Then
+		assertEquals("2024abcd", formattedDate); // 원래 문자열 반환
+	}
+
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [ ] 버그수정 Bug fixes
- [X] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

1. `EgovCcmZipManageController ` 의 화면/처리 메서드 분리
- 화면을 보여주기 위한 처리와 데이터 등록 처리를 하나의 메서드에서 담당하고 있어 하나의 메서드가 하나의 역할을 할 수 있도록 분리하였습니다.
  - 등록
    - 화면 : `/sym/ccm/zip/EgovCcmZipRegistView.do`
    - 처리 : `/sym/ccm/zip/EgovCcmZipRegist.do`
  - 수정
    - 화면 : `/sym/ccm/zip/EgovCcmZipModifyView.do`
    - 처리 : `/sym/ccm/zip/EgovCcmZipModify.do`

2. 위 사유 (하나의 메서드에서 화면과 처리를 함께함)로 인해 bindingResult가 작동하지 않는 점을 개선했습니다.



## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [x] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [X] Chrome
- [X] Firefox
- [X] Edge
- [X] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

### 일반주소 등록

https://github.com/user-attachments/assets/d1c82cdc-f742-42bb-81a2-eedb58531399

### 일반주소 수정

https://github.com/user-attachments/assets/304511a9-4e10-4577-8d21-1a7776301b79

### 일반주소 삭제

https://github.com/user-attachments/assets/622a0159-a919-4605-935f-5f4d52d58b64

### 도로명주소 등록

https://github.com/user-attachments/assets/ec48d9b2-9343-4ec9-80ee-c2b6da661c4a

### 도로명주소 수정

https://github.com/user-attachments/assets/ef3921bb-a499-44fd-9b52-6933d9762b3f

### 도로명주소 삭제

https://github.com/user-attachments/assets/343fe453-12ed-4a31-8d50-0fe53bff0f5d















