### PR TITLE
1000. 우편번호관리 - 상세화면에서 목록 이동 시 이전에 보던 목록으로 이동하도록 수정

### DIFF
--- a/src/main/java/egovframework/com/sym/ccm/zip/web/EgovCcmZipManageController.java
+++ b/src/main/java/egovframework/com/sym/ccm/zip/web/EgovCcmZipManageController.java
@@ -291,7 +291,7 @@ public class EgovCcmZipManageController {
 			model.addAttribute("result", vo);
 			model.addAttribute("searchList", searchVO.getSearchList());
 		}
-
+		model.addAttribute("searchVO", searchVO);
 		return "egovframework/com/sym/ccm/zip/EgovCcmZipDetail";
 	}
 

--- a/src/main/webapp/WEB-INF/jsp/egovframework/com/sym/ccm/zip/EgovCcmZipDetail.jsp
+++ b/src/main/webapp/WEB-INF/jsp/egovframework/com/sym/ccm/zip/EgovCcmZipDetail.jsp
@@ -32,8 +32,10 @@
 /* ********************************************************
  * 목록 으로 가기
  ******************************************************** */
-function fn_egov_list_Zip(){
-	location.href = "<c:url value='/sym/ccm/zip/EgovCcmZipList.do' />";
+function fn_egov_list_Zip() {
+	var varForm = document.getElementById("Form");
+	varForm.action = "<c:url value='/sym/ccm/zip/EgovCcmZipList.do'/>";
+	varForm.submit();
 }
 /* ********************************************************
  * 수정화면으로  바로가기
@@ -157,10 +159,12 @@ function fn_egov_delete_Zip(){
 <input class="btnStyle02" type="submit" value="<spring:message code="button.list" />" onclick="fn_egov_list_Zip(); return false;"></td>
 </div>
 <form name="Form" id="Form" method="post" action="">
-	<input type=hidden name="zip">
-	<input type=hidden name="sn">
-	<input type=hidden name="rdmnCode">
-	<input type=hidden name="searchList" value="${searchList}">
+	<input type=hidden id="sn" name="sn" value="${not empty result.sn ? result.sn : 0}" />
+	<input type=hidden id="zip" name="zip" />
+	<input type=hidden id="rdmnCode" name="rdmnCode" />
+	<input type=hidden id="searchList" name="searchList" value="${searchVO.searchList}" />
+	<input type=hidden id="searchCondition2" name="searchCondition2" value="${searchVO.searchKeyword}" />
+	<input type=hidden id="searchKeyword" name="searchKeyword" value="${searchVO.searchKeyword}" />
 </form>
 </div>
 </body>


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others


우편번호 관리 상세화면에서 목록으로 이동 시 원래 보고 있던 목록이 유지되지 않는 점을 수정하였습니다.
ex ) 도로명주소 목록 > 상세화면 > 일반주소 목록으로 이동하던 문제


## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

- `EgovCcmZipManageController.java`
  - 상세 페이지에서 목록으로 넘어갈 때 이전 페이지 파라미터를 model에 추가
- `EgovCcmZipDetail.jsp`
  - model에서 이전 목록 조회 파라미터를 받아 form에 세팅, form submit을 통해 검색 파라미터와 함께 목록 페이지를 호출



## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [X] Chrome
- [X] Firefox
- [X] Edge
- [X] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

### 수정 전


https://github.com/user-attachments/assets/284c73d0-79e8-4254-b6e4-d6f8cb80a353



### 수정 후



https://github.com/user-attachments/assets/a6497560-898f-4f3e-b0c6-23e0727e19d3



