### PR TITLE
[10. 로그인][LoginDAO.searchPassword] DAO 단위 테스트

### DIFF
--- a/src/test/java/egovframework/com/uat/uia/service/impl/LoginDAOTestSearchPasswordTest.java
+++ b/src/test/java/egovframework/com/uat/uia/service/impl/LoginDAOTestSearchPasswordTest.java
@@ -19,7 +19,7 @@ import lombok.extern.slf4j.Slf4j;
  * [10. 로그인][LoginDAO.searchPassword] DAO 단위 테스트
  * 
  * @author 이백행
- * @since 2024-09-16
+ * @since 2024-09-17
  *
  */
 @ContextConfiguration(classes = { LoginDAOTestSearchPasswordTest.class, EgovTestAbstractDAO.class })

--- a/src/test/java/egovframework/com/uat/uia/service/impl/LoginDAOTestSearchPasswordTest.java
+++ b/src/test/java/egovframework/com/uat/uia/service/impl/LoginDAOTestSearchPasswordTest.java
@@ -1,0 +1,105 @@
+package egovframework.com.uat.uia.service.impl;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.ComponentScan.Filter;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.test.context.ContextConfiguration;
+
+import egovframework.com.cmm.LoginVO;
+import egovframework.com.test.EgovTestAbstractDAO;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * [10. 로그인][LoginDAO.searchPassword] DAO 단위 테스트
+ * 
+ * @author 이백행
+ * @since 2024-09-16
+ *
+ */
+@ContextConfiguration(classes = { LoginDAOTestSearchPasswordTest.class, EgovTestAbstractDAO.class })
+@Configuration
+@ComponentScan(useDefaultFilters = false, basePackages = {
+		"egovframework.com.uat.uia.service.impl" }, includeFilters = {
+				@Filter(type = FilterType.ASSIGNABLE_TYPE, classes = { LoginDAO.class }) })
+@NoArgsConstructor
+@Slf4j
+public class LoginDAOTestSearchPasswordTest extends EgovTestAbstractDAO {
+
+	/**
+	 * 일반 로그인, 인증서 로그인을 처리하는 DAO 클래스
+	 */
+	@Autowired
+	private LoginDAO loginDAO;
+
+	/**
+	 * 비밀번호를 찾는다.
+	 * 
+	 * @throws Exception
+	 */
+	@Test
+	public void test() throws Exception {
+		if (log.isDebugEnabled()) {
+			log.debug("비밀번호를 찾는다.");
+		}
+
+		// given
+		final LoginVO loginVO = new LoginVO();
+		// 일반회원
+		loginVO.setUserSe("GNR");
+
+		loginVO.setId("USER");
+		loginVO.setName("일반회원");
+		loginVO.setEmail("egovframesupport@gmail.com");
+		loginVO.setPasswordHint("P01");
+		loginVO.setPasswordCnsr("전자정부표준프레임워크센터");
+
+		loginVO.setPassword("6TAJYwhKCgkgzPXDb83ZUiHi2/TKHhD7t5Ba6RN2qoo=");
+
+//		// 기업회원
+//		loginVO.setUserSe("ENT");
+//
+//		loginVO.setId("ENTERPRISE");
+//		loginVO.setName("NIA");
+//		loginVO.setEmail("egovframesupport@gmail.com");
+//		loginVO.setPasswordHint("P01");
+//		loginVO.setPasswordCnsr("전자정부표준프레임워크센터");
+//
+//		loginVO.setPassword("ZQhr3oB5QWjBnBO0kbFF7bvQDLkk+Em0ExjTq5JtVTo=");
+
+//		// 업무사용자
+//		loginVO.setUserSe("USR");
+//
+//		loginVO.setId("TEST1");
+//		loginVO.setName("테스트1");
+//		loginVO.setEmail("egovframesupport@gmail.com");
+//		loginVO.setPasswordHint("P01");
+//		loginVO.setPasswordCnsr("전자정부표준프레임워크센터");
+//
+//		loginVO.setPassword("raHLBnHFcunwNzcDcfad4PhD11hHgXSUr7fc1Jk9uoQ=");
+
+		// when
+		final LoginVO resultVO = loginDAO.searchPassword(loginVO);
+
+		// then
+		debug(loginVO, resultVO);
+
+		assertEquals("getPassword 패스워드", loginVO.getPassword(), resultVO.getPassword());
+	}
+
+	private void debug(final LoginVO loginVO, final LoginVO resultVO) {
+		if (log.isDebugEnabled()) {
+			log.debug("resultVO={}", resultVO);
+			log.debug("getPassword={}", resultVO.getPassword());
+
+			log.debug("assert");
+			log.debug("getPassword={}, {}", resultVO.getPassword(), resultVO.getPassword());
+		}
+	}
+
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

### [10. 로그인][LoginDAO.searchPassword] DAO 단위 테스트

- `아이디를 찾는다.` DAO 단위 테스트

브랜치 생성
```
2024/test/LoginDAO/searchPassword
```

테스트 패키지 생성
```
egovframework.com.uat.uia.service.impl
```

테스트 파일 생성
```
LoginDAOTestSearchPasswordTest
```

```sql
SELECT A.MBER_ID, A.MBER_NM, A.MBER_EMAIL_ADRES, A.PASSWORD_HINT, A.PASSWORD_CNSR, A.MBER_STTUS, A.PASSWORD FROM COMTNGNRLMBER A
;

SELECT A.ENTRPRS_MBER_ID, A.CMPNY_NM, A.APPLCNT_EMAIL_ADRES, A.ENTRPRS_MBER_PASSWORD_HINT, A.ENTRPRS_MBER_PASSWORD_CNSR, A.ENTRPRS_MBER_STTUS, A.ENTRPRS_MBER_PASSWORD FROM COMTNENTRPRSMBER A
;

SELECT A.EMPLYR_ID, A.USER_NM, A.EMAIL_ADRES, A.PASSWORD_HINT, A.PASSWORD_CNSR, A.EMPLYR_STTUS_CODE, A.PASSWORD FROM COMTNEMPLYRINFO A
;
```

[2024년 전자정부 표준프레임워크 컨트리뷰션][공통컴포넌트][10. 로그인][LoginDAO.searchId] DAO 단위 테스트

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [x] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

https://youtu.be/oR3y4r4lhjs
