### PR TITLE
[버그수정] 340. 일지관리 > 목록 화면 - Uncaught TypeError: Cannot read properties of undefined 에러 수정

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/egovframework/com/cop/smt/dsm/EgovDiaryManageList.jsp
+++ b/src/main/webapp/WEB-INF/jsp/egovframework/com/cop/smt/dsm/EgovDiaryManageList.jsp
@@ -74,7 +74,7 @@ function fn_egov_search_DiaryManage(){
 
 <div class="board">
 	<h1>${pageTitle} <spring:message code="title.list" /></h1>
-	<form name="StplatListForm" action="<c:url value='/cop/smt/dsm/EgovDiaryManageList.do'/>" method="post"> 
+	<form id="listForm" name="listForm" action="<c:url value='/cop/smt/dsm/EgovDiaryManageList.do'/>" method="post"> 
 		<!-- 검색영역 -->
 		<div class="search_box" title="<spring:message code="common.searchCondition.msg" />">
 			<ul>
@@ -95,8 +95,8 @@ function fn_egov_search_DiaryManage(){
 				</li>
 			</ul>
 		</div>
-	<input name="diaryId" type="hidden" value="">
-	<input name="pageIndex" type="hidden" value="<c:out value='${searchVO.pageIndex}'/>">
+        <input id="diaryId" name="diaryId" type="hidden" value="">
+        <input id="pageIndex" name="pageIndex" type="hidden" value="<c:out value='${searchVO.pageIndex}'/>">
 	</form>
 
 	<!-- 목록영역 -->


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

-`EgovDiaryManageList.jsp`
  - 페이징 처리 함수 `linkPage` 에서 `Uncaught TypeError: Cannot read properties of undefined` 에러가 발생 수정
  - 스크립트에서 참조하는 element들의 올바른 id 값을 지정함


## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [X] Chrome
- [X] Firefox
- [X] Edge
- [X] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

### 수정 전

![image](https://github.com/user-attachments/assets/d53a8fb0-c4b8-4247-99ce-c95dd7644f85)


### 수정 후

![image](https://github.com/user-attachments/assets/320a5d6a-9c6a-4e5a-8e6f-3436e57474d7)

