### PR TITLE
[버그수정] 620. 응답자관리 > 목록 검색 SQL 오류 수정

### DIFF
--- a/src/main/resources/egovframework/mapper/com/uss/olp/qrm/EgovQustnrRespondManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/qrm/EgovQustnrRespondManage_SQL_altibase.xml
@@ -83,7 +83,7 @@
 		SELECT
 			(
 			SELECT QUSTNR_SJ FROM COMTNQESTNRINFO
-			WHERE 1=1
+			WHERE 1 = 1
 			AND QESTNR_ID = A.QESTNR_ID
 			) QESTNR_SJ,
 			A.QESTNR_ID,
@@ -98,19 +98,21 @@
 			A.QUSTNR_TMPLAT_ID AS QESTNR_TMPLAT_ID,
 			A.FRST_REGIST_PNTTM AS FRST_REGIST_PNTTM,
 			A.FRST_REGISTER_ID,
-			(SELECT USER_NM FROM COMTNEMPLYRINFO WHERE ESNTL_ID = A.FRST_REGISTER_ID) FRST_REGISTER_NM,
+			(B.USER_NM) AS FRST_REGISTER_NM,
 			A.LAST_UPDT_PNTTM,
 			A.LAST_UPDUSR_ID
 		FROM COMTNQUSTNRRESPONDINFO A
-		WHERE 1=1
+		LEFT OUTER JOIN COMTNEMPLYRINFO B
+		     ON B.ESNTL_ID = A.FRST_REGISTER_ID
+		WHERE 1 = 1
 	]]> 
 	 <if test="searchKeyword != null and searchKeyword != ''">
 	 	
 	 		<if test="searchCondition == 'RESPOND_NM'">
-	 			AND RESPOND_NM LIKE '%' || #{searchKeyword} || '%'
+	 			AND A.RESPOND_NM LIKE '%' || #{searchKeyword} || '%'
 	 		</if>
-	 		<if test="searchCondition == 'BRTH'">
-	 			AND BRTHDY LIKE '%' || #{searchKeyword} || '%'
+	 		<if test="searchCondition == 'FRST_REGISTER_ID'">
+	 			AND B.USER_NM LIKE '%' || #{searchKeyword} || '%'
 	 		</if>
 	 	
 	 </if>
@@ -129,16 +131,18 @@
 		<![CDATA[
 		SELECT
 		COUNT(*) totcnt
-		FROM COMTNQUSTNRRESPONDINFO
-		WHERE 1=1
+		FROM COMTNQUSTNRRESPONDINFO A
+		LEFT OUTER JOIN COMTNEMPLYRINFO B
+             ON B.ESNTL_ID = A.FRST_REGISTER_ID
+		WHERE 1 = 1
 		]]>
 	 <if test="searchKeyword != null and searchKeyword != ''">
 	 	
 	 		<if test="searchCondition == 'RESPOND_NM'">
-	 			AND RESPOND_NM LIKE '%' || #{searchKeyword} || '%'
+	 			AND A.RESPOND_NM LIKE '%' || #{searchKeyword} || '%'
 	 		</if>
-	 		<if test="searchCondition == 'BRTH'">
-	 			AND BRTHDY LIKE '%' || #{searchKeyword} || '%'
+	 		<if test="searchCondition == 'FRST_REGISTER_ID'">
+	 			AND B.USER_NM LIKE '%' || #{searchKeyword} || '%'
 	 		</if>
 	 	
 	 </if>

--- a/src/main/resources/egovframework/mapper/com/uss/olp/qrm/EgovQustnrRespondManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/qrm/EgovQustnrRespondManage_SQL_cubrid.xml
@@ -83,7 +83,7 @@
 		SELECT
 			(
 			SELECT QUSTNR_SJ FROM COMTNQESTNRINFO
-			WHERE 1=1
+			WHERE 1 = 1
 			AND QESTNR_ID = A.QESTNR_ID
 			) QESTNR_SJ,
 			A.QESTNR_ID,
@@ -98,19 +98,21 @@
 			A.QUSTNR_TMPLAT_ID AS QESTNR_TMPLAT_ID,
 			A.FRST_REGIST_PNTTM AS FRST_REGIST_PNTTM,
 			A.FRST_REGISTER_ID,
-			(SELECT USER_NM FROM COMTNEMPLYRINFO WHERE ESNTL_ID = A.FRST_REGISTER_ID) FRST_REGISTER_NM,
+			(B.USER_NM) AS FRST_REGISTER_NM,
 			A.LAST_UPDT_PNTTM,
 			A.LAST_UPDUSR_ID
 		FROM COMTNQUSTNRRESPONDINFO A
-		WHERE 1=1
+		LEFT OUTER JOIN COMTNEMPLYRINFO B
+             ON B.ESNTL_ID = A.FRST_REGISTER_ID
+		WHERE 1 = 1
 	]]> 
 	 <if test="searchKeyword != null and searchKeyword != ''">
 	 	
 	 		<if test="searchCondition == 'RESPOND_NM'">
-	 			AND RESPOND_NM LIKE '%' || #{searchKeyword} || '%'
+	 			AND A.RESPOND_NM LIKE '%' || #{searchKeyword} || '%'
 	 		</if>
-	 		<if test="searchCondition == 'BRTH'">
-	 			AND BRTHDY LIKE '%' || #{searchKeyword} || '%'
+	 		<if test="searchCondition == 'FRST_REGISTER_ID'">
+	 			AND B.USER_NM LIKE '%' || #{searchKeyword} || '%'
 	 		</if>
 	 	
 	 </if>
@@ -129,16 +131,18 @@
 		<![CDATA[
 		SELECT
 		COUNT(*) totcnt
-		FROM COMTNQUSTNRRESPONDINFO
-		WHERE 1=1
+		FROM COMTNQUSTNRRESPONDINFO A
+		LEFT OUTER JOIN COMTNEMPLYRINFO B
+             ON B.ESNTL_ID = A.FRST_REGISTER_ID
+		WHERE 1 = 1
 		]]>
 	 <if test="searchKeyword != null and searchKeyword != ''">
 	 	
 	 		<if test="searchCondition == 'RESPOND_NM'">
-	 			AND RESPOND_NM LIKE '%' || #{searchKeyword} || '%'
+	 			AND A.RESPOND_NM LIKE '%' || #{searchKeyword} || '%'
 	 		</if>
-	 		<if test="searchCondition == 'BRTH'">
-	 			AND BRTHDY LIKE '%' || #{searchKeyword} || '%'
+	 		<if test="searchCondition == 'FRST_REGISTER_ID'">
+	 			AND B.USER_NM LIKE '%' || #{searchKeyword} || '%'
 	 		</if>
 	 	
 	 </if>

--- a/src/main/resources/egovframework/mapper/com/uss/olp/qrm/EgovQustnrRespondManage_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/qrm/EgovQustnrRespondManage_SQL_goldilocks.xml
@@ -83,7 +83,7 @@
 		SELECT
 			(
 			SELECT QUSTNR_SJ FROM COMTNQESTNRINFO
-			WHERE 1=1
+			WHERE 1 = 1
 			AND QESTNR_ID = A.QESTNR_ID
 			) QESTNR_SJ,
 			A.QESTNR_ID,
@@ -98,19 +98,21 @@
 			A.QUSTNR_TMPLAT_ID AS QESTNR_TMPLAT_ID,
 			A.FRST_REGIST_PNTTM AS FRST_REGIST_PNTTM,
 			A.FRST_REGISTER_ID,
-			(SELECT USER_NM FROM COMTNEMPLYRINFO WHERE ESNTL_ID = A.FRST_REGISTER_ID) FRST_REGISTER_NM,
+			(B.USER_NM) AS FRST_REGISTER_NM,
 			A.LAST_UPDT_PNTTM,
 			A.LAST_UPDUSR_ID
 		FROM COMTNQUSTNRRESPONDINFO A
-		WHERE 1=1
+		LEFT OUTER JOIN COMTNEMPLYRINFO B
+             ON B.ESNTL_ID = A.FRST_REGISTER_ID
+		WHERE 1 = 1
 	]]> 
 	 <if test="searchKeyword != null and searchKeyword != ''">
 	 	
 	 		<if test="searchCondition == 'RESPOND_NM'">
-	 			AND RESPOND_NM LIKE '%' || #{searchKeyword} || '%'
+	 			AND A.RESPOND_NM LIKE '%' || #{searchKeyword} || '%'
 	 		</if>
-	 		<if test="searchCondition == 'BRTH'">
-	 			AND BRTHDY LIKE '%' || #{searchKeyword} || '%'
+	 		<if test="searchCondition == 'FRST_REGISTER_ID'">
+	 			AND B.USER_NM LIKE '%' || #{searchKeyword} || '%'
 	 		</if>
 	 	
 	 </if>
@@ -129,16 +131,18 @@
 		<![CDATA[
 		SELECT
 		COUNT(*) totcnt
-		FROM COMTNQUSTNRRESPONDINFO
-		WHERE 1=1
+		FROM COMTNQUSTNRRESPONDINFO A
+		LEFT OUTER JOIN COMTNEMPLYRINFO B
+             ON B.ESNTL_ID = A.FRST_REGISTER_ID
+		WHERE 1 = 1
 		]]>
 	 <if test="searchKeyword != null and searchKeyword != ''">
 	 	
 	 		<if test="searchCondition == 'RESPOND_NM'">
-	 			AND RESPOND_NM LIKE '%' || #{searchKeyword} || '%'
+	 			AND A.RESPOND_NM LIKE '%' || #{searchKeyword} || '%'
 	 		</if>
-	 		<if test="searchCondition == 'BRTH'">
-	 			AND BRTHDY LIKE '%' || #{searchKeyword} || '%'
+	 		<if test="searchCondition == 'FRST_REGISTER_ID'">
+	 			AND B.USER_NM LIKE '%' || #{searchKeyword} || '%'
 	 		</if>
 	 	
 	 </if>

--- a/src/main/resources/egovframework/mapper/com/uss/olp/qrm/EgovQustnrRespondManage_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/qrm/EgovQustnrRespondManage_SQL_maria.xml
@@ -77,7 +77,7 @@
 		SELECT
 			(
 			SELECT QUSTNR_SJ FROM COMTNQESTNRINFO
-			WHERE 1=1
+			WHERE 1 = 1
 			AND QESTNR_ID = A.QESTNR_ID
 			) QESTNR_SJ,
 			A.QESTNR_ID,
@@ -92,19 +92,21 @@
 			A.QUSTNR_TMPLAT_ID AS QESTNR_TMPLAT_ID,
 			DATE_FORMAT(A.FRST_REGIST_PNTTM,'%Y-%m-%d') AS FRST_REGIST_PNTTM,
 			A.FRST_REGISTER_ID,
-			(SELECT USER_NM FROM COMTNEMPLYRINFO WHERE ESNTL_ID = A.FRST_REGISTER_ID) FRST_REGISTER_NM,
+			(B.USER_NM) AS FRST_REGISTER_NM,
 			DATE_FORMAT(A.LAST_UPDT_PNTTM,'%Y-%m-%d') AS LAST_UPDT_PNTTM,
 			A.LAST_UPDUSR_ID
 		FROM COMTNQUSTNRRESPONDINFO A
-		WHERE 1=1
+		LEFT OUTER JOIN COMTNEMPLYRINFO B
+             ON B.ESNTL_ID = A.FRST_REGISTER_ID
+		WHERE 1 = 1
 	 	]]>
 	 <if test="searchKeyword != null and searchKeyword != ''">
 	 	
 	 		<if test="searchCondition == 'RESPOND_NM'">
-	 			AND RESPOND_NM LIKE CONCAT('%', #{searchKeyword}, '%')
+	 			AND A.RESPOND_NM LIKE CONCAT('%', #{searchKeyword}, '%')
 	 		</if>
-	 		<if test="searchCondition == 'BRTH'">
-	 			AND BRTHDY LIKE CONCAT('%', #{searchKeyword}, '%')
+	 		<if test="searchCondition == 'FRST_REGISTER_ID'">
+	 			AND B.USER_NM LIKE CONCAT('%', #{searchKeyword}, '%')
 	 		</if>
 	 	
 	 </if>
@@ -119,16 +121,18 @@
 		<![CDATA[
 		SELECT
 		COUNT(*) totcnt
-		FROM COMTNQUSTNRRESPONDINFO
-		WHERE 1=1
+		FROM COMTNQUSTNRRESPONDINFO A
+		LEFT OUTER JOIN COMTNEMPLYRINFO B
+             ON B.ESNTL_ID = A.FRST_REGISTER_ID
+		WHERE 1 = 1
 		]]>
 	 <if test="searchKeyword != null and searchKeyword != ''">
 	 	
 	 		<if test="searchCondition == 'RESPOND_NM'">
-	 			AND RESPOND_NM LIKE CONCAT('%', #{searchKeyword}, '%')
+	 			AND A.RESPOND_NM LIKE CONCAT('%', #{searchKeyword}, '%')
 	 		</if>
-	 		<if test="searchCondition == 'BRTH'">
-	 			AND BRTHDY LIKE CONCAT('%', #{searchKeyword}, '%')
+	 		<if test="searchCondition == 'FRST_REGISTER_ID'">
+	 			AND B.USER_NM LIKE CONCAT('%', #{searchKeyword}, '%')
 	 		</if>
 	 	
 	 </if>

--- a/src/main/resources/egovframework/mapper/com/uss/olp/qrm/EgovQustnrRespondManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/qrm/EgovQustnrRespondManage_SQL_mysql.xml
@@ -77,7 +77,7 @@
 		SELECT
 			(
 			SELECT QUSTNR_SJ FROM COMTNQESTNRINFO
-			WHERE 1=1
+			WHERE 1 = 1
 			AND QESTNR_ID = A.QESTNR_ID
 			) QESTNR_SJ,
 			A.QESTNR_ID,
@@ -92,19 +92,21 @@
 			A.QUSTNR_TMPLAT_ID AS QESTNR_TMPLAT_ID,
 			DATE_FORMAT(A.FRST_REGIST_PNTTM,'%Y-%m-%d') AS FRST_REGIST_PNTTM,
 			A.FRST_REGISTER_ID,
-			(SELECT USER_NM FROM COMTNEMPLYRINFO WHERE ESNTL_ID = A.FRST_REGISTER_ID) FRST_REGISTER_NM,
+			(B.USER_NM) AS FRST_REGISTER_NM,
 			DATE_FORMAT(A.LAST_UPDT_PNTTM,'%Y-%m-%d') AS LAST_UPDT_PNTTM,
 			A.LAST_UPDUSR_ID
 		FROM COMTNQUSTNRRESPONDINFO A
-		WHERE 1=1
+		LEFT OUTER JOIN COMTNEMPLYRINFO B
+             ON B.ESNTL_ID = A.FRST_REGISTER_ID
+		WHERE 1 = 1
 	 	]]>
 	 <if test="searchKeyword != null and searchKeyword != ''">
 	 	
 	 		<if test="searchCondition == 'RESPOND_NM'">
-	 			AND RESPOND_NM LIKE CONCAT('%', #{searchKeyword}, '%')
+	 			AND A.RESPOND_NM LIKE CONCAT('%', #{searchKeyword}, '%')
 	 		</if>
-	 		<if test="searchCondition == 'BRTH'">
-	 			AND BRTHDY LIKE CONCAT('%', #{searchKeyword}, '%')
+	 		<if test="searchCondition == 'FRST_REGISTER_ID'">
+	 			AND B.USER_NM LIKE CONCAT('%', #{searchKeyword}, '%')
 	 		</if>
 	 	
 	 </if>
@@ -119,16 +121,18 @@
 		<![CDATA[
 		SELECT
 		COUNT(*) totcnt
-		FROM COMTNQUSTNRRESPONDINFO
-		WHERE 1=1
+		FROM COMTNQUSTNRRESPONDINFO A
+		LEFT OUTER JOIN COMTNEMPLYRINFO B
+             ON B.ESNTL_ID = A.FRST_REGISTER_ID
+		WHERE 1 = 1
 		]]>
 	 <if test="searchKeyword != null and searchKeyword != ''">
 	 	
 	 		<if test="searchCondition == 'RESPOND_NM'">
-	 			AND RESPOND_NM LIKE CONCAT('%', #{searchKeyword}, '%')
+	 			AND A.RESPOND_NM LIKE CONCAT('%', #{searchKeyword}, '%')
 	 		</if>
-	 		<if test="searchCondition == 'BRTH'">
-	 			AND BRTHDY LIKE CONCAT('%', #{searchKeyword}, '%')
+	 		<if test="searchCondition == 'FRST_REGISTER_ID'">
+	 			AND B.USER_NM LIKE CONCAT('%', #{searchKeyword}, '%')
 	 		</if>
 	 	
 	 </if>

--- a/src/main/resources/egovframework/mapper/com/uss/olp/qrm/EgovQustnrRespondManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/qrm/EgovQustnrRespondManage_SQL_oracle.xml
@@ -83,7 +83,7 @@
 		SELECT
 			(
 			SELECT QUSTNR_SJ FROM COMTNQESTNRINFO
-			WHERE 1=1
+			WHERE 1 = 1
 			AND QESTNR_ID = A.QESTNR_ID
 			) QESTNR_SJ,
 			A.QESTNR_ID,
@@ -98,19 +98,21 @@
 			A.QUSTNR_TMPLAT_ID AS QESTNR_TMPLAT_ID,
 			A.FRST_REGIST_PNTTM AS FRST_REGIST_PNTTM,
 			A.FRST_REGISTER_ID,
-			(SELECT USER_NM FROM COMTNEMPLYRINFO WHERE ESNTL_ID = A.FRST_REGISTER_ID) FRST_REGISTER_NM,
+			(B.USER_NM) FRST_REGISTER_NM,
 			A.LAST_UPDT_PNTTM,
 			A.LAST_UPDUSR_ID
 		FROM COMTNQUSTNRRESPONDINFO A
-		WHERE 1=1
+        LEFT OUTER JOIN COMTNEMPLYRINFO B
+             ON B.ESNTL_ID = A.FRST_REGISTER_ID
+		WHERE 1 = 1
 	]]> 
 	 <if test="searchKeyword != null and searchKeyword != ''">
 	 	
 	 		<if test="searchCondition == 'RESPOND_NM'">
-	 			AND RESPOND_NM LIKE '%' || #{searchKeyword} || '%'
+	 			AND A.RESPOND_NM LIKE '%' || #{searchKeyword} || '%'
 	 		</if>
-	 		<if test="searchCondition == 'BRTH'">
-	 			AND BRTHDY LIKE '%' || #{searchKeyword} || '%'
+	 		<if test="searchCondition == 'FRST_REGISTER_ID'">
+	 			AND B.USER_NM LIKE '%' || #{searchKeyword} || '%'
 	 		</if>
 	 	
 	 </if>
@@ -129,16 +131,18 @@
 		<![CDATA[
 		SELECT
 		COUNT(*) totcnt
-		FROM COMTNQUSTNRRESPONDINFO
-		WHERE 1=1
+		FROM COMTNQUSTNRRESPONDINFO A
+		LEFT OUTER JOIN COMTNEMPLYRINFO B
+             ON B.ESNTL_ID = A.FRST_REGISTER_ID
+		WHERE 1 = 1
 		]]>
 	 <if test="searchKeyword != null and searchKeyword != ''">
 	 	
 	 		<if test="searchCondition == 'RESPOND_NM'">
-	 			AND RESPOND_NM LIKE '%' || #{searchKeyword} || '%'
+	 			AND A.RESPOND_NM LIKE '%' || #{searchKeyword} || '%'
 	 		</if>
-	 		<if test="searchCondition == 'BRTH'">
-	 			AND BRTHDY LIKE '%' || #{searchKeyword} || '%'
+	 		<if test="searchCondition == 'FRST_REGISTER_ID'">
+	 			AND B.USER_NM LIKE '%' || #{searchKeyword} || '%'
 	 		</if>
 	 	
 	 </if>

--- a/src/main/resources/egovframework/mapper/com/uss/olp/qrm/EgovQustnrRespondManage_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/qrm/EgovQustnrRespondManage_SQL_postgres.xml
@@ -77,7 +77,7 @@
 		SELECT
 			(
 			SELECT QUSTNR_SJ FROM COMTNQESTNRINFO
-			WHERE 1=1
+			WHERE 1 = 1
 			AND QESTNR_ID = A.QESTNR_ID
 			) QESTNR_SJ,
 			A.QESTNR_ID,
@@ -92,19 +92,21 @@
 			A.QUSTNR_TMPLAT_ID AS QESTNR_TMPLAT_ID,
 			A.FRST_REGIST_PNTTM AS FRST_REGIST_PNTTM,
 			A.FRST_REGISTER_ID,
-			(SELECT USER_NM FROM COMTNEMPLYRINFO WHERE ESNTL_ID = A.FRST_REGISTER_ID) FRST_REGISTER_NM,
+			(B.USER_NM) AS FRST_REGISTER_NM,
 			A.LAST_UPDT_PNTTM,
 			A.LAST_UPDUSR_ID
 		FROM COMTNQUSTNRRESPONDINFO A
-		WHERE 1=1
+		LEFT OUTER JOIN COMTNEMPLYRINFO B
+             ON B.ESNTL_ID = A.FRST_REGISTER_ID
+		WHERE 1 = 1
 	 	]]>
 	 <if test="searchKeyword != null and searchKeyword != ''">
 	 	
 	 		<if test="searchCondition == 'RESPOND_NM'">
-	 			AND RESPOND_NM LIKE CONCAT('%', #{searchKeyword}, '%')
+	 			AND A.RESPOND_NM LIKE CONCAT('%', #{searchKeyword}, '%')
 	 		</if>
-	 		<if test="searchCondition == 'BRTH'">
-	 			AND BRTHDY LIKE CONCAT('%', #{searchKeyword}, '%')
+	 		<if test="searchCondition == 'FRST_REGISTER_ID'">
+	 			AND B.USER_NM LIKE CONCAT('%', #{searchKeyword}, '%')
 	 		</if>
 	 	
 	 </if>
@@ -119,16 +121,18 @@
 		<![CDATA[
 		SELECT
 		COUNT(*) totcnt
-		FROM COMTNQUSTNRRESPONDINFO
-		WHERE 1=1
+		FROM COMTNQUSTNRRESPONDINFO A
+		LEFT OUTER JOIN COMTNEMPLYRINFO B
+             ON B.ESNTL_ID = A.FRST_REGISTER_ID
+		WHERE 1 = 1
 		]]>
 	 <if test="searchKeyword != null and searchKeyword != ''">
 	 	
 	 		<if test="searchCondition == 'RESPOND_NM'">
-	 			AND RESPOND_NM LIKE CONCAT('%', #{searchKeyword}, '%')
+	 			AND A.RESPOND_NM LIKE CONCAT('%', #{searchKeyword}, '%')
 	 		</if>
-	 		<if test="searchCondition == 'BRTH'">
-	 			AND BRTHDY LIKE CONCAT('%', #{searchKeyword}, '%')
+	 		<if test="searchCondition == 'FRST_REGISTER_ID'">
+	 			AND B.USER_NM LIKE CONCAT('%', #{searchKeyword}, '%')
 	 		</if>
 	 	
 	 </if>

--- a/src/main/resources/egovframework/mapper/com/uss/olp/qrm/EgovQustnrRespondManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/qrm/EgovQustnrRespondManage_SQL_tibero.xml
@@ -83,7 +83,7 @@
 		SELECT
 			(
 			SELECT QUSTNR_SJ FROM COMTNQESTNRINFO
-			WHERE 1=1
+			WHERE 1 = 1
 			AND QESTNR_ID = A.QESTNR_ID
 			) QESTNR_SJ,
 			A.QESTNR_ID,
@@ -98,19 +98,21 @@
 			A.QUSTNR_TMPLAT_ID AS QESTNR_TMPLAT_ID,
 			A.FRST_REGIST_PNTTM AS FRST_REGIST_PNTTM,
 			A.FRST_REGISTER_ID,
-			(SELECT USER_NM FROM COMTNEMPLYRINFO WHERE ESNTL_ID = A.FRST_REGISTER_ID) FRST_REGISTER_NM,
+			(B.USER_NM) AS FRST_REGISTER_NM,
 			A.LAST_UPDT_PNTTM,
 			A.LAST_UPDUSR_ID
 		FROM COMTNQUSTNRRESPONDINFO A
-		WHERE 1=1
+		LEFT OUTER JOIN COMTNEMPLYRINFO B
+             ON B.ESNTL_ID = A.FRST_REGISTER_ID
+		WHERE 1 = 1
 	]]> 
 	 <if test="searchKeyword != null and searchKeyword != ''">
 	 	
 	 		<if test="searchCondition == 'RESPOND_NM'">
-	 			AND RESPOND_NM LIKE '%' || #{searchKeyword} || '%'
+	 			AND A.RESPOND_NM LIKE '%' || #{searchKeyword} || '%'
 	 		</if>
-	 		<if test="searchCondition == 'BRTH'">
-	 			AND BRTHDY LIKE '%' || #{searchKeyword} || '%'
+	 		<if test="searchCondition == 'FRST_REGISTER_ID'">
+	 			AND B.USER_NM LIKE '%' || #{searchKeyword} || '%'
 	 		</if>
 	 	
 	 </if>
@@ -129,16 +131,18 @@
 		<![CDATA[
 		SELECT
 		COUNT(*) totcnt
-		FROM COMTNQUSTNRRESPONDINFO
-		WHERE 1=1
+		FROM COMTNQUSTNRRESPONDINFO A
+		LEFT OUTER JOIN COMTNEMPLYRINFO B
+             ON B.ESNTL_ID = A.FRST_REGISTER_ID
+		WHERE 1 = 1
 		]]>
 	 <if test="searchKeyword != null and searchKeyword != ''">
 	 	
 	 		<if test="searchCondition == 'RESPOND_NM'">
-	 			AND RESPOND_NM LIKE '%' || #{searchKeyword} || '%'
+	 			AND A.RESPOND_NM LIKE '%' || #{searchKeyword} || '%'
 	 		</if>
-	 		<if test="searchCondition == 'BRTH'">
-	 			AND BRTHDY LIKE '%' || #{searchKeyword} || '%'
+	 		<if test="searchCondition == 'FRST_REGISTER_ID'">
+	 			AND B.USER_NM LIKE '%' || #{searchKeyword} || '%'
 	 		</if>
 	 	
 	 </if>


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

수정된 파일 리스트
- EgovQustnrRespondManage_SQL_altibase.xml
- EgovQustnrRespondManage_SQL_cubrid.xml
- EgovQustnrRespondManage_SQL_goldilocks.xml
- EgovQustnrRespondManage_SQL_maria.xml
- EgovQustnrRespondManage_SQL_mysql.xml
- EgovQustnrRespondManage_SQL_oracle.xml
- EgovQustnrRespondManage_SQL_postgres.xml
- EgovQustnrRespondManage_SQL_tibero.xml

공통적으로 수정된 내용

**SQL ID**
- `selectQustnrRespondManage`
- `selectQustnrRespondManageCnt`


#### 1. 등록자 검색 조건을 처리하는 mybatis if 조건의 오류
  - 해당 검색 조건과 관련 없는 `BRTHDY` 를 쿼리에서 검색 조건으로 활용하고 있어 기능에 맞게 수정하였습니다.

**AS-IS**

```xml
<if test="searchCondition == 'BRTH'">
	AND BRTHDY LIKE '%' || #{searchKeyword} || '%'
</if>
```

**TO-BE**

```xml
<if test="searchCondition == 'FRST_REGISTER_ID'">
	AND B.USER_NM LIKE '%' || #{searchKeyword} || '%'
</if>
```

#### 2. 검색을 위해 LEFT OUTER JOIN 추가
- 기존 BRTHDY 검색을 USER_NM 기준 검색으로 변경하기 위해 LEFT OUTER JOIN을 추가하고, 기존에 등록자를 서브쿼리로 가져오던 부분을 LEFT OUTER JOIN의 필드를 사용하도록 수정하였습니다.

**AS-IS**

```sql
	(SELECT USER_NM FROM COMTNEMPLYRINFO WHERE ESNTL_ID = A.FRST_REGISTER_ID) FRST_REGISTER_NM,
	A.LAST_UPDT_PNTTM,
	A.LAST_UPDUSR_ID
FROM COMTNQUSTNRRESPONDINFO A
WHERE 1=1
AND BRTHDY LIKE '%' || '웹마스터' || '%'
```

**TO-BE**

```sql
	(B.USER_NM) AS FRST_REGISTER_NM,
	A.LAST_UPDT_PNTTM,
	A.LAST_UPDUSR_ID
FROM COMTNQUSTNRRESPONDINFO A
LEFT OUTER JOIN COMTNEMPLYRINFO B
     ON B.ESNTL_ID = A.FRST_REGISTER_ID
WHERE 1 = 1
AND B.USER_NM LIKE '%' || '웹마스터' || '%'
```

#### 3. 검색 쿼리 변경에 따라 카운트 조회 쿼리도 변경





## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [X] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

### 수정 전


https://github.com/user-attachments/assets/9f5afd67-25da-4200-9aef-e3139434715d




### 수정 후 (완전한 해결을 위해서는 #441 와 함께 반영되어야합니다.)


https://github.com/user-attachments/assets/b079b7db-03e4-44e6-b7af-146c73b1684d



