### PR TITLE
[버그수정] 581. 상담답변관리 > 목록 검색 조건이 작동하지 않는 오류 수정

### DIFF
--- a/src/main/resources/egovframework/mapper/com/uss/olp/cns/EgovCnsltManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/cns/EgovCnsltManage_SQL_altibase.xml
@@ -289,9 +289,9 @@
 			<if test="searchCondition == 'wrterNm'">AND
 				WRTER_NM LIKE '%' || #{searchKeyword} || '%'
 			</if>
-			<if test="searchCondition == 'qnaProcessSttusCodeNm'">AND
-				QNA_PROCESS_STTUS_CODE_NM LIKE '%' || #{searchKeyword} || '%'
-			</if>
+            <if test="searchCondition == 'cnsltSj'">AND
+                CNSLT_SJ LIKE CONCAT('%', #{searchKeyword}, '%')
+            </if>
 	</select>
 
 	<update id="updateCnsltDtlsAnswer">

--- a/src/main/resources/egovframework/mapper/com/uss/olp/cns/EgovCnsltManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/cns/EgovCnsltManage_SQL_cubrid.xml
@@ -289,9 +289,9 @@
 			<if test="searchCondition == 'wrterNm'">AND
 				WRTER_NM LIKE '%' || #{searchKeyword} || '%'
 			</if>
-			<if test="searchCondition == 'qnaProcessSttusCodeNm'">AND
-				QNA_PROCESS_STTUS_CODE_NM LIKE '%' || #{searchKeyword} || '%'
-			</if>
+            <if test="searchCondition == 'cnsltSj'">AND
+                CNSLT_SJ LIKE CONCAT('%', #{searchKeyword}, '%')
+            </if>
 	</select>
 
 	<update id="updateCnsltDtlsAnswer">

--- a/src/main/resources/egovframework/mapper/com/uss/olp/cns/EgovCnsltManage_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/cns/EgovCnsltManage_SQL_goldilocks.xml
@@ -289,9 +289,9 @@
 			<if test="searchCondition == 'wrterNm'">AND
 				WRTER_NM LIKE '%' || #{searchKeyword} || '%'
 			</if>
-			<if test="searchCondition == 'qnaProcessSttusCodeNm'">AND
-				QNA_PROCESS_STTUS_CODE_NM LIKE '%' || #{searchKeyword} || '%'
-			</if>
+            <if test="searchCondition == 'cnsltSj'">AND
+                CNSLT_SJ LIKE CONCAT('%', #{searchKeyword}, '%')
+            </if>
 	</select>
 
 	<update id="updateCnsltDtlsAnswer">

--- a/src/main/resources/egovframework/mapper/com/uss/olp/cns/EgovCnsltManage_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/cns/EgovCnsltManage_SQL_maria.xml
@@ -227,9 +227,9 @@
 			<if test="searchCondition == 'wrterNm'">AND
 				WRTER_NM LIKE CONCAT('%', #{searchKeyword}, '%')
 			</if>
-			<if test="searchCondition == 'qnaProcessSttusCodeNm'">AND
-				CODE_NM LIKE CONCAT('%', #{searchKeyword}, '%')
-			</if>
+            <if test="searchCondition == 'cnsltSj'">AND
+                CNSLT_SJ LIKE CONCAT('%', #{searchKeyword}, '%')
+            </if>
 			ORDER BY CNSLT_SJ DESC
 			LIMIT  #{recordCountPerPage} OFFSET #{firstIndex}
 </select>
@@ -243,9 +243,9 @@
 			<if test="searchCondition == 'wrterNm'">AND
 				WRTER_NM LIKE CONCAT('%', #{searchKeyword}, '%')
 			</if>
-			<if test="searchCondition == 'qnaProcessSttusCodeNm'">AND
-				QNA_PROCESS_STTUS_CODE_NM LIKE CONCAT('%', #{searchKeyword}, '%')
-			</if>
+            <if test="searchCondition == 'cnsltSj'">AND
+                CNSLT_SJ LIKE CONCAT('%', #{searchKeyword}, '%')
+            </if>
 	</select>
 
 	<update id="updateCnsltDtlsAnswer">

--- a/src/main/resources/egovframework/mapper/com/uss/olp/cns/EgovCnsltManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/cns/EgovCnsltManage_SQL_mysql.xml
@@ -227,8 +227,8 @@
 			<if test="searchCondition == 'wrterNm'">AND
 				WRTER_NM LIKE CONCAT('%', #{searchKeyword}, '%')
 			</if>
-			<if test="searchCondition == 'qnaProcessSttusCodeNm'">AND
-				CODE_NM LIKE CONCAT('%', #{searchKeyword}, '%')
+			<if test="searchCondition == 'cnsltSj'">AND
+				CNSLT_SJ LIKE CONCAT('%', #{searchKeyword}, '%')
 			</if>
 			ORDER BY CNSLT_SJ DESC
 			LIMIT  #{recordCountPerPage} OFFSET #{firstIndex}
@@ -243,9 +243,9 @@
 			<if test="searchCondition == 'wrterNm'">AND
 				WRTER_NM LIKE CONCAT('%', #{searchKeyword}, '%')
 			</if>
-			<if test="searchCondition == 'qnaProcessSttusCodeNm'">AND
-				QNA_PROCESS_STTUS_CODE_NM LIKE CONCAT('%', #{searchKeyword}, '%')
-			</if>
+            <if test="searchCondition == 'cnsltSj'">AND
+                CNSLT_SJ LIKE CONCAT('%', #{searchKeyword}, '%')
+            </if>
 	</select>
 
 	<update id="updateCnsltDtlsAnswer">

--- a/src/main/resources/egovframework/mapper/com/uss/olp/cns/EgovCnsltManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/cns/EgovCnsltManage_SQL_oracle.xml
@@ -289,9 +289,9 @@
 			<if test="searchCondition == 'wrterNm'">AND
 				WRTER_NM LIKE '%' || #{searchKeyword} || '%'
 			</if>
-			<if test="searchCondition == 'qnaProcessSttusCodeNm'">AND
-				QNA_PROCESS_STTUS_CODE_NM LIKE '%' || #{searchKeyword} || '%'
-			</if>
+            <if test="searchCondition == 'cnsltSj'">AND
+                CNSLT_SJ LIKE CONCAT('%', #{searchKeyword}, '%')
+            </if>
 	</select>
 
 	<update id="updateCnsltDtlsAnswer">

--- a/src/main/resources/egovframework/mapper/com/uss/olp/cns/EgovCnsltManage_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/cns/EgovCnsltManage_SQL_postgres.xml
@@ -227,9 +227,9 @@
 			<if test="searchCondition == 'wrterNm'">AND
 				WRTER_NM LIKE CONCAT('%', #{searchKeyword}, '%')
 			</if>
-			<if test="searchCondition == 'qnaProcessSttusCodeNm'">AND
-				CODE_NM LIKE CONCAT('%', #{searchKeyword}, '%')
-			</if>
+            <if test="searchCondition == 'cnsltSj'">AND
+                CNSLT_SJ LIKE CONCAT('%', #{searchKeyword}, '%')
+            </if>
 			ORDER BY CNSLT_SJ DESC
 			LIMIT  #{recordCountPerPage} OFFSET #{firstIndex}
 </select>
@@ -243,9 +243,9 @@
 			<if test="searchCondition == 'wrterNm'">AND
 				WRTER_NM LIKE CONCAT('%', #{searchKeyword}, '%')
 			</if>
-			<if test="searchCondition == 'qnaProcessSttusCodeNm'">AND
-				QNA_PROCESS_STTUS_CODE_NM LIKE CONCAT('%', #{searchKeyword}, '%')
-			</if>
+            <if test="searchCondition == 'cnsltSj'">AND
+                CNSLT_SJ LIKE CONCAT('%', #{searchKeyword}, '%')
+            </if>
 	</select>
 
 	<update id="updateCnsltDtlsAnswer">

--- a/src/main/resources/egovframework/mapper/com/uss/olp/cns/EgovCnsltManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/cns/EgovCnsltManage_SQL_tibero.xml
@@ -289,9 +289,9 @@
 			<if test="searchCondition == 'wrterNm'">AND
 				WRTER_NM LIKE '%' || #{searchKeyword} || '%'
 			</if>
-			<if test="searchCondition == 'qnaProcessSttusCodeNm'">AND
-				QNA_PROCESS_STTUS_CODE_NM LIKE '%' || #{searchKeyword} || '%'
-			</if>
+            <if test="searchCondition == 'cnsltSj'">AND
+                CNSLT_SJ LIKE CONCAT('%', #{searchKeyword}, '%')
+            </if>
 	</select>
 
 	<update id="updateCnsltDtlsAnswer">


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

수정된 파일 모록
- EgovCnsltManage_SQL_altibase.xml
- EgovCnsltManage_SQL_cubrid.xml
- EgovCnsltManage_SQL_goldilocks.xml
- EgovCnsltManage_SQL_maria.xml
- EgovCnsltManage_SQL_mysql.xml
- EgovCnsltManage_SQL_oracle.xml
- EgovCnsltManage_SQL_postgres.xml
- EgovCnsltManage_SQL_tibero.xml

수정 내용
- 목록 화면 검색 조건인 **상담제목**과 무관한 조건이 sql에 선언되어있어 올바른 쿼리로 변경하였습니다.

SQL ID
- `selectCnsltAnswerList`

Before

```xml
<if test="searchCondition == 'qnaProcessSttusCodeNm'">AND
CODE_NM LIKE CONCAT('%', #{searchKeyword}, '%')
</if>
```

After

```xml
<if test="searchCondition == 'cnsltSj'">AND
CNSLT_SJ LIKE CONCAT('%', #{searchKeyword}, '%')
</if>
```


- `selectCnsltAnswerListTotCnt`

Before

```xml
<if test="searchCondition == 'qnaProcessSttusCodeNm'">AND
QNA_PROCESS_STTUS_CODE_NM LIKE CONCAT('%', #{searchKeyword}, '%')
</if>
```

After

```xml
<if test="searchCondition == 'cnsltSj'">AND
CNSLT_SJ LIKE CONCAT('%', #{searchKeyword}, '%')
</if>
```






## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [X] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

### 수정 전


https://github.com/user-attachments/assets/653aba59-7a0f-4588-8951-d376e0e0441d



### 수정 후



https://github.com/user-attachments/assets/2ac8f5be-5528-4784-ac5e-bb5f41873605



