### PR TITLE
[버그수정] 780. 통합링크관리 > 목록의 등록일자 미표시 오류 수정

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/egovframework/com/uss/ion/ulm/EgovUnityLinkList.jsp
+++ b/src/main/webapp/WEB-INF/jsp/egovframework/com/uss/ion/ulm/EgovUnityLinkList.jsp
@@ -133,7 +133,7 @@ function fn_egov_search_UnityLink(){
 			    </td>
 			    <td class="left"><c:out value="${resultInfo.unityLinkUrl}"/></td>
 			    <td><c:out value="${resultInfo.frstRegisterNm}"/></td>
-			    <td><c:out value="${fn:substring(resultInfo.frstRegisterPnttm, 0, 10)}"/></td>
+			    <td><c:out value="${resultInfo.frstRegistPnttm}"/></td>
 			</tr>
 			</c:forEach>
 		</tbody>


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

- `EgovUnityLinkList.jsp`
  - 등록일자를 표시하는 변수를 올바른 값을 가진 변수로 수정하였습니다.
  - `${fn:substring(resultInfo.frstRegisterPnttm, 0, 10)}` → `${resultInfo.frstRegistPnttm}`

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [X] Chrome
- [X] Firefox
- [X] Edge
- [X] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

### 수정 전

![image](https://github.com/user-attachments/assets/fff7a3e2-6cbe-4eaf-a3ad-b079004ef91a)


### 수정 후

![image](https://github.com/user-attachments/assets/72ddbfe3-0d22-4992-a74c-4448d9b54151)
