### PR TITLE
[430. 메모보고] 시큐어코딩 Exception 제거

### DIFF
--- a/src/main/java/egovframework/com/cmm/service/EgovFileMngService.java
+++ b/src/main/java/egovframework/com/cmm/service/EgovFileMngService.java
@@ -43,17 +43,15 @@ public interface EgovFileMngService {
 	 * 여러 개의 파일에 대한 정보(속성 및 상세)를 등록한다.
 	 *
 	 * @param fvoList
-	 * @throws Exception
 	 */
-	public String insertFileInfs(List<FileVO> fvoList) throws Exception;
+	public String insertFileInfs(List<FileVO> fvoList);
 
 	/**
 	 * 여러 개의 파일에 대한 정보(속성 및 상세)를 수정한다.
 	 *
 	 * @param fvoList
-	 * @throws Exception
 	 */
-	public void updateFileInfs(List<FileVO> fvoList) throws Exception;
+	public void updateFileInfs(List<FileVO> fvoList);
 
 	/**
 	 * 여러 개의 파일을 삭제한다.
@@ -85,17 +83,15 @@ public interface EgovFileMngService {
 	 *
 	 * @param fvo
 	 * @return
-	 * @throws Exception
 	 */
-	public int getMaxFileSN(FileVO fvo) throws Exception;
+	public int getMaxFileSN(FileVO fvo);
 
 	/**
 	 * 전체 파일을 삭제한다.
 	 *
 	 * @param fvo
-	 * @throws Exception
 	 */
-	public void deleteAllFileInf(FileVO fvo) throws Exception;
+	public void deleteAllFileInf(FileVO fvo);
 
 	/**
 	 * 파일명 검색에 대한 목록을 조회한다.

--- a/src/main/java/egovframework/com/cmm/service/EgovFileMngService.java
+++ b/src/main/java/egovframework/com/cmm/service/EgovFileMngService.java
@@ -7,11 +7,13 @@ import java.util.Map;
  * @Class Name : EgovFileMngService.java
  * @Description : 파일정보의 관리를 위한 서비스 인터페이스
  * @Modification Information
- *
+ * 
+ *               <pre>
  *    수정일       수정자         수정내용
  *    -------        -------     -------------------
  *    2009. 3. 25.     이삼섭    최초생성
- *
+ *               </pre>
+ * 
  * @author 공통 서비스 개발팀 이삼섭
  * @since 2009. 3. 25.
  * @version
@@ -20,96 +22,96 @@ import java.util.Map;
  */
 public interface EgovFileMngService {
 
-    /**
-     * 파일에 대한 목록을 조회한다.
-     *
-     * @param fvo
-     * @return
-     * @throws Exception
-     */
-    public List<FileVO> selectFileInfs(FileVO fvo) throws Exception;
+	/**
+	 * 파일에 대한 목록을 조회한다.
+	 *
+	 * @param fvo
+	 * @return
+	 * @throws Exception
+	 */
+	public List<FileVO> selectFileInfs(FileVO fvo) throws Exception;
 
-    /**
-     * 하나의 파일에 대한 정보(속성 및 상세)를 등록한다.
-     *
-     * @param fvo
-     * @throws Exception
-     */
-    public String insertFileInf(FileVO fvo) throws Exception;
+	/**
+	 * 하나의 파일에 대한 정보(속성 및 상세)를 등록한다.
+	 *
+	 * @param fvo
+	 * @throws Exception
+	 */
+	public String insertFileInf(FileVO fvo) throws Exception;
 
-    /**
-     * 여러 개의 파일에 대한 정보(속성 및 상세)를 등록한다.
-     *
-     * @param fvoList
-     * @throws Exception
-     */
-    public String insertFileInfs(List<FileVO> fvoList) throws Exception;
+	/**
+	 * 여러 개의 파일에 대한 정보(속성 및 상세)를 등록한다.
+	 *
+	 * @param fvoList
+	 * @throws Exception
+	 */
+	public String insertFileInfs(List<FileVO> fvoList) throws Exception;
 
-    /**
-     * 여러 개의 파일에 대한 정보(속성 및 상세)를 수정한다.
-     *
-     * @param fvoList
-     * @throws Exception
-     */
-    public void updateFileInfs(List<FileVO> fvoList) throws Exception;
+	/**
+	 * 여러 개의 파일에 대한 정보(속성 및 상세)를 수정한다.
+	 *
+	 * @param fvoList
+	 * @throws Exception
+	 */
+	public void updateFileInfs(List<FileVO> fvoList) throws Exception;
 
-    /**
-     * 여러 개의 파일을 삭제한다.
-     *
-     * @param fvoList
-     * @throws Exception
-     */
-    public void deleteFileInfs(List<FileVO> fvoList) throws Exception;
+	/**
+	 * 여러 개의 파일을 삭제한다.
+	 *
+	 * @param fvoList
+	 * @throws Exception
+	 */
+	public void deleteFileInfs(List<FileVO> fvoList) throws Exception;
 
-    /**
-     * 하나의 파일을 삭제한다.
-     *
-     * @param fvo
-     * @throws Exception
-     */
-    public void deleteFileInf(FileVO fvo) throws Exception;
+	/**
+	 * 하나의 파일을 삭제한다.
+	 *
+	 * @param fvo
+	 * @throws Exception
+	 */
+	public void deleteFileInf(FileVO fvo) throws Exception;
 
-    /**
-     * 파일에 대한 상세정보를 조회한다.
-     *
-     * @param fvo
-     * @return
-     * @throws Exception
-     */
-    public FileVO selectFileInf(FileVO fvo) throws Exception;
+	/**
+	 * 파일에 대한 상세정보를 조회한다.
+	 *
+	 * @param fvo
+	 * @return
+	 * @throws Exception
+	 */
+	public FileVO selectFileInf(FileVO fvo) throws Exception;
 
-    /**
-     * 파일 구분자에 대한 최대값을 구한다.
-     *
-     * @param fvo
-     * @return
-     * @throws Exception
-     */
-    public int getMaxFileSN(FileVO fvo) throws Exception;
+	/**
+	 * 파일 구분자에 대한 최대값을 구한다.
+	 *
+	 * @param fvo
+	 * @return
+	 * @throws Exception
+	 */
+	public int getMaxFileSN(FileVO fvo) throws Exception;
 
-    /**
-     * 전체 파일을 삭제한다.
-     *
-     * @param fvo
-     * @throws Exception
-     */
-    public void deleteAllFileInf(FileVO fvo) throws Exception;
+	/**
+	 * 전체 파일을 삭제한다.
+	 *
+	 * @param fvo
+	 * @throws Exception
+	 */
+	public void deleteAllFileInf(FileVO fvo) throws Exception;
 
-    /**
-     * 파일명 검색에 대한 목록을 조회한다.
-     *
-     * @param fvo
-     * @return
-     * @throws Exception
-     */
-    public Map<String, Object> selectFileListByFileNm(FileVO fvo) throws Exception;
+	/**
+	 * 파일명 검색에 대한 목록을 조회한다.
+	 *
+	 * @param fvo
+	 * @return
+	 * @throws Exception
+	 */
+	public Map<String, Object> selectFileListByFileNm(FileVO fvo) throws Exception;
 
-    /**
-     * 이미지 파일에 대한 목록을 조회한다.
-     *
-     * @param vo
-     * @return
-     * @throws Exception
-     */
-    public List<FileVO> selectImageFileList(FileVO vo) throws Exception;
+	/**
+	 * 이미지 파일에 대한 목록을 조회한다.
+	 *
+	 * @param vo
+	 * @return
+	 * @throws Exception
+	 */
+	public List<FileVO> selectImageFileList(FileVO vo) throws Exception;
 }

--- a/src/main/java/egovframework/com/cmm/service/EgovFileMngUtil.java
+++ b/src/main/java/egovframework/com/cmm/service/EgovFileMngUtil.java
@@ -38,10 +38,11 @@ import egovframework.com.cmm.util.EgovResourceCloseHelper;
 /**
  * @author 공통 서비스 개발팀 이삼섭
  * @version 1.0
- * @Class Name  : EgovFileMngUtil.java
+ * @Class Name : EgovFileMngUtil.java
  * @Description : 메시지 처리 관련 유틸리티
  * @Modification Information
- *
+ * 
+ *               <pre>
  *   수정일               수정자            수정내용
  *   ----------   --------   ---------------------------
  *   2009.02.13   이삼섭            최초 생성
@@ -49,7 +50,8 @@ import egovframework.com.cmm.util.EgovResourceCloseHelper;
  *   2017.03.03   조성원            시큐어코딩(ES)-부적절한 예외 처리[CWE-253, CWE-440, CWE-754]
  *   2020.10.26   신용호            parseFileInf(List<MultipartFile> files ...) 추가
  *   2022.11.11   김혜준            시큐어코딩 처리
- *
+ *               </pre>
+ * 
  * @see
  * @since 2009. 02. 13
  *
@@ -72,7 +74,8 @@ public class EgovFileMngUtil {
 	 * @return
 	 * @throws Exception
 	 */
-	public List<FileVO> parseFileInf(Map<String, MultipartFile> files, String KeyStr, int fileKeyParam, String atchFileId, String storePath) throws Exception {
+	public List<FileVO> parseFileInf(Map<String, MultipartFile> files, String KeyStr, int fileKeyParam,
+			String atchFileId, String storePath) throws Exception {
 		int fileKey = fileKeyParam;
 
 		String storePathString = "";
@@ -93,7 +96,7 @@ public class EgovFileMngUtil {
 		File saveFolder = new File(EgovWebUtil.filePathBlackList(storePathString));
 
 		if (!saveFolder.exists() || saveFolder.isFile()) {
-			//2017.03.03 	조성원 	시큐어코딩(ES)-부적절한 예외 처리[CWE-253, CWE-440, CWE-754]
+			// 2017.03.03 조성원 시큐어코딩(ES)-부적절한 예외 처리[CWE-253, CWE-440, CWE-754]
 			if (saveFolder.mkdirs()) {
 				LOGGER.debug("[file.mkdirs] saveFolder : Creation Success ");
 			} else {
@@ -144,7 +147,8 @@ public class EgovFileMngUtil {
 	 * @return
 	 * @throws Exception
 	 */
-	public List<FileVO> parseFileInf(List<MultipartFile> files, String KeyStr, int fileKeyParam, String atchFileId, String storePath) throws Exception {
+	public List<FileVO> parseFileInf(List<MultipartFile> files, String KeyStr, int fileKeyParam, String atchFileId,
+			String storePath) throws Exception {
 		int fileKey = fileKeyParam;
 
 		String storePathString = "";
@@ -230,7 +234,8 @@ public class EgovFileMngUtil {
 				}
 			}
 
-			String writeFilePath = EgovWebUtil.filePathBlackList(FILE_STORE_PATH + File.separator + FilenameUtils.getName(newName));
+			String writeFilePath = EgovWebUtil
+					.filePathBlackList(FILE_STORE_PATH + File.separator + FilenameUtils.getName(newName));
 			bos = new FileOutputStream(writeFilePath);
 
 			int bytesRead = 0;
@@ -280,10 +285,11 @@ public class EgovFileMngUtil {
 			throw new FileNotFoundException(downFileName);
 		}
 
-		byte[] buffer = new byte[BUFF_SIZE]; //buffer size 2K.
+		byte[] buffer = new byte[BUFF_SIZE]; // buffer size 2K.
 
 		response.setContentType("application/x-msdownload");
-		response.setHeader("Content-Disposition:", "attachment; filename=" + new String(orgFileName.getBytes(), "UTF-8"));
+		response.setHeader("Content-Disposition:",
+				"attachment; filename=" + new String(orgFileName.getBytes(), "UTF-8"));
 		response.setHeader("Content-Transfer-Encoding", "binary");
 		response.setHeader("Pragma", "no-cache");
 		response.setHeader("Expires", "0");
@@ -329,7 +335,7 @@ public class EgovFileMngUtil {
 		map.put(Globals.ORIGIN_FILE_NM, orginFileName);
 		map.put(Globals.UPLOAD_FILE_NM, newName);
 		map.put(Globals.FILE_EXT, fileExt);
-		map.put(Globals.FILE_PATH, FILE_STORE_PATH );
+		map.put(Globals.FILE_PATH, FILE_STORE_PATH);
 		map.put(Globals.FILE_SIZE, String.valueOf(size));
 
 		return map;
@@ -349,18 +355,19 @@ public class EgovFileMngUtil {
 
 		try {
 			stream = file.getInputStream();
-			File cFile = new File(EgovWebUtil.filePathBlackList(FILE_STORE_PATH ));
+			File cFile = new File(EgovWebUtil.filePathBlackList(FILE_STORE_PATH));
 
 			if (!cFile.isDirectory()) {
-				//2017.03.03 	조성원 	시큐어코딩(ES)-부적절한 예외 처리[CWE-253, CWE-440, CWE-754]
-				if (cFile.mkdirs()){
+				// 2017.03.03 조성원 시큐어코딩(ES)-부적절한 예외 처리[CWE-253, CWE-440, CWE-754]
+				if (cFile.mkdirs()) {
 					LOGGER.debug("[file.mkdirs] saveFolder : Creation Success ");
 				} else {
 					LOGGER.error("[file.mkdirs] saveFolder : Creation Fail ");
 				}
 			}
 
-			bos = new FileOutputStream(EgovWebUtil.filePathBlackList(FILE_STORE_PATH  + File.separator + FilenameUtils.getName(newName)));
+			bos = new FileOutputStream(
+					EgovWebUtil.filePathBlackList(FILE_STORE_PATH + File.separator + FilenameUtils.getName(newName)));
 
 			int bytesRead = 0;
 			byte[] buffer = new byte[BUFF_SIZE];
@@ -377,7 +384,7 @@ public class EgovFileMngUtil {
 	 * 서버 파일에 대하여 다운로드를 처리한다.
 	 *
 	 * @param response
-	 * @param streFileNm 파일저장 경로가 포함된 형태
+	 * @param streFileNm  파일저장 경로가 포함된 형태
 	 * @param orignFileNm
 	 * @throws Exception
 	 */
@@ -404,13 +411,13 @@ public class EgovFileMngUtil {
 
 				String mimetype = "application/x-msdownload";
 
-				//response.setBufferSize(fSize);
+				// response.setBufferSize(fSize);
 				response.setContentType(mimetype);
 				response.setHeader("Content-Disposition:", "attachment; filename=" + orgFileName);
 				response.setContentLength(fSize);
-				//response.setHeader("Content-Transfer-Encoding","binary");
-				//response.setHeader("Pragma","no-cache");
-				//response.setHeader("Expires","0");
+				// response.setHeader("Content-Transfer-Encoding","binary");
+				// response.setHeader("Pragma","no-cache");
+				// response.setHeader("Expires","0");
 				FileCopyUtils.copy(in, response.getOutputStream());
 			} finally {
 				EgovResourceCloseHelper.close(in);
@@ -420,62 +427,54 @@ public class EgovFileMngUtil {
 		}
 
 		/*
-		String uploadPath = propertiesService.getString("fileDir");
-
-		File uFile = new File(uploadPath, requestedFile);
-		int fSize = (int) uFile.length();
-
-		if (fSize > 0) {
-		    BufferedInputStream in = new BufferedInputStream(new FileInputStream(uFile));
-
-		    String mimetype = "text/html";
-
-		    //response.setBufferSize(fSize);
-		    response.setContentType(mimetype);
-		    response.setHeader("Content-Disposition", "attachment; filename=\"" + requestedFile + "\"");
-		    response.setContentLength(fSize);
-
-		    FileCopyUtils.copy(in, response.getOutputStream());
-		    in.close();
-		    response.getOutputStream().flush();
-		    response.getOutputStream().close();
-		} else {
-		    response.setContentType("text/html");
-		    PrintWriter printwriter = response.getWriter();
-		    printwriter.println("<html>");
-		    printwriter.println("<br><br><br><h2>Could not get file name:<br>" + requestedFile + "</h2>");
-		    printwriter.println("<br><br><br><center><h3><a href='javascript: history.go(-1)'>Back</a></h3></center>");
-		    printwriter.println("<br><br><br>&copy; webAccess");
-		    printwriter.println("</html>");
-		    printwriter.flush();
-		    printwriter.close();
-		}
-		//*/
+		 * String uploadPath = propertiesService.getString("fileDir");
+		 * 
+		 * File uFile = new File(uploadPath, requestedFile); int fSize = (int)
+		 * uFile.length();
+		 * 
+		 * if (fSize > 0) { BufferedInputStream in = new BufferedInputStream(new
+		 * FileInputStream(uFile));
+		 * 
+		 * String mimetype = "text/html";
+		 * 
+		 * //response.setBufferSize(fSize); response.setContentType(mimetype);
+		 * response.setHeader("Content-Disposition", "attachment; filename=\"" +
+		 * requestedFile + "\""); response.setContentLength(fSize);
+		 * 
+		 * FileCopyUtils.copy(in, response.getOutputStream()); in.close();
+		 * response.getOutputStream().flush(); response.getOutputStream().close(); }
+		 * else { response.setContentType("text/html"); PrintWriter printwriter =
+		 * response.getWriter(); printwriter.println("<html>");
+		 * printwriter.println("<br><br><br><h2>Could not get file name:<br>" +
+		 * requestedFile + "</h2>"); printwriter.
+		 * println("<br><br><br><center><h3><a href='javascript: history.go(-1)'>Back</a></h3></center>"
+		 * ); printwriter.println("<br><br><br>&copy; webAccess");
+		 * printwriter.println("</html>"); printwriter.flush(); printwriter.close(); }
+		 * //
+		 */
 
 		/*
-		response.setContentType("application/x-msdownload");
-		response.setHeader("Content-Disposition:", "attachment; filename=" + new String(orgFileName.getBytes(),"UTF-8" ));
-		response.setHeader("Content-Transfer-Encoding","binary");
-		response.setHeader("Pragma","no-cache");
-		response.setHeader("Expires","0");
-
-		BufferedInputStream fin = new BufferedInputStream(new FileInputStream(file));
-		BufferedOutputStream outs = new BufferedOutputStream(response.getOutputStream());
-		int read = 0;
-
-		while ((read = fin.read(b)) != -1) {
-		    outs.write(b,0,read);
-		}
-		log.debug(this.getClass().getName()+" BufferedOutputStream Write Complete!!! ");
-
-		outs.close();
-		fin.close();
-		//*/
+		 * response.setContentType("application/x-msdownload");
+		 * response.setHeader("Content-Disposition:", "attachment; filename=" + new
+		 * String(orgFileName.getBytes(),"UTF-8" ));
+		 * response.setHeader("Content-Transfer-Encoding","binary");
+		 * response.setHeader("Pragma","no-cache"); response.setHeader("Expires","0");
+		 * 
+		 * BufferedInputStream fin = new BufferedInputStream(new FileInputStream(file));
+		 * BufferedOutputStream outs = new
+		 * BufferedOutputStream(response.getOutputStream()); int read = 0;
+		 * 
+		 * while ((read = fin.read(b)) != -1) { outs.write(b,0,read); }
+		 * log.debug(this.getClass().getName()
+		 * +" BufferedOutputStream Write Complete!!! ");
+		 * 
+		 * outs.close(); fin.close(); //
+		 */
 	}
 
 	/**
-	 * 공통 컴포넌트 utl.fcc 패키지와 Dependency 제거를 위해 내부 메서드로 추가 정의함
-	 * 응용어플리케이션에서 고유값을 사용하기 위해 시스템에서 17자리의 TIMESTAMP값을 구하는 기능
+	 * 공통 컴포넌트 utl.fcc 패키지와 Dependency 제거를 위해 내부 메서드로 추가 정의함 응용어플리케이션에서 고유값을 사용하기 위해
+	 * 시스템에서 17자리의 TIMESTAMP값을 구하는 기능
 	 *
 	 * @param
 	 * @return Timestamp 값

--- a/src/main/java/egovframework/com/cmm/service/EgovFileMngUtil.java
+++ b/src/main/java/egovframework/com/cmm/service/EgovFileMngUtil.java
@@ -25,6 +25,8 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang.StringUtils;
+import org.egovframe.rte.fdl.cmmn.exception.BaseRuntimeException;
+import org.egovframe.rte.fdl.cmmn.exception.FdlException;
 import org.egovframe.rte.fdl.idgnr.EgovIdGnrService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -145,10 +147,9 @@ public class EgovFileMngUtil {
 	 *
 	 * @param files
 	 * @return
-	 * @throws Exception
 	 */
 	public List<FileVO> parseFileInf(List<MultipartFile> files, String KeyStr, int fileKeyParam, String atchFileId,
-			String storePath) throws Exception {
+			String storePath) {
 		int fileKey = fileKeyParam;
 
 		String storePathString = "";
@@ -161,7 +162,11 @@ public class EgovFileMngUtil {
 		}
 
 		if (atchFileId == null || "".equals(atchFileId)) {
-			atchFileIdString = idgenService.getNextStringId();
+			try {
+				atchFileIdString = idgenService.getNextStringId();
+			} catch (FdlException e) {
+				throw new BaseRuntimeException("FdlException: egovFileIdGnrService", e);
+			}
 		} else {
 			atchFileIdString = atchFileId;
 		}
@@ -192,7 +197,11 @@ public class EgovFileMngUtil {
 			String newName = KeyStr + getTimeStamp() + fileKey;
 			long size = file.getSize();
 			String filePath = storePathString + File.separator + newName;
-			file.transferTo(new File(EgovWebUtil.filePathBlackList(filePath)));
+			try {
+				file.transferTo(new File(EgovWebUtil.filePathBlackList(filePath)));
+			} catch (IllegalStateException | IOException e) {
+				throw new BaseRuntimeException("IllegalStateException | IOException: transferTo", e);
+			}
 
 			fvo = new FileVO();
 			fvo.setFileExtsn(fileExt);

--- a/src/main/java/egovframework/com/cmm/service/impl/EgovFileMngServiceImpl.java
+++ b/src/main/java/egovframework/com/cmm/service/impl/EgovFileMngServiceImpl.java
@@ -65,7 +65,7 @@ public class EgovFileMngServiceImpl extends EgovAbstractServiceImpl implements E
 	 * @see egovframework.com.cmm.service.EgovFileMngService#insertFileInfs(java.util.List)
 	 */
 	@Override
-	public String insertFileInfs(List<FileVO> fvoList) throws Exception {
+	public String insertFileInfs(List<FileVO> fvoList) {
 		String atchFileId = "";
 
 		if (fvoList.size() != 0) {
@@ -93,7 +93,7 @@ public class EgovFileMngServiceImpl extends EgovAbstractServiceImpl implements E
 	 * @see egovframework.com.cmm.service.EgovFileMngService#updateFileInfs(java.util.List)
 	 */
 	@Override
-	public void updateFileInfs(List<FileVO> fvoList) throws Exception {
+	public void updateFileInfs(List<FileVO> fvoList) {
 		// Delete & Insert
 		fileMngDAO.updateFileInfs(fvoList);
 	}
@@ -124,7 +124,7 @@ public class EgovFileMngServiceImpl extends EgovAbstractServiceImpl implements E
 	 * @see egovframework.com.cmm.service.EgovFileMngService#getMaxFileSN(egovframework.com.cmm.service.FileVO)
 	 */
 	@Override
-	public int getMaxFileSN(FileVO fvo) throws Exception {
+	public int getMaxFileSN(FileVO fvo) {
 		return fileMngDAO.getMaxFileSN(fvo);
 	}
 
@@ -134,7 +134,7 @@ public class EgovFileMngServiceImpl extends EgovAbstractServiceImpl implements E
 	 * @see egovframework.com.cmm.service.EgovFileMngService#deleteAllFileInf(egovframework.com.cmm.service.FileVO)
 	 */
 	@Override
-	public void deleteAllFileInf(FileVO fvo) throws Exception {
+	public void deleteAllFileInf(FileVO fvo) {
 		fileMngDAO.deleteAllFileInf(fvo);
 	}
 

--- a/src/main/java/egovframework/com/cmm/service/impl/EgovFileMngServiceImpl.java
+++ b/src/main/java/egovframework/com/cmm/service/impl/EgovFileMngServiceImpl.java
@@ -4,24 +4,25 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import egovframework.com.cmm.service.EgovFileMngService;
-import egovframework.com.cmm.service.FileVO;
-
-import org.egovframe.rte.fdl.cmmn.EgovAbstractServiceImpl;
-
 import javax.annotation.Resource;
 
+import org.egovframe.rte.fdl.cmmn.EgovAbstractServiceImpl;
 import org.springframework.stereotype.Service;
+
+import egovframework.com.cmm.service.EgovFileMngService;
+import egovframework.com.cmm.service.FileVO;
 
 /**
  * @Class Name : EgovFileMngServiceImpl.java
  * @Description : 파일정보의 관리를 위한 구현 클래스
  * @Modification Information
- *
+ * 
+ *               <pre>
  *    수정일       수정자         수정내용
  *    -------        -------     -------------------
  *    2009. 3. 25.     이삼섭    최초생성
- *
+ *               </pre>
+ * 
  * @author 공통 서비스 개발팀 이삼섭
  * @since 2009. 3. 25.
  * @version
@@ -39,6 +40,7 @@ public class EgovFileMngServiceImpl extends EgovAbstractServiceImpl implements E
 	 *
 	 * @see egovframework.com.cmm.service.EgovFileMngService#deleteFileInfs(java.util.List)
 	 */
+	@Override
 	public void deleteFileInfs(List<FileVO> fvoList) throws Exception {
 		fileMngDAO.deleteFileInfs(fvoList);
 	}
@@ -48,6 +50,7 @@ public class EgovFileMngServiceImpl extends EgovAbstractServiceImpl implements E
 	 *
 	 * @see egovframework.com.cmm.service.EgovFileMngService#insertFileInf(egovframework.com.cmm.service.FileVO)
 	 */
+	@Override
 	public String insertFileInf(FileVO fvo) throws Exception {
 		String atchFileId = fvo.getAtchFileId();
 
@@ -61,6 +64,7 @@ public class EgovFileMngServiceImpl extends EgovAbstractServiceImpl implements E
 	 *
 	 * @see egovframework.com.cmm.service.EgovFileMngService#insertFileInfs(java.util.List)
 	 */
+	@Override
 	public String insertFileInfs(List<FileVO> fvoList) throws Exception {
 		String atchFileId = "";
 
@@ -78,6 +82,7 @@ public class EgovFileMngServiceImpl extends EgovAbstractServiceImpl implements E
 	 *
 	 * @see egovframework.com.cmm.service.EgovFileMngService#selectFileInfs(egovframework.com.cmm.service.FileVO)
 	 */
+	@Override
 	public List<FileVO> selectFileInfs(FileVO fvo) throws Exception {
 		return fileMngDAO.selectFileInfs(fvo);
 	}
@@ -87,8 +92,9 @@ public class EgovFileMngServiceImpl extends EgovAbstractServiceImpl implements E
 	 *
 	 * @see egovframework.com.cmm.service.EgovFileMngService#updateFileInfs(java.util.List)
 	 */
+	@Override
 	public void updateFileInfs(List<FileVO> fvoList) throws Exception {
-		//Delete & Insert
+		// Delete & Insert
 		fileMngDAO.updateFileInfs(fvoList);
 	}
 
@@ -97,6 +103,7 @@ public class EgovFileMngServiceImpl extends EgovAbstractServiceImpl implements E
 	 *
 	 * @see egovframework.com.cmm.service.EgovFileMngService#deleteFileInf(egovframework.com.cmm.service.FileVO)
 	 */
+	@Override
 	public void deleteFileInf(FileVO fvo) throws Exception {
 		fileMngDAO.deleteFileInf(fvo);
 	}
@@ -106,6 +113,7 @@ public class EgovFileMngServiceImpl extends EgovAbstractServiceImpl implements E
 	 *
 	 * @see egovframework.com.cmm.service.EgovFileMngService#selectFileInf(egovframework.com.cmm.service.FileVO)
 	 */
+	@Override
 	public FileVO selectFileInf(FileVO fvo) throws Exception {
 		return fileMngDAO.selectFileInf(fvo);
 	}
@@ -115,6 +123,7 @@ public class EgovFileMngServiceImpl extends EgovAbstractServiceImpl implements E
 	 *
 	 * @see egovframework.com.cmm.service.EgovFileMngService#getMaxFileSN(egovframework.com.cmm.service.FileVO)
 	 */
+	@Override
 	public int getMaxFileSN(FileVO fvo) throws Exception {
 		return fileMngDAO.getMaxFileSN(fvo);
 	}
@@ -124,6 +133,7 @@ public class EgovFileMngServiceImpl extends EgovAbstractServiceImpl implements E
 	 *
 	 * @see egovframework.com.cmm.service.EgovFileMngService#deleteAllFileInf(egovframework.com.cmm.service.FileVO)
 	 */
+	@Override
 	public void deleteAllFileInf(FileVO fvo) throws Exception {
 		fileMngDAO.deleteAllFileInf(fvo);
 	}
@@ -133,6 +143,7 @@ public class EgovFileMngServiceImpl extends EgovAbstractServiceImpl implements E
 	 *
 	 * @see egovframework.com.cmm.service.EgovFileMngService#selectFileListByFileNm(egovframework.com.cmm.service.FileVO)
 	 */
+	@Override
 	public Map<String, Object> selectFileListByFileNm(FileVO fvo) throws Exception {
 		List<FileVO> result = fileMngDAO.selectFileListByFileNm(fvo);
 		int cnt = fileMngDAO.selectFileListCntByFileNm(fvo);
@@ -150,6 +161,7 @@ public class EgovFileMngServiceImpl extends EgovAbstractServiceImpl implements E
 	 *
 	 * @see egovframework.com.cmm.service.EgovFileMngService#selectImageFileList(egovframework.com.cmm.service.FileVO)
 	 */
+	@Override
 	public List<FileVO> selectImageFileList(FileVO vo) throws Exception {
 		return fileMngDAO.selectImageFileList(vo);
 	}

--- a/src/main/java/egovframework/com/cmm/service/impl/FileManageDAO.java
+++ b/src/main/java/egovframework/com/cmm/service/impl/FileManageDAO.java
@@ -3,19 +3,21 @@ package egovframework.com.cmm.service.impl;
 import java.util.Iterator;
 import java.util.List;
 
-import egovframework.com.cmm.service.FileVO;
-
 import org.springframework.stereotype.Repository;
+
+import egovframework.com.cmm.service.FileVO;
 
 /**
  * @Class Name : EgovFileMngDAO.java
  * @Description : 파일정보 관리를 위한 데이터 처리 클래스
  * @Modification Information
- *
+ * 
+ *               <pre>
  *    수정일       수정자         수정내용
  *    -------        -------     -------------------
  *    2009. 3. 25.     이삼섭    최초생성
- *
+ *               </pre>
+ * 
  * @author 공통 서비스 개발팀 이삼섭
  * @since 2009. 3. 25.
  * @version

--- a/src/main/java/egovframework/com/cmm/service/impl/FileManageDAO.java
+++ b/src/main/java/egovframework/com/cmm/service/impl/FileManageDAO.java
@@ -32,9 +32,8 @@ public class FileManageDAO extends EgovComAbstractDAO {
 	 *
 	 * @param fileList
 	 * @return
-	 * @throws Exception
 	 */
-	public String insertFileInfs(List<FileVO> fileList) throws Exception {
+	public String insertFileInfs(List<FileVO> fileList) {
 		FileVO vo = fileList.get(0);
 		String atchFileId = vo.getAtchFileId();
 
@@ -65,9 +64,8 @@ public class FileManageDAO extends EgovComAbstractDAO {
 	 * 여러 개의 파일에 대한 정보(속성 및 상세)를 수정한다.
 	 *
 	 * @param fileList
-	 * @throws Exception
 	 */
-	public void updateFileInfs(List<FileVO> fileList) throws Exception {
+	public void updateFileInfs(List<FileVO> fileList) {
 		FileVO vo;
 		Iterator<FileVO> iter = fileList.iterator();
 		while (iter.hasNext()) {
@@ -118,9 +116,8 @@ public class FileManageDAO extends EgovComAbstractDAO {
 	 *
 	 * @param fvo
 	 * @return
-	 * @throws Exception
 	 */
-	public int getMaxFileSN(FileVO fvo) throws Exception {
+	public int getMaxFileSN(FileVO fvo) {
 		return (Integer) selectOne("FileManageDAO.getMaxFileSN", fvo);
 	}
 
@@ -139,9 +136,8 @@ public class FileManageDAO extends EgovComAbstractDAO {
 	 * 전체 파일을 삭제한다.
 	 *
 	 * @param fvo
-	 * @throws Exception
 	 */
-	public void deleteAllFileInf(FileVO fvo) throws Exception {
+	public void deleteAllFileInf(FileVO fvo) {
 		update("FileManageDAO.deleteCOMTNFILE", fvo);
 	}
 

--- a/src/main/java/egovframework/com/cop/smt/mrm/service/EgovMemoReprtService.java
+++ b/src/main/java/egovframework/com/cop/smt/mrm/service/EgovMemoReprtService.java
@@ -21,7 +21,8 @@ import java.util.Map;
  *   
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
- *   2010.7.19	장철호          최초 생성
+ *   2010.07.19  장철호          최초 생성
+ *   2024.09.12  이백행          컨트리뷰션 시큐어코딩 Exception 제거
  *
  *          </pre>
  */
@@ -34,7 +35,7 @@ public interface EgovMemoReprtService {
 	 * 
 	 * @param reportrVO
 	 */
-	public Map<String, Object> selectReportrList(ReportrVO reportrVO) throws Exception;
+	public Map<String, Object> selectReportrList(ReportrVO reportrVO);
 
 	/**
 	 * 사용자 직위명을 정보를 조회한다.
@@ -44,7 +45,7 @@ public interface EgovMemoReprtService {
 	 * 
 	 * @param String
 	 */
-	public String selectWrterClsfNm(String wrterId) throws Exception;
+	public String selectWrterClsfNm(String wrterId);
 
 	/**
 	 * 메모보고 목록을 조회한다.
@@ -54,7 +55,7 @@ public interface EgovMemoReprtService {
 	 * 
 	 * @param memoReprtVO
 	 */
-	public Map<String, Object> selectMemoReprtList(MemoReprtVO memoReprtVO) throws Exception;
+	public Map<String, Object> selectMemoReprtList(MemoReprtVO memoReprtVO);
 
 	/**
 	 * 메모보고 정보를 조회한다.
@@ -64,7 +65,7 @@ public interface EgovMemoReprtService {
 	 * 
 	 * @param memoReprtVO
 	 */
-	public MemoReprtVO selectMemoReprt(MemoReprtVO memoReprtVO) throws Exception;
+	public MemoReprtVO selectMemoReprt(MemoReprtVO memoReprtVO);
 
 	/**
 	 * 메모보고 정보의 보고자 조회일시를 수정한다.
@@ -73,7 +74,7 @@ public interface EgovMemoReprtService {
 	 * 
 	 * @param memoReprt
 	 */
-	public void readMemoReprt(MemoReprt memoReprt) throws Exception;
+	public void readMemoReprt(MemoReprt memoReprt);
 
 	/**
 	 * 메모보고 정보를 수정한다.
@@ -82,7 +83,7 @@ public interface EgovMemoReprtService {
 	 * 
 	 * @param memoReprt
 	 */
-	public void updateMemoReprt(MemoReprt memoReprt) throws Exception;
+	public void updateMemoReprt(MemoReprt memoReprt);
 
 	/**
 	 * 메모보고 정보의 지시사항을 등록한다.
@@ -91,7 +92,7 @@ public interface EgovMemoReprtService {
 	 * 
 	 * @param memoReprt
 	 */
-	public void updateMemoReprtDrctMatter(MemoReprt memoReprt) throws Exception;
+	public void updateMemoReprtDrctMatter(MemoReprt memoReprt);
 
 	/**
 	 * 메모보고 정보를 등록한다.
@@ -109,6 +110,6 @@ public interface EgovMemoReprtService {
 	 * 
 	 * @param memoReprt
 	 */
-	public void deleteMemoReprt(MemoReprt memoReprt) throws Exception;
+	public void deleteMemoReprt(MemoReprt memoReprt);
 
 }

--- a/src/main/java/egovframework/com/cop/smt/mrm/service/EgovMemoReprtService.java
+++ b/src/main/java/egovframework/com/cop/smt/mrm/service/EgovMemoReprtService.java
@@ -3,48 +3,54 @@ package egovframework.com.cop.smt.mrm.service;
 import java.util.Map;
 
 /**
+ * <pre>
  * 개요
  * - 메모보고에 대한 Service Interface를 정의한다.
  * 
  * 상세내용
  * - 메모보고에 대한 등록, 수정, 삭제, 조회기능을 제공한다.
  * - 메모보고의 조회기능은 목록조회, 상세조회로 구분된다.
+ * </pre>
+ * 
  * @author 장철호
  * @version 1.0
  * @created 19-7-2010 오전 10:14:53
- *  <pre>
+ * 
+ *          <pre>
  * << 개정이력(Modification Information) >>
  *   
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2010.7.19	장철호          최초 생성
  *
- * </pre>
+ *          </pre>
  */
 public interface EgovMemoReprtService {
 	/**
 	 * 보고자 목록을 조회한다.
+	 * 
 	 * @param ReportrVO
-	 * @return  Map<String, Object>
+	 * @return Map<String, Object>
 	 * 
 	 * @param reportrVO
 	 */
 	public Map<String, Object> selectReportrList(ReportrVO reportrVO) throws Exception;
-	
-	
+
 	/**
 	 * 사용자 직위명을 정보를 조회한다.
+	 * 
 	 * @param String
-	 * @return  String
+	 * @return String
 	 * 
 	 * @param String
 	 */
 	public String selectWrterClsfNm(String wrterId) throws Exception;
-	
+
 	/**
 	 * 메모보고 목록을 조회한다.
+	 * 
 	 * @param MemoReprtVO - 메모보고 VO
-	 * @return  List<MemoReprtVO> - 메모보고 List
+	 * @return List<MemoReprtVO> - 메모보고 List
 	 * 
 	 * @param memoReprtVO
 	 */
@@ -52,8 +58,9 @@ public interface EgovMemoReprtService {
 
 	/**
 	 * 메모보고 정보를 조회한다.
+	 * 
 	 * @param MemoReprtVO - 메모보고 VO
-	 * @return  MemoReprtVO - 메모보고 VO
+	 * @return MemoReprtVO - 메모보고 VO
 	 * 
 	 * @param memoReprtVO
 	 */
@@ -61,6 +68,7 @@ public interface EgovMemoReprtService {
 
 	/**
 	 * 메모보고 정보의 보고자 조회일시를 수정한다.
+	 * 
 	 * @param MemoReprt - 메모보고 model
 	 * 
 	 * @param memoReprt
@@ -69,6 +77,7 @@ public interface EgovMemoReprtService {
 
 	/**
 	 * 메모보고 정보를 수정한다.
+	 * 
 	 * @param MemoReprt - 메모보고 model
 	 * 
 	 * @param memoReprt
@@ -77,6 +86,7 @@ public interface EgovMemoReprtService {
 
 	/**
 	 * 메모보고 정보의 지시사항을 등록한다.
+	 * 
 	 * @param MemoReprt - 메모보고 model
 	 * 
 	 * @param memoReprt
@@ -85,6 +95,7 @@ public interface EgovMemoReprtService {
 
 	/**
 	 * 메모보고 정보를 등록한다.
+	 * 
 	 * @param MemoReprt - 메모보고 model
 	 * 
 	 * @param memoReprt
@@ -93,6 +104,7 @@ public interface EgovMemoReprtService {
 
 	/**
 	 * 메모보고 정보를 삭제한다.
+	 * 
 	 * @param MemoReprt - 메모보고 model
 	 * 
 	 * @param memoReprt

--- a/src/main/java/egovframework/com/cop/smt/mrm/service/impl/EgovMemoReprtServiceImpl.java
+++ b/src/main/java/egovframework/com/cop/smt/mrm/service/impl/EgovMemoReprtServiceImpl.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import javax.annotation.Resource;
 
 import org.egovframe.rte.fdl.cmmn.EgovAbstractServiceImpl;
+import org.egovframe.rte.fdl.cmmn.exception.FdlException;
 import org.egovframe.rte.fdl.idgnr.EgovIdGnrService;
 import org.springframework.stereotype.Service;
 
@@ -34,7 +35,8 @@ import egovframework.com.cop.smt.mrm.service.ReportrVO;
  *   
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
- *   2010.7.19	장철호          최초 생성
+ *   2010.07.19  장철호          최초 생성
+ *   2024.09.12  이백행          컨트리뷰션 시큐어코딩 Exception 제거
  *
  *          </pre>
  */
@@ -56,7 +58,7 @@ public class EgovMemoReprtServiceImpl extends EgovAbstractServiceImpl implements
 	 * @param reportrVO
 	 */
 	@Override
-	public Map<String, Object> selectReportrList(ReportrVO reportrVO) throws Exception {
+	public Map<String, Object> selectReportrList(ReportrVO reportrVO) {
 		List<ReportrVO> result = memoReprtDAO.selectReportrList(reportrVO);
 		int cnt = memoReprtDAO.selectReportrListCnt(reportrVO);
 
@@ -77,7 +79,7 @@ public class EgovMemoReprtServiceImpl extends EgovAbstractServiceImpl implements
 	 * @param String
 	 */
 	@Override
-	public String selectWrterClsfNm(String wrterId) throws Exception {
+	public String selectWrterClsfNm(String wrterId) {
 		return memoReprtDAO.selectWrterClsfNm(wrterId);
 	}
 
@@ -90,7 +92,7 @@ public class EgovMemoReprtServiceImpl extends EgovAbstractServiceImpl implements
 	 * @param memoReprtVO
 	 */
 	@Override
-	public Map<String, Object> selectMemoReprtList(MemoReprtVO memoReprtVO) throws Exception {
+	public Map<String, Object> selectMemoReprtList(MemoReprtVO memoReprtVO) {
 		List<MemoReprtVO> result = memoReprtDAO.selectMemoReprtList(memoReprtVO);
 		int cnt = memoReprtDAO.selectMemoReprtListCnt(memoReprtVO);
 
@@ -111,7 +113,7 @@ public class EgovMemoReprtServiceImpl extends EgovAbstractServiceImpl implements
 	 * @param memoReprtVO
 	 */
 	@Override
-	public MemoReprtVO selectMemoReprt(MemoReprtVO memoReprtVO) throws Exception {
+	public MemoReprtVO selectMemoReprt(MemoReprtVO memoReprtVO) {
 		MemoReprtVO resultVO = memoReprtDAO.selectMemoReprt(memoReprtVO);
 		if (resultVO.getReportrInqireDt() == null || resultVO.getReportrInqireDt().equals("")) {
 			resultVO.setReprtSttus("미확인");
@@ -137,7 +139,7 @@ public class EgovMemoReprtServiceImpl extends EgovAbstractServiceImpl implements
 	 * @param memoReprt
 	 */
 	@Override
-	public void readMemoReprt(MemoReprt memoReprt) throws Exception {
+	public void readMemoReprt(MemoReprt memoReprt) {
 		java.text.SimpleDateFormat formatter = new java.text.SimpleDateFormat("yyyyMMddHHmmss", java.util.Locale.KOREA);
 		memoReprt.setReportrInqireDt(formatter.format(new java.util.Date()));
 		memoReprtDAO.readMemoReprt(memoReprt);
@@ -151,7 +153,7 @@ public class EgovMemoReprtServiceImpl extends EgovAbstractServiceImpl implements
 	 * @param memoReprt
 	 */
 	@Override
-	public void updateMemoReprt(MemoReprt memoReprt) throws Exception {
+	public void updateMemoReprt(MemoReprt memoReprt) {
 		memoReprtDAO.updateMemoReprt(memoReprt);
 	}
 
@@ -163,7 +165,7 @@ public class EgovMemoReprtServiceImpl extends EgovAbstractServiceImpl implements
 	 * @param memoReprt
 	 */
 	@Override
-	public void updateMemoReprtDrctMatter(MemoReprt memoReprt) throws Exception {
+	public void updateMemoReprtDrctMatter(MemoReprt memoReprt) {
 		java.text.SimpleDateFormat formatter = new java.text.SimpleDateFormat("yyyyMMddHHmmss", java.util.Locale.KOREA);
 		memoReprt.setDrctMatterRegistDt(formatter.format(new java.util.Date()));
 		memoReprtDAO.updateMemoReprtDrctMatter(memoReprt);
@@ -175,10 +177,15 @@ public class EgovMemoReprtServiceImpl extends EgovAbstractServiceImpl implements
 	 * @param MemoReprt - 메모보고 model
 	 * 
 	 * @param memoReprt
+	 * @throws Exception
 	 */
 	@Override
 	public void insertMemoReprt(MemoReprt memoReprt) throws Exception {
-		memoReprt.setReprtId(idgenServiceMemoReprt.getNextStringId());
+		try {
+			memoReprt.setReprtId(idgenServiceMemoReprt.getNextStringId());
+		} catch (FdlException e) {
+			throw processException("FdlException: egovMemoReprtIdGnrService", e);
+		}
 		memoReprtDAO.insertMemoReprt(memoReprt);
 	}
 
@@ -190,7 +197,7 @@ public class EgovMemoReprtServiceImpl extends EgovAbstractServiceImpl implements
 	 * @param memoReprt
 	 */
 	@Override
-	public void deleteMemoReprt(MemoReprt memoReprt) throws Exception {
+	public void deleteMemoReprt(MemoReprt memoReprt) {
 		memoReprtDAO.deleteMemoReprt(memoReprt);
 	}
 

--- a/src/main/java/egovframework/com/cop/smt/mrm/service/impl/EgovMemoReprtServiceImpl.java
+++ b/src/main/java/egovframework/com/cop/smt/mrm/service/impl/EgovMemoReprtServiceImpl.java
@@ -1,91 +1,101 @@
 package egovframework.com.cop.smt.mrm.service.impl;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import javax.annotation.Resource;
+
+import org.egovframe.rte.fdl.cmmn.EgovAbstractServiceImpl;
+import org.egovframe.rte.fdl.idgnr.EgovIdGnrService;
+import org.springframework.stereotype.Service;
 
 import egovframework.com.cop.smt.mrm.service.EgovMemoReprtService;
 import egovframework.com.cop.smt.mrm.service.MemoReprt;
 import egovframework.com.cop.smt.mrm.service.MemoReprtVO;
 import egovframework.com.cop.smt.mrm.service.ReportrVO;
 
-import org.egovframe.rte.fdl.cmmn.EgovAbstractServiceImpl;
-import org.egovframe.rte.fdl.idgnr.EgovIdGnrService;
-
-import javax.annotation.Resource;
-
-import org.springframework.stereotype.Service;
-
 /**
+ * <pre>
  * 개요
  * 메모보고에 대한 ServiceImpl 클래스를 정의한다.
  * 
  * 상세내용
  * - 메모보고에 대한 등록, 수정, 삭제, 조회기능을 제공한다.
  * - 메모보고의 조회기능은 목록조회, 상세조회로 구분된다.
+ * </pre>
+ * 
  * @author 장철호
  * @version 1.0
  * @created 19-7-2010 오전 10:14:53
- *  <pre>
+ * 
+ *          <pre>
  * << 개정이력(Modification Information) >>
  *   
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2010.7.19	장철호          최초 생성
  *
- * </pre>
+ *          </pre>
  */
 @Service("EgovMemoReprtService")
 public class EgovMemoReprtServiceImpl extends EgovAbstractServiceImpl implements EgovMemoReprtService {
-	
+
 	@Resource(name = "MemoReprtDAO")
-    private MemoReprtDAO memoReprtDAO;
-	
-	@Resource(name="egovMemoReprtIdGnrService")
+	private MemoReprtDAO memoReprtDAO;
+
+	@Resource(name = "egovMemoReprtIdGnrService")
 	private EgovIdGnrService idgenServiceMemoReprt;
-	
+
 	/**
 	 * 보고자 목록을 조회한다.
+	 * 
 	 * @param ReportrVO
-	 * @return  Map<String, Object>
+	 * @return Map<String, Object>
 	 * 
 	 * @param reportrVO
 	 */
-	public Map<String, Object> selectReportrList(ReportrVO reportrVO) throws Exception{
+	@Override
+	public Map<String, Object> selectReportrList(ReportrVO reportrVO) throws Exception {
 		List<ReportrVO> result = memoReprtDAO.selectReportrList(reportrVO);
 		int cnt = memoReprtDAO.selectReportrListCnt(reportrVO);
-		
+
 		Map<String, Object> map = new HashMap<String, Object>();
-		
+
 		map.put("resultList", result);
 		map.put("resultCnt", Integer.toString(cnt));
 
 		return map;
 	}
-	
+
 	/**
 	 * 사용자 직위명을 정보를 조회한다.
+	 * 
 	 * @param String
-	 * @return  String
+	 * @return String
 	 * 
 	 * @param String
 	 */
-	public String selectWrterClsfNm(String wrterId) throws Exception{
+	@Override
+	public String selectWrterClsfNm(String wrterId) throws Exception {
 		return memoReprtDAO.selectWrterClsfNm(wrterId);
 	}
-	
+
 	/**
 	 * 메모보고 목록을 조회한다.
+	 * 
 	 * @param MemoReprtVO - 메모보고 VO
-	 * @return  Map<String, Object> - 메모보고 List
+	 * @return Map<String, Object> - 메모보고 List
 	 * 
 	 * @param memoReprtVO
 	 */
-	public Map<String, Object> selectMemoReprtList(MemoReprtVO memoReprtVO) throws Exception{
+	@Override
+	public Map<String, Object> selectMemoReprtList(MemoReprtVO memoReprtVO) throws Exception {
 		List<MemoReprtVO> result = memoReprtDAO.selectMemoReprtList(memoReprtVO);
 		int cnt = memoReprtDAO.selectMemoReprtListCnt(memoReprtVO);
-		
+
 		Map<String, Object> map = new HashMap<String, Object>();
-		
+
 		map.put("resultList", result);
 		map.put("resultCnt", Integer.toString(cnt));
 
@@ -94,36 +104,40 @@ public class EgovMemoReprtServiceImpl extends EgovAbstractServiceImpl implements
 
 	/**
 	 * 메모보고 정보를 조회한다.
+	 * 
 	 * @param MemoReprtVO - 메모보고 VO
-	 * @return  MemoReprtVO - 메모보고 VO
+	 * @return MemoReprtVO - 메모보고 VO
 	 * 
 	 * @param memoReprtVO
 	 */
-	public MemoReprtVO selectMemoReprt(MemoReprtVO memoReprtVO) throws Exception{
+	@Override
+	public MemoReprtVO selectMemoReprt(MemoReprtVO memoReprtVO) throws Exception {
 		MemoReprtVO resultVO = memoReprtDAO.selectMemoReprt(memoReprtVO);
-		if(resultVO.getReportrInqireDt() == null || resultVO.getReportrInqireDt().equals("")){
+		if (resultVO.getReportrInqireDt() == null || resultVO.getReportrInqireDt().equals("")) {
 			resultVO.setReprtSttus("미확인");
-		}else{
-			String year = resultVO.getReportrInqireDt().substring(0,4);
-			String month = resultVO.getReportrInqireDt().substring(4,6);
-			String day = resultVO.getReportrInqireDt().substring(6,8);
-			String hour = resultVO.getReportrInqireDt().substring(8,10);
-			String min = resultVO.getReportrInqireDt().substring(10,12);
-			
+		} else {
+			String year = resultVO.getReportrInqireDt().substring(0, 4);
+			String month = resultVO.getReportrInqireDt().substring(4, 6);
+			String day = resultVO.getReportrInqireDt().substring(6, 8);
+			String hour = resultVO.getReportrInqireDt().substring(8, 10);
+			String min = resultVO.getReportrInqireDt().substring(10, 12);
+
 			String yymmddhhmm = year + "/" + month + "/" + day + "  " + hour + "시 " + min + "분";
-			resultVO.setReprtSttus("확인 (" + yymmddhhmm  + ") ");
+			resultVO.setReprtSttus("확인 (" + yymmddhhmm + ") ");
 		}
-		
+
 		return resultVO;
 	}
 
 	/**
 	 * 메모보고 정보의 보고자 조회일시를 수정한다.
+	 * 
 	 * @param MemoReprt - 메모보고 model
 	 * 
 	 * @param memoReprt
 	 */
-	public void readMemoReprt(MemoReprt memoReprt) throws Exception{
+	@Override
+	public void readMemoReprt(MemoReprt memoReprt) throws Exception {
 		java.text.SimpleDateFormat formatter = new java.text.SimpleDateFormat("yyyyMMddHHmmss", java.util.Locale.KOREA);
 		memoReprt.setReportrInqireDt(formatter.format(new java.util.Date()));
 		memoReprtDAO.readMemoReprt(memoReprt);
@@ -131,21 +145,25 @@ public class EgovMemoReprtServiceImpl extends EgovAbstractServiceImpl implements
 
 	/**
 	 * 메모보고 정보를 수정한다.
+	 * 
 	 * @param MemoReprt - 메모보고 model
 	 * 
 	 * @param memoReprt
 	 */
-	public void updateMemoReprt(MemoReprt memoReprt) throws Exception{
+	@Override
+	public void updateMemoReprt(MemoReprt memoReprt) throws Exception {
 		memoReprtDAO.updateMemoReprt(memoReprt);
 	}
 
 	/**
 	 * 메모보고 정보의 지시사항을 등록한다.
+	 * 
 	 * @param MemoReprt - 메모보고 model
 	 * 
 	 * @param memoReprt
 	 */
-	public void updateMemoReprtDrctMatter(MemoReprt memoReprt) throws Exception{
+	@Override
+	public void updateMemoReprtDrctMatter(MemoReprt memoReprt) throws Exception {
 		java.text.SimpleDateFormat formatter = new java.text.SimpleDateFormat("yyyyMMddHHmmss", java.util.Locale.KOREA);
 		memoReprt.setDrctMatterRegistDt(formatter.format(new java.util.Date()));
 		memoReprtDAO.updateMemoReprtDrctMatter(memoReprt);
@@ -153,22 +171,26 @@ public class EgovMemoReprtServiceImpl extends EgovAbstractServiceImpl implements
 
 	/**
 	 * 메모보고 정보를 등록한다.
+	 * 
 	 * @param MemoReprt - 메모보고 model
 	 * 
 	 * @param memoReprt
 	 */
-	public void insertMemoReprt(MemoReprt memoReprt) throws Exception{
+	@Override
+	public void insertMemoReprt(MemoReprt memoReprt) throws Exception {
 		memoReprt.setReprtId(idgenServiceMemoReprt.getNextStringId());
 		memoReprtDAO.insertMemoReprt(memoReprt);
 	}
 
 	/**
 	 * 메모보고 정보를 삭제한다.
+	 * 
 	 * @param MemoReprt - 메모보고 model
 	 * 
 	 * @param memoReprt
 	 */
-	public void deleteMemoReprt(MemoReprt memoReprt) throws Exception{
+	@Override
+	public void deleteMemoReprt(MemoReprt memoReprt) throws Exception {
 		memoReprtDAO.deleteMemoReprt(memoReprt);
 	}
 

--- a/src/main/java/egovframework/com/cop/smt/mrm/service/impl/MemoReprtDAO.java
+++ b/src/main/java/egovframework/com/cop/smt/mrm/service/impl/MemoReprtDAO.java
@@ -1,5 +1,8 @@
 package egovframework.com.cop.smt.mrm.service.impl;
+
 import java.util.List;
+
+import org.springframework.stereotype.Repository;
 
 import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.cop.smt.mrm.service.MemoReprt;
@@ -8,77 +11,83 @@ import egovframework.com.cop.smt.mrm.service.ReportrVO;
 import egovframework.com.utl.fcc.service.EgovDateUtil;
 import egovframework.com.utl.fcc.service.EgovStringUtil;
 
-import org.springframework.stereotype.Repository;
-
 /**
+ * <pre>
  * 개요
  * - 메모보고에 대한 DAO 클래스를 정의한다.
  * 
  * 상세내용
  * - 메모보고에 대한 등록, 수정, 삭제, 조회기능을 제공한다.
  * - 메모보고의 조회기능은 목록조회, 상세조회로 구분된다.
+ * </pre>
+ * 
  * @author 장철호
  * @version 1.0
  * @created 19-7-2010 오전 10:14:53
- *  <pre>
+ * 
+ *          <pre>
  * << 개정이력(Modification Information) >>
  *   
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2010.7.19	장철호          최초 생성
  *
- * </pre>
+ *          </pre>
  */
 @Repository("MemoReprtDAO")
 public class MemoReprtDAO extends EgovComAbstractDAO {
-	
+
 	/**
 	 * 주어진 조건에 맞는 보고자를 불러온다.
+	 * 
 	 * @param ReportrVO
 	 * @return List
 	 * 
 	 * @param reportrVO
 	 */
-	public List<ReportrVO> selectReportrList(ReportrVO reportrVO) throws Exception{
+	public List<ReportrVO> selectReportrList(ReportrVO reportrVO) throws Exception {
 		return selectList("MemoReprtDAO.selectReportrList", reportrVO);
 	}
-	
+
 	/**
 	 * 보고자 목록에 대한 전체 건수를 조회한다.
+	 * 
 	 * @param ReportrVO
 	 * @return int
 	 * 
 	 * @param reportrVO
 	 */
-	public int selectReportrListCnt(ReportrVO reportrVO) throws Exception{
-		return (Integer)selectOne("MemoReprtDAO.selectReportrListCnt", reportrVO);
+	public int selectReportrListCnt(ReportrVO reportrVO) throws Exception {
+		return (Integer) selectOne("MemoReprtDAO.selectReportrListCnt", reportrVO);
 	}
-	
+
 	/**
 	 * 주어진 조건에 맞는 직위명을 불러온다.
+	 * 
 	 * @param DeptVO
 	 * @return String
 	 * 
 	 * @param DeptVO
 	 */
-	public String selectWrterClsfNm(String wrterId) throws Exception{
-		return (String)selectOne("MemoReprtDAO.selectWrterClsfNm", wrterId);
+	public String selectWrterClsfNm(String wrterId) throws Exception {
+		return (String) selectOne("MemoReprtDAO.selectWrterClsfNm", wrterId);
 	}
-	
+
 	/**
 	 * 주어진 조건에 따른 메모보고 목록을 불러온다.
+	 * 
 	 * @param MemoReprtVO - 메모보고 VO
 	 * @return List<MemoReprtVO> - 메모보고 List
 	 * 
 	 * @param memoReprtVO
 	 */
-	public List<MemoReprtVO> selectMemoReprtList(MemoReprtVO memoReprtVO) throws Exception{
-		//날짜관련
+	public List<MemoReprtVO> selectMemoReprtList(MemoReprtVO memoReprtVO) throws Exception {
+		// 날짜관련
 		memoReprtVO.setSearchBgnDe(memoReprtVO.getSearchBgnDe().replaceAll("-", ""));
 		memoReprtVO.setSearchEndDe(memoReprtVO.getSearchEndDe().replaceAll("-", ""));
-		
+
 		List<MemoReprtVO> resultList = selectList("MemoReprtDAO.selectMemoReprtList", memoReprtVO);
-		for(int i=0; i < resultList.size(); i++){
+		for (int i = 0; i < resultList.size(); i++) {
 			MemoReprtVO resultVO = resultList.get(i);
 			resultVO.setReprtDe(EgovDateUtil.convertDate(resultVO.getReprtDe(), "0000", "yyyy-MM-dd"));
 			resultList.set(i, resultVO);
@@ -88,84 +97,95 @@ public class MemoReprtDAO extends EgovComAbstractDAO {
 
 	/**
 	 * 주어진 조건에 맞는 메모보고를 불러온다.
+	 * 
 	 * @param MemoReprtVO - 메모보고 VO
 	 * @return MemoReprtVO - 메모보고 VO
 	 * 
 	 * @param memoReprtVO
 	 */
-	public MemoReprtVO selectMemoReprt(MemoReprtVO memoReprtVO) throws Exception{
-		MemoReprtVO resultVO = (MemoReprtVO)selectOne("MemoReprtDAO.selectMemoReprt", memoReprtVO);
+	public MemoReprtVO selectMemoReprt(MemoReprtVO memoReprtVO) throws Exception {
+		MemoReprtVO resultVO = (MemoReprtVO) selectOne("MemoReprtDAO.selectMemoReprt", memoReprtVO);
 		resultVO.setReprtDe(EgovDateUtil.convertDate(resultVO.getReprtDe(), "0000", "yyyy-MM-dd"));
 		return resultVO;
 	}
 
 	/**
 	 * 메모보고 정보의 보고자 조회일시를 수정한다.
+	 * 
 	 * @param MemoReprt - 메모보고 model
 	 * 
 	 * @param memoReprt
 	 */
-	public void readMemoReprt(MemoReprt memoReprt) throws Exception{
+	public void readMemoReprt(MemoReprt memoReprt) throws Exception {
 		update("MemoReprtDAO.readMemoReprt", memoReprt);
 	}
 
 	/**
 	 * 메모보고 정보를 수정한다.
+	 * 
 	 * @param MemoReprt - 메모보고 model
 	 * 
 	 * @param memoReprt
 	 */
-	public void updateMemoReprt(MemoReprt memoReprt) throws Exception{
-		//날짜관련
-		memoReprt.setReprtDe(EgovStringUtil.isNullToString(memoReprt.getReprtDe()).replaceAll("-", ""));//KISA 보안약점 조치 (2018-10-29, 윤창원)
+	public void updateMemoReprt(MemoReprt memoReprt) throws Exception {
+		// 날짜관련
+		memoReprt.setReprtDe(EgovStringUtil.isNullToString(memoReprt.getReprtDe()).replaceAll("-", ""));// KISA 보안약점 조치
+																										// (2018-10-29,
+																										// 윤창원)
 		update("MemoReprtDAO.updateMemoReprt", memoReprt);
 	}
 
 	/**
 	 * 메모보고 정보의 지시사항을 등록한다.
+	 * 
 	 * @param MemoReprt - 메모보고 model
 	 * 
 	 * @param memoReprt
 	 */
-	public void updateMemoReprtDrctMatter(MemoReprt memoReprt) throws Exception{
+	public void updateMemoReprtDrctMatter(MemoReprt memoReprt) throws Exception {
 		update("MemoReprtDAO.updateMemoReprtDrctMatter", memoReprt);
 	}
 
 	/**
 	 * 메모보고 정보를 등록한다.
+	 * 
 	 * @param MemoReprt - 메모보고 model
 	 * 
 	 * @param memoReprt
 	 */
-	public void insertMemoReprt(MemoReprt memoReprt) throws Exception{
-		//날짜관련
-		memoReprt.setReprtDe(EgovStringUtil.isNullToString(memoReprt.getReprtDe()).replaceAll("-", ""));//KISA 보안약점 조치 (2018-10-29, 윤창원)
+	public void insertMemoReprt(MemoReprt memoReprt) throws Exception {
+		// 날짜관련
+		memoReprt.setReprtDe(EgovStringUtil.isNullToString(memoReprt.getReprtDe()).replaceAll("-", ""));// KISA 보안약점 조치
+																										// (2018-10-29,
+																										// 윤창원)
 		insert("MemoReprtDAO.insertMemoReprt", memoReprt);
 	}
 
 	/**
 	 * 메모보고 정보를 삭제한다.
+	 * 
 	 * @param MemoReprt - 메모보고 model
 	 * 
 	 * @param memoReprt
 	 */
-	public void deleteMemoReprt(MemoReprt memoReprt) throws Exception{
+	public void deleteMemoReprt(MemoReprt memoReprt) throws Exception {
 		delete("MemoReprtDAO.deleteMemoReprt", memoReprt);
 	}
 
 	/**
 	 * 메모보고 목록에 대한 전체 건수를 조회한다.
+	 * 
 	 * @param MemoReprtVO - 메모보고 VO
 	 * @return int - 메모보고 목록 개수
 	 * 
 	 * @param memoReprtVO
 	 */
-	public int selectMemoReprtListCnt(MemoReprtVO memoReprtVO) throws Exception{
-		//날짜관련
+	public int selectMemoReprtListCnt(MemoReprtVO memoReprtVO) throws Exception {
+		// 날짜관련
 		memoReprtVO.setSearchBgnDe(memoReprtVO.getSearchBgnDe().replaceAll("-", ""));
 		memoReprtVO.setSearchEndDe(memoReprtVO.getSearchEndDe().replaceAll("-", ""));
-		
-		return (Integer)selectOne("MemoReprtDAO.selectMemoReprtListCnt", memoReprtVO);
+
+		return (Integer) selectOne("MemoReprtDAO.selectMemoReprtListCnt", memoReprtVO);
 	}
 
 }

--- a/src/main/java/egovframework/com/cop/smt/mrm/service/impl/MemoReprtDAO.java
+++ b/src/main/java/egovframework/com/cop/smt/mrm/service/impl/MemoReprtDAO.java
@@ -30,7 +30,8 @@ import egovframework.com.utl.fcc.service.EgovStringUtil;
  *   
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
- *   2010.7.19	장철호          최초 생성
+ *   2010.07.19  장철호          최초 생성
+ *   2024.09.12  이백행          컨트리뷰션 시큐어코딩 Exception 제거
  *
  *          </pre>
  */
@@ -45,7 +46,7 @@ public class MemoReprtDAO extends EgovComAbstractDAO {
 	 * 
 	 * @param reportrVO
 	 */
-	public List<ReportrVO> selectReportrList(ReportrVO reportrVO) throws Exception {
+	public List<ReportrVO> selectReportrList(ReportrVO reportrVO) {
 		return selectList("MemoReprtDAO.selectReportrList", reportrVO);
 	}
 
@@ -57,7 +58,7 @@ public class MemoReprtDAO extends EgovComAbstractDAO {
 	 * 
 	 * @param reportrVO
 	 */
-	public int selectReportrListCnt(ReportrVO reportrVO) throws Exception {
+	public int selectReportrListCnt(ReportrVO reportrVO) {
 		return (Integer) selectOne("MemoReprtDAO.selectReportrListCnt", reportrVO);
 	}
 
@@ -69,7 +70,7 @@ public class MemoReprtDAO extends EgovComAbstractDAO {
 	 * 
 	 * @param DeptVO
 	 */
-	public String selectWrterClsfNm(String wrterId) throws Exception {
+	public String selectWrterClsfNm(String wrterId) {
 		return (String) selectOne("MemoReprtDAO.selectWrterClsfNm", wrterId);
 	}
 
@@ -81,7 +82,7 @@ public class MemoReprtDAO extends EgovComAbstractDAO {
 	 * 
 	 * @param memoReprtVO
 	 */
-	public List<MemoReprtVO> selectMemoReprtList(MemoReprtVO memoReprtVO) throws Exception {
+	public List<MemoReprtVO> selectMemoReprtList(MemoReprtVO memoReprtVO) {
 		// 날짜관련
 		memoReprtVO.setSearchBgnDe(memoReprtVO.getSearchBgnDe().replaceAll("-", ""));
 		memoReprtVO.setSearchEndDe(memoReprtVO.getSearchEndDe().replaceAll("-", ""));
@@ -103,7 +104,7 @@ public class MemoReprtDAO extends EgovComAbstractDAO {
 	 * 
 	 * @param memoReprtVO
 	 */
-	public MemoReprtVO selectMemoReprt(MemoReprtVO memoReprtVO) throws Exception {
+	public MemoReprtVO selectMemoReprt(MemoReprtVO memoReprtVO) {
 		MemoReprtVO resultVO = (MemoReprtVO) selectOne("MemoReprtDAO.selectMemoReprt", memoReprtVO);
 		resultVO.setReprtDe(EgovDateUtil.convertDate(resultVO.getReprtDe(), "0000", "yyyy-MM-dd"));
 		return resultVO;
@@ -116,7 +117,7 @@ public class MemoReprtDAO extends EgovComAbstractDAO {
 	 * 
 	 * @param memoReprt
 	 */
-	public void readMemoReprt(MemoReprt memoReprt) throws Exception {
+	public void readMemoReprt(MemoReprt memoReprt) {
 		update("MemoReprtDAO.readMemoReprt", memoReprt);
 	}
 
@@ -127,7 +128,7 @@ public class MemoReprtDAO extends EgovComAbstractDAO {
 	 * 
 	 * @param memoReprt
 	 */
-	public void updateMemoReprt(MemoReprt memoReprt) throws Exception {
+	public void updateMemoReprt(MemoReprt memoReprt) {
 		// 날짜관련
 		memoReprt.setReprtDe(EgovStringUtil.isNullToString(memoReprt.getReprtDe()).replaceAll("-", ""));// KISA 보안약점 조치
 																										// (2018-10-29,
@@ -142,7 +143,7 @@ public class MemoReprtDAO extends EgovComAbstractDAO {
 	 * 
 	 * @param memoReprt
 	 */
-	public void updateMemoReprtDrctMatter(MemoReprt memoReprt) throws Exception {
+	public void updateMemoReprtDrctMatter(MemoReprt memoReprt) {
 		update("MemoReprtDAO.updateMemoReprtDrctMatter", memoReprt);
 	}
 
@@ -153,7 +154,7 @@ public class MemoReprtDAO extends EgovComAbstractDAO {
 	 * 
 	 * @param memoReprt
 	 */
-	public void insertMemoReprt(MemoReprt memoReprt) throws Exception {
+	public void insertMemoReprt(MemoReprt memoReprt) {
 		// 날짜관련
 		memoReprt.setReprtDe(EgovStringUtil.isNullToString(memoReprt.getReprtDe()).replaceAll("-", ""));// KISA 보안약점 조치
 																										// (2018-10-29,
@@ -168,7 +169,7 @@ public class MemoReprtDAO extends EgovComAbstractDAO {
 	 * 
 	 * @param memoReprt
 	 */
-	public void deleteMemoReprt(MemoReprt memoReprt) throws Exception {
+	public void deleteMemoReprt(MemoReprt memoReprt) {
 		delete("MemoReprtDAO.deleteMemoReprt", memoReprt);
 	}
 
@@ -180,7 +181,7 @@ public class MemoReprtDAO extends EgovComAbstractDAO {
 	 * 
 	 * @param memoReprtVO
 	 */
-	public int selectMemoReprtListCnt(MemoReprtVO memoReprtVO) throws Exception {
+	public int selectMemoReprtListCnt(MemoReprtVO memoReprtVO) {
 		// 날짜관련
 		memoReprtVO.setSearchBgnDe(memoReprtVO.getSearchBgnDe().replaceAll("-", ""));
 		memoReprtVO.setSearchEndDe(memoReprtVO.getSearchEndDe().replaceAll("-", ""));

--- a/src/main/java/egovframework/com/cop/smt/mrm/web/EgovMemoReprtController.java
+++ b/src/main/java/egovframework/com/cop/smt/mrm/web/EgovMemoReprtController.java
@@ -1,9 +1,12 @@
 package egovframework.com.cop.smt.mrm.web;
+
 import java.util.List;
 import java.util.Map;
 
 import javax.annotation.Resource;
 
+import org.egovframe.rte.fdl.property.EgovPropertyService;
+import org.egovframe.rte.ptl.mvc.tags.ui.pagination.PaginationInfo;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
@@ -28,20 +31,22 @@ import egovframework.com.cop.smt.mrm.service.MemoReprt;
 import egovframework.com.cop.smt.mrm.service.MemoReprtVO;
 import egovframework.com.cop.smt.mrm.service.ReportrVO;
 import egovframework.com.utl.fcc.service.EgovStringUtil;
-import org.egovframe.rte.fdl.property.EgovPropertyService;
-import org.egovframe.rte.ptl.mvc.tags.ui.pagination.PaginationInfo;
 
 /**
+ * <pre>
  * 개요
  * - 메모보고에 대한 controller 클래스를 정의한다.
  * 
  * 상세내용
  * - 메모보고에 대한 등록, 수정, 삭제, 조회기능을 제공한다.
  * - 메모보고의 조회기능은 목록조회, 상세조회로 구분된다.
+ * </pre>
+ * 
  * @author 장철호
  * @version 1.0
  * @created 19-7-2010 오전 10:14:53
- * <pre>
+ * 
+ *          <pre>
  * << 개정이력(Modification Information) >>
  *   
  *  수정일               수정자             수정내용
@@ -50,58 +55,61 @@ import org.egovframe.rte.ptl.mvc.tags.ui.pagination.PaginationInfo;
  *  2011.08.26   정진오            IncludedInfo annotation 추가
  *  2019.12.09   신용호            KISA 보안약점 조치 (위험한 형식 파일 업로드)
  *
- * </pre>
+ *          </pre>
  */
 
 @Controller
 public class EgovMemoReprtController {
 
-	@Resource(name="EgovMemoReprtService")
-    protected EgovMemoReprtService memoReprtService;
-	
-	@Resource(name="propertiesService")
-    protected EgovPropertyService propertyService;
-    
-    @Resource(name="egovMessageSource")
-    EgovMessageSource egovMessageSource;
-    
-    @Autowired
-    private DefaultBeanValidator beanValidator;
-    
-    // 첨부파일 관련 
-	@Resource(name="EgovFileMngService")
-	private EgovFileMngService fileMngService;	
-	 
-	@Resource(name="EgovFileMngUtil")
+	@Resource(name = "EgovMemoReprtService")
+	protected EgovMemoReprtService memoReprtService;
+
+	@Resource(name = "propertiesService")
+	protected EgovPropertyService propertyService;
+
+	@Resource(name = "egovMessageSource")
+	EgovMessageSource egovMessageSource;
+
+	@Autowired
+	private DefaultBeanValidator beanValidator;
+
+	// 첨부파일 관련
+	@Resource(name = "EgovFileMngService")
+	private EgovFileMngService fileMngService;
+
+	@Resource(name = "EgovFileMngUtil")
 	private EgovFileMngUtil fileUtil;
-    
-    //Logger log = Logger.getLogger(this.getClass());
-    
-    /**
+
+	// Logger log = Logger.getLogger(this.getClass());
+
+	/**
 	 * 보고자 정보에 대한 팝업 목록을 조회한다.
+	 * 
 	 * @param ReportrVO
-	 * @return  String
+	 * @return String
 	 * 
 	 * @param reportrVO
 	 */
 	@RequestMapping("/cop/smt/mrm/selectReportrListPopup.do")
-	public String selectReportrListPopup(@ModelAttribute("searchVO") ReportrVO reportrVO, ModelMap model) throws Exception{
+	public String selectReportrListPopup(@ModelAttribute("searchVO") ReportrVO reportrVO, ModelMap model)
+			throws Exception {
 		return "egovframework/com/cop/smt/mrm/EgovReportrListPopup";
 	}
-	
+
 	/**
 	 * 보고자 정보에 대한 목록을 조회한다.
+	 * 
 	 * @param ReportrVO
-	 * @return  String
+	 * @return String
 	 * 
 	 * @param reportrVO
 	 */
 	@RequestMapping("/cop/smt/mrm/selectReportrList.do")
-	public String selectReportrList(@ModelAttribute("searchVO") ReportrVO reportrVO, ModelMap model) throws Exception{
-		//LoginVO user = (LoginVO)EgovUserDetailsHelper.getAuthenticatedUser();
-		
-		//reportrVO.setUniqId(user.getUniqId());
-		
+	public String selectReportrList(@ModelAttribute("searchVO") ReportrVO reportrVO, ModelMap model) throws Exception {
+		// LoginVO user = (LoginVO)EgovUserDetailsHelper.getAuthenticatedUser();
+
+		// reportrVO.setUniqId(user.getUniqId());
+
 		reportrVO.setPageUnit(propertyService.getInt("pageUnit"));
 		reportrVO.setPageSize(propertyService.getInt("pageSize"));
 
@@ -115,7 +123,7 @@ public class EgovMemoReprtController {
 		reportrVO.setRecordCountPerPage(paginationInfo.getRecordCountPerPage());
 
 		Map<String, Object> map = memoReprtService.selectReportrList(reportrVO);
-		int totCnt = Integer.parseInt((String)map.get("resultCnt"));
+		int totCnt = Integer.parseInt((String) map.get("resultCnt"));
 		paginationInfo.setTotalRecordCount(totCnt);
 
 		model.addAttribute("resultList", map.get("resultList"));
@@ -124,27 +132,29 @@ public class EgovMemoReprtController {
 
 		return "egovframework/com/cop/smt/mrm/EgovReportrList";
 	}
-	
+
 	/**
 	 * 메모보고 정보에 대한 목록을 조회한다.
+	 * 
 	 * @param MemoReprtVO - 메모보고 VO
-	 * @return  String - 리턴 URL
+	 * @return String - 리턴 URL
 	 * 
 	 * @param memoReprtVO
 	 * @param model
 	 */
-	@IncludedInfo(name="메모보고", order = 430 ,gid = 40)
-    @RequestMapping("/cop/smt/mrm/selectMemoReprtList.do")
-	public String selectMemoReprtList(@ModelAttribute("searchVO") MemoReprtVO memoReprtVO, ModelMap model) throws Exception{
-    	//로그인 객체 선언
-		LoginVO loginVO = (LoginVO)EgovUserDetailsHelper.getAuthenticatedUser();
-   	 	// KISA 보안취약점 조치 (2018-12-10, 신용호)
-        Boolean isAuthenticated = EgovUserDetailsHelper.isAuthenticated();
+	@IncludedInfo(name = "메모보고", order = 430, gid = 40)
+	@RequestMapping("/cop/smt/mrm/selectMemoReprtList.do")
+	public String selectMemoReprtList(@ModelAttribute("searchVO") MemoReprtVO memoReprtVO, ModelMap model)
+			throws Exception {
+		// 로그인 객체 선언
+		LoginVO loginVO = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();
+		// KISA 보안취약점 조치 (2018-12-10, 신용호)
+		Boolean isAuthenticated = EgovUserDetailsHelper.isAuthenticated();
 
-        if(!isAuthenticated) {
-            return "redirect:/uat/uia/egovLoginUsr.do";
-        }
-		
+		if (!isAuthenticated) {
+			return "redirect:/uat/uia/egovLoginUsr.do";
+		}
+
 		memoReprtVO.setPageUnit(propertyService.getInt("pageUnit"));
 		memoReprtVO.setPageSize(propertyService.getInt("pageSize"));
 
@@ -156,14 +166,13 @@ public class EgovMemoReprtController {
 		memoReprtVO.setFirstIndex(paginationInfo.getFirstRecordIndex());
 		memoReprtVO.setLastIndex(paginationInfo.getLastRecordIndex());
 		memoReprtVO.setRecordCountPerPage(paginationInfo.getRecordCountPerPage());
-		
+
 		memoReprtVO.setSearchId(loginVO == null ? "" : EgovStringUtil.isNullToString(loginVO.getUniqId()));
-		
-	
+
 		Map<String, Object> map = memoReprtService.selectMemoReprtList(memoReprtVO);
-		int totCnt = Integer.parseInt((String)map.get("resultCnt"));
+		int totCnt = Integer.parseInt((String) map.get("resultCnt"));
 		paginationInfo.setTotalRecordCount(totCnt);
-		
+
 		model.addAttribute("resultList", map.get("resultList"));
 		model.addAttribute("resultCnt", map.get("resultCnt"));
 		model.addAttribute("paginationInfo", paginationInfo);
@@ -173,29 +182,32 @@ public class EgovMemoReprtController {
 
 	/**
 	 * 메모보고 정보를 조회한다.
+	 * 
 	 * @param MemoReprtVO - 메모보고 VO
-	 * @return  String - 리턴 URL
+	 * @return String - 리턴 URL
 	 * 
 	 * @param memoReprtVO
 	 * @param model
 	 */
-    @RequestMapping("/cop/smt/mrm/selectMemoReprt.do")
-	public String selectMemoReprt(@ModelAttribute("memoReprtVO") MemoReprtVO memoReprtVO, ModelMap model) throws Exception{
-    	MemoReprt memoReprt = memoReprtService.selectMemoReprt(memoReprtVO);
+	@RequestMapping("/cop/smt/mrm/selectMemoReprt.do")
+	public String selectMemoReprt(@ModelAttribute("memoReprtVO") MemoReprtVO memoReprtVO, ModelMap model)
+			throws Exception {
+		MemoReprt memoReprt = memoReprtService.selectMemoReprt(memoReprtVO);
 		model.addAttribute("memoReprt", memoReprt);
-    	
-    	// 1. 로그인 객체 선언
-		LoginVO loginVO = (LoginVO)EgovUserDetailsHelper.getAuthenticatedUser();
-   	 	// KISA 보안취약점 조치 (2018-12-10, 신용호)
-        Boolean isAuthenticated = EgovUserDetailsHelper.isAuthenticated();
 
-        if(!isAuthenticated) {
-            return "redirect:/uat/uia/egovLoginUsr.do";
-        }
-		
+		// 1. 로그인 객체 선언
+		LoginVO loginVO = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();
+		// KISA 보안취약점 조치 (2018-12-10, 신용호)
+		Boolean isAuthenticated = EgovUserDetailsHelper.isAuthenticated();
+
+		if (!isAuthenticated) {
+			return "redirect:/uat/uia/egovLoginUsr.do";
+		}
+
 		model.addAttribute("uniqId", loginVO == null ? "" : EgovStringUtil.isNullToString(loginVO.getUniqId()));
-    	
-		if((loginVO == null ? "" : EgovStringUtil.isNullToString(loginVO.getUniqId())).equals(memoReprt.getReportrId())){
+
+		if ((loginVO == null ? "" : EgovStringUtil.isNullToString(loginVO.getUniqId()))
+				.equals(memoReprt.getReportrId())) {
 			memoReprtService.readMemoReprt(memoReprt);
 		}
 		return "egovframework/com/cop/smt/mrm/EgovMemoReprtDetail";
@@ -203,60 +215,65 @@ public class EgovMemoReprtController {
 
 	/**
 	 * 메모보고 정보의 등록페이지로 이동한다.
+	 * 
 	 * @param MemoReprt - 메모보고 model
-	 * @return  String - 리턴 URL
+	 * @return String - 리턴 URL
 	 * 
 	 * @param memoReprt
 	 * @param model
 	 */
-    @RequestMapping("/cop/smt/mrm/addMemoReprt.do")
-	public String addMemoReprt(@ModelAttribute("memoReprtVO") MemoReprtVO memoReprtVO, BindingResult bindingResult, ModelMap model) throws Exception{
-    	String sLocationUrl = "egovframework/com/cop/smt/mrm/EgovMemoReprtRegist";
-		
-    	// 파일업로드 제한
-    	String whiteListFileUploadExtensions = EgovProperties.getProperty("Globals.fileUpload.Extensions");
-    	String fileUploadMaxSize = EgovProperties.getProperty("Globals.fileUpload.maxSize");
-    	
-    	// 0. Spring Security 사용자권한 처리
-    	Boolean isAuthenticated = EgovUserDetailsHelper.isAuthenticated();
-    	if(!isAuthenticated) {
-    		model.addAttribute("message", egovMessageSource.getMessage("fail.common.login"));
-        	return "redirect:/uat/uia/egovLoginUsr.do";
-    	}
-    	
-    	// 1. 로그인 객체 선언
-		LoginVO loginVO = (LoginVO)EgovUserDetailsHelper.getAuthenticatedUser();
-		
-    	java.text.SimpleDateFormat formatter = new java.text.SimpleDateFormat("yyyy-MM-dd", java.util.Locale.KOREA);
+	@RequestMapping("/cop/smt/mrm/addMemoReprt.do")
+	public String addMemoReprt(@ModelAttribute("memoReprtVO") MemoReprtVO memoReprtVO, BindingResult bindingResult,
+			ModelMap model) throws Exception {
+		String sLocationUrl = "egovframework/com/cop/smt/mrm/EgovMemoReprtRegist";
+
+		// 파일업로드 제한
+		String whiteListFileUploadExtensions = EgovProperties.getProperty("Globals.fileUpload.Extensions");
+		String fileUploadMaxSize = EgovProperties.getProperty("Globals.fileUpload.maxSize");
+
+		// 0. Spring Security 사용자권한 처리
+		Boolean isAuthenticated = EgovUserDetailsHelper.isAuthenticated();
+		if (!isAuthenticated) {
+			model.addAttribute("message", egovMessageSource.getMessage("fail.common.login"));
+			return "redirect:/uat/uia/egovLoginUsr.do";
+		}
+
+		// 1. 로그인 객체 선언
+		LoginVO loginVO = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();
+
+		java.text.SimpleDateFormat formatter = new java.text.SimpleDateFormat("yyyy-MM-dd", java.util.Locale.KOREA);
 		memoReprtVO.setReprtDe(formatter.format(new java.util.Date()));
-    	memoReprtVO.setWrterId(loginVO == null ? "" : EgovStringUtil.isNullToString(loginVO.getUniqId()));
-    	memoReprtVO.setWrterNm(loginVO == null ? "" : EgovStringUtil.isNullToString(loginVO.getName()));
-    	memoReprtVO.setWrterClsfNm(memoReprtService.selectWrterClsfNm(loginVO == null ? "" : EgovStringUtil.isNullToString(loginVO.getUniqId())));
-    	
-    	model.addAttribute("fileUploadExtensions", whiteListFileUploadExtensions);
-        model.addAttribute("fileUploadMaxSize", fileUploadMaxSize);
-        
-    	return sLocationUrl; 	
+		memoReprtVO.setWrterId(loginVO == null ? "" : EgovStringUtil.isNullToString(loginVO.getUniqId()));
+		memoReprtVO.setWrterNm(loginVO == null ? "" : EgovStringUtil.isNullToString(loginVO.getName()));
+		memoReprtVO.setWrterClsfNm(memoReprtService
+				.selectWrterClsfNm(loginVO == null ? "" : EgovStringUtil.isNullToString(loginVO.getUniqId())));
+
+		model.addAttribute("fileUploadExtensions", whiteListFileUploadExtensions);
+		model.addAttribute("fileUploadMaxSize", fileUploadMaxSize);
+
+		return sLocationUrl;
 	}
 
 	/**
 	 * 메모보고 정보의 수정페이지로 이동한다.
+	 * 
 	 * @param MemoReprt - 메모보고 model
-	 * @return  String - 리턴 URL
+	 * @return String - 리턴 URL
 	 * 
 	 * @param memoReprt
 	 * @param model
 	 */
-    @RequestMapping("/cop/smt/mrm/modifyMemoReprt.do")
-	public String modifyMemoReprt(@ModelAttribute("memoReprtVO") MemoReprtVO memoReprtVO, BindingResult bindingResult, ModelMap model) throws Exception{
-    	// 0. Spring Security 사용자권한 처리
-    	Boolean isAuthenticated = EgovUserDetailsHelper.isAuthenticated();
-    	if(!isAuthenticated) {
-    		model.addAttribute("message", egovMessageSource.getMessage("fail.common.login"));
-        	return "redirect:/uat/uia/egovLoginUsr.do";
-    	}
-		
-    	MemoReprtVO resultVO = memoReprtService.selectMemoReprt(memoReprtVO);
+	@RequestMapping("/cop/smt/mrm/modifyMemoReprt.do")
+	public String modifyMemoReprt(@ModelAttribute("memoReprtVO") MemoReprtVO memoReprtVO, BindingResult bindingResult,
+			ModelMap model) throws Exception {
+		// 0. Spring Security 사용자권한 처리
+		Boolean isAuthenticated = EgovUserDetailsHelper.isAuthenticated();
+		if (!isAuthenticated) {
+			model.addAttribute("message", egovMessageSource.getMessage("fail.common.login"));
+			return "redirect:/uat/uia/egovLoginUsr.do";
+		}
+
+		MemoReprtVO resultVO = memoReprtService.selectMemoReprt(memoReprtVO);
 		resultVO.setSearchCnd(memoReprtVO.getSearchCnd());
 		resultVO.setSearchWrd(memoReprtVO.getSearchWrd());
 		resultVO.setSearchBgnDe(memoReprtVO.getSearchBgnDe());
@@ -264,61 +281,64 @@ public class EgovMemoReprtController {
 		resultVO.setSearchSttus(memoReprtVO.getSearchSttus());
 		resultVO.setSearchDrctMatter(memoReprtVO.getSearchDrctMatter());
 		resultVO.setPageIndex(memoReprtVO.getPageIndex());
-        model.addAttribute("memoReprtVO", resultVO);
-        
+		model.addAttribute("memoReprtVO", resultVO);
+
 		return "egovframework/com/cop/smt/mrm/EgovMemoReprtUpdt";
 	}
 
 	/**
 	 * 메모보고 정보를 수정한다.
+	 * 
 	 * @param MemoReprt - 메모보고 model
-	 * @return  String - 리턴 URL
+	 * @return String - 리턴 URL
 	 * 
 	 * @param memoReprt
 	 * @param model
 	 */
-    @RequestMapping("/cop/smt/mrm/updateMemoReprt.do")
-	public String updateMemoReprt(final MultipartHttpServletRequest multiRequest, @RequestParam Map<?, ?> commandMap, @ModelAttribute("memoReprtVO") MemoReprtVO memoReprtVO, BindingResult bindingResult, ModelMap model) throws Exception{
-    	LoginVO user = (LoginVO)EgovUserDetailsHelper.getAuthenticatedUser();
+	@RequestMapping("/cop/smt/mrm/updateMemoReprt.do")
+	public String updateMemoReprt(final MultipartHttpServletRequest multiRequest, @RequestParam Map<?, ?> commandMap,
+			@ModelAttribute("memoReprtVO") MemoReprtVO memoReprtVO, BindingResult bindingResult, ModelMap model)
+			throws Exception {
+		LoginVO user = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();
 		Boolean isAuthenticated = EgovUserDetailsHelper.isAuthenticated();
 
 		beanValidator.validate(memoReprtVO, bindingResult);
 		if (bindingResult.hasErrors()) {
 			MemoReprt memoReprt = memoReprtService.selectMemoReprt(memoReprtVO);
-		    model.addAttribute("memoReprt", memoReprt);
-		    return "egovframework/com/cop/smt/mrm/EgovMemoReprtUpdt";
+			model.addAttribute("memoReprt", memoReprt);
+			return "egovframework/com/cop/smt/mrm/EgovMemoReprtUpdt";
 		}
 
 		if (isAuthenticated) {
-			/* *****************************************************************
-        	// 첨부파일 관련 ID 생성 start....
-			****************************************************************** */
-    		String _atchFileId = memoReprtVO.getAtchFileId();	
-    		
-    		
-    		//final Map<String, MultipartFile> files = multiRequest.getFileMap();
-    		final List<MultipartFile> files = multiRequest.getFiles("file_1");
-    		
-    		if(!files.isEmpty()){
-    			String atchFileAt = commandMap.get("atchFileAt") == null ? "" : (String)commandMap.get("atchFileAt");
-    			if("N".equals(atchFileAt)){
-    				List<FileVO> _result = fileUtil.parseFileInf(files, "DSCH_", 0, _atchFileId, "");	
-    				_atchFileId = fileMngService.insertFileInfs(_result);
-    							
-    				// 첨부파일 ID 셋팅
-    				memoReprtVO.setAtchFileId(_atchFileId);    	// 첨부파일 ID
-    				
-    			}else{				
-    				FileVO fvo = new FileVO();
-    				fvo.setAtchFileId(_atchFileId);
-    				int _cnt = fileMngService.getMaxFileSN(fvo);
-    				List<FileVO> _result = fileUtil.parseFileInf(files, "DSCH_", _cnt, _atchFileId, "");	
-    				fileMngService.updateFileInfs(_result);
-    			}
-    		}	
-    		
-    		memoReprtVO.setLastUpdusrId(user == null ? "" : EgovStringUtil.isNullToString(user.getUniqId()));		    
-    		memoReprtService.updateMemoReprt(memoReprtVO);
+			/*
+			 * ***************************************************************** // 첨부파일 관련
+			 * ID 생성 start....
+			 */
+			String _atchFileId = memoReprtVO.getAtchFileId();
+
+			// final Map<String, MultipartFile> files = multiRequest.getFileMap();
+			final List<MultipartFile> files = multiRequest.getFiles("file_1");
+
+			if (!files.isEmpty()) {
+				String atchFileAt = commandMap.get("atchFileAt") == null ? "" : (String) commandMap.get("atchFileAt");
+				if ("N".equals(atchFileAt)) {
+					List<FileVO> _result = fileUtil.parseFileInf(files, "DSCH_", 0, _atchFileId, "");
+					_atchFileId = fileMngService.insertFileInfs(_result);
+
+					// 첨부파일 ID 셋팅
+					memoReprtVO.setAtchFileId(_atchFileId); // 첨부파일 ID
+
+				} else {
+					FileVO fvo = new FileVO();
+					fvo.setAtchFileId(_atchFileId);
+					int _cnt = fileMngService.getMaxFileSN(fvo);
+					List<FileVO> _result = fileUtil.parseFileInf(files, "DSCH_", _cnt, _atchFileId, "");
+					fileMngService.updateFileInfs(_result);
+				}
+			}
+
+			memoReprtVO.setLastUpdusrId(user == null ? "" : EgovStringUtil.isNullToString(user.getUniqId()));
+			memoReprtService.updateMemoReprt(memoReprtVO);
 		}
 
 		return "forward:/cop/smt/mrm/selectMemoReprtList.do";
@@ -326,19 +346,21 @@ public class EgovMemoReprtController {
 
 	/**
 	 * 메모보고 정보의 지시사항을 등록한다.
+	 * 
 	 * @param MemoReprt - 메모보고 model
-	 * @return  String - 리턴 URL
+	 * @return String - 리턴 URL
 	 * 
 	 * @param memoReprt
 	 * @param model
 	 */
-    @SuppressWarnings("unused")
+	@SuppressWarnings("unused")
 	@RequestMapping("/cop/smt/mrm/updateMemoReprtDrctMatter.do")
-	public String updateMemoReprtDrctMatter(@ModelAttribute("memoReprtVO") MemoReprtVO memoReprtVO, ModelMap model) throws Exception{
-    	LoginVO user = (LoginVO)EgovUserDetailsHelper.getAuthenticatedUser();
+	public String updateMemoReprtDrctMatter(@ModelAttribute("memoReprtVO") MemoReprtVO memoReprtVO, ModelMap model)
+			throws Exception {
+		LoginVO user = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();
 		Boolean isAuthenticated = EgovUserDetailsHelper.isAuthenticated();
 
-		if (isAuthenticated) {	    
+		if (isAuthenticated) {
 			memoReprtService.updateMemoReprtDrctMatter(memoReprtVO);
 		}
 
@@ -347,93 +369,98 @@ public class EgovMemoReprtController {
 
 	/**
 	 * 메모보고 정보를 등록한다.
+	 * 
 	 * @param MemoReprt - 메모보고 model
-	 * @return  String - 리턴 URL
+	 * @return String - 리턴 URL
 	 * 
 	 * @param memoReprt
 	 * @param model
 	 */
-    @RequestMapping("/cop/smt/mrm/insertMemoReprt.do")
-	public String insertMemoReprt(final MultipartHttpServletRequest multiRequest, @ModelAttribute("memoReprtVO") MemoReprtVO memoReprtVO, BindingResult bindingResult, ModelMap model) throws Exception{
-    	// 0. Spring Security 사용자권한 처리
-    	Boolean isAuthenticated = EgovUserDetailsHelper.isAuthenticated();
-    	if(!isAuthenticated) {
-    		model.addAttribute("message", egovMessageSource.getMessage("fail.common.login"));
-        	return "redirect:/uat/uia/egovLoginUsr.do";
-    	}
-    	
-		//로그인 객체 선언
-		LoginVO loginVO = (LoginVO)EgovUserDetailsHelper.getAuthenticatedUser();
-		
-		String sLocationUrl = "egovframework/com/cop/smt/mrm/EgovMemoReprtRegist"; 
-		
-		//서버  validate 체크
-        beanValidator.validate(memoReprtVO, bindingResult);
-		if(bindingResult.hasErrors()){
-			
-			// 파일업로드 제한
-	    	String whiteListFileUploadExtensions = EgovProperties.getProperty("Globals.fileUpload.Extensions");
-	    	String fileUploadMaxSize = EgovProperties.getProperty("Globals.fileUpload.maxSize");
+	@RequestMapping("/cop/smt/mrm/insertMemoReprt.do")
+	public String insertMemoReprt(final MultipartHttpServletRequest multiRequest,
+			@ModelAttribute("memoReprtVO") MemoReprtVO memoReprtVO, BindingResult bindingResult, ModelMap model)
+			throws Exception {
+		// 0. Spring Security 사용자권한 처리
+		Boolean isAuthenticated = EgovUserDetailsHelper.isAuthenticated();
+		if (!isAuthenticated) {
+			model.addAttribute("message", egovMessageSource.getMessage("fail.common.login"));
+			return "redirect:/uat/uia/egovLoginUsr.do";
+		}
 
-	        model.addAttribute("fileUploadExtensions", whiteListFileUploadExtensions);
-	        model.addAttribute("fileUploadMaxSize", fileUploadMaxSize);
-			
+		// 로그인 객체 선언
+		LoginVO loginVO = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();
+
+		String sLocationUrl = "egovframework/com/cop/smt/mrm/EgovMemoReprtRegist";
+
+		// 서버 validate 체크
+		beanValidator.validate(memoReprtVO, bindingResult);
+		if (bindingResult.hasErrors()) {
+
+			// 파일업로드 제한
+			String whiteListFileUploadExtensions = EgovProperties.getProperty("Globals.fileUpload.Extensions");
+			String fileUploadMaxSize = EgovProperties.getProperty("Globals.fileUpload.maxSize");
+
+			model.addAttribute("fileUploadExtensions", whiteListFileUploadExtensions);
+			model.addAttribute("fileUploadMaxSize", fileUploadMaxSize);
+
 			return sLocationUrl;
 		}
-		
+
 		// 첨부파일 관련 첨부파일ID 생성
 		List<FileVO> _result = null;
 		String _atchFileId = "";
-		
-		//final Map<String, MultipartFile> files = multiRequest.getFileMap();
+
+		// final Map<String, MultipartFile> files = multiRequest.getFileMap();
 		final List<MultipartFile> files = multiRequest.getFiles("file_1");
-		
-		if(!files.isEmpty()){
-		 _result = fileUtil.parseFileInf(files, "DSCH_", 0, "", ""); 
-		 _atchFileId = fileMngService.insertFileInfs(_result);  //파일이 생성되고나면 생성된 첨부파일 ID를 리턴한다.
+
+		if (!files.isEmpty()) {
+			_result = fileUtil.parseFileInf(files, "DSCH_", 0, "", "");
+			_atchFileId = fileMngService.insertFileInfs(_result); // 파일이 생성되고나면 생성된 첨부파일 ID를 리턴한다.
 		}
-		
-    	// 리턴받은 첨부파일ID를 셋팅한다..
-		memoReprtVO.setAtchFileId(_atchFileId);			// 첨부파일 ID
-		
-		//아이디 설정
+
+		// 리턴받은 첨부파일ID를 셋팅한다..
+		memoReprtVO.setAtchFileId(_atchFileId); // 첨부파일 ID
+
+		// 아이디 설정
 		memoReprtVO.setFrstRegisterId(loginVO == null ? "" : EgovStringUtil.isNullToString(loginVO.getUniqId()));
 		memoReprtVO.setLastUpdusrId(loginVO == null ? "" : EgovStringUtil.isNullToString(loginVO.getUniqId()));
-		
+
 		memoReprtService.insertMemoReprt(memoReprtVO);
-    	sLocationUrl = "forward:/cop/smt/mrm/selectMemoReprtList.do";
-        
-        return sLocationUrl;
+		sLocationUrl = "forward:/cop/smt/mrm/selectMemoReprtList.do";
+
+		return sLocationUrl;
 	}
 
 	/**
 	 * 메모보고 정보를 삭제한다.
+	 * 
 	 * @param MemoReprt - 메모보고 model
-	 * @return  String - 리턴 URL
+	 * @return String - 리턴 URL
 	 * 
 	 * @param memoReprt
 	 * @param model
 	 */
-    @RequestMapping("/cop/smt/mrm/deleteMemoReprt.do")
-	public String deleteMemoReprt(@ModelAttribute("memoReprtVO") MemoReprtVO memoReprtVO, ModelMap model) throws Exception{
-    	// 0. Spring Security 사용자권한 처리
-    	Boolean isAuthenticated = EgovUserDetailsHelper.isAuthenticated();
-    	if(!isAuthenticated) {
-    		model.addAttribute("message", egovMessageSource.getMessage("fail.common.login"));
-        	return "redirect:/uat/uia/egovLoginUsr.do";
-    	}
-    	
-    	// 첨부파일 삭제를 위한 ID 생성 start....
-		String _atchFileId = memoReprtVO.getAtchFileId();	
-    	
-		// 첨부파일을 삭제하기 위한  Vo
-    	FileVO fvo = new FileVO();
-    	fvo.setAtchFileId(_atchFileId);
-    			
-    	fileMngService.deleteAllFileInf(fvo);
-    	// 첨부파일 삭제 End.............
-    	
-    	memoReprtService.deleteMemoReprt(memoReprtVO);
+	@RequestMapping("/cop/smt/mrm/deleteMemoReprt.do")
+	public String deleteMemoReprt(@ModelAttribute("memoReprtVO") MemoReprtVO memoReprtVO, ModelMap model)
+			throws Exception {
+		// 0. Spring Security 사용자권한 처리
+		Boolean isAuthenticated = EgovUserDetailsHelper.isAuthenticated();
+		if (!isAuthenticated) {
+			model.addAttribute("message", egovMessageSource.getMessage("fail.common.login"));
+			return "redirect:/uat/uia/egovLoginUsr.do";
+		}
+
+		// 첨부파일 삭제를 위한 ID 생성 start....
+		String _atchFileId = memoReprtVO.getAtchFileId();
+
+		// 첨부파일을 삭제하기 위한 Vo
+		FileVO fvo = new FileVO();
+		fvo.setAtchFileId(_atchFileId);
+
+		fileMngService.deleteAllFileInf(fvo);
+		// 첨부파일 삭제 End.............
+
+		memoReprtService.deleteMemoReprt(memoReprtVO);
 		return "forward:/cop/smt/mrm/selectMemoReprtList.do";
 	}
 

--- a/src/main/java/egovframework/com/cop/smt/mrm/web/EgovMemoReprtController.java
+++ b/src/main/java/egovframework/com/cop/smt/mrm/web/EgovMemoReprtController.java
@@ -51,9 +51,10 @@ import egovframework.com.utl.fcc.service.EgovStringUtil;
  *   
  *  수정일               수정자             수정내용
  *  ----------   --------   ---------------------------
- *  2010.07.19   장철호            최초 생성
- *  2011.08.26   정진오            IncludedInfo annotation 추가
- *  2019.12.09   신용호            KISA 보안약점 조치 (위험한 형식 파일 업로드)
+ *   2010.07.19  장철호          최초 생성
+ *   2011.08.26  정진오          IncludedInfo annotation 추가
+ *   2019.12.09  신용호          KISA 보안약점 조치 (위험한 형식 파일 업로드)
+ *   2024.09.12  이백행          컨트리뷰션 시큐어코딩 Exception 제거
  *
  *          </pre>
  */
@@ -91,8 +92,7 @@ public class EgovMemoReprtController {
 	 * @param reportrVO
 	 */
 	@RequestMapping("/cop/smt/mrm/selectReportrListPopup.do")
-	public String selectReportrListPopup(@ModelAttribute("searchVO") ReportrVO reportrVO, ModelMap model)
-			throws Exception {
+	public String selectReportrListPopup(@ModelAttribute("searchVO") ReportrVO reportrVO, ModelMap model) {
 		return "egovframework/com/cop/smt/mrm/EgovReportrListPopup";
 	}
 
@@ -105,7 +105,7 @@ public class EgovMemoReprtController {
 	 * @param reportrVO
 	 */
 	@RequestMapping("/cop/smt/mrm/selectReportrList.do")
-	public String selectReportrList(@ModelAttribute("searchVO") ReportrVO reportrVO, ModelMap model) throws Exception {
+	public String selectReportrList(@ModelAttribute("searchVO") ReportrVO reportrVO, ModelMap model) {
 		// LoginVO user = (LoginVO)EgovUserDetailsHelper.getAuthenticatedUser();
 
 		// reportrVO.setUniqId(user.getUniqId());
@@ -144,8 +144,7 @@ public class EgovMemoReprtController {
 	 */
 	@IncludedInfo(name = "메모보고", order = 430, gid = 40)
 	@RequestMapping("/cop/smt/mrm/selectMemoReprtList.do")
-	public String selectMemoReprtList(@ModelAttribute("searchVO") MemoReprtVO memoReprtVO, ModelMap model)
-			throws Exception {
+	public String selectMemoReprtList(@ModelAttribute("searchVO") MemoReprtVO memoReprtVO, ModelMap model) {
 		// 로그인 객체 선언
 		LoginVO loginVO = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();
 		// KISA 보안취약점 조치 (2018-12-10, 신용호)
@@ -190,8 +189,7 @@ public class EgovMemoReprtController {
 	 * @param model
 	 */
 	@RequestMapping("/cop/smt/mrm/selectMemoReprt.do")
-	public String selectMemoReprt(@ModelAttribute("memoReprtVO") MemoReprtVO memoReprtVO, ModelMap model)
-			throws Exception {
+	public String selectMemoReprt(@ModelAttribute("memoReprtVO") MemoReprtVO memoReprtVO, ModelMap model) {
 		MemoReprt memoReprt = memoReprtService.selectMemoReprt(memoReprtVO);
 		model.addAttribute("memoReprt", memoReprt);
 
@@ -224,7 +222,7 @@ public class EgovMemoReprtController {
 	 */
 	@RequestMapping("/cop/smt/mrm/addMemoReprt.do")
 	public String addMemoReprt(@ModelAttribute("memoReprtVO") MemoReprtVO memoReprtVO, BindingResult bindingResult,
-			ModelMap model) throws Exception {
+			ModelMap model) {
 		String sLocationUrl = "egovframework/com/cop/smt/mrm/EgovMemoReprtRegist";
 
 		// 파일업로드 제한
@@ -265,7 +263,7 @@ public class EgovMemoReprtController {
 	 */
 	@RequestMapping("/cop/smt/mrm/modifyMemoReprt.do")
 	public String modifyMemoReprt(@ModelAttribute("memoReprtVO") MemoReprtVO memoReprtVO, BindingResult bindingResult,
-			ModelMap model) throws Exception {
+			ModelMap model) {
 		// 0. Spring Security 사용자권한 처리
 		Boolean isAuthenticated = EgovUserDetailsHelper.isAuthenticated();
 		if (!isAuthenticated) {
@@ -297,8 +295,7 @@ public class EgovMemoReprtController {
 	 */
 	@RequestMapping("/cop/smt/mrm/updateMemoReprt.do")
 	public String updateMemoReprt(final MultipartHttpServletRequest multiRequest, @RequestParam Map<?, ?> commandMap,
-			@ModelAttribute("memoReprtVO") MemoReprtVO memoReprtVO, BindingResult bindingResult, ModelMap model)
-			throws Exception {
+			@ModelAttribute("memoReprtVO") MemoReprtVO memoReprtVO, BindingResult bindingResult, ModelMap model) {
 		LoginVO user = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();
 		Boolean isAuthenticated = EgovUserDetailsHelper.isAuthenticated();
 
@@ -355,8 +352,7 @@ public class EgovMemoReprtController {
 	 */
 	@SuppressWarnings("unused")
 	@RequestMapping("/cop/smt/mrm/updateMemoReprtDrctMatter.do")
-	public String updateMemoReprtDrctMatter(@ModelAttribute("memoReprtVO") MemoReprtVO memoReprtVO, ModelMap model)
-			throws Exception {
+	public String updateMemoReprtDrctMatter(@ModelAttribute("memoReprtVO") MemoReprtVO memoReprtVO, ModelMap model) {
 		LoginVO user = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();
 		Boolean isAuthenticated = EgovUserDetailsHelper.isAuthenticated();
 
@@ -375,6 +371,7 @@ public class EgovMemoReprtController {
 	 * 
 	 * @param memoReprt
 	 * @param model
+	 * @throws Exception
 	 */
 	@RequestMapping("/cop/smt/mrm/insertMemoReprt.do")
 	public String insertMemoReprt(final MultipartHttpServletRequest multiRequest,
@@ -441,8 +438,7 @@ public class EgovMemoReprtController {
 	 * @param model
 	 */
 	@RequestMapping("/cop/smt/mrm/deleteMemoReprt.do")
-	public String deleteMemoReprt(@ModelAttribute("memoReprtVO") MemoReprtVO memoReprtVO, ModelMap model)
-			throws Exception {
+	public String deleteMemoReprt(@ModelAttribute("memoReprtVO") MemoReprtVO memoReprtVO, ModelMap model) {
 		// 0. Spring Security 사용자권한 처리
 		Boolean isAuthenticated = EgovUserDetailsHelper.isAuthenticated();
 		if (!isAuthenticated) {


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

### [430. 메모보고] 시큐어코딩 Exception 제거

- Source > Format
- `@throws Exception/throws Exception` 제거
- ` *   2024.09.12  이백행          컨트리뷰션 시큐어코딩 Exception 제거` 개정이력 수정
- `processException` 사용
  - EgovBizException 으로 리턴하면 좋겠음
  - processRuntimeException(BaseRuntimeException) 추가되면 좋겠음

크롬 링크 주소 복사
```
http://localhost:8080/egovframework-all-in-one/cop/smt/mrm/selectMemoReprtList.do
```

검색(Search)
```
/cop/smt/mrm/selectMemoReprtList.do
```

브랜치 생성
```
2024/pmd/EgovMemoReprtController
```

```java
	 * @throws Exception
	 */
	@Override
	public void insertMemoReprt(MemoReprt memoReprt) throws Exception {
		try {
			memoReprt.setReprtId(idgenServiceMemoReprt.getNextStringId());
		} catch (FdlException e) {
			throw processException("FdlException: egovMemoReprtIdGnrService", e);
		}
```

[2024년 전자정부 표준프레임워크 컨트리뷰션][공통컴포넌트][430. 메모보고] 시큐어코딩 Exception 제거

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [x] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

https://youtu.be/C51rGCfunNQ
