### PR TITLE
[기능개선] 1000. 우편번호관리 - 등록/수정 화면과 처리 로직 분리, 백엔드 필수값 검증 적용

### DIFF
--- a/src/main/java/egovframework/com/sym/ccm/zip/service/EgovCcmRdnmadZipManageService.java
+++ b/src/main/java/egovframework/com/sym/ccm/zip/service/EgovCcmRdnmadZipManageService.java
@@ -43,7 +43,7 @@ public interface EgovCcmRdnmadZipManageService {
 	 * @param zip
 	 * @throws Exception
 	 */
-	void insertZip(Zip zip) throws Exception;
+	void insertZip(Zip zip);
 
 	/**
 	 * 우편번호 엑셀파일을 등록한다.

--- a/src/main/java/egovframework/com/sym/ccm/zip/service/EgovCcmZipManageService.java
+++ b/src/main/java/egovframework/com/sym/ccm/zip/service/EgovCcmZipManageService.java
@@ -43,7 +43,7 @@ public interface EgovCcmZipManageService {
 	 * @param zip
 	 * @throws Exception
 	 */
-	void insertZip(Zip zip) throws Exception;
+	void insertZip(Zip zip);
 
 	/**
 	 * 우편번호 엑셀파일을 등록한다.

--- a/src/main/java/egovframework/com/sym/ccm/zip/service/Zip.java
+++ b/src/main/java/egovframework/com/sym/ccm/zip/service/Zip.java
@@ -1,5 +1,6 @@
 package egovframework.com.sym.ccm.zip.service;
 
+import javax.validation.constraints.NotEmpty;
 import java.io.Serializable;
 
 /**
@@ -26,6 +27,7 @@ public class Zip implements Serializable {
 	/*
 	 * 우편번호
 	 */
+	@NotEmpty(message = "우편번호{common.required.msg}")
     private String zip            = "";
 
     /*
@@ -36,16 +38,19 @@ public class Zip implements Serializable {
     /*
      * 시도명
      */
+    @NotEmpty(message = "시도명{common.required.msg}")
 	private String ctprvnNm       = "";
 
 	/*
 	 * 시군구명
 	 */
+	@NotEmpty(message = "시군구명{common.required.msg}")
     private String signguNm       = "";
 
     /*
      * 읍면동명
      */
+    @NotEmpty(message = "읍면동명{common.required.msg}")
     private String emdNm          = "";
 
     /*

--- a/src/main/java/egovframework/com/sym/ccm/zip/service/impl/EgovCcmRdnmadZipServiceImpl.java
+++ b/src/main/java/egovframework/com/sym/ccm/zip/service/impl/EgovCcmRdnmadZipServiceImpl.java
@@ -62,7 +62,7 @@ public class EgovCcmRdnmadZipServiceImpl extends EgovAbstractServiceImpl impleme
 	 * 우편번호를 등록한다.
 	 */
 	@Override
-	public void insertZip(Zip zip) throws Exception {
+	public void insertZip(Zip zip) {
 		rdnmadZipDAO.insertZip(zip);
 	}
 

--- a/src/main/java/egovframework/com/sym/ccm/zip/service/impl/EgovCcmZipManageServiceImpl.java
+++ b/src/main/java/egovframework/com/sym/ccm/zip/service/impl/EgovCcmZipManageServiceImpl.java
@@ -63,7 +63,7 @@ public class EgovCcmZipManageServiceImpl extends EgovAbstractServiceImpl impleme
 	 * 우편번호를 등록한다.
 	 */
 	@Override
-	public void insertZip(Zip zip) throws Exception {
+	public void insertZip(Zip zip) {
     	zipManageDAO.insertZip(zip);
 	}
 

--- a/src/main/java/egovframework/com/sym/ccm/zip/service/impl/RdnmadZipDAO.java
+++ b/src/main/java/egovframework/com/sym/ccm/zip/service/impl/RdnmadZipDAO.java
@@ -51,7 +51,7 @@ public class RdnmadZipDAO extends EgovComAbstractDAO {
 	 * @param zip
 	 * @throws Exception
 	 */
-	public void insertZip(Zip zip) throws Exception {
+	public void insertZip(Zip zip) {
         insert("RdnmadZipDAO.insertZip", zip);
 	}
 

--- a/src/main/java/egovframework/com/sym/ccm/zip/service/impl/ZipManageDAO.java
+++ b/src/main/java/egovframework/com/sym/ccm/zip/service/impl/ZipManageDAO.java
@@ -51,7 +51,7 @@ public class ZipManageDAO extends EgovComAbstractDAO {
 	 * @param zip
 	 * @throws Exception
 	 */
-	public void insertZip(Zip zip) throws Exception {
+	public void insertZip(Zip zip) {
         insert("ZipManageDAO.insertZip", zip);
 	}
 

--- a/src/main/java/egovframework/com/sym/ccm/zip/web/EgovCcmZipManageController.java
+++ b/src/main/java/egovframework/com/sym/ccm/zip/web/EgovCcmZipManageController.java
@@ -53,12 +53,13 @@ import org.egovframe.rte.ptl.mvc.tags.ui.pagination.PaginationInfo;
  *
  *  수정일               수정자            수정내용
  *  ----------   --------   ---------------------------
- *  2009.04.01   이중호            최초 생성
- *  2011.08.26   정진오            IncludedInfo annotation 추가
- *  2011.10.07   이기하            보안취약점 수정(파일 업로드시 엑셀파일만 가능하도록 추가)
- *  2011.11.21   이기하            도로명주소 추가(rdnmadZip)
- *  2021.02.16   신용호            WebUtils.getNativeRequest(request,MultipartHttpServletRequest.class);
- *  2022.11.11   김혜준			   시큐어코딩 처리
+ *  2009.04.01   이중호         최초 생성
+ *  2011.08.26   정진오         IncludedInfo annotation 추가
+ *  2011.10.07   이기하         보안취약점 수정(파일 업로드시 엑셀파일만 가능하도록 추가)
+ *  2011.11.21   이기하         도로명주소 추가(rdnmadZip)
+ *  2021.02.16   신용호         WebUtils.getNativeRequest(request,MultipartHttpServletRequest.class);
+ *  2022.11.11   김혜준         시큐어코딩 처리
+ *  2024.08.31   권태성         등록 & 수정의 화면과 데이터를 처리하는 method 분리, validation 적용
  *
  * </pre>
  */
@@ -162,44 +163,65 @@ public class EgovCcmZipManageController {
 	}
 
 	/**
-	 * 우편번호를 등록한다.
+	 * 우편번호 등록 화면
+	 * @param loginVO
+	 * @param zip
+	 * @param model
+	 * @return "egovframework/com/sym/ccm/zip/EgovCcmZipRegist"
+	 */
+	@RequestMapping(value = "/sym/ccm/zip/EgovCcmZipRegistView.do")
+	public String insertZip(@ModelAttribute("loginVO") LoginVO loginVO
+			, @ModelAttribute("zip") Zip zip
+			, ZipVO searchVO
+			, ModelMap model) {
+		model.addAttribute("searchList", searchVO.getSearchList());
+		model.addAttribute("isRoadAddr", ("2".equals(searchVO.getSearchList()))); // true : 도로명주소등록, false : 일반주소등록
+		return "egovframework/com/sym/ccm/zip/EgovCcmZipRegist";
+	}
+
+	/**
+	 * 우편번호를 등록 한다.
 	 * @param loginVO
 	 * @param zip
 	 * @param bindingResult
+	 * @param searchVO
 	 * @param model
-	 * @return "egovframework/com/sym/ccm/zip/EgovCcmZipRegist"
+	 * @return
 	 * @throws Exception
 	 */
 	@RequestMapping(value = "/sym/ccm/zip/EgovCcmZipRegist.do")
-	public String insertZip(@ModelAttribute("loginVO") LoginVO loginVO, @ModelAttribute("zip") Zip zip, ZipVO searchVO,
-		BindingResult bindingResult, ModelMap model)
-		throws Exception {
-
+	public String insertZip(@ModelAttribute("loginVO") LoginVO loginVO
+			, @ModelAttribute("zip") Zip zip
+			, BindingResult bindingResult
+			, ZipVO searchVO
+			, ModelMap model) {
 		model.addAttribute("searchList", searchVO.getSearchList());
 
-		if (zip.getZip() == null || zip.getZip().equals("")) {
+		boolean isRoadAddr = ("2".equals(searchVO.getSearchList()));
 
+		beanValidator.validate(zip, bindingResult);
+		if (!isRoadAddr && bindingResult.hasErrors()) {
+			model.addAttribute("errorMessage", bindingResult.getAllErrors());
+			model.addAttribute("zip", zip);
 			return "egovframework/com/sym/ccm/zip/EgovCcmZipRegist";
 		}
-
-		if (searchVO.getSearchList().equals("1")) {
+		/* 2024-08-31 권태성 - 기존 코드에서 도로명주소 일 때 validate를 주석 처리해두어 주석을 유지함
+		else {
 			beanValidator.validate(zip, bindingResult);
-			if (bindingResult.hasErrors()) {
-				return "egovframework/com/sym/ccm/zip/EgovCcmZipRegist";
-			}
-
-			zip.setFrstRegisterId(loginVO.getUniqId());
-			zipManageService.insertZip(zip);
-		} else {
-			/*beanValidator.validate(zip, bindingResult);
 			if (bindingResult.hasErrors()){
 				return "egovframework/com/sym/ccm/zip/EgovCcmZipRegist";
-			}*/
-
-			zip.setFrstRegisterId(loginVO.getUniqId());
-			rdnmadZipService.insertZip(zip);
+			}
 		}
-		return "forward:/sym/ccm/zip/EgovCcmZipList.do";
+		*/
+
+		zip.setFrstRegisterId(loginVO.getUniqId());
+		if (isRoadAddr) {
+			rdnmadZipService.insertZip(zip);
+		} else {
+			zipManageService.insertZip(zip);
+		}
+
+		return "redirect:/sym/ccm/zip/EgovCcmZipList.do";
 	}
 
 	/**
@@ -341,53 +363,72 @@ public class EgovCcmZipManageController {
 	}
 
 	/**
-	 * 우편번호를 수정한다.
+	 * 우편번호 수정화면
 	 * @param loginVO
 	 * @param zip
-	 * @param bindingResult
-	 * @param commandMap
 	 * @param model
 	 * @return "egovframework/com/sym/ccm/zip/EgovCcmZipModify"
 	 * @throws Exception
 	 */
-	@RequestMapping(value = "/sym/ccm/zip/EgovCcmZipModify.do")
-	public String updateZip(@ModelAttribute("loginVO") LoginVO loginVO, @ModelAttribute("zip") Zip zip, ZipVO searchVO,
-		BindingResult bindingResult, @RequestParam Map<String, Object> commandMap,
-		ModelMap model) throws Exception {
-		String sCmd = commandMap.get("cmd") == null ? "" : (String)commandMap.get("cmd");
+	@RequestMapping(value = "/sym/ccm/zip/EgovCcmZipModifyView.do")
+	public String updateZip(@ModelAttribute("loginVO") LoginVO loginVO
+			, @ModelAttribute("zip") Zip zip
+			, ZipVO searchVO
+			, ModelMap model) throws Exception {
 		model.addAttribute("searchList", searchVO.getSearchList());
-		if (sCmd.equals("")) {
-			if (searchVO.getSearchList().equals("1")) {
-				Zip vo = zipManageService.selectZipDetail(zip);
-				model.addAttribute("zip", vo);
-			} else {
-				Zip vo = rdnmadZipService.selectZipDetail(zip);
-				model.addAttribute("zip", vo);
-			}
-			return "egovframework/com/sym/ccm/zip/EgovCcmZipModify";
-		} else if (sCmd.equals("Modify")) {
-			if (searchVO.getSearchList().equals("1")) {
-				beanValidator.validate(zip, bindingResult);
-				if (bindingResult.hasErrors()) {
-					return "egovframework/com/sym/ccm/zip/EgovCcmZipModify";
-				}
-
-				zip.setLastUpdusrId(loginVO.getUniqId());
-				zipManageService.updateZip(zip);
-			} else {
-				/*beanValidator.validate(zip, bindingResult);
-				if (bindingResult.hasErrors()){
-					return "egovframework/com/sym/ccm/zip/EgovCcmZipModify";
-				}*/
-
-				zip.setLastUpdusrId(loginVO.getUniqId());
-				rdnmadZipService.updateZip(zip);
-			}
-
-			return "forward:/sym/ccm/zip/EgovCcmZipList.do";
+		boolean isRoadAddr = ("2".equals(searchVO.getSearchList()));
+		Zip vo = null;
+		if (isRoadAddr) {
+			vo = rdnmadZipService.selectZipDetail(zip);
 		} else {
-			return "forward:/sym/ccm/zip/EgovCcmZipList.do";
+			vo = zipManageService.selectZipDetail(zip);
 		}
+		model.addAttribute("zip", vo);
+		model.addAttribute("isRoadAddr", isRoadAddr);
+		return "egovframework/com/sym/ccm/zip/EgovCcmZipModify";
+	}
+
+	/**
+	 * 우편번호를 수정한다.
+	 * @param loginVO
+	 * @param zip
+	 * @param bindingResult
+	 * @param searchVO
+	 * @param model
+	 * @return
+	 * @throws Exception
+	 */
+	@RequestMapping(value = "/sym/ccm/zip/EgovCcmZipModify.do")
+	public String updateZip(@ModelAttribute("loginVO") LoginVO loginVO
+			, @ModelAttribute("zip") Zip zip
+			, BindingResult bindingResult
+			, ZipVO searchVO
+			, ModelMap model) throws Exception {
+		if (zip.getSn() == 0) {
+			return "redirect:/sym/ccm/zip/EgovCcmZipList.do";
+		}
+		boolean isRoadAddr = ("2".equals(searchVO.getSearchList()));
+		beanValidator.validate(zip, bindingResult);
+		if (!isRoadAddr && bindingResult.hasErrors()) {
+			model.addAttribute("searchList", searchVO.getSearchList());
+			return "egovframework/com/sym/ccm/zip/EgovCcmZipModify";
+		}
+		/* 2024-08-31 권태성 - 기존 코드에서 도로명주소 일 때 validate를 주석 처리해두어 주석을 유지함
+		else {
+			beanValidator.validate(zip, bindingResult);
+			if (bindingResult.hasErrors()){
+				return "egovframework/com/sym/ccm/zip/EgovCcmZipModify";
+			}
+		}
+		*/
+
+		zip.setLastUpdusrId(loginVO.getUniqId());
+		if (isRoadAddr) {
+			rdnmadZipService.updateZip(zip);
+		} else {
+			zipManageService.updateZip(zip);
+		}
+		return "redirect:/sym/ccm/zip/EgovCcmZipList.do";
 	}
 
 	/**

--- a/src/main/webapp/WEB-INF/jsp/egovframework/com/sym/ccm/zip/EgovCcmZipDetail.jsp
+++ b/src/main/webapp/WEB-INF/jsp/egovframework/com/sym/ccm/zip/EgovCcmZipDetail.jsp
@@ -1,19 +1,19 @@
 <%
- /**
-  * @Class Name  : EgovCcmZipDetail.jsp
-  * @Description : EgovCcmZipDetail 화면
-  * @Modification Information
-  * @
-  * @  수정일             수정자                   수정내용
-  * @ -------    --------    ---------------------------
-  * @ 2009.04.01   이중호              최초 생성
-  * @ 2017.09.01   양희훈              표준프레임워크 v3.7 개선
-  *  @author 공통서비스팀
-  *  @since 2009.04.01
-  *  @version 1.0
-  *  @see
-  *
-  */
+	/**
+	 * @Class Name  : EgovCcmZipDetail.jsp
+	 * @Description : EgovCcmZipDetail 화면
+	 * @Modification Information
+	 * @
+	 * @  수정일             수정자                   수정내용
+	 * @ -------    --------    ---------------------------
+	 * @ 2009.04.01   이중호              최초 생성
+	 * @ 2017.09.01   양희훈              표준프레임워크 v3.7 개선
+	 *  @author 공통서비스팀
+	 *  @since 2009.04.01
+	 *  @version 1.0
+	 *  @see
+	 *
+	 */
 %>
 
 <%@ page contentType="text/html; charset=utf-8"%>
@@ -24,144 +24,144 @@
 <c:set var="pageTitle"><spring:message code="comSymCcmZip.zipVO.title"/></c:set>
 <html lang="ko">
 <head>
-<title>${pageTitle } <spring:message code="title.detail" /></title>
-<meta http-equiv="content-type" content="text/html; charset=utf-8">
-<link type="text/css" rel="stylesheet" href="<c:url value='/css/egovframework/com/cop/bbs/style.css' />">
-<script type="text/javaScript" language="javascript">
-<!--
-/* ********************************************************
- * 목록 으로 가기
- ******************************************************** */
-function fn_egov_list_Zip(){
-	location.href = "<c:url value='/sym/ccm/zip/EgovCcmZipList.do' />";
-}
-/* ********************************************************
- * 수정화면으로  바로가기
- ******************************************************** */
-function fn_egov_modify_Zip(){
-	var varForm				 = document.getElementById("Form");
-	varForm.action           = "<c:url value='/sym/ccm/zip/EgovCcmZipModify.do'/>";
-	if (${searchList} == "1") {
-		varForm.zip.value        = "${result.zip}";
-		varForm.sn.value         = "${result.sn}";
-	} else {
-		varForm.rdmnCode.value   = "${result.rdmnCode}";
-		varForm.sn.value         = "${result.sn}";
-	}
-	varForm.submit();
-}
-/* ********************************************************
- * 삭제 처리 함수
- ******************************************************** */
-function fn_egov_delete_Zip(){
-	if (confirm("<spring:message code='common.delete.msg'/>")) {
-		var varForm				 = document.getElementById("Form");
-		varForm.action           = "<c:url value='/sym/ccm/zip/EgovCcmZipRemove.do'/>";
-		if (${searchList} == "1") {
-			varForm.zip.value        = "${result.zip}";
-			varForm.sn.value         = "${result.sn}";
-		} else {
-			varForm.rdmnCode.value   = "${result.rdmnCode}";
-			varForm.sn.value         = "${result.sn}";
+	<title>${pageTitle } <spring:message code="title.detail" /></title>
+	<meta http-equiv="content-type" content="text/html; charset=utf-8">
+	<link type="text/css" rel="stylesheet" href="<c:url value='/css/egovframework/com/cop/bbs/style.css' />">
+	<script type="text/javaScript" language="javascript">
+		<!--
+		/* ********************************************************
+         * 목록 으로 가기
+         ******************************************************** */
+		function fn_egov_list_Zip(){
+			location.href = "<c:url value='/sym/ccm/zip/EgovCcmZipList.do' />";
 		}
-		varForm.submit();
-	}
-}
--->
-</script>
+		/* ********************************************************
+         * 수정화면으로  바로가기
+         ******************************************************** */
+		function fn_egov_modify_Zip(){
+			var varForm				 = document.getElementById("Form");
+			varForm.action           = "<c:url value='/sym/ccm/zip/EgovCcmZipModifyView.do'/>";
+			if (${searchList} == "1") {
+				varForm.zip.value        = "${result.zip}";
+				varForm.sn.value         = "${result.sn}";
+			} else {
+				varForm.rdmnCode.value   = "${result.rdmnCode}";
+				varForm.sn.value         = "${result.sn}";
+			}
+			varForm.submit();
+		}
+		/* ********************************************************
+         * 삭제 처리 함수
+         ******************************************************** */
+		function fn_egov_delete_Zip(){
+			if (confirm("<spring:message code='common.delete.msg'/>")) {
+				var varForm				 = document.getElementById("Form");
+				varForm.action           = "<c:url value='/sym/ccm/zip/EgovCcmZipRemove.do'/>";
+				if (${searchList} == "1") {
+					varForm.zip.value        = "${result.zip}";
+					varForm.sn.value         = "${result.sn}";
+				} else {
+					varForm.rdmnCode.value   = "${result.rdmnCode}";
+					varForm.sn.value         = "${result.sn}";
+				}
+				varForm.submit();
+			}
+		}
+		-->
+	</script>
 </head>
 <body>
 <div class="note">
-<noscript class="noScriptTitle"><spring:message code="common.noScriptTitle.msg"/></noscript> <!-- 자바스크립트를 지원하지 않는 브라우저에서는 일부 기능을 사용하실 수 없습니다. -->
-<table width="700" cellpadding="8" class="table-search" border="0">
- <tr>
-  <td width="100%" class="title_left"><h1 class="title_left">
-   <img src="<c:url value='/images/egovframework/com/cmm/icon/tit_icon.gif' />" width="16" height="16" hspace="3" style="vertical-align: middle" alt="<spring:message code="comSymCcmZip.zipVO.altImg"/>">&nbsp;${pageTitle } <spring:message code="title.detail" /></h1></td>
- </tr>
-</table>
-<table class="tbl_note" width="700" border="0" cellpadding="0" cellspacing="1" summary="<spring:message code="comSymCcmZip.zipVO.summaryDetail"/>"> <!-- 우편번호, 시도명, 시군구명, 읍면동명, 리건물명, 번지동호를 가지고 있는 우편번호 상세조회 테이블이다. -->
-<CAPTION style="display: none;">${pageTitle } <spring:message code="title.detail" /></CAPTION>
-  <c:if test="${searchList == '1'}">
-	  <tr>
-	    <th class="ic_none" width="20%" height="23" scope="row" nowrap ><spring:message code="comSymCcmZip.zipVO.zip"/> <span class="pilsu">*</span></th> <!-- 우편번호 -->
-	    <td><c:out value='${fn:substring(result.zip, 0,3)}'/>-<c:out value='${fn:substring(result.zip, 3,6)}'/></td>
-	  </tr>
-	  <tr>
-	    <th class="ic_none" width="20%" height="23" scope="row" nowrap ><spring:message code="comSymCcmZip.zipVO.ctprvnNm"/> <span class="pilsu">*</span></th> <!-- 시도명 -->
-	    <td>${result.ctprvnNm}</td>
-	  </tr>
-	  <tr>
-	    <th class="ic_none" width="20%" height="23" scope="row" nowrap ><spring:message code="comSymCcmZip.zipVO.signguNm"/> <span class="pilsu">*</span></th> <!-- 시군구명 -->
-	    <td>${result.signguNm}</td>
-	  </tr>
-	  <tr>
-	    <th class="ic_none" width="20%" height="23" scope="row" nowrap ><spring:message code="comSymCcmZip.zipVO.emdNm"/> <span class="pilsu">*</span></th> <!-- 읍면동명 -->
-	    <td>${result.emdNm}</td>
-	  </tr>
-	  <tr>
-	    <th class="ic_none" width="20%" height="23" scope="row" nowrap ><spring:message code="comSymCcmZip.zipVO.liBuldNm"/></th> <!-- 리건물명 -->
-	    <td>${result.liBuldNm}</td>
-	  </tr>
-	  <tr>
-	    <th class="ic_none" width="20%" height="23" scope="row" nowrap ><spring:message code="comSymCcmZip.zipVO.lnbrDongHo"/></th><!-- 번지동호 -->
-	    <td>${result.lnbrDongHo}</td>
-	  </tr>
-  </c:if>
-  <c:if test="${searchList == '2'}">
-	  <tr>
-	    <th class="ic_none" width="20%" height="23" scope="row" nowrap ><spring:message code="comSymCcmZip.zipVO.zip"/> <span class="pilsu">*</span></th><!-- 우편번호 -->
-	    <td><c:out value='${fn:substring(result.zip, 0,3)}'/>-<c:out value='${fn:substring(result.zip, 3,6)}'/></td>
-	  </tr>
-	  <tr>
-	    <th class="ic_none" width="20%" height="23" scope="row" nowrap ><spring:message code="comSymCcmZip.zipVO.rdmnCode"/> <span class="pilsu">*</span></th><!-- 도로명코드 -->
-	    <td>${result.rdmnCode}</td>
-	  </tr>
-	  <tr>
-	    <th class="ic_none" width="20%" height="23" scope="row" nowrap ><spring:message code="comSymCcmZip.zipVO.ctprvnNm"/> <span class="pilsu">*</span></th> <!-- 시도명 -->
-	    <td>${result.ctprvnNm}</td>
-	  </tr>
-	  <tr>
-	    <th class="ic_none" width="20%" height="23" scope="row" nowrap ><spring:message code="comSymCcmZip.zipVO.signguNm"/> <span class="pilsu">*</span></th> <!-- 시군구명 -->
-	    <td>${result.signguNm}</td>
-	  </tr>
-	  <tr>
-	    <th class="ic_none" width="20%" height="23" scope="row" nowrap ><spring:message code="comSymCcmZip.zipVO.rdmn"/> <span class="pilsu">*</span></th> <!-- 도로명 -->
-	    <td>${result.rdmn}</td>
-	  </tr>
-	  <tr>
-	    <th class="ic_none" width="20%" height="23" scope="row" nowrap ><spring:message code="comSymCcmZip.zipVO.bdnbrMnnm"/></th> <!-- 건물번호본번 -->
-	    <td>${result.bdnbrMnnm}</td>
-	  </tr>
-	  <tr>
-	    <th class="ic_none" width="20%" height="23" scope="row" nowrap ><spring:message code="comSymCcmZip.zipVO.bdnbrSlno"/></th> <!-- 건물번호부번 -->
-	    <td>${result.bdnbrSlno}</td>
-	  </tr>
-	  <tr>
-	    <th class="ic_none" width="20%" height="23" scope="row" nowrap ><spring:message code="comSymCcmZip.zipVO.buldNm"/></th> <!-- 건물명 -->
-	    <td>${result.buldNm}</td>
-	  </tr>
-	  <tr>
-	    <th class="ic_none" width="20%" height="23" scope="row" nowrap ><spring:message code="comSymCcmZip.zipVO.detailBuldNm"/></th> <!-- 상세건물명 -->
-	    <td>${result.detailBuldNm}</td>
-	  </tr>
-  </c:if>
-</table>
-<table width="700" border="0" cellspacing="0" cellpadding="0">
-  <tr>
-    <td height="10"></td>
-  </tr>
-</table>
-<div class="txt-cnt mt20">
-<input class="btnStyle02" type="submit" value="<spring:message code="button.update" />" onclick="fn_egov_modify_Zip(); return false;"></td>
-<input class="btnStyle02" type="submit" value="<spring:message code="title.delete" />" onclick="fn_egov_delete_Zip(); return false;"></td>
-<input class="btnStyle02" type="submit" value="<spring:message code="button.list" />" onclick="fn_egov_list_Zip(); return false;"></td>
-</div>
-<form name="Form" id="Form" method="post" action="">
-	<input type=hidden name="zip">
-	<input type=hidden name="sn">
-	<input type=hidden name="rdmnCode">
-	<input type=hidden name="searchList" value="${searchList}">
-</form>
+	<noscript class="noScriptTitle"><spring:message code="common.noScriptTitle.msg"/></noscript> <!-- 자바스크립트를 지원하지 않는 브라우저에서는 일부 기능을 사용하실 수 없습니다. -->
+	<table width="700" cellpadding="8" class="table-search" border="0">
+		<tr>
+			<td width="100%" class="title_left"><h1 class="title_left">
+				<img src="<c:url value='/images/egovframework/com/cmm/icon/tit_icon.gif' />" width="16" height="16" hspace="3" style="vertical-align: middle" alt="<spring:message code="comSymCcmZip.zipVO.altImg"/>">&nbsp;${pageTitle } <spring:message code="title.detail" /></h1></td>
+		</tr>
+	</table>
+	<table class="tbl_note" width="700" border="0" cellpadding="0" cellspacing="1" summary="<spring:message code="comSymCcmZip.zipVO.summaryDetail"/>"> <!-- 우편번호, 시도명, 시군구명, 읍면동명, 리건물명, 번지동호를 가지고 있는 우편번호 상세조회 테이블이다. -->
+		<CAPTION style="display: none;">${pageTitle } <spring:message code="title.detail" /></CAPTION>
+		<c:if test="${searchList == '1'}">
+			<tr>
+				<th class="ic_none" width="20%" height="23" scope="row" nowrap ><spring:message code="comSymCcmZip.zipVO.zip"/> <span class="pilsu">*</span></th> <!-- 우편번호 -->
+				<td><c:out value='${fn:substring(result.zip, 0,3)}'/>-<c:out value='${fn:substring(result.zip, 3,6)}'/></td>
+			</tr>
+			<tr>
+				<th class="ic_none" width="20%" height="23" scope="row" nowrap ><spring:message code="comSymCcmZip.zipVO.ctprvnNm"/> <span class="pilsu">*</span></th> <!-- 시도명 -->
+				<td>${result.ctprvnNm}</td>
+			</tr>
+			<tr>
+				<th class="ic_none" width="20%" height="23" scope="row" nowrap ><spring:message code="comSymCcmZip.zipVO.signguNm"/> <span class="pilsu">*</span></th> <!-- 시군구명 -->
+				<td>${result.signguNm}</td>
+			</tr>
+			<tr>
+				<th class="ic_none" width="20%" height="23" scope="row" nowrap ><spring:message code="comSymCcmZip.zipVO.emdNm"/> <span class="pilsu">*</span></th> <!-- 읍면동명 -->
+				<td>${result.emdNm}</td>
+			</tr>
+			<tr>
+				<th class="ic_none" width="20%" height="23" scope="row" nowrap ><spring:message code="comSymCcmZip.zipVO.liBuldNm"/></th> <!-- 리건물명 -->
+				<td>${result.liBuldNm}</td>
+			</tr>
+			<tr>
+				<th class="ic_none" width="20%" height="23" scope="row" nowrap ><spring:message code="comSymCcmZip.zipVO.lnbrDongHo"/></th><!-- 번지동호 -->
+				<td>${result.lnbrDongHo}</td>
+			</tr>
+		</c:if>
+		<c:if test="${searchList == '2'}">
+			<tr>
+				<th class="ic_none" width="20%" height="23" scope="row" nowrap ><spring:message code="comSymCcmZip.zipVO.zip"/> <span class="pilsu">*</span></th><!-- 우편번호 -->
+				<td><c:out value='${fn:substring(result.zip, 0,3)}'/>-<c:out value='${fn:substring(result.zip, 3,6)}'/></td>
+			</tr>
+			<tr>
+				<th class="ic_none" width="20%" height="23" scope="row" nowrap ><spring:message code="comSymCcmZip.zipVO.rdmnCode"/> <span class="pilsu">*</span></th><!-- 도로명코드 -->
+				<td>${result.rdmnCode}</td>
+			</tr>
+			<tr>
+				<th class="ic_none" width="20%" height="23" scope="row" nowrap ><spring:message code="comSymCcmZip.zipVO.ctprvnNm"/> <span class="pilsu">*</span></th> <!-- 시도명 -->
+				<td>${result.ctprvnNm}</td>
+			</tr>
+			<tr>
+				<th class="ic_none" width="20%" height="23" scope="row" nowrap ><spring:message code="comSymCcmZip.zipVO.signguNm"/> <span class="pilsu">*</span></th> <!-- 시군구명 -->
+				<td>${result.signguNm}</td>
+			</tr>
+			<tr>
+				<th class="ic_none" width="20%" height="23" scope="row" nowrap ><spring:message code="comSymCcmZip.zipVO.rdmn"/> <span class="pilsu">*</span></th> <!-- 도로명 -->
+				<td>${result.rdmn}</td>
+			</tr>
+			<tr>
+				<th class="ic_none" width="20%" height="23" scope="row" nowrap ><spring:message code="comSymCcmZip.zipVO.bdnbrMnnm"/></th> <!-- 건물번호본번 -->
+				<td>${result.bdnbrMnnm}</td>
+			</tr>
+			<tr>
+				<th class="ic_none" width="20%" height="23" scope="row" nowrap ><spring:message code="comSymCcmZip.zipVO.bdnbrSlno"/></th> <!-- 건물번호부번 -->
+				<td>${result.bdnbrSlno}</td>
+			</tr>
+			<tr>
+				<th class="ic_none" width="20%" height="23" scope="row" nowrap ><spring:message code="comSymCcmZip.zipVO.buldNm"/></th> <!-- 건물명 -->
+				<td>${result.buldNm}</td>
+			</tr>
+			<tr>
+				<th class="ic_none" width="20%" height="23" scope="row" nowrap ><spring:message code="comSymCcmZip.zipVO.detailBuldNm"/></th> <!-- 상세건물명 -->
+				<td>${result.detailBuldNm}</td>
+			</tr>
+		</c:if>
+	</table>
+	<table width="700" border="0" cellspacing="0" cellpadding="0">
+		<tr>
+			<td height="10"></td>
+		</tr>
+	</table>
+	<div class="txt-cnt mt20">
+		<input class="btnStyle02" type="submit" value="<spring:message code="button.update" />" onclick="fn_egov_modify_Zip(); return false;"></td>
+		<input class="btnStyle02" type="submit" value="<spring:message code="title.delete" />" onclick="fn_egov_delete_Zip(); return false;"></td>
+		<input class="btnStyle02" type="submit" value="<spring:message code="button.list" />" onclick="fn_egov_list_Zip(); return false;"></td>
+	</div>
+	<form name="Form" id="Form" method="post" action="">
+		<input type=hidden name="zip">
+		<input type=hidden name="sn">
+		<input type=hidden name="rdmnCode">
+		<input type=hidden name="searchList" value="${searchList}">
+	</form>
 </div>
 </body>
 </html>

--- a/src/main/webapp/WEB-INF/jsp/egovframework/com/sym/ccm/zip/EgovCcmZipList.jsp
+++ b/src/main/webapp/WEB-INF/jsp/egovframework/com/sym/ccm/zip/EgovCcmZipList.jsp
@@ -1,19 +1,19 @@
 <%
- /**
-  * @Class Name  : EgovCcmZipList.jsp
-  * @Description : EgovCcmZipList 화면
-  * @Modification Information
-  * @
-  * @  수정일             수정자                   수정내용
-  * @ -------    --------    ---------------------------
-  * @ 2009.04.01   이중호              최초 생성
-  * @ 2017.09.01   양희훈              표준프레임워크 v3.7 개선
-  *  @author 공통서비스팀
-  *  @since 2009.04.01
-  *  @version 1.0
-  *  @see
-  *
-  */
+	/**
+	 * @Class Name  : EgovCcmZipList.jsp
+	 * @Description : EgovCcmZipList 화면
+	 * @Modification Information
+	 * @
+	 * @  수정일             수정자                   수정내용
+	 * @ -------    --------    ---------------------------
+	 * @ 2009.04.01   이중호              최초 생성
+	 * @ 2017.09.01   양희훈              표준프레임워크 v3.7 개선
+	 *  @author 공통서비스팀
+	 *  @since 2009.04.01
+	 *  @version 1.0
+	 *  @see
+	 *
+	 */
 %>
 
 <%@ page contentType="text/html; charset=utf-8"%>
@@ -24,197 +24,197 @@
 <c:set var="pageTitle"><spring:message code="comSymCcmZip.zipVO.title"/></c:set>
 <html lang="ko">
 <head>
-<title>${pageTitle}<spring:message code="title.list" /></title>
-<meta http-equiv="content-type" content="text/html; charset=utf-8">
-<link type="text/css" rel="stylesheet" href="<c:url value='/css/egovframework/com/com.css' />">
-<link type="text/css" rel="stylesheet" href="<c:url value='/css/egovframework/com/button.css' />" >
-<script type="text/javaScript" language="javascript">
-<!--
-/* ********************************************************
- * 페이징 처리 함수
- ******************************************************** */
-function fn_egov_pageview(pageNo){
-	document.listForm.pageIndex.value = pageNo;
-	document.listForm.action = "<c:url value='/sym/ccm/zip/EgovCcmZipList.do'/>";
-   	document.listForm.submit();
-}
-/* ********************************************************
- * 조회 처리
- ******************************************************** */
-function fn_egov_search_Zip(){
-	sC1 = document.listForm.searchCondition.value;
-	sC2 = document.listForm.searchCondition2.value;
-	sK = document.listForm.searchKeyword.value;
-	if (sC1 == "1" || sC2 == "1") {
-		document.listForm.searchKeyword.value = sK.replace(/\-/, "");
-	}
-	document.listForm.pageIndex.value = 1;
-   	document.listForm.submit();
-}
-/* ********************************************************
- * 등록 처리 함수
- ******************************************************** */
-function fn_egov_regist_Zip(no){
-//	location.href = "<c:url value='/sym/ccm/zip/EgovCcmZipRegist.do'/>";
-	var varForm	   			 = document.getElementById("Form");
-	varForm.action 			 = "<c:url value='/sym/ccm/zip/EgovCcmZipRegist.do'/>";
-	varForm.searchList.value = no;
-	varForm.submit();
-}
-/* ********************************************************
- * 엑셀등록 처리 함수
- ******************************************************** */
-function fn_egov_regist_ExcelZip(no){
+	<title>${pageTitle}<spring:message code="title.list" /></title>
+	<meta http-equiv="content-type" content="text/html; charset=utf-8">
+	<link type="text/css" rel="stylesheet" href="<c:url value='/css/egovframework/com/com.css' />">
+	<link type="text/css" rel="stylesheet" href="<c:url value='/css/egovframework/com/button.css' />" >
+	<script type="text/javaScript" language="javascript">
+		<!--
+		/* ********************************************************
+         * 페이징 처리 함수
+         ******************************************************** */
+		function fn_egov_pageview(pageNo){
+			document.listForm.pageIndex.value = pageNo;
+			document.listForm.action = "<c:url value='/sym/ccm/zip/EgovCcmZipList.do'/>";
+			document.listForm.submit();
+		}
+		/* ********************************************************
+         * 조회 처리
+         ******************************************************** */
+		function fn_egov_search_Zip(){
+			sC1 = document.listForm.searchCondition.value;
+			sC2 = document.listForm.searchCondition2.value;
+			sK = document.listForm.searchKeyword.value;
+			if (sC1 == "1" || sC2 == "1") {
+				document.listForm.searchKeyword.value = sK.replace(/\-/, "");
+			}
+			document.listForm.pageIndex.value = 1;
+			document.listForm.submit();
+		}
+		/* ********************************************************
+         * 등록 처리 함수
+         ******************************************************** */
+		function fn_egov_regist_Zip(no){
+//	location.href = "<c:url value='/sym/ccm/zip/EgovCcmZipRegistView.do'/>";
+			var varForm	   			 = document.getElementById("Form");
+			varForm.action 			 = "<c:url value='/sym/ccm/zip/EgovCcmZipRegistView.do'/>";
+			varForm.searchList.value = no;
+			varForm.submit();
+		}
+		/* ********************************************************
+         * 엑셀등록 처리 함수
+         ******************************************************** */
+		function fn_egov_regist_ExcelZip(no){
 //	location.href = "<c:url value='/sym/ccm/zip/EgovCcmExcelZipRegist.do' />";
-	var varForm	   			 = document.getElementById("Form");
-	varForm.action 			 = "<c:url value='/sym/ccm/zip/EgovCcmExcelZipRegist.do'/>";
-	varForm.searchList.value = no;
-	varForm.submit();
-}
-/* ********************************************************
- * 수정 처리 함수
- ******************************************************** */
-function fn_egov_modify_Zip(){
-	location.href = "";
-}
-/* ********************************************************
- * 상세회면 처리 함수(일반주소)
- ******************************************************** */
-function fn_egov_detail_Zip(zip,sn){
-	var varForm				 = document.getElementById("Form");
-	varForm.action           = "<c:url value='/sym/ccm/zip/EgovCcmZipDetail.do'/>";
-	varForm.zip.value        = zip;
-	varForm.sn.value         = sn;
-	varForm.searchList.value = "1";
-	varForm.submit();
-}
-/* ********************************************************
- * 상세회면 처리 함수(도로명주소)
- ******************************************************** */
-function fn_egov_detail_RdmnCode_Zip(rdmnCode, sn){
-	var varForm				 = document.getElementById("Form");
-	varForm.action           = "<c:url value='/sym/ccm/zip/EgovCcmZipDetail.do'/>";
-	varForm.rdmnCode.value   = rdmnCode;
-	varForm.sn.value         = sn;
-	varForm.searchList.value = "2";
-	varForm.submit();
-}
-/* ********************************************************
- * 목록회면 처리 함수
- ******************************************************** */
-function fn_egov_list(){
-	if (document.getElementById("searchList").value == 1) {
-		document.getElementById("searchCondition").style.display="block";
-		document.getElementById("searchCondition2").style.display="none";
-	} else {
-		document.getElementById("searchCondition").style.display="none";
-		document.getElementById("searchCondition2").style.display="block";
-	}
-}
--->
-</script>
+			var varForm	   			 = document.getElementById("Form");
+			varForm.action 			 = "<c:url value='/sym/ccm/zip/EgovCcmExcelZipRegist.do'/>";
+			varForm.searchList.value = no;
+			varForm.submit();
+		}
+		/* ********************************************************
+         * 수정 처리 함수
+         ******************************************************** */
+		function fn_egov_modify_Zip(){
+			location.href = "";
+		}
+		/* ********************************************************
+         * 상세회면 처리 함수(일반주소)
+         ******************************************************** */
+		function fn_egov_detail_Zip(zip,sn){
+			var varForm				 = document.getElementById("Form");
+			varForm.action           = "<c:url value='/sym/ccm/zip/EgovCcmZipDetail.do'/>";
+			varForm.zip.value        = zip;
+			varForm.sn.value         = sn;
+			varForm.searchList.value = "1";
+			varForm.submit();
+		}
+		/* ********************************************************
+         * 상세회면 처리 함수(도로명주소)
+         ******************************************************** */
+		function fn_egov_detail_RdmnCode_Zip(rdmnCode, sn){
+			var varForm				 = document.getElementById("Form");
+			varForm.action           = "<c:url value='/sym/ccm/zip/EgovCcmZipDetail.do'/>";
+			varForm.rdmnCode.value   = rdmnCode;
+			varForm.sn.value         = sn;
+			varForm.searchList.value = "2";
+			varForm.submit();
+		}
+		/* ********************************************************
+         * 목록회면 처리 함수
+         ******************************************************** */
+		function fn_egov_list(){
+			if (document.getElementById("searchList").value == 1) {
+				document.getElementById("searchCondition").style.display="block";
+				document.getElementById("searchCondition2").style.display="none";
+			} else {
+				document.getElementById("searchCondition").style.display="none";
+				document.getElementById("searchCondition2").style.display="block";
+			}
+		}
+		-->
+	</script>
 </head>
 <body onLoad="fn_egov_list()">
 <noscript class="noScriptTitle"><spring:message code="common.noScriptTitle.msg"/></noscript>
 <form name="listForm" action="<c:url value='/sym/ccm/zip/EgovCcmZipList.do'/>" method="post">
-<div class="board">
-<h1>${pageTitle} <spring:message code="title.list" /></h1>
-	<div class="search_box">
-		<ul>
-			<li>
-		   	<select name="searchList" id="searchList" class="select" title="searchList" onChange="fn_egov_list()"> 
-			   <option value='1' <c:if test="${searchVO.searchList == '1'}">selected="selected"</c:if>><spring:message code="comSymCcmZip.zipVO.SearchAddrr" /></option>		<!-- 주소 -->
-			   <option value='2' <c:if test="${searchVO.searchList == '2'}">selected="selected"</c:if>><spring:message code="comSymCcmZip.zipVO.SearchRdmn" /></option>			<!-- 우편번호 -->
-		    </select>
-		    </li>
-			<li>
-			<select name="searchCondition" id="searchCondition" class="select" title="searchCondition" style="display:none">
-			   <option value='1' <c:if test="${searchVO.searchCondition == '1'}">selected="selected"</c:if>><spring:message code="comSymCcmZip.zipVO.zip" /></option>			<!-- 우편번호 -->
-			   <option value='2' <c:if test="${searchVO.searchCondition == '2'}">selected="selected"</c:if>><spring:message code="comSymCcmZip.zipVO.ctprvnNm" /></option>		<!-- 시도명 -->
-			   <option value='3' <c:if test="${searchVO.searchCondition == '3'}">selected="selected"</c:if>><spring:message code="comSymCcmZip.zipVO.signguNm" /></option>		<!-- 시군구명 -->
-			   <option value='4' <c:if test="${searchVO.searchCondition == '4'}">selected="selected"</c:if>><spring:message code="comSymCcmZip.zipVO.emdNm" /></option>			<!-- 읍면동명 -->
-			   <option value='5' <c:if test="${searchVO.searchCondition == '5'}">selected="selected"</c:if>><spring:message code="comSymCcmZip.zipVO.liBuldNm" /></option>		<!-- 리건물명 -->
-			</select>
-			</li>
-			<li>
-		   	<select name="searchCondition2" id="searchCondition2" class="select" title="searchCondition" style="display:none">
-			   <option value='1' <c:if test="${searchVO.searchCondition2 == '1'}">selected="selected"</c:if>><spring:message code="comSymCcmZip.zipVO.zip" /></option>			<!-- 우편번호 -->
-			   <option value='2' <c:if test="${searchVO.searchCondition2 == '2'}">selected="selected"</c:if>><spring:message code="comSymCcmZip.zipVO.ctprvnNm" /></option>		<!-- 시도명 -->
-			   <option value='3' <c:if test="${searchVO.searchCondition2 == '3'}">selected="selected"</c:if>><spring:message code="comSymCcmZip.zipVO.signguNm" /></option>		<!-- 시군구명 -->
-			   <option value='4' <c:if test="${searchVO.searchCondition2 == '4'}">selected="selected"</c:if>><spring:message code="comSymCcmZip.zipVO.emdNm" /></option>		<!-- 읍면동명 -->
-			   <option value='5' <c:if test="${searchVO.searchCondition2 == '5'}">selected="selected"</c:if>><spring:message code="comSymCcmZip.zipVO.liBuldNm" /></option>		<!-- 리건물명 -->
-			   <option value='6' <c:if test="${searchVO.searchCondition2 == '6'}">selected="selected"</c:if>><spring:message code="comSymCcmZip.zipVO.detailBuldNm" /></option>	<!-- 상세건물명 -->
-			</select>
-			</li>
-			<li>
-		    <input name="searchKeyword" type="text" size="25" value="${searchVO.searchKeyword}"  maxlength="25" id="searchKeyword">
-		    <input type="submit" class="s_btn" value="<spring:message code="button.inquire" />" onclick="fn_egov_search_Zip(); return false;">	<!-- 조회 -->
-		    </li>
-		    <li style="margin-top:5px;">
-		    <input type="submit" class="s_btn" value="<spring:message code="comSymCcmZip.zipVO.SearchAddrr" /> <spring:message code="title.create" />" onclick="fn_egov_regist_Zip(1); return false;">	<!-- 일반주소 등록 -->
-		    <input type="submit" class="s_btn" value="<spring:message code="comSymCcmZip.zipVO.SearchRdmn" /> <spring:message code="title.create" />" onclick="fn_egov_regist_Zip(2); return false;">	<!-- 도로명주소 등록 -->
-		    <input type="submit" class="s_btn" value="<spring:message code="comSymCcmZip.zipVO.SearchAddrr" /> <spring:message code="comSymCcmZip.zipVO.excelFile" /> <spring:message code="title.create" />" onclick="fn_egov_regist_ExcelZip(1); return false;">	<!-- 일반주소 엑셀파일 등록 -->
-		    <input type="submit" class="s_btn" value="<spring:message code="comSymCcmZip.zipVO.SearchRdmn" /> <spring:message code="comSymCcmZip.zipVO.excelFile" /> <spring:message code="title.create" />" onclick="fn_egov_regist_ExcelZip(2); return false;">	<!-- 도로명주소 엑셀파일 등록 -->
-		    </li>
-	  	<ul>
-	  </div>
+	<div class="board">
+		<h1>${pageTitle} <spring:message code="title.list" /></h1>
+		<div class="search_box">
+			<ul>
+				<li>
+					<select name="searchList" id="searchList" class="select" title="searchList" onChange="fn_egov_list()">
+						<option value='1' <c:if test="${searchVO.searchList == '1'}">selected="selected"</c:if>><spring:message code="comSymCcmZip.zipVO.SearchAddrr" /></option>		<!-- 주소 -->
+						<option value='2' <c:if test="${searchVO.searchList == '2'}">selected="selected"</c:if>><spring:message code="comSymCcmZip.zipVO.SearchRdmn" /></option>			<!-- 우편번호 -->
+					</select>
+				</li>
+				<li>
+					<select name="searchCondition" id="searchCondition" class="select" title="searchCondition" style="display:none">
+						<option value='1' <c:if test="${searchVO.searchCondition == '1'}">selected="selected"</c:if>><spring:message code="comSymCcmZip.zipVO.zip" /></option>			<!-- 우편번호 -->
+						<option value='2' <c:if test="${searchVO.searchCondition == '2'}">selected="selected"</c:if>><spring:message code="comSymCcmZip.zipVO.ctprvnNm" /></option>		<!-- 시도명 -->
+						<option value='3' <c:if test="${searchVO.searchCondition == '3'}">selected="selected"</c:if>><spring:message code="comSymCcmZip.zipVO.signguNm" /></option>		<!-- 시군구명 -->
+						<option value='4' <c:if test="${searchVO.searchCondition == '4'}">selected="selected"</c:if>><spring:message code="comSymCcmZip.zipVO.emdNm" /></option>			<!-- 읍면동명 -->
+						<option value='5' <c:if test="${searchVO.searchCondition == '5'}">selected="selected"</c:if>><spring:message code="comSymCcmZip.zipVO.liBuldNm" /></option>		<!-- 리건물명 -->
+					</select>
+				</li>
+				<li>
+					<select name="searchCondition2" id="searchCondition2" class="select" title="searchCondition" style="display:none">
+						<option value='1' <c:if test="${searchVO.searchCondition2 == '1'}">selected="selected"</c:if>><spring:message code="comSymCcmZip.zipVO.zip" /></option>			<!-- 우편번호 -->
+						<option value='2' <c:if test="${searchVO.searchCondition2 == '2'}">selected="selected"</c:if>><spring:message code="comSymCcmZip.zipVO.ctprvnNm" /></option>		<!-- 시도명 -->
+						<option value='3' <c:if test="${searchVO.searchCondition2 == '3'}">selected="selected"</c:if>><spring:message code="comSymCcmZip.zipVO.signguNm" /></option>		<!-- 시군구명 -->
+						<option value='4' <c:if test="${searchVO.searchCondition2 == '4'}">selected="selected"</c:if>><spring:message code="comSymCcmZip.zipVO.emdNm" /></option>		<!-- 읍면동명 -->
+						<option value='5' <c:if test="${searchVO.searchCondition2 == '5'}">selected="selected"</c:if>><spring:message code="comSymCcmZip.zipVO.liBuldNm" /></option>		<!-- 리건물명 -->
+						<option value='6' <c:if test="${searchVO.searchCondition2 == '6'}">selected="selected"</c:if>><spring:message code="comSymCcmZip.zipVO.detailBuldNm" /></option>	<!-- 상세건물명 -->
+					</select>
+				</li>
+				<li>
+					<input name="searchKeyword" type="text" size="25" value="${searchVO.searchKeyword}"  maxlength="25" id="searchKeyword">
+					<input type="submit" class="s_btn" value="<spring:message code="button.inquire" />" onclick="fn_egov_search_Zip(); return false;">	<!-- 조회 -->
+				</li>
+				<li style="margin-top:5px;">
+					<input type="submit" class="s_btn" value="<spring:message code="comSymCcmZip.zipVO.SearchAddrr" /> <spring:message code="title.create" />" onclick="fn_egov_regist_Zip(1); return false;">	<!-- 일반주소 등록 -->
+					<input type="submit" class="s_btn" value="<spring:message code="comSymCcmZip.zipVO.SearchRdmn" /> <spring:message code="title.create" />" onclick="fn_egov_regist_Zip(2); return false;">	<!-- 도로명주소 등록 -->
+					<input type="submit" class="s_btn" value="<spring:message code="comSymCcmZip.zipVO.SearchAddrr" /> <spring:message code="comSymCcmZip.zipVO.excelFile" /> <spring:message code="title.create" />" onclick="fn_egov_regist_ExcelZip(1); return false;">	<!-- 일반주소 엑셀파일 등록 -->
+					<input type="submit" class="s_btn" value="<spring:message code="comSymCcmZip.zipVO.SearchRdmn" /> <spring:message code="comSymCcmZip.zipVO.excelFile" /> <spring:message code="title.create" />" onclick="fn_egov_regist_ExcelZip(2); return false;">	<!-- 도로명주소 엑셀파일 등록 -->
+				</li>
+				<ul>
+		</div>
 
-<table class="board_list" summary="<spring:message code="comSymCcmZip.zipVO.summaryList"/>"> <!-- 우편번호와 주소를 출력하는 우편번호 목록 테이블이다. -->
-	<caption>${pageTitle}<spring:message code="title.list" /></caption>
-		<colgroup>
-			<col style="width: 10%;">
-			<col style="width: 20%;">
-			<col style="width: 70%;">
-	    </colgroup>
-	<thead>
-	<tr>
-		<th><spring:message code="comSymCcmZip.zipVO.Snum" /></th>			<!-- 순번 -->
-		<th><spring:message code="comSymCcmZip.zipVO.zip" /></th>			<!-- 우편번호 -->
-		<th><spring:message code="comSymCcmZip.zipVO.SearchAddr" /></th>	<!-- 주소 -->
-	</tr>
-	</thead>
+		<table class="board_list" summary="<spring:message code="comSymCcmZip.zipVO.summaryList"/>"> <!-- 우편번호와 주소를 출력하는 우편번호 목록 테이블이다. -->
+			<caption>${pageTitle}<spring:message code="title.list" /></caption>
+			<colgroup>
+				<col style="width: 10%;">
+				<col style="width: 20%;">
+				<col style="width: 70%;">
+			</colgroup>
+			<thead>
+			<tr>
+				<th><spring:message code="comSymCcmZip.zipVO.Snum" /></th>			<!-- 순번 -->
+				<th><spring:message code="comSymCcmZip.zipVO.zip" /></th>			<!-- 우편번호 -->
+				<th><spring:message code="comSymCcmZip.zipVO.SearchAddr" /></th>	<!-- 주소 -->
+			</tr>
+			</thead>
 
-<tbody>
-<c:choose>
-<c:when test="${searchVO.searchList != '2'}">
-	<c:forEach items="${resultList}" var="resultInfo" varStatus="status">
-	<tr style="cursor:pointer;cursor:hand;" onclick="javascript:fn_egov_detail_Zip('${resultInfo.zip}','${resultInfo.sn}');">
-		<td class="lt_text3" nowrap><c:out value="${(searchVO.pageIndex - 1) * searchVO.pageSize + status.count}"/></td>
-		<td class="lt_text3" nowrap><c:out value='${fn:substring(resultInfo.zip, 0,5)}'/></td>
-		<td class="lt_text"  nowrap>${resultInfo.ctprvnNm} ${resultInfo.signguNm} ${resultInfo.emdNm} ${resultInfo.liBuldNm} ${resultInfo.lnbrDongHo}</td>
-	</tr>
-	</c:forEach>
-</c:when>
-<c:otherwise>
-	<c:forEach items="${resultList}" var="resultInfo" varStatus="status">
-	<tr style="cursor:pointer;cursor:hand;" onclick="javascript:fn_egov_detail_RdmnCode_Zip('${resultInfo.rdmnCode}','${resultInfo.sn}');">
-		<td class="lt_text3" nowrap><c:out value="${(searchVO.pageIndex - 1) * searchVO.pageSize + status.count}"/></td>
-		<td class="lt_text3" nowrap><c:out value='${fn:substring(resultInfo.zip, 0,3)}'/>-<c:out value='${fn:substring(resultInfo.zip, 3,6)}'/></td>
-		<td class="lt_text"  nowrap>${resultInfo.ctprvnNm} ${resultInfo.signguNm} ${resultInfo.rdmn} ${resultInfo.bdnbrMnnm} <c:if test="${resultInfo.bdnbrSlno != ''}">- ${resultInfo.bdnbrSlno}</c:if> ${resultInfo.buldNm} ${resultInfo.detailBuldNm}</td>
-	</tr>
-	</c:forEach>
-</c:otherwise>
-</c:choose>
+			<tbody>
+			<c:choose>
+				<c:when test="${searchVO.searchList != '2'}">
+					<c:forEach items="${resultList}" var="resultInfo" varStatus="status">
+						<tr style="cursor:pointer;cursor:hand;" onclick="javascript:fn_egov_detail_Zip('${resultInfo.zip}','${resultInfo.sn}');">
+							<td class="lt_text3" nowrap><c:out value="${(searchVO.pageIndex - 1) * searchVO.pageSize + status.count}"/></td>
+							<td class="lt_text3" nowrap><c:out value='${fn:substring(resultInfo.zip, 0,5)}'/></td>
+							<td class="lt_text"  nowrap>${resultInfo.ctprvnNm} ${resultInfo.signguNm} ${resultInfo.emdNm} ${resultInfo.liBuldNm} ${resultInfo.lnbrDongHo}</td>
+						</tr>
+					</c:forEach>
+				</c:when>
+				<c:otherwise>
+					<c:forEach items="${resultList}" var="resultInfo" varStatus="status">
+						<tr style="cursor:pointer;cursor:hand;" onclick="javascript:fn_egov_detail_RdmnCode_Zip('${resultInfo.rdmnCode}','${resultInfo.sn}');">
+							<td class="lt_text3" nowrap><c:out value="${(searchVO.pageIndex - 1) * searchVO.pageSize + status.count}"/></td>
+							<td class="lt_text3" nowrap><c:out value='${fn:substring(resultInfo.zip, 0,3)}'/>-<c:out value='${fn:substring(resultInfo.zip, 3,6)}'/></td>
+							<td class="lt_text"  nowrap>${resultInfo.ctprvnNm} ${resultInfo.signguNm} ${resultInfo.rdmn} ${resultInfo.bdnbrMnnm} <c:if test="${resultInfo.bdnbrSlno != ''}">- ${resultInfo.bdnbrSlno}</c:if> ${resultInfo.buldNm} ${resultInfo.detailBuldNm}</td>
+						</tr>
+					</c:forEach>
+				</c:otherwise>
+			</c:choose>
 
-<c:if test="${fn:length(resultList) == 0}">
-	<tr>
-		<td class="lt_text3" colspan=3>
-			<spring:message code="common.nodata.msg" />
-		</td>
-	</tr>
-</c:if>
+			<c:if test="${fn:length(resultList) == 0}">
+				<tr>
+					<td class="lt_text3" colspan=3>
+						<spring:message code="common.nodata.msg" />
+					</td>
+				</tr>
+			</c:if>
 
-</tbody>
-</table>
-<!-- paging navigation -->
-<div class="pagination">
-	<ul>
-		<ui:pagination paginationInfo = "${paginationInfo}" type="image" jsFunction="fn_egov_pageview"/>
-	</ul>
-</div>
+			</tbody>
+		</table>
+		<!-- paging navigation -->
+		<div class="pagination">
+			<ul>
+				<ui:pagination paginationInfo = "${paginationInfo}" type="image" jsFunction="fn_egov_pageview"/>
+			</ul>
+		</div>
 
 
-<input name="pageIndex" type="hidden" value="<c:out value='${searchVO.pageIndex}'/>"/>
+		<input name="pageIndex" type="hidden" value="<c:out value='${searchVO.pageIndex}'/>"/>
 </form>
 <form name="Form" id="Form" method="post" action="">
 	<input type=hidden name="zip">

--- a/src/main/webapp/WEB-INF/jsp/egovframework/com/sym/ccm/zip/EgovCcmZipModify.jsp
+++ b/src/main/webapp/WEB-INF/jsp/egovframework/com/sym/ccm/zip/EgovCcmZipModify.jsp
@@ -1,19 +1,19 @@
 <%
- /**
-  * @Class Name  : EgovCcmZipModify.jsp
-  * @Description : EgovCcmZipModify 화면
-  * @Modification Information
-  * @
-  * @  수정일             수정자                   수정내용
-  * @ -------    --------    ---------------------------
-  * @ 2009.04.01   이중호              최초 생성
-  *
-  *  @author 공통서비스팀 
-  *  @since 2009.04.01
-  *  @version 1.0
-  *  @see
-  *  
-  */
+	/**
+	 * @Class Name  : EgovCcmZipModify.jsp
+	 * @Description : EgovCcmZipModify 화면
+	 * @Modification Information
+	 * @
+	 * @  수정일             수정자                   수정내용
+	 * @ -------    --------    ---------------------------
+	 * @ 2009.04.01   이중호              최초 생성
+	 *
+	 *  @author 공통서비스팀
+	 *  @since 2009.04.01
+	 *  @version 1.0
+	 *  @see
+	 *
+	 */
 %>
 
 <%@ page contentType="text/html; charset=utf-8"%>
@@ -27,41 +27,41 @@
 <!DOCTYPE html>
 <html lang="ko">
 <head>
-<title>${pageTitle } <spring:message code="title.update" /></title>
-<meta http-equiv="content-type" content="text/html; charset=utf-8">
-<link type="text/css" rel="stylesheet" href="<c:url value='/css/egovframework/com/cop/bbs/style.css' />">
-<script type="text/javascript" src="<c:url value="/validator.do"/>"></script>
-<validator:javascript formName="zip" staticJavascript="false" xhtml="true" cdata="false"/>
-<script type="text/javaScript" language="javascript">
-<!--
-/* ********************************************************
- * 목록 으로 가기
- ******************************************************** */
-function fn_egov_list_Zip(){
-	location.href = "<c:url value='/sym/ccm/zip/EgovCcmZipList.do' />";
-}
-/* ********************************************************
- * 저장처리화면
- ******************************************************** */
-function fn_egov_modify_Zip(form){
-	if(confirm("<spring:message code='common.save.msg'/>")){
-		if(!validateZip(form)){ 			
-			return;
-		}else{
-			form.submit();
+	<title>${pageTitle } <spring:message code="title.update" /></title>
+	<meta http-equiv="content-type" content="text/html; charset=utf-8">
+	<link type="text/css" rel="stylesheet" href="<c:url value='/css/egovframework/com/cop/bbs/style.css' />">
+	<script type="text/javascript" src="<c:url value="/validator.do"/>"></script>
+	<validator:javascript formName="zip" staticJavascript="false" xhtml="true" cdata="false"/>
+	<script type="text/javaScript" language="javascript">
+		<!--
+		/* ********************************************************
+         * 목록 으로 가기
+         ******************************************************** */
+		function fn_egov_list_Zip(){
+			location.href = "<c:url value='/sym/ccm/zip/EgovCcmZipList.do' />";
 		}
-	}
-}
--->
-</script>
+		/* ********************************************************
+         * 저장처리화면
+         ******************************************************** */
+		function fn_egov_modify_Zip(form){
+			if(confirm("<spring:message code='common.save.msg'/>")){
+				if(!validateZip(form)){
+					return;
+				}else{
+					form.submit();
+				}
+			}
+		}
+		-->
+	</script>
 </head>
 <body>
-<form:form modelAttribute="zip" name="zip" method="post">
+<form:form modelAttribute="zip" name="zip" method="post" action="/sym/ccm/zip/EgovCcmZipModify.do">
 <input name="cmd" type="hidden" value="Modify">
-	<form:hidden path="zip"/>
-	<form:hidden path="sn"/>
-	<form:hidden path="ctprvnNm"/>
-	<form:hidden path="signguNm"/>
+<form:hidden path="zip"/>
+<form:hidden path="sn"/>
+<form:hidden path="ctprvnNm"/>
+<form:hidden path="signguNm"/>
 <c:if test="${searchList == '1'}">
 	<form:hidden path="emdNm"/>
 </c:if>
@@ -70,130 +70,130 @@ function fn_egov_modify_Zip(form){
 	<form:hidden path="rdmn"/>
 </c:if>
 <div id="note" style="width:730px";>
-<noscript class="noScriptTitle"><spring:message code="common.noScriptTitle.msg"/></noscript>
-<!-- 상단타이틀 -->
+	<noscript class="noScriptTitle"><spring:message code="common.noScriptTitle.msg"/></noscript>
+	<!-- 상단타이틀 -->
 
-<!-- 상단 타이틀  영역 -->
-<h1>
-  <c:set var="titleZip"><spring:message code="comSymCcmZip.zipVO.zipUpdate"/></c:set>
-  <c:set var="titleRdmn"><spring:message code="comSymCcmZip.zipVO.rdmnUpdate"/></c:set>
-    <c:if test="${searchList == '1'}">
-     <img src="<c:url value='/images/egovframework/com/cmm/icon/tit_icon.gif' />" width="16" height="16" hspace="3" style="vertical-align: middle">&nbsp;${titleZip }</h1></td>
-    </c:if>
-    <c:if test="${searchList == '2'}">
-     <img src="<c:url value='/images/egovframework/com/cmm/icon/tit_icon.gif' />" width="16" height="16" hspace="3" style="vertical-align: middle">&nbsp;${titleRdmn }</h1></td>
-    </c:if>
+	<!-- 상단 타이틀  영역 -->
+	<h1>
+		<c:set var="titleZip"><spring:message code="comSymCcmZip.zipVO.zipUpdate"/></c:set>
+		<c:set var="titleRdmn"><spring:message code="comSymCcmZip.zipVO.rdmnUpdate"/></c:set>
+		<c:if test="${searchList == '1'}">
+		<img src="<c:url value='/images/egovframework/com/cmm/icon/tit_icon.gif' />" width="16" height="16" hspace="3" style="vertical-align: middle">&nbsp;${titleZip }</h1></td>
+	</c:if>
+	<c:if test="${searchList == '2'}">
+		<img src="<c:url value='/images/egovframework/com/cmm/icon/tit_icon.gif' />" width="16" height="16" hspace="3" style="vertical-align: middle">&nbsp;${titleRdmn }</h1></td>
+	</c:if>
 
-<!-- 등록  폼 영역  -->
-<table class="tbl_note" width="700" border="0" cellpadding="0" cellspacing="1" summary="<spring:message code="comSymCcmZip.zipVO.summaryInsert"/>"> <!-- 리건물명과 번지동호를 수정하는 우편번호 수정 테이블이다. -->
-<CAPTION style="display: none;">${pageTitle } <spring:message code="title.update" /></CAPTION>
-  <c:if test="${searchList == '1'}">
-	  <tr>
-	    <th class="ic_none" width="20%" height="23" scope="row" nowrap><spring:message code="comSymCcmZip.zipVO.zip"/> <span class="pilsu">*</span></th> <!-- 우편번호 -->          
-	    <td>
-	    	<c:out value='${fn:substring(zip.zip, 0,3)}'/>-<c:out value='${fn:substring(zip.zip, 3,6)}'/>
-	    </td>
-	  </tr> 
-	  <tr> 
-	    <th class="ic_none" width="20%" height="23" scope="row" nowrap><spring:message code="comSymCcmZip.zipVO.ctprvnNm"/> <span class="pilsu">*</span></th> <!-- 시도명 -->
-	    <td>
-	    	<c:out value='${zip.ctprvnNm}'/>
-	    </td>    
-	  </tr>
-	  <tr>
-	    <th class="ic_none" width="20%" height="23" scope="row" nowrap><spring:message code="comSymCcmZip.zipVO.signguNm"/> <span class="pilsu">*</span></th> <!-- 시군구명 -->          
-	    <td>
-	    	<c:out value='${zip.signguNm}'/>
-	    </td>    
-	  </tr> 
-	  <tr>
-	    <th class="ic_none" width="20%" height="23" scope="row" nowrap><spring:message code="comSymCcmZip.zipVO.emdNm"/> <span class="pilsu">*</span></th> <!-- 읍면동명 -->          
-	    <td>
-			<c:out value='${zip.emdNm}'/>    
-	    </td>    
-	  </tr> 
-	  <tr>
-	    <th class="ic_none" width="20%" height="23" scope="row" nowrap><label for="liBuldNm"><spring:message code="comSymCcmZip.zipVO.liBuldNm"/></label></th> <!-- 리건물명 -->           
-	    <td>
-	    	<input name="liBuldNm" type="text" size="60" value="<c:out value='${zip.liBuldNm}'/>"  maxlength="60" id="liBuldNm" >
-	    </td>    
-	  </tr> 
-	  <tr>
-	    <th class="ic_none" width="20%" height="23" scope="row" nowrap><label for="lnbrDongHo"><spring:message code="comSymCcmZip.zipVO.lnbrDongHo"/></label></th> <!-- 번지동호 -->          
-	    <td>
-	    	<input name="lnbrDongHo" type="text" size="20" value="<c:out value='${zip.lnbrDongHo}'/>"  maxlength="20" id="lnbrDongHo">
-	    </td>    
-	  </tr>
-  	  <input type=hidden name="rdmnCode" id="rdmnCode" value="0"/>
-	  <input type=hidden name="rdmn" id="rdmn" value="0"/> 
-  </c:if>
-  <c:if test="${searchList == '2'}">
-	  <tr>
-	    <th class="ic_none" width="20%" height="23" scope="row" nowrap><spring:message code="comSymCcmZip.zipVO.zip"/> <span class="pilsu">*</span></th><!-- 우편번호 -->
-	    <td><c:out value='${fn:substring(zip.zip, 0,3)}'/>-<c:out value='${fn:substring(zip.zip, 3,6)}'/></td>
-	  </tr>
-	  <tr>
-	    <th class="ic_none" width="20%" height="23" scope="row" nowrap><spring:message code="comSymCcmZip.zipVO.rdmnCode"/> <span class="pilsu">*</span></th> <!-- 도로명코드 -->
-	    <td><c:out value='${zip.rdmnCode}'/></td>
-	  </tr>
-	  <tr>
-	    <th class="ic_none" width="20%" height="23" scope="row" nowrap><spring:message code="comSymCcmZip.zipVO.ctprvnNm"/> <span class="pilsu">*</span></th> <!-- 시도명 -->
-	    <td><c:out value='${zip.ctprvnNm}'/>}</td>
-	  </tr>
-	  <tr>
-	    <th class="ic_none" width="20%" height="23" scope="row" nowrap><spring:message code="comSymCcmZip.zipVO.signguNm"/> <span class="pilsu">*</span></th> <!-- 시군구명 -->
-	    <td><c:out value='${zip.signguNm}'/></td>
-	  </tr>
-	  <tr>
-	    <th class="ic_none" width="20%" height="23" scope="row" nowrap><spring:message code="comSymCcmZip.zipVO.rdmn"/> <span class="pilsu">*</span></th> <!-- 도로명 -->
-	    <td><c:out value='${zip.rdmn}'/></td>
-	  </tr>
-	  <tr>
-	    <th class="ic_none" width="20%" height="23" scope="row" nowrap><spring:message code="comSymCcmZip.zipVO.bdnbrMnnm"/></th> <!-- 건물번호본번 -->
-	    <td>
-	    <input name="bdnbrMnnm" type="text" size="5" value="<c:out value='${zip.bdnbrMnnm}'/>"  maxlength="5" id="bdnbrMnnm">
-	    </td>
-	  </tr>
-	  <tr>
-	    <th class="ic_none" width="20%" height="23" scope="row" nowrap><spring:message code="comSymCcmZip.zipVO.bdnbrSlno"/></th> <!-- 건물번호부번 -->
-	    <td>
-	    <input name="bdnbrSlno" type="text" size="5" value="<c:out value='${zip.bdnbrSlno}'/>"  maxlength="5" id="bdnbrSlno">
-	    </td>
-	  </tr>
-	  <tr>
-	    <th class="ic_none" width="20%" height="23" scope="row" nowrap><spring:message code="comSymCcmZip.zipVO.buldNm"/></th> <!-- 건물명 -->
-	    <td>
-	    <input name="buldNm" type="text" size="60" value="<c:out value='${zip.buldNm}'/>"  maxlength="60" id="buldNm">
-	    </td>
-	  </tr>
-	  <tr>
-	    <th class="ic_none" width="20%" height="23" scope="row" nowrap><spring:message code="comSymCcmZip.zipVO.detailBuldNm"/></th> <!-- 상세건물명 -->
-	    <td>
-	    <input name="detailBuldNm" type="text" size="60" value="<c:out value='${zip.detailBuldNm}'/>"  maxlength="60" id="detailBuldNm">
-	    </td>
-	  </tr>
-  	  <input type=hidden name="emdNm" id="emdNm" value="0"/>
-  </c:if>
-</table>
-<table width="700" border="0" cellspacing="0" cellpadding="0">
-  <tr> 
-    <td height="10"></td>
-  </tr>
-</table>
+	<!-- 등록  폼 영역  -->
+	<table class="tbl_note" width="700" border="0" cellpadding="0" cellspacing="1" summary="<spring:message code="comSymCcmZip.zipVO.summaryInsert"/>"> <!-- 리건물명과 번지동호를 수정하는 우편번호 수정 테이블이다. -->
+		<CAPTION style="display: none;">${pageTitle } <spring:message code="title.update" /></CAPTION>
+		<c:if test="${searchList == '1'}">
+			<tr>
+				<th class="ic_none" width="20%" height="23" scope="row" nowrap><spring:message code="comSymCcmZip.zipVO.zip"/> <span class="pilsu">*</span></th> <!-- 우편번호 -->
+				<td>
+					<c:out value='${zip.zip}'/>
+				</td>
+			</tr>
+			<tr>
+				<th class="ic_none" width="20%" height="23" scope="row" nowrap><spring:message code="comSymCcmZip.zipVO.ctprvnNm"/> <span class="pilsu">*</span></th> <!-- 시도명 -->
+				<td>
+					<c:out value='${zip.ctprvnNm}'/>
+				</td>
+			</tr>
+			<tr>
+				<th class="ic_none" width="20%" height="23" scope="row" nowrap><spring:message code="comSymCcmZip.zipVO.signguNm"/> <span class="pilsu">*</span></th> <!-- 시군구명 -->
+				<td>
+					<c:out value='${zip.signguNm}'/>
+				</td>
+			</tr>
+			<tr>
+				<th class="ic_none" width="20%" height="23" scope="row" nowrap><spring:message code="comSymCcmZip.zipVO.emdNm"/> <span class="pilsu">*</span></th> <!-- 읍면동명 -->
+				<td>
+					<c:out value='${zip.emdNm}'/>
+				</td>
+			</tr>
+			<tr>
+				<th class="ic_none" width="20%" height="23" scope="row" nowrap><label for="liBuldNm"><spring:message code="comSymCcmZip.zipVO.liBuldNm"/></label></th> <!-- 리건물명 -->
+				<td>
+					<input name="liBuldNm" type="text" size="60" value="<c:out value='${zip.liBuldNm}'/>"  maxlength="60" id="liBuldNm" >
+				</td>
+			</tr>
+			<tr>
+				<th class="ic_none" width="20%" height="23" scope="row" nowrap><label for="lnbrDongHo"><spring:message code="comSymCcmZip.zipVO.lnbrDongHo"/></label></th> <!-- 번지동호 -->
+				<td>
+					<input name="lnbrDongHo" type="text" size="20" value="<c:out value='${zip.lnbrDongHo}'/>"  maxlength="20" id="lnbrDongHo">
+				</td>
+			</tr>
+			<input type=hidden name="rdmnCode" id="rdmnCode" value="0"/>
+			<input type=hidden name="rdmn" id="rdmn" value="0"/>
+		</c:if>
+		<c:if test="${searchList == '2'}">
+			<tr>
+				<th class="ic_none" width="20%" height="23" scope="row" nowrap><spring:message code="comSymCcmZip.zipVO.zip"/> <span class="pilsu">*</span></th><!-- 우편번호 -->
+				<td><c:out value='${fn:substring(zip.zip, 0,3)}'/>-<c:out value='${fn:substring(zip.zip, 3,6)}'/></td>
+			</tr>
+			<tr>
+				<th class="ic_none" width="20%" height="23" scope="row" nowrap><spring:message code="comSymCcmZip.zipVO.rdmnCode"/> <span class="pilsu">*</span></th> <!-- 도로명코드 -->
+				<td><c:out value='${zip.rdmnCode}'/></td>
+			</tr>
+			<tr>
+				<th class="ic_none" width="20%" height="23" scope="row" nowrap><spring:message code="comSymCcmZip.zipVO.ctprvnNm"/> <span class="pilsu">*</span></th> <!-- 시도명 -->
+				<td><c:out value='${zip.ctprvnNm}'/></td>
+			</tr>
+			<tr>
+				<th class="ic_none" width="20%" height="23" scope="row" nowrap><spring:message code="comSymCcmZip.zipVO.signguNm"/> <span class="pilsu">*</span></th> <!-- 시군구명 -->
+				<td><c:out value='${zip.signguNm}'/></td>
+			</tr>
+			<tr>
+				<th class="ic_none" width="20%" height="23" scope="row" nowrap><spring:message code="comSymCcmZip.zipVO.rdmn"/> <span class="pilsu">*</span></th> <!-- 도로명 -->
+				<td><c:out value='${zip.rdmn}'/></td>
+			</tr>
+			<tr>
+				<th class="ic_none" width="20%" height="23" scope="row" nowrap><spring:message code="comSymCcmZip.zipVO.bdnbrMnnm"/></th> <!-- 건물번호본번 -->
+				<td>
+					<input name="bdnbrMnnm" type="text" size="5" value="<c:out value='${zip.bdnbrMnnm}'/>"  maxlength="5" id="bdnbrMnnm">
+				</td>
+			</tr>
+			<tr>
+				<th class="ic_none" width="20%" height="23" scope="row" nowrap><spring:message code="comSymCcmZip.zipVO.bdnbrSlno"/></th> <!-- 건물번호부번 -->
+				<td>
+					<input name="bdnbrSlno" type="text" size="5" value="<c:out value='${zip.bdnbrSlno}'/>"  maxlength="5" id="bdnbrSlno">
+				</td>
+			</tr>
+			<tr>
+				<th class="ic_none" width="20%" height="23" scope="row" nowrap><spring:message code="comSymCcmZip.zipVO.buldNm"/></th> <!-- 건물명 -->
+				<td>
+					<input name="buldNm" type="text" size="60" value="<c:out value='${zip.buldNm}'/>"  maxlength="60" id="buldNm">
+				</td>
+			</tr>
+			<tr>
+				<th class="ic_none" width="20%" height="23" scope="row" nowrap><spring:message code="comSymCcmZip.zipVO.detailBuldNm"/></th> <!-- 상세건물명 -->
+				<td>
+					<input name="detailBuldNm" type="text" size="60" value="<c:out value='${zip.detailBuldNm}'/>"  maxlength="60" id="detailBuldNm">
+				</td>
+			</tr>
+			<input type=hidden name="emdNm" id="emdNm" value="0"/>
+		</c:if>
+	</table>
+	<table width="700" border="0" cellspacing="0" cellpadding="0">
+		<tr>
+			<td height="10"></td>
+		</tr>
+	</table>
 
-<!-- 줄간격조정  -->
-<table width="700" cellspacing="0" cellpadding="0" border="0">
-<tr>
-	<td height="3px"></td>
-</tr>
-</table>
-<!-- 목록/저장버튼  -->
-<div class="txt-cnt mt20">
-  <input class="btnStyle02 bg_gray" type="submit" value="<spring:message code="button.list" />" onclick="fn_egov_list_Zip(); return false;"> <!-- 목록 -->
-  <input class="btnStyle02" type="submit" value="<spring:message code="button.save" />" onclick="fn_egov_modify_Zip(document.zip); return false;">  <!-- 등록 -->    
-  <input name="searchList" type="hidden" value="${searchList}">
-</div><div style="clear:both;"></div>
-</form:form>
+	<!-- 줄간격조정  -->
+	<table width="700" cellspacing="0" cellpadding="0" border="0">
+		<tr>
+			<td height="3px"></td>
+		</tr>
+	</table>
+	<!-- 목록/저장버튼  -->
+	<div class="txt-cnt mt20">
+		<input class="btnStyle02 bg_gray" type="submit" value="<spring:message code="button.list" />" onclick="fn_egov_list_Zip(); return false;"> <!-- 목록 -->
+		<input class="btnStyle02" type="submit" value="<spring:message code="button.save" />" onclick="fn_egov_modify_Zip(document.zip); return false;">  <!-- 등록 -->
+		<input name="searchList" type="hidden" value="${searchList}">
+	</div><div style="clear:both;"></div>
+	</form:form>
 </div>
 </body>
 </html>

--- a/src/main/webapp/WEB-INF/jsp/egovframework/com/sym/ccm/zip/EgovCcmZipRegist.jsp
+++ b/src/main/webapp/WEB-INF/jsp/egovframework/com/sym/ccm/zip/EgovCcmZipRegist.jsp
@@ -1,22 +1,22 @@
 <!DOCTYPE html>
 <%
- /**
-  * @Class Name  : EgovCcmZipRegist.jsp
-  * @Description : EgovCcmZipRegist 화면
-  * @Modification Information
-  * @
-  * @ 수정일               수정자            수정내용
-  * @ ----------   --------   ---------------------------
-  * @ 2009.04.01   이중호            최초 생성
-  * @ 2017.08.30   양희훈            표준프레임워크 v3.7 개선
-  * @ 2019.12.11   신용호            KISA 보안약점 조치 (크로스사이트 스크립트)
-  * 
-  *  @author 공통서비스팀
-  *  @since 2009.04.01
-  *  @version 1.0
-  *  @see
-  *
-  */
+	/**
+	 * @Class Name  : EgovCcmZipRegist.jsp
+	 * @Description : EgovCcmZipRegist 화면
+	 * @Modification Information
+	 * @
+	 * @ 수정일               수정자            수정내용
+	 * @ ----------   --------   ---------------------------
+	 * @ 2009.04.01   이중호            최초 생성
+	 * @ 2017.08.30   양희훈            표준프레임워크 v3.7 개선
+	 * @ 2019.12.11   신용호            KISA 보안약점 조치 (크로스사이트 스크립트)
+	 *
+	 *  @author 공통서비스팀
+	 *  @since 2009.04.01
+	 *  @version 1.0
+	 *  @see
+	 *
+	 */
 %>
 
 <%@ page contentType="text/html; charset=utf-8"%>
@@ -29,234 +29,234 @@
 <c:set var="pageTitle"><spring:message code="comSymCcmZip.zipVO.title"/></c:set>
 <html lang="ko">
 <head>
-<title>${pageTitle} <spring:message code="title.create" /></title>
-<meta http-equiv="content-type" content="text/html; charset=utf-8">
-<link type="text/css" rel="stylesheet" href="<c:url value='/css/egovframework/com/cop/bbs/style.css' />">
-<script type="text/javascript" src="<c:url value="/validator.do"/>"></script>
-<validator:javascript formName="zip" staticJavascript="false" xhtml="true" cdata="false"/>
-<script type="text/javaScript" language="javascript">
-/* ********************************************************
- * 목록 으로 가기
- ******************************************************** */
-function fn_egov_list_Zip(){
-	location.href = "<c:url value='/sym/ccm/zip/EgovCcmZipList.do' />";
-}
-/* ********************************************************
- * 등록처리
- ******************************************************** */
-function fn_egov_regist_Zip(form){
-	if(confirm("<spring:message code='common.save.msg'/>")){
-		if(!validateZip(form)){
-			return;
-		}else{
-			form.submit();
+	<title>${pageTitle} <spring:message code="title.create" /></title>
+	<meta http-equiv="content-type" content="text/html; charset=utf-8">
+	<link type="text/css" rel="stylesheet" href="<c:url value='/css/egovframework/com/cop/bbs/style.css' />">
+	<script type="text/javascript" src="<c:url value="/validator.do"/>"></script>
+	<validator:javascript formName="zip" staticJavascript="false" xhtml="true" cdata="false"/>
+	<script type="text/javaScript" language="javascript">
+		/* ********************************************************
+         * 목록 으로 가기
+         ******************************************************** */
+		function fn_egov_list_Zip(){
+			location.href = "<c:url value='/sym/ccm/zip/EgovCcmZipList.do' />";
 		}
-	}
-}
-/* ********************************************************
- * 주소검색
- ******************************************************** */
-function goAddSearch() {
-	// 호출된 페이지(jusopopup.jsp)에서 실제 주소검색URL(http://www.juso.go.kr/addrlink/addrLinkUrl.do)를 호출하게 됩니다.
-    var pop = window.open("<c:url value='/sym/ccm/zip/EgovAdressPop.do' />","pop","width=570,height=420, scrollbars=yes, resizable=yes"); 
-    
-	// 모바일 웹인 경우, 호출된 페이지(jusopopup.jsp)에서 실제 주소검색URL(http://www.juso.go.kr/addrlink/addrMobileLinkUrl.do)를 호출하게 됩니다.
-    //var pop = window.open("/popup/jusoPopup.jsp","pop","scrollbars=yes, resizable=yes"); 
-}
+		/* ********************************************************
+         * 등록처리
+         ******************************************************** */
+		function fn_egov_regist_Zip(form){
+			if(confirm("<spring:message code='common.save.msg'/>")){
+				if(!validateZip(form)){
+					return;
+				}else{
+						form.submit();
+				}
+			}
+		}
+		/* ********************************************************
+         * 주소검색
+         ******************************************************** */
+		function goAddSearch() {
+			// 호출된 페이지(jusopopup.jsp)에서 실제 주소검색URL(http://www.juso.go.kr/addrlink/addrLinkUrl.do)를 호출하게 됩니다.
+			var pop = window.open("<c:url value='/sym/ccm/zip/EgovAdressPop.do' />","pop","width=570,height=420, scrollbars=yes, resizable=yes");
 
-function jusoCallBack(zipNo,rnMgtSn,siNm,sggNm,roadFullAddr,buldMnnm,buldSlno,bdNm,detBdNmList){
-	// 팝업페이지에서 주소입력한 정보를 받아서, 현 페이지에 정보를 등록합니다.
-	document.zip.zip.value = zipNo; 										/* 우편번호 */
-	document.zip.rdmnCode.value = rnMgtSn; 						/* 도로명코드 */
-	document.zip.ctprvnNm.value = siNm; 								/* 시도명 */
-	document.zip.signguNm.value = sggNm; 							/* 시군구명 */
-	document.zip.rdmn.value = roadFullAddr; 						    /* 도로명 */
-	document.zip.bdnbrMnnm.value = buldMnnm; 					/* 건물본번 */
-	document.zip.bdnbrSlno.value = buldSlno; 						/* 건물부번 */
-	document.zip.buldNm.value = bdNm; 								/* 건물명 */
-	document.zip.detailBuldNm.value = detBdNmList; 				/* 상세건물명 */
-}
-</script>
+			// 모바일 웹인 경우, 호출된 페이지(jusopopup.jsp)에서 실제 주소검색URL(http://www.juso.go.kr/addrlink/addrMobileLinkUrl.do)를 호출하게 됩니다.
+			//var pop = window.open("/popup/jusoPopup.jsp","pop","scrollbars=yes, resizable=yes");
+		}
+
+		function jusoCallBack(zipNo,rnMgtSn,siNm,sggNm,roadFullAddr,buldMnnm,buldSlno,bdNm,detBdNmList){
+			// 팝업페이지에서 주소입력한 정보를 받아서, 현 페이지에 정보를 등록합니다.
+			document.zip.zip.value = zipNo; 										/* 우편번호 */
+			document.zip.rdmnCode.value = rnMgtSn; 						/* 도로명코드 */
+			document.zip.ctprvnNm.value = siNm; 								/* 시도명 */
+			document.zip.signguNm.value = sggNm; 							/* 시군구명 */
+			document.zip.rdmn.value = roadFullAddr; 						    /* 도로명 */
+			document.zip.bdnbrMnnm.value = buldMnnm; 					/* 건물본번 */
+			document.zip.bdnbrSlno.value = buldSlno; 						/* 건물부번 */
+			document.zip.buldNm.value = bdNm; 								/* 건물명 */
+			document.zip.detailBuldNm.value = detBdNmList; 				/* 상세건물명 */
+		}
+	</script>
 </head>
 <body>
 <noscript class="noScriptTitle"><spring:message code="common.noScriptTitle.msg"/></noscript>
-<form:form modelAttribute="zip" name="zip" method="post">
+<form:form modelAttribute="zip" name="zip" method="post" action="/sym/ccm/zip/EgovCcmZipRegist.do">
 <div class="note">
 
-<!-- 상단 타이틀  영역 -->
-  <h1>
-  <c:set var="titleZip"><spring:message code="comSymCcmZip.zipVO.zipCreate"/></c:set>
-  <c:set var="titleRdmn"><spring:message code="comSymCcmZip.zipVO.rdmnCreate"/></c:set>
-  <c:if test="${searchList == '1'}">
-   <img src="<c:url value='/images/egovframework/com/cmm/icon/tit_icon.gif' />" width="16" height="16" hspace="3" style="vertical-align: middle" alt="제목아이콘이미지">&nbsp;${titleZip }</h1></td>
-  </c:if>
-  <c:if test="${searchList == '2'}">
-   <img src="<c:url value='/images/egovframework/com/cmm/icon/tit_icon.gif' />" width="16" height="16" hspace="3" style="vertical-align: middle" alt="제목아이콘이미지">&nbsp;${titleRdmn }</h1></td>
-  </c:if>
+	<!-- 상단 타이틀  영역 -->
+	<h1>
+		<c:set var="titleZip"><spring:message code="comSymCcmZip.zipVO.zipCreate"/></c:set>
+		<c:set var="titleRdmn"><spring:message code="comSymCcmZip.zipVO.rdmnCreate"/></c:set>
+		<c:if test="${!isRoadAddr}">
+		<img src="<c:url value='/images/egovframework/com/cmm/icon/tit_icon.gif' />" width="16" height="16" hspace="3" style="vertical-align: middle" alt="제목아이콘이미지">&nbsp;${titleZip }</h1></td>
+	</c:if>
+	<c:if test="${isRoadAddr}">
+		<img src="<c:url value='/images/egovframework/com/cmm/icon/tit_icon.gif' />" width="16" height="16" hspace="3" style="vertical-align: middle" alt="제목아이콘이미지">&nbsp;${titleRdmn }</h1></td>
+	</c:if>
 
-<!-- 등록  폼 영역  -->
-<c:set var="titleMessage"><spring:message code="comSymCcmZip.zipVO.zipMessage"/></c:set>
-<table class="tbl_note" summary="<spring:message code="comSymCcmZip.zipVO.summaryInsert"/>"><!-- 우편번호, 시도명, 시군구명, 읍면동명, 리건물명, 번지동호를 입력하는 우편번호 등록 테이블입니다. -->
-<caption>${pageTitle } <spring:message code="title.create" /></caption>
-<colgroup>
-	<col style="width: 20%;"><col style="width: ;">
-</colgroup>
-<tbody>
-  <c:if test="${searchList == '1'}">
-  	  <!-- 우편번호  -->
-	  <c:set var="title"><spring:message code="comSymCcmZip.zipVO.zip"/></c:set>
-	  <tr>
-	    <th class="ic_none"><label for="zip">${title} <span class="pilsu">*</span></label></th>
-	    <td class="left">
-	      <form:input path="zip" size="5" maxlength="5" id="zip"/>
-	      <form:errors path="zip"/> &nbsp;* ${titleMessage } <!-- 우편번호의 '-'를 제외하고 입력하시오. -->
-	    </td>
-	  </tr>
-	  <!-- 시도명  -->
-	  <c:set var="title"><spring:message code="comSymCcmZip.zipVO.ctprvnNm"/></c:set>
-	  <tr>
-	    <th class="ic_none"><label for="ctprvnNm">${title} <span class="pilsu">*</label></th>
-	    <td>
-	      <form:input  path="ctprvnNm" size="20" maxlength="20" id="ctprvnNm"/>
-	      <form:errors path="ctprvnNm"/>
-	    </td>
-	  </tr>
-	  <!-- 시군구명 -->
-	  <c:set var="title"><spring:message code="comSymCcmZip.zipVO.signguNm"/></c:set>
-	  <tr>
-	    <th class="ic_none"><label for="signguNm">${title} <span class="pilsu">*</label></th>
-	    <td>
-	      <form:input  path="signguNm" size="20" maxlength="20" id="signguNm"/>
-	      <form:errors path="signguNm"/>
-	    </td>
-	  </tr>
-	  <!-- 읍면동명 -->
-	  <c:set var="title"><spring:message code="comSymCcmZip.zipVO.emdNm"/></c:set>
-	  <tr>
-	    <th class="ic_none"><label for="emdNm">${title} <span class="pilsu">*</label></th>
-	    <td>
-	      <form:input  path="emdNm" size="30" maxlength="30" id="emdNm"/>
-	      <form:errors path="emdNm"/>
-	    </td>
-	  </tr>
-	  <!-- 리건물명 -->
-	  <c:set var="title"><spring:message code="comSymCcmZip.zipVO.liBuldNm"/></c:set>
-	  <tr>
-	    <th class="ic_none"><label for="liBuldNm">${title}</label></th>
-	    <td>
-	      <form:input  path="liBuldNm" size="60" maxlength="60" id="liBuldNm"/>
-	      <form:errors path="liBuldNm"/>
-	    </td>
-	  </tr>
-	  <!-- 번지동호 -->
-	  <c:set var="title"><spring:message code="comSymCcmZip.zipVO.lnbrDongHo"/></c:set>
-	  <tr>
-	    <th class="ic_none"><label for="lnbrDongHo">${title}</label></th>
-	    <td>
-	      <form:input  path="lnbrDongHo" size="20" maxlength="20" id="lnbrDongHo"/>
-	      <form:errors path="lnbrDongHo"/>
-	    </td>
-	  </tr>
-	  <input type=hidden name="rdmnCode" id="rdmnCode" value="0"/>
-	  <input type=hidden name="rdmn" id="rdmn" value="0"/>
-  </c:if>
-  <c:if test="${searchList == '2'}">
-  	  <!-- 우편번호  -->
-	  <c:set var="title"><spring:message code="comSymCcmZip.zipVO.zip"/></c:set>
-	  <c:set var="address"><spring:message code="comSymCcmZip.zipVO.rdmnSearch"/></c:set>
-	  <tr>
-	    <th class="ic_none"><label for="zip">${title} <span class="pilsu">*</label></th>
-	    <td>
-	      <form:input  path="zip" size="5" maxlength="5" id="zip" name="zip"/>
-	      <form:errors path="zip"/> <input type="button" class="btn_s" onClick="goAddSearch();" value="${address }"/>
-	    </td>
-	  </tr>
-	  <!-- 도로명코드  -->
-	  <c:set var="title"><spring:message code="comSymCcmZip.zipVO.rdmnCode"/></c:set>
-  	  <tr>
-	    <th class="ic_none"><label for="rdmnCode">${title} <span class="pilsu">*</label></th>
-	    <td>
-	      <form:input  path="rdmnCode" size="12" maxlength="12" id="rdmnCode"/>
-	      <form:errors path="rdmnCode"/>
-	    </td>
-	  </tr>
-	  <!-- 시도명  -->
-	  <c:set var="title"><spring:message code="comSymCcmZip.zipVO.ctprvnNm"/></c:set>
-	  <tr>
-	    <th class="ic_none"><label for="ctprvnNm">${title} <span class="pilsu">*</label></th>
-	    <td>
-	      <form:input  path="ctprvnNm" size="20" maxlength="20" id="ctprvnNm"/>
-	      <form:errors path="ctprvnNm"/>
-	    </td>
-	  </tr>
-	  <!-- 시군구명 -->
-	  <c:set var="title"><spring:message code="comSymCcmZip.zipVO.signguNm"/></c:set>
-	  <tr>
-	    <th class="ic_none"><label for="signguNm">${title} <span class="pilsu">*</label></th>
-	    <td>
-	      <form:input  path="signguNm" size="20" maxlength="20" id="signguNm"/>
-	      <form:errors path="signguNm"/>
-	    </td>
-	  </tr>
-	  <!-- 도로명 -->
-	  <c:set var="title"><spring:message code="comSymCcmZip.zipVO.rdmn"/></c:set>
-	  <tr>
-	    <th class="ic_none"><label for="rdmn">${title} <span class="pilsu">*</label></th>
-	    <td>
-	      <form:input  path="rdmn" size="60" maxlength="60" id="rdmn"/>
-	      <form:errors path="rdmn"/>
-	    </td>
-	  </tr>
-	  <!-- 건물번호본번 -->
-	  <c:set var="title"><spring:message code="comSymCcmZip.zipVO.bdnbrMnnm"/></c:set>
-	  <tr>
-	    <th class="ic_none"><label for="bdnbrMnnm">${title}</label></th>
-	    <td>
-	      <form:input  path="bdnbrMnnm" size="5" maxlength="5" id="bdnbrMnnm"/>
-	      <form:errors path="bdnbrMnnm"/>
-	    </td>
-	  </tr>
-	  <!-- 건물번호부번 -->
-	  <c:set var="title"><spring:message code="comSymCcmZip.zipVO.bdnbrSlno"/></c:set>
-	  <tr>
-	    <th class="ic_none"><label for="bdnbrSlno">${title}</label></th>
-	    <td>
-	      <form:input  path="bdnbrSlno" size="5" maxlength="5" id="bdnbrSlno"/>
-	      <form:errors path="bdnbrSlno"/>
-	    </td>
-	  </tr>
-	  <!-- 건물명 -->
-	  <c:set var="title"><spring:message code="comSymCcmZip.zipVO.buldNm"/></c:set>
-	  <tr>
-	    <th class="ic_none"><label for="buldNm">${title}</label></th>
-	    <td>
-	      <form:input  path="buldNm" size="60" maxlength="60" id="buldNm"/>
-	      <form:errors path="buldNm"/>
-	    </td>
-	  </tr>
-	  <!-- 상세건물명 -->
-	  <c:set var="title"><spring:message code="comSymCcmZip.zipVO.detailBuldNm"/></c:set>
-	  <tr>
-	    <th class="ic_none"><label for="detailBuldNm">${title}</label></th>
-	    <td>
-	      <form:input  path="detailBuldNm" size="60" maxlength="60" id="detailBuldNm"/>
-	      <form:errors path="detailBuldNm"/>
-	    </td>
-	  </tr>
-	  <input type=hidden name="emdNm" id="emdNm" value="0"/>
-  </c:if>
-  </tbody>
-</table>
+	<!-- 등록  폼 영역  -->
+	<c:set var="titleMessage"><spring:message code="comSymCcmZip.zipVO.zipMessage"/></c:set>
+	<table class="tbl_note" summary="<spring:message code="comSymCcmZip.zipVO.summaryInsert"/>"><!-- 우편번호, 시도명, 시군구명, 읍면동명, 리건물명, 번지동호를 입력하는 우편번호 등록 테이블입니다. -->
+		<caption>${pageTitle } <spring:message code="title.create" /></caption>
+		<colgroup>
+			<col style="width: 20%;"><col style="width: ;">
+		</colgroup>
+		<tbody>
+		<c:if test="${!isRoadAddr}">
+			<!-- 우편번호  -->
+			<c:set var="title"><spring:message code="comSymCcmZip.zipVO.zip"/></c:set>
+			<tr>
+				<th class="ic_none"><label for="zip">${title} <span class="pilsu">*</span></label></th>
+				<td class="left">
+					<form:input path="zip" size="5" maxlength="5" id="zip"/>
+					<form:errors path="zip"/> &nbsp;* ${titleMessage } <!-- 우편번호의 '-'를 제외하고 입력하시오. -->
+				</td>
+			</tr>
+			<!-- 시도명  -->
+			<c:set var="title"><spring:message code="comSymCcmZip.zipVO.ctprvnNm"/></c:set>
+			<tr>
+				<th class="ic_none"><label for="ctprvnNm">${title} <span class="pilsu">*</label></th>
+				<td>
+					<form:input  path="ctprvnNm" size="20" maxlength="20" id="ctprvnNm"/>
+					<form:errors path="ctprvnNm"/>
+				</td>
+			</tr>
+			<!-- 시군구명 -->
+			<c:set var="title"><spring:message code="comSymCcmZip.zipVO.signguNm"/></c:set>
+			<tr>
+				<th class="ic_none"><label for="signguNm">${title} <span class="pilsu">*</label></th>
+				<td>
+					<form:input  path="signguNm" size="20" maxlength="20" id="signguNm"/>
+					<form:errors path="signguNm"/>
+				</td>
+			</tr>
+			<!-- 읍면동명 -->
+			<c:set var="title"><spring:message code="comSymCcmZip.zipVO.emdNm"/></c:set>
+			<tr>
+				<th class="ic_none"><label for="emdNm">${title} <span class="pilsu">*</label></th>
+				<td>
+					<form:input  path="emdNm" size="30" maxlength="30" id="emdNm"/>
+					<form:errors path="emdNm"/>
+				</td>
+			</tr>
+			<!-- 리건물명 -->
+			<c:set var="title"><spring:message code="comSymCcmZip.zipVO.liBuldNm"/></c:set>
+			<tr>
+				<th class="ic_none"><label for="liBuldNm">${title}</label></th>
+				<td>
+					<form:input  path="liBuldNm" size="60" maxlength="60" id="liBuldNm"/>
+					<form:errors path="liBuldNm"/>
+				</td>
+			</tr>
+			<!-- 번지동호 -->
+			<c:set var="title"><spring:message code="comSymCcmZip.zipVO.lnbrDongHo"/></c:set>
+			<tr>
+				<th class="ic_none"><label for="lnbrDongHo">${title}</label></th>
+				<td>
+					<form:input  path="lnbrDongHo" size="20" maxlength="20" id="lnbrDongHo"/>
+					<form:errors path="lnbrDongHo"/>
+				</td>
+			</tr>
+			<input type=hidden name="rdmnCode" id="rdmnCode" value="0"/>
+			<input type=hidden name="rdmn" id="rdmn" value="0"/>
+		</c:if>
+		<c:if test="${isRoadAddr}">
+			<!-- 우편번호  -->
+			<c:set var="title"><spring:message code="comSymCcmZip.zipVO.zip"/></c:set>
+			<c:set var="address"><spring:message code="comSymCcmZip.zipVO.rdmnSearch"/></c:set>
+			<tr>
+				<th class="ic_none"><label for="zip">${title} <span class="pilsu">*</label></th>
+				<td>
+					<form:input  path="zip" size="5" maxlength="5" id="zip" name="zip"/>
+					<form:errors path="zip"/> <input type="button" class="btn_s" onClick="goAddSearch();" value="${address }"/>
+				</td>
+			</tr>
+			<!-- 도로명코드  -->
+			<c:set var="title"><spring:message code="comSymCcmZip.zipVO.rdmnCode"/></c:set>
+			<tr>
+				<th class="ic_none"><label for="rdmnCode">${title} <span class="pilsu">*</label></th>
+				<td>
+					<form:input  path="rdmnCode" size="12" maxlength="12" id="rdmnCode"/>
+					<form:errors path="rdmnCode"/>
+				</td>
+			</tr>
+			<!-- 시도명  -->
+			<c:set var="title"><spring:message code="comSymCcmZip.zipVO.ctprvnNm"/></c:set>
+			<tr>
+				<th class="ic_none"><label for="ctprvnNm">${title} <span class="pilsu">*</label></th>
+				<td>
+					<form:input  path="ctprvnNm" size="20" maxlength="20" id="ctprvnNm"/>
+					<form:errors path="ctprvnNm"/>
+				</td>
+			</tr>
+			<!-- 시군구명 -->
+			<c:set var="title"><spring:message code="comSymCcmZip.zipVO.signguNm"/></c:set>
+			<tr>
+				<th class="ic_none"><label for="signguNm">${title} <span class="pilsu">*</label></th>
+				<td>
+					<form:input  path="signguNm" size="20" maxlength="20" id="signguNm"/>
+					<form:errors path="signguNm"/>
+				</td>
+			</tr>
+			<!-- 도로명 -->
+			<c:set var="title"><spring:message code="comSymCcmZip.zipVO.rdmn"/></c:set>
+			<tr>
+				<th class="ic_none"><label for="rdmn">${title} <span class="pilsu">*</label></th>
+				<td>
+					<form:input  path="rdmn" size="60" maxlength="60" id="rdmn"/>
+					<form:errors path="rdmn"/>
+				</td>
+			</tr>
+			<!-- 건물번호본번 -->
+			<c:set var="title"><spring:message code="comSymCcmZip.zipVO.bdnbrMnnm"/></c:set>
+			<tr>
+				<th class="ic_none"><label for="bdnbrMnnm">${title}</label></th>
+				<td>
+					<form:input  path="bdnbrMnnm" size="5" maxlength="5" id="bdnbrMnnm"/>
+					<form:errors path="bdnbrMnnm"/>
+				</td>
+			</tr>
+			<!-- 건물번호부번 -->
+			<c:set var="title"><spring:message code="comSymCcmZip.zipVO.bdnbrSlno"/></c:set>
+			<tr>
+				<th class="ic_none"><label for="bdnbrSlno">${title}</label></th>
+				<td>
+					<form:input  path="bdnbrSlno" size="5" maxlength="5" id="bdnbrSlno"/>
+					<form:errors path="bdnbrSlno"/>
+				</td>
+			</tr>
+			<!-- 건물명 -->
+			<c:set var="title"><spring:message code="comSymCcmZip.zipVO.buldNm"/></c:set>
+			<tr>
+				<th class="ic_none"><label for="buldNm">${title}</label></th>
+				<td>
+					<form:input  path="buldNm" size="60" maxlength="60" id="buldNm"/>
+					<form:errors path="buldNm"/>
+				</td>
+			</tr>
+			<!-- 상세건물명 -->
+			<c:set var="title"><spring:message code="comSymCcmZip.zipVO.detailBuldNm"/></c:set>
+			<tr>
+				<th class="ic_none"><label for="detailBuldNm">${title}</label></th>
+				<td>
+					<form:input  path="detailBuldNm" size="60" maxlength="60" id="detailBuldNm"/>
+					<form:errors path="detailBuldNm"/>
+				</td>
+			</tr>
+			<input type=hidden name="emdNm" id="emdNm" value="0"/>
+		</c:if>
+		</tbody>
+	</table>
 
-<!-- 목록/저장버튼  -->
-<div class="txt-cnt mt20">
-  <input type="submit" class="btnStyle02 bg_gray" value="<spring:message code="button.list" />" onclick="fn_egov_list_Zip(); return false;"> <!-- 목록 -->
-  <input type="submit" class="btnStyle02" value="<spring:message code="button.create" />" onclick="fn_egov_regist_Zip(document.zip); return false;"></span> <!-- 등록 -->
-</div><div style="clear:both;"></div>
+	<!-- 목록/저장버튼  -->
+	<div class="txt-cnt mt20">
+		<input type="submit" class="btnStyle02 bg_gray" value="<spring:message code="button.list" />" onclick="fn_egov_list_Zip(); return false;"> <!-- 목록 -->
+		<input type="submit" class="btnStyle02" value="<spring:message code="button.create" />" onclick="fn_egov_regist_Zip(document.zip); return false;"></span> <!-- 등록 -->
+	</div><div style="clear:both;"></div>
 
-<input name="cmd" type="hidden" value="<c:out value='save'/>">
-<input name="searchList" type="hidden" value="<c:out value='${searchList}'/>">
-</form:form>
+	<input name="cmd" type="hidden" value="<c:out value='save'/>">
+	<input name="searchList" type="hidden" value="<c:out value='${searchList}'/>">
+	</form:form>
 </div>
 </body>
 </html>

--- a/src/main/webapp/WEB-INF/jsp/egovframework/com/sym/ccm/zip/EgovCcmZipSearchList.jsp
+++ b/src/main/webapp/WEB-INF/jsp/egovframework/com/sym/ccm/zip/EgovCcmZipSearchList.jsp
@@ -25,62 +25,62 @@
 <%@ taglib prefix="spring" uri="http://www.springframework.org/tags"%>
 <html lang="ko">
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8" >
-<title><spring:message code="comSymCcmZip.ccmZipSearchList.title"/></title><!-- 우편번호 찾기 -->
-<link href="<c:url value="/css/egovframework/com/com.css"/>" rel="stylesheet" type="text/css">
-<link href="<c:url value="/css/egovframework/com/button.css"/>" rel="stylesheet" type="text/css">
-<script type="text/javascript" src="<c:url value='/js/egovframework/com/cmm/showModalDialogCallee.js'/>" ></script>
-<script type="text/javascript">
-<!--
-/* ********************************************************
- * 페이징 처리 함수
- ******************************************************** */
-function fn_egov_pageview(pageNo){
-	document.listForm.pageIndex.value = pageNo;
-	document.listForm.action = "<c:url value='/sym/ccm/zip/EgovCcmZipSearchList.do'/>";
-   	document.listForm.submit();
-}
-/* ********************************************************
- * 조회 처리
- ******************************************************** */
-function fn_egov_search_Zip(){
-	document.listForm.pageIndex.value = 1;
-	document.listForm.searchList.value = document.getElementById("searchList").value;
-	document.listForm.searchCondition.value = document.getElementById("searchCondition").value;
-	document.listForm.searchCondition2.value = document.getElementById("searchCondition2").value;
-   	document.listForm.submit();
-}
-/* ********************************************************
- * 결과 우편번호,주소 반환
- ******************************************************** */
-function fn_egov_return_Zip(zip,addr){
-	var retVal   = new Object();
-	var sZip     = zip;
-	var vZip     = zip.substring(0,3)+zip.substring(3,6);
-	var sAddr    = addr.replace(/^\s+|\s+$/g,"");
-	retVal.sZip  = sZip;
-	retVal.vZip  = vZip;
-	retVal.sAddr = sAddr;
-	
-	setReturnValue(retVal);
-	
-	parent.window.returnValue = retVal;
-	parent.window.close();
-}
-/* ********************************************************
- * 목록회면 처리 함수
- ******************************************************** */
-function fn_egov_list(){
-	if (document.getElementById("searchList").value == 1) {
-		document.getElementById("searchCondition").style.display="";
-		document.getElementById("searchCondition2").style.display="none";
-	} else {
-		document.getElementById("searchCondition").style.display="none";
-		document.getElementById("searchCondition2").style.display="";
-	}
-}
--->
-</script>
+	<meta http-equiv="Content-Type" content="text/html; charset=utf-8" >
+	<title><spring:message code="comSymCcmZip.ccmZipSearchList.title"/></title><!-- 우편번호 찾기 -->
+	<link href="<c:url value="/css/egovframework/com/com.css"/>" rel="stylesheet" type="text/css">
+	<link href="<c:url value="/css/egovframework/com/button.css"/>" rel="stylesheet" type="text/css">
+	<script type="text/javascript" src="<c:url value='/js/egovframework/com/cmm/showModalDialogCallee.js'/>" ></script>
+	<script type="text/javascript">
+		<!--
+		/* ********************************************************
+         * 페이징 처리 함수
+         ******************************************************** */
+		function fn_egov_pageview(pageNo){
+			document.listForm.pageIndex.value = pageNo;
+			document.listForm.action = "<c:url value='/sym/ccm/zip/EgovCcmZipSearchList.do'/>";
+			document.listForm.submit();
+		}
+		/* ********************************************************
+         * 조회 처리
+         ******************************************************** */
+		function fn_egov_search_Zip(){
+			document.listForm.pageIndex.value = 1;
+			document.listForm.searchList.value = document.getElementById("searchList").value;
+			document.listForm.searchCondition.value = document.getElementById("searchCondition").value;
+			document.listForm.searchCondition2.value = document.getElementById("searchCondition2").value;
+			document.listForm.submit();
+		}
+		/* ********************************************************
+         * 결과 우편번호,주소 반환
+         ******************************************************** */
+		function fn_egov_return_Zip(zip,addr){
+			var retVal   = new Object();
+			var sZip     = zip;
+			var vZip     = zip.substring(0,3)+zip.substring(3,6);
+			var sAddr    = addr.replace(/^\s+|\s+$/g,"");
+			retVal.sZip  = sZip;
+			retVal.vZip  = vZip;
+			retVal.sAddr = sAddr;
+
+			setReturnValue(retVal);
+
+			parent.window.returnValue = retVal;
+			parent.window.close();
+		}
+		/* ********************************************************
+         * 목록회면 처리 함수
+         ******************************************************** */
+		function fn_egov_list(){
+			if (document.getElementById("searchList").value == 1) {
+				document.getElementById("searchCondition").style.display="";
+				document.getElementById("searchCondition2").style.display="none";
+			} else {
+				document.getElementById("searchCondition").style.display="none";
+				document.getElementById("searchCondition2").style.display="";
+			}
+		}
+		-->
+	</script>
 </head>
 
 <body onLoad="fn_egov_list()">
@@ -89,59 +89,59 @@ function fn_egov_list(){
 
 <form name="listForm" action="<c:url value='/sym/ccm/zip/EgovCcmZipSearchList.do'/>" method="post">
 
-<div class="board" style="width:680px">
+	<div class="board" style="width:680px">
 
-	<h1><spring:message code="comSymCcmZip.ccmZipSearchList.title"/></h1><!-- 우편번호 찾기 -->
+		<h1><spring:message code="comSymCcmZip.ccmZipSearchList.title"/></h1><!-- 우편번호 찾기 -->
 
-	<div class="search_box" title="<spring:message code="common.searchCondition.msg" />"><!-- 이 레이아웃은 하단 정보를 대한 검색 정보로 구성되어 있습니다. -->
-		<ul>
-			<li>
-				<select name="searchList" id="searchList" title="searchList" onchange="fn_egov_list()"> 
-					<option value='1' <c:if test="${searchList == '1'}">selected="selected"</c:if>><spring:message code="comSymCcmZip.zipVO.SearchAddr"/></option><!-- 주소 -->
-					<option value='2' <c:if test="${searchList == '2'}">selected="selected"</c:if>><spring:message code="comSymCcmZip.zipVO.SearchRdmn"/></option><!-- 도로명주소 -->
-				</select>
-				<select name="searchCondition" id="searchCondition" title="searchCondition" style="display:none">
-				   <option value='1' <c:if test="${searchVO.searchCondition == '1'}">selected="selected"</c:if>><spring:message code="comSymCcmZip.zipVO.zip"/></option><!-- 우편번호 -->
-				   <option value='2' <c:if test="${searchVO.searchCondition == '2'}">selected="selected"</c:if>><spring:message code="comSymCcmZip.zipVO.ctprvnNm"/></option><!-- 시도명 -->
-				   <option value='3' <c:if test="${searchVO.searchCondition == '3'}">selected="selected"</c:if>><spring:message code="comSymCcmZip.zipVO.signguNm"/></option><!-- 시군구명 -->
-				   <option value='4' <c:if test="${searchVO.searchCondition == '4'}">selected="selected"</c:if>><spring:message code="comSymCcmZip.zipVO.emdNm"/></option><!-- 읍면동명 -->
-				   <option value='5' <c:if test="${searchVO.searchCondition == '5'}">selected="selected"</c:if>><spring:message code="comSymCcmZip.zipVO.liBuldNm"/></option><!-- 리건물명 -->
-				</select>
-			   	<select name="searchCondition2" id="searchCondition2" title="searchCondition" style="display:none">
-				   <option value='1' <c:if test="${searchVO.searchCondition2 == '1'}">selected="selected"</c:if>><spring:message code="comSymCcmZip.zipVO.zip"/></option><!-- 우편번호 -->
-				   <option value='2' <c:if test="${searchVO.searchCondition2 == '2'}">selected="selected"</c:if>><spring:message code="comSymCcmZip.zipVO.ctprvnNm"/></option><!-- 시도명 -->
-				   <option value='3' <c:if test="${searchVO.searchCondition2 == '3'}">selected="selected"</c:if>><spring:message code="comSymCcmZip.zipVO.signguNm"/></option><!-- 시군구명 -->
-				   <option value='4' <c:if test="${searchVO.searchCondition2 == '4'}">selected="selected"</c:if>><spring:message code="comSymCcmZip.zipVO.rdmn"/></option><!-- 도로명 -->
-				   <option value='5' <c:if test="${searchVO.searchCondition2 == '5'}">selected="selected"</c:if>><spring:message code="comSymCcmZip.zipVO.buldNm"/></option><!-- 건물명 -->
-				   <option value='6' <c:if test="${searchVO.searchCondition2 == '6'}">selected="selected"</c:if>><spring:message code="comSymCcmZip.zipVO.detailBuldNm"/></option><!-- 상세건물명 -->
-				</select>
-				<input class="s_input2 vat" name="searchKeyword" type="text" value="${searchVO.searchKeyword}" maxlength="20" size="20" title="<spring:message code="comSymCcmZip.ccmZipSearchList.inputText"/>" /><!-- 입력창 -->
-				
-				<input class="s_btn" type="submit" value="<spring:message code="title.inquire"/>"  title="<spring:message code="title.inquire"/>" onclick="fn_egov_search_Zip();" /><!-- 조회 -->
-			</li>
-		</ul>
-	</div>
+		<div class="search_box" title="<spring:message code="common.searchCondition.msg" />"><!-- 이 레이아웃은 하단 정보를 대한 검색 정보로 구성되어 있습니다. -->
+			<ul>
+				<li>
+					<select name="searchList" id="searchList" title="searchList" onchange="fn_egov_list()">
+						<option value='1' <c:if test="${searchList == '1'}">selected="selected"</c:if>><spring:message code="comSymCcmZip.zipVO.SearchAddr"/></option><!-- 주소 -->
+						<option value='2' <c:if test="${searchList == '2'}">selected="selected"</c:if>><spring:message code="comSymCcmZip.zipVO.SearchRdmn"/></option><!-- 도로명주소 -->
+					</select>
+					<select name="searchCondition" id="searchCondition" title="searchCondition" style="display:none">
+						<option value='1' <c:if test="${searchVO.searchCondition == '1'}">selected="selected"</c:if>><spring:message code="comSymCcmZip.zipVO.zip"/></option><!-- 우편번호 -->
+						<option value='2' <c:if test="${searchVO.searchCondition == '2'}">selected="selected"</c:if>><spring:message code="comSymCcmZip.zipVO.ctprvnNm"/></option><!-- 시도명 -->
+						<option value='3' <c:if test="${searchVO.searchCondition == '3'}">selected="selected"</c:if>><spring:message code="comSymCcmZip.zipVO.signguNm"/></option><!-- 시군구명 -->
+						<option value='4' <c:if test="${searchVO.searchCondition == '4'}">selected="selected"</c:if>><spring:message code="comSymCcmZip.zipVO.emdNm"/></option><!-- 읍면동명 -->
+						<option value='5' <c:if test="${searchVO.searchCondition == '5'}">selected="selected"</c:if>><spring:message code="comSymCcmZip.zipVO.liBuldNm"/></option><!-- 리건물명 -->
+					</select>
+					<select name="searchCondition2" id="searchCondition2" title="searchCondition" style="display:none">
+						<option value='1' <c:if test="${searchVO.searchCondition2 == '1'}">selected="selected"</c:if>><spring:message code="comSymCcmZip.zipVO.zip"/></option><!-- 우편번호 -->
+						<option value='2' <c:if test="${searchVO.searchCondition2 == '2'}">selected="selected"</c:if>><spring:message code="comSymCcmZip.zipVO.ctprvnNm"/></option><!-- 시도명 -->
+						<option value='3' <c:if test="${searchVO.searchCondition2 == '3'}">selected="selected"</c:if>><spring:message code="comSymCcmZip.zipVO.signguNm"/></option><!-- 시군구명 -->
+						<option value='4' <c:if test="${searchVO.searchCondition2 == '4'}">selected="selected"</c:if>><spring:message code="comSymCcmZip.zipVO.rdmn"/></option><!-- 도로명 -->
+						<option value='5' <c:if test="${searchVO.searchCondition2 == '5'}">selected="selected"</c:if>><spring:message code="comSymCcmZip.zipVO.buldNm"/></option><!-- 건물명 -->
+						<option value='6' <c:if test="${searchVO.searchCondition2 == '6'}">selected="selected"</c:if>><spring:message code="comSymCcmZip.zipVO.detailBuldNm"/></option><!-- 상세건물명 -->
+					</select>
+					<input class="s_input2 vat" name="searchKeyword" type="text" value="${searchVO.searchKeyword}" maxlength="20" size="20" title="<spring:message code="comSymCcmZip.ccmZipSearchList.inputText"/>" /><!-- 입력창 -->
 
-	<table class="board_list">
-		<caption></caption>
-		<colgroup>
-			<col style="width:25%" />
-			<col style="width:75%" />
-		</colgroup>
-		<thead>
+					<input class="s_btn" type="submit" value="<spring:message code="title.inquire"/>"  title="<spring:message code="title.inquire"/>" onclick="fn_egov_search_Zip();" /><!-- 조회 -->
+				</li>
+			</ul>
+		</div>
+
+		<table class="board_list">
+			<caption></caption>
+			<colgroup>
+				<col style="width:25%" />
+				<col style="width:75%" />
+			</colgroup>
+			<thead>
 			<tr>
-			   <th scope="col"></th>
-			   <th scope="col"></th>
+				<th scope="col"></th>
+				<th scope="col"></th>
 			</tr>
-		</thead>
-		<tbody>
+			</thead>
+			<tbody>
 			<%-- 데이터를 없을때 화면에 메세지를 출력해준다 --%>
 			<c:if test="${fn:length(resultList) == 0}">
-			<tr>
-			<td class="lt_text3" colspan="2">
-				<spring:message code="common.nodata.msg" />
-			</td>
-			</tr>
+				<tr>
+					<td class="lt_text3" colspan="2">
+						<spring:message code="common.nodata.msg" />
+					</td>
+				</tr>
 			</c:if>
 			<c:if test="${searchList == '1'}">
 				<c:forEach items="${resultList}" var="resultInfo" varStatus="status">
@@ -159,18 +159,18 @@ function fn_egov_list(){
 					</tr>
 				</c:forEach>
 			</c:if>
-		</tbody>
-	</table>
+			</tbody>
+		</table>
 
-	<!-- paging navigation -->
-	<div class="pagination">
-		<ul>
-			<ui:pagination paginationInfo="${paginationInfo}" type="image" jsFunction="fn_egov_pageview"/>
-		</ul>
+		<!-- paging navigation -->
+		<div class="pagination">
+			<ul>
+				<ui:pagination paginationInfo="${paginationInfo}" type="image" jsFunction="fn_egov_pageview"/>
+			</ul>
+		</div>
 	</div>
-</div>
-<input name="pageIndex" type="hidden" value="<c:out value='${searchVO.pageIndex}'/>">
-<input type=hidden name="searchList">
+	<input name="pageIndex" type="hidden" value="<c:out value='${searchVO.pageIndex}'/>">
+	<input type=hidden name="searchList">
 </form>
 </body>
 </html>


### PR DESCRIPTION
1000. 우편번호 관리 - 등록/수정 화면과 처리 로직 분리, 백엔드 필수값 검증 적용 #407


## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [ ] 버그수정 Bug fixes
- [X] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

1. `EgovCcmZipManageController ` 의 화면/처리 메서드 분리
- 화면을 보여주기 위한 처리와 데이터 등록 처리를 하나의 메서드에서 담당하고 있어 하나의 메서드가 하나의 역할을 할 수 있도록 분리하였습니다.
  - 등록
    - 화면 : `/sym/ccm/zip/EgovCcmZipRegistView.do`
    - 처리 : `/sym/ccm/zip/EgovCcmZipRegist.do`
  - 수정
    - 화면 : `/sym/ccm/zip/EgovCcmZipModifyView.do`
    - 처리 : `/sym/ccm/zip/EgovCcmZipModify.do`

2. 위 사유 (하나의 메서드에서 화면과 처리를 함께함)로 인해 bindingResult가 작동하지 않는 점을 개선했습니다.



## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [x] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [X] Chrome
- [X] Firefox
- [X] Edge
- [X] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

### 일반주소 등록

https://github.com/user-attachments/assets/d1c82cdc-f742-42bb-81a2-eedb58531399

### 일반주소 수정

https://github.com/user-attachments/assets/304511a9-4e10-4577-8d21-1a7776301b79

### 일반주소 삭제

https://github.com/user-attachments/assets/622a0159-a919-4605-935f-5f4d52d58b64

### 도로명주소 등록

https://github.com/user-attachments/assets/ec48d9b2-9343-4ec9-80ee-c2b6da661c4a

### 도로명주소 수정

https://github.com/user-attachments/assets/ef3921bb-a499-44fd-9b52-6933d9762b3f

### 도로명주소 삭제

https://github.com/user-attachments/assets/343fe453-12ed-4a31-8d50-0fe53bff0f5d




