### PR TITLE
[버그수정] 1000. 우편번호관리 - 2015년 개정된 5자리 우편번호에 맞게 우편번호 표기 방식 개선

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/egovframework/com/sym/ccm/zip/EgovCcmZipDetail.jsp
+++ b/src/main/webapp/WEB-INF/jsp/egovframework/com/sym/ccm/zip/EgovCcmZipDetail.jsp
@@ -84,7 +84,7 @@ function fn_egov_delete_Zip(){
   <c:if test="${searchList == '1'}">
 	  <tr>
 	    <th class="ic_none" width="20%" height="23" scope="row" nowrap ><spring:message code="comSymCcmZip.zipVO.zip"/> <span class="pilsu">*</span></th> <!-- 우편번호 -->
-	    <td><c:out value='${fn:substring(result.zip, 0,3)}'/>-<c:out value='${fn:substring(result.zip, 3,6)}'/></td>
+	    <td>${result.zip}</td>
 	  </tr>
 	  <tr>
 	    <th class="ic_none" width="20%" height="23" scope="row" nowrap ><spring:message code="comSymCcmZip.zipVO.ctprvnNm"/> <span class="pilsu">*</span></th> <!-- 시도명 -->
@@ -110,7 +110,7 @@ function fn_egov_delete_Zip(){
   <c:if test="${searchList == '2'}">
 	  <tr>
 	    <th class="ic_none" width="20%" height="23" scope="row" nowrap ><spring:message code="comSymCcmZip.zipVO.zip"/> <span class="pilsu">*</span></th><!-- 우편번호 -->
-	    <td><c:out value='${fn:substring(result.zip, 0,3)}'/>-<c:out value='${fn:substring(result.zip, 3,6)}'/></td>
+	    <td>${result.zip}</td>
 	  </tr>
 	  <tr>
 	    <th class="ic_none" width="20%" height="23" scope="row" nowrap ><spring:message code="comSymCcmZip.zipVO.rdmnCode"/> <span class="pilsu">*</span></th><!-- 도로명코드 -->

--- a/src/main/webapp/WEB-INF/jsp/egovframework/com/sym/ccm/zip/EgovCcmZipList.jsp
+++ b/src/main/webapp/WEB-INF/jsp/egovframework/com/sym/ccm/zip/EgovCcmZipList.jsp
@@ -189,7 +189,7 @@ function fn_egov_list(){
 	<c:forEach items="${resultList}" var="resultInfo" varStatus="status">
 	<tr style="cursor:pointer;cursor:hand;" onclick="javascript:fn_egov_detail_RdmnCode_Zip('${resultInfo.rdmnCode}','${resultInfo.sn}');">
 		<td class="lt_text3" nowrap><c:out value="${(searchVO.pageIndex - 1) * searchVO.pageSize + status.count}"/></td>
-		<td class="lt_text3" nowrap><c:out value='${fn:substring(resultInfo.zip, 0,3)}'/>-<c:out value='${fn:substring(resultInfo.zip, 3,6)}'/></td>
+		<td class="lt_text3" nowrap>${resultInfo.zip}</td>
 		<td class="lt_text"  nowrap>${resultInfo.ctprvnNm} ${resultInfo.signguNm} ${resultInfo.rdmn} ${resultInfo.bdnbrMnnm} <c:if test="${resultInfo.bdnbrSlno != ''}">- ${resultInfo.bdnbrSlno}</c:if> ${resultInfo.buldNm} ${resultInfo.detailBuldNm}</td>
 	</tr>
 	</c:forEach>


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

우편번호 관리의 목록과 상세화면 JSP 페이지에서 우편번호를 출력할 때 2015년 개정된 5자리 우편번호가 아닌 과거 `-` 이 포함된 6자리 우편번호에 맞춰 출력하고 있어 이를 개선하였습니다.

- `EgovCcmZipList.jsp`
  - before : `<c:out value='${fn:substring(result.zip, 0,3)}'/>-<c:out value='${fn:substring(result.zip, 3,6)}'/>`
  - after : `${result.zip}`
- `EgovCcmZipDetail.jsp`
  - before : `<c:out value='${fn:substring(resultInfo.zip, 0,3)}'/>-<c:out value='${fn:substring(resultInfo.zip, 3,6)}'/>`
  - after : `${resultInfo.zip}`



## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [X] Chrome
- [X] Firefox
- [X] Edge
- [X] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

### 일반 주소 상세조회

![image](https://github.com/user-attachments/assets/d2336343-c8f2-4555-883e-67039363efcc)

### 도로명 주소 상세 조회

![image](https://github.com/user-attachments/assets/e99ad76c-b2cf-4d9c-8e19-ab03d78d8052)

### 도로명 주소 목록 조회

![image](https://github.com/user-attachments/assets/ea40ebab-7bd1-411c-ab0e-ef511797b8db)



