### PR TITLE
[버그수정] 620. 응답자관리 - 목록 화면 > Uncaught TypeError 에러 수정

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/egovframework/com/uss/olp/qrm/EgovQustnrRespondManageList.jsp
+++ b/src/main/webapp/WEB-INF/jsp/egovframework/com/uss/olp/qrm/EgovQustnrRespondManageList.jsp
@@ -110,9 +110,9 @@ function fn_egov_search_QustnrRespondManage(){
 		</ul>
 	</div>
 	
-<%-- <input name="qestnrRespondId" type="hidden" value="${resultInfo.qestnrRespondId}">
-<input name="pageIndex" type="hidden" value="<c:out value='${searchVO.pageIndex}'/>">
-<input name="searchMode" type="hidden" value=""> --%>	
+    <input name="qestnrRespondId" type="hidden" value="${resultInfo.qestnrRespondId}" />
+    <input name="pageIndex" type="hidden" value="<c:out value='${searchVO.pageIndex}'/>" />
+    <input name="searchMode" type="hidden" value="" />
 	
 </form>
 


### PR DESCRIPTION
…efined (setting 'value') 에러 수정

## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

- `EgovQustnrRespondManageList.jsp`
  - JavaScript 함수 `linkPage`에서 `pageNo`를 설정하는 `pageIndex`  element가 존재하지 않아 Uncaught TypeError 에러가 발생
  -  `pageIndex`  element를 주석 처리한 코드를 제거하였습니다.



## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [X] Chrome
- [X] Firefox
- [X] Edge
- [X] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

### 수정 전

![image](https://github.com/user-attachments/assets/78654b1e-c6fb-42d1-907f-a4d2d5c96a18)


### 수정 후

![image](https://github.com/user-attachments/assets/9d218bf5-8c3f-40f9-8e32-2dcc84bfd5d8)



