### PR TITLE
[버그수정] 780. 통합링크관리 > Uncaught TypeError: varFrom.onsubmit is not a function 에러 수정

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/egovframework/com/uss/ion/ulm/EgovUnityLinkRegist.jsp
+++ b/src/main/webapp/WEB-INF/jsp/egovframework/com/uss/ion/ulm/EgovUnityLinkRegist.jsp
@@ -43,7 +43,7 @@ function fn_egov_init_UnityLink(){
  ******************************************************** */
 function fn_egov_save_UnityLink(){
 	var varFrom = document.unityLink;
-	varFrom.onsubmit();
+
 	if(confirm("<spring:message code="common.save.msg" />")){
 		varFrom.action =  "<c:url value='/uss/ion/ulm/registUnityLink.do' />";
 		if(!validateUnityLink(varFrom)){


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

- `EgovUnityLinkRegist.jsp`
  - 함수의 기능 상 불필요한 코드가 `onsubmit` 함수를 호출하여 Uncaught TypeError 에러가 발생해 해당 코드를 제거하였습니다. 



## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [x] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [X] Chrome
- [X] Firefox
- [X] Edge
- [X] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

### 수정 전

![image](https://github.com/user-attachments/assets/a46ce3c0-4d20-48f2-9c52-88977d2eb041)

### 수정 후

![image](https://github.com/user-attachments/assets/364105ad-d802-4221-aeb5-d09e379a6177)

