### PR TITLE
[기능개선] 1250. 개인지식관리 > 목록으로 돌아올 때 검색 조건이 유지되도록 수정

### DIFF
--- a/src/main/java/egovframework/com/dam/per/web/EgovKnoPersonalController.java
+++ b/src/main/java/egovframework/com/dam/per/web/EgovKnoPersonalController.java
@@ -135,6 +135,7 @@ public class EgovKnoPersonalController {
 		int totCnt = knoPersonalService.selectKnoPersonalTotCnt(searchVO);
 		paginationInfo.setTotalRecordCount(totCnt);
 		model.addAttribute("paginationInfo", paginationInfo);
+		model.addAttribute("searchVO", searchVO);
 
 		return "egovframework/com/dam/per/EgovComDamPersonalList";
 	}
@@ -147,11 +148,12 @@ public class EgovKnoPersonalController {
 	 * @param KnoPersonalVO
 	 */
 	@RequestMapping(value="/dam/per/EgovComDamPersonal.do")
-	public String selectKnoPersonal(KnoPersonal knoPersonal
+	public String selectKnoPersonal(KnoPersonalVO knoPersonal
 			, ModelMap model
 			) throws Exception {
 		KnoPersonal result = knoPersonalService.selectKnoPersonal(knoPersonal);
 		model.addAttribute("result", result);
+		model.addAttribute("searchVO", knoPersonal);
 		return "egovframework/com/dam/per/EgovComDamPersonalDetail";
 	}
 
@@ -162,12 +164,12 @@ public class EgovKnoPersonalController {
 	 *
 	 * @param KnoNm
 	 */
-	@GetMapping(value="/dam/per/EgovComDamPersonalRegistView.do")
+	@RequestMapping(value="/dam/per/EgovComDamPersonalRegistView.do")
 	public String insertKnoPersonalView(
-			KnoPersonal knoPersonal
+			KnoPersonalVO knoPersonal
 			, ModelMap model
 			) throws Exception {
-		insertKnoPersonalView(model);
+		setInsertKnoPersonalViewModel(knoPersonal, model);
 		return "egovframework/com/dam/per/EgovComDamPersonalRegist";
 	}
 	
@@ -177,7 +179,8 @@ public class EgovKnoPersonalController {
      * @param model
      * @throws Exception
      */
-    private void insertKnoPersonalView(ModelMap model) throws Exception {
+    private void setInsertKnoPersonalViewModel(KnoPersonalVO knoPersonal, ModelMap model) throws Exception {
+    	model.addAttribute("knoPersonal", knoPersonal);
         MapTeamVO mapTeamVO = new MapTeamVO();
         mapTeamVO.setRecordCountPerPage(Integer.MAX_VALUE);
         mapTeamVO.setFirstIndex(0);
@@ -202,7 +205,7 @@ public class EgovKnoPersonalController {
 	@PostMapping(value="/dam/per/EgovComDamPersonalRegist.do")
 	public String insertKnoPersonal(
 			final MultipartHttpServletRequest multiRequest
-			, KnoPersonal knoPersonal
+			, KnoPersonalVO knoPersonal
 			, BindingResult bindingResult
 			, ModelMap model
 			) throws Exception {
@@ -220,7 +223,7 @@ public class EgovKnoPersonalController {
 
 		beanValidator.validate(knoPersonal, bindingResult);
 		if (bindingResult.hasErrors()){
-			insertKnoPersonalView(model);
+			setInsertKnoPersonalViewModel(knoPersonal, model);
 			return sLocationUrl;
 		}
 
@@ -255,10 +258,11 @@ public class EgovKnoPersonalController {
 	 * @param KnoNm
 	 */
 	@PostMapping(value="/dam/per/EgovComDamPersonalModifyView.do")
-	public String updateKnoPersonalView(KnoPersonal knoPersonal
+	public String updateKnoPersonalView(KnoPersonalVO knoPersonal
 			, ModelMap model
 			) throws Exception {
 		updateKnoPersonalViewInit(knoPersonal, model);
+		model.addAttribute("searchVO", knoPersonal);
 		return "egovframework/com/dam/per/EgovComDamPersonalModify";
 	}
 	

--- a/src/main/webapp/WEB-INF/jsp/egovframework/com/dam/per/EgovComDamPersonalDetail.jsp
+++ b/src/main/webapp/WEB-INF/jsp/egovframework/com/dam/per/EgovComDamPersonalDetail.jsp
@@ -43,13 +43,15 @@
 		 * 목록 으로 가기
 		 ******************************************************** */
 		function fnList(){
-			location.href = "<c:url value='/dam/per/EgovComDamPersonalList.do'/>";
+            var varForm         = document.frm;
+            varForm.action      = "<c:url value='/dam/per/EgovComDamPersonalList.do'/>";
+            varForm.submit();
 		}
 		/* ********************************************************
 		 * 수정화면으로  바로가기
 		 ******************************************************** */
 		function fnModify(){
-			var varForm			= document.all["Form"];
+			var varForm			= document.frm;
 			varForm.action      = "<c:url value='/dam/per/EgovComDamPersonalModifyView.do'/>";
 			varForm.knoId.value = "${result.knoId}";
 			varForm.submit();
@@ -59,7 +61,7 @@
 		 ******************************************************** */
 		function fnDelete(){
 			if (confirm("<spring:message code="common.delete.msg" />")) {
-				var varForm			= document.all["Form"];
+				var varForm			= document.frm;
 				varForm.action      = "<c:url value='/dam/per/EgovComDamPersonalRemove.do'/>";
 				varForm.knoId.value = "${result.knoId}";
 				varForm.submit();
@@ -71,87 +73,89 @@
 	
 	<body>
 	
-	<!-- 자바스크립트 경고 태그  -->
-	<noscript class="noScriptTitle"><spring:message code="common.noScriptTitle.msg" /><spring:message code="common.noScriptTitle.msg" /></noscript><!-- 자바스크립트를 지원하지 않는 브라우저에서는 일부 기능을 사용하실 수 없습니다. -->
-	
-	<form name="Form" action="<c:url value='/dam/per/EgovComDamPersonalModify.do'/>" method="post">
-	<input name="knoId" type="hidden">
-	
-	<div class="wTableFrm">
-		<!-- 타이틀 -->
-		<h2><spring:message code="comDamPer.comDamPersonalDetail.pageTop.title"/></h2><!-- 개인지식 상세조회 -->
-	
-		<!-- 등록폼 -->
-		<table class="wTable">
-			<colgroup>
-				<col style="width:16%" />
-				<col style="" />
-			</colgroup>
-			<tr>
-				<th><spring:message code="comDamPer.comDamPersonalDetail.orgnztNm"/> <span class="pilsu">*</span></th><!-- 조직명 -->
-				<td class="left">
-				    ${result.orgnztNm}
-				</td>
-			</tr>
-			<tr>
-				<th><spring:message code="comDamPer.comDamPersonalDetail.knoTypeNm"/> <span class="pilsu">*</span></th><!-- 지식유형명 -->
-				<td class="left">
-				    ${result.knoTypeNm}
-				</td>
-			</tr>
-			<tr>
-				<th><spring:message code="comDamPer.comDamPersonalDetail.knoNm"/> <span class="pilsu">*</span></th><!-- 지식명 -->
-				<td class="left">
-				    ${result.knoNm}
-				</td>
-			</tr>
-			<tr>
-				<th><spring:message code="comDamPer.comDamPersonalDetail.knoCn"/> <span class="pilsu">*</span></th><!-- 지식내용 -->
-				<td class="left">
-				    <textarea name="knoCn" class="textarea" title="<spring:message code="comDamPer.comDamPersonalDetail.knoCn"/>"  cols="300" rows="10" readonly="readonly">${result.knoCn}</textarea><!-- 지식내용 -->
-				</td>
-			</tr>
-			<tr>
-				<th><spring:message code="comDamPer.comDamPersonalDetail.colYmd"/> <span class="pilsu">*</span></th><!-- 수집일자 -->
-				<td class="left">
-				    ${result.colYmd}
-				</td>
-			</tr>
-			<tr>
-				<th><spring:message code="comDamPer.comDamPersonalDetail.othbcAt"/></th><!-- 공개여부 -->
-				<td class="left">
-				    <c:choose>
-				    	<c:when test="${result.othbcAt == 'Y'}">
-				    		<spring:message code="comDamPer.comDamPersonalDetail.public" />
-				    	</c:when>
-				    	<c:otherwise>
-				    		<spring:message code="comDamPer.comDamPersonalDetail.private" />
-				    	</c:otherwise>
-				    </c:choose>
-				</td>
-			</tr>
-			<c:if test="${result.atchFileId != ''}">
-			<tr>
-				<th><spring:message code="comDamPer.comDamPersonalDetail.atchFileId"/></th><!-- 첨부파일 목록 -->
-				<td class="left">
-				    <c:import url="/cmm/fms/selectFileInfs.do" >
-						<c:param name="param_atchFileId" value="${egovc:encrypt(result.atchFileId)}" />
-					</c:import>
-				</td>
-			</tr>			
-			</c:if>
-		</table>
-	
-		<!-- 하단 버튼 -->
-		<div class="btn">
-			<input class="s_submit" type="submit" value='<spring:message code="button.update" />' onclick="fnModify(); return false;" /><!-- 수정 -->
-			<input class="s_submit" type="submit" value='<spring:message code="button.delete" />' onclick="fnDelete(); return false;" /><!-- 삭제 -->
-			<input class="s_submit" type="submit" value='<spring:message code="button.list" />' onclick="fnList(); return false;" /><!-- 목록 -->
-		</div>
-		<div style="clear:both;"></div>
-	</div>
-	
-	</form>
-
+    	<!-- 자바스크립트 경고 태그  -->
+    	<noscript class="noScriptTitle"><spring:message code="common.noScriptTitle.msg" /><spring:message code="common.noScriptTitle.msg" /></noscript><!-- 자바스크립트를 지원하지 않는 브라우저에서는 일부 기능을 사용하실 수 없습니다. -->
+    	
+    	<form id="frm" name="frm" action="<c:url value='/dam/per/EgovComDamPersonalModify.do'/>" method="post">
+        	<input name="knoId" type="hidden">
+            <input type="hidden" id="searchCondition" name="searchCondition" value="${searchVO.searchCondition}" />
+            <input type="hidden" id="searchKeyword" name="searchKeyword" value="${searchVO.searchKeyword}" />
+            <input type="hidden" id="pageIndex" name="pageIndex" value="${searchVO.pageIndex}" />
+        
+        	<div class="wTableFrm">
+        		<!-- 타이틀 -->
+        		<h2><spring:message code="comDamPer.comDamPersonalDetail.pageTop.title"/></h2><!-- 개인지식 상세조회 -->
+        	
+        		<!-- 등록폼 -->
+        		<table class="wTable">
+        			<colgroup>
+        				<col style="width:16%" />
+        				<col style="" />
+        			</colgroup>
+        			<tr>
+        				<th><spring:message code="comDamPer.comDamPersonalDetail.orgnztNm"/> <span class="pilsu">*</span></th><!-- 조직명 -->
+        				<td class="left">
+        				    ${result.orgnztNm}
+        				</td>
+        			</tr>
+        			<tr>
+        				<th><spring:message code="comDamPer.comDamPersonalDetail.knoTypeNm"/> <span class="pilsu">*</span></th><!-- 지식유형명 -->
+        				<td class="left">
+        				    ${result.knoTypeNm}
+        				</td>
+        			</tr>
+        			<tr>
+        				<th><spring:message code="comDamPer.comDamPersonalDetail.knoNm"/> <span class="pilsu">*</span></th><!-- 지식명 -->
+        				<td class="left">
+        				    ${result.knoNm}
+        				</td>
+        			</tr>
+        			<tr>
+        				<th><spring:message code="comDamPer.comDamPersonalDetail.knoCn"/> <span class="pilsu">*</span></th><!-- 지식내용 -->
+        				<td class="left">
+        				    <textarea name="knoCn" class="textarea" title="<spring:message code="comDamPer.comDamPersonalDetail.knoCn"/>"  cols="300" rows="10" readonly="readonly">${result.knoCn}</textarea><!-- 지식내용 -->
+        				</td>
+        			</tr>
+        			<tr>
+        				<th><spring:message code="comDamPer.comDamPersonalDetail.colYmd"/> <span class="pilsu">*</span></th><!-- 수집일자 -->
+        				<td class="left">
+        				    ${result.colYmd}
+        				</td>
+        			</tr>
+        			<tr>
+        				<th><spring:message code="comDamPer.comDamPersonalDetail.othbcAt"/></th><!-- 공개여부 -->
+        				<td class="left">
+        				    <c:choose>
+        				    	<c:when test="${result.othbcAt == 'Y'}">
+        				    		<spring:message code="comDamPer.comDamPersonalDetail.public" />
+        				    	</c:when>
+        				    	<c:otherwise>
+        				    		<spring:message code="comDamPer.comDamPersonalDetail.private" />
+        				    	</c:otherwise>
+        				    </c:choose>
+        				</td>
+        			</tr>
+        			<c:if test="${result.atchFileId != ''}">
+        			<tr>
+        				<th><spring:message code="comDamPer.comDamPersonalDetail.atchFileId"/></th><!-- 첨부파일 목록 -->
+        				<td class="left">
+        				    <c:import url="/cmm/fms/selectFileInfs.do" >
+        						<c:param name="param_atchFileId" value="${egovc:encrypt(result.atchFileId)}" />
+        					</c:import>
+        				</td>
+        			</tr>			
+        			</c:if>
+        		</table>
+        	
+        		<!-- 하단 버튼 -->
+        		<div class="btn">
+        			<input class="s_submit" type="submit" value='<spring:message code="button.update" />' onclick="fnModify(); return false;" /><!-- 수정 -->
+        			<input class="s_submit" type="submit" value='<spring:message code="button.delete" />' onclick="fnDelete(); return false;" /><!-- 삭제 -->
+        			<input class="s_submit" type="submit" value='<spring:message code="button.list" />' onclick="fnList(); return false;" /><!-- 목록 -->
+        		</div>
+        		<div style="clear:both;"></div>
+        	</div>
+    	
+    	</form>
 	</body>
 </html>

--- a/src/main/webapp/WEB-INF/jsp/egovframework/com/dam/per/EgovComDamPersonalList.jsp
+++ b/src/main/webapp/WEB-INF/jsp/egovframework/com/dam/per/EgovComDamPersonalList.jsp
@@ -59,8 +59,17 @@
 		 * 등록 처리 함수 
 		 ******************************************************** */
 		function fnRegist(){
-			location.href = "<c:url value='/dam/per/EgovComDamPersonalRegist.do' />";
+			document.listForm.action = "<c:url value='/dam/per/EgovComDamPersonalRegistView.do' />";
+            document.listForm.submit();
 		}
+        /* ********************************************************
+         * 상세화면 이동 함수 
+         ******************************************************** */
+        function fnDetail(knoId) {
+            document.listForm.action = "<c:url value='/dam/per/EgovComDamPersonal.do'/>";
+            document.listForm.knoId.value = knoId;
+            document.listForm.submit();
+        }
 		-->
 		</script>
 	</head>
@@ -86,7 +95,7 @@
 						<input class="s_input2 vat" name="searchKeyword" type="text" value="${searchVO.searchKeyword}" maxlength="35" size="35" onkeypress="press();" title="<spring:message code="title.searchCondition"/>" /><!-- 검색어 입력 -->
 						
 						<input class="s_btn" type="submit" value='<spring:message code="button.inquire" />' title='<spring:message code="button.inquire" />' onclick="fnSearch(); return false;" /><!-- 조회 -->
-						<span class="btn_b"><a href="<c:url value='/dam/per/EgovComDamPersonalRegistView.do'/>" onclick="" title='<spring:message code="button.create" />'><spring:message code="button.create" /></a></span><!-- 등록 -->
+						<span class="btn_b"><a href="#" onclick="fnRegist(); return false;" title='<spring:message code="button.create" />'><spring:message code="button.create" /></a></span><!-- 등록 -->
 					</li>
 				</ul>
 			</div>
@@ -120,7 +129,7 @@
 							<td>${resultInfo.orgnztNm}</td>
 							<td>${resultInfo.knoTypeNm}</td>								
 							<td>
-								<a href="<c:url value='/dam/per/EgovComDamPersonal.do'/>?pageIndex=${searchVO.pageIndex}&amp;knoId=${resultInfo.knoId}"><c:out value="${resultInfo.knoNm}"/></a>								
+								<a href="#" onclick="fnDetail('${resultInfo.knoId}'); return false;"><c:out value="${resultInfo.knoNm}"/></a>
 							</td>
 							<td>${resultInfo.userNm}</td>
 							<td>${resultInfo.colYmd}</td>
@@ -149,7 +158,7 @@
 				</ul>
 			</div>
 
-			<input type="hidden" name="knoId">	
+			<input type="hidden" id="knoId" name="knoId">
 			<input name="pageIndex" type="hidden" value="<c:out value='${searchVO.pageIndex}'/>">
 			</form>
 

--- a/src/main/webapp/WEB-INF/jsp/egovframework/com/dam/per/EgovComDamPersonalModify.jsp
+++ b/src/main/webapp/WEB-INF/jsp/egovframework/com/dam/per/EgovComDamPersonalModify.jsp
@@ -85,8 +85,11 @@ function fn_egov_initl_knoPersonal(){
 /* ********************************************************
  * 목록 으로 가기
  ******************************************************** */
-function fn_egov_list_KnoPersonal(){
-	location.href = "<c:url value='/dam/per/EgovComDamPersonalList.do'/>";
+function fnList(){
+    var varForm         = document.knoPersonal;
+    varForm.action      = "<c:url value='/dam/per/EgovComDamPersonalList.do'/>";
+    varForm.submit();
+
 }
 /* ********************************************************
  * 저장처리화면
@@ -113,112 +116,115 @@ function fn_egov_modify_KnoPersonal(){
 <body onLoad="fn_egov_initl_knoPersonal();">
 
 
-<!-- 파일첨부를 위한 폼명 및 Enctype 설정 -->
-<form:form modelAttribute="knoPersonal" name="knoPersonal" action="<c:url value='/dam/per/EgovComDamPersonalModifyView.do'/>" method="post" enctype="multipart/form-data">
+    <!-- 파일첨부를 위한 폼명 및 Enctype 설정 -->
+    <form:form modelAttribute="knoPersonal" name="knoPersonal" action="<c:url value='/dam/per/EgovComDamPersonalModifyView.do'/>" method="post" enctype="multipart/form-data">
+    
+        <input name="cmd" type="hidden" value="Modify">
+        <input name="knoId" type="hidden" value="<c:out value='${knoPersonal.knoId}'/>">
+        <form:hidden path="orgnztId"/>
+        <form:hidden path="knoTypeCd"/>
+        <form:hidden path="orgnztNm"/>
+        <form:hidden path="knoTypeNm"/>
+        <input type="hidden" id="searchCondition" name="searchCondition" value="${searchVO.searchCondition}" />
+        <input type="hidden" id="searchKeyword" name="searchKeyword" value="${searchVO.searchKeyword}" />
+        <input type="hidden" id="pageIndex" name="pageIndex" value="${searchVO.pageIndex}" />
 
-<input name="cmd" type="hidden" value="Modify">
-<input name="knoId" type="hidden" value="<c:out value='${knoPersonal.knoId}'/>">
-<form:hidden path="orgnztId"/>
-<form:hidden path="knoTypeCd"/>
-<form:hidden path="orgnztNm"/>
-<form:hidden path="knoTypeNm"/>
-
-<div class="wTableFrm">
-	<!-- 타이틀 -->
-	<h2><spring:message code="comDamPer.comDamPersonalModify.pageTop.title"/></h2><!-- 개인지식 수정 -->
-
-	<!-- 등록폼 -->
-	<table class="wTable">
-		<colgroup>
-			<col style="width:16%" />
-			<col style="" />
-		</colgroup>
-		<tr>
-			<th><spring:message code="comDamPer.comDamPersonalModify.orgnztNm"/> <span class="pilsu">*</span></th><!-- 조직명 -->
-			<td class="left">
-			    ${knoPersonal.orgnztNm}
-			</td>
-		</tr>
-		<tr>
-			<th><spring:message code="comDamPer.comDamPersonalModify.knoTypeNm"/> <span class="pilsu">*</span></th><!-- 지식유형명 -->
-			<td class="left">
-			    ${knoPersonal.knoTypeNm}
-			</td>
-		</tr>
-		<tr>
-			<th><spring:message code="comDamPer.comDamPersonalModify.knoNm"/> <span class="pilsu">*</span></th><!-- 지식명 -->
-			<td class="left">
-			    <form:input  path="knoNm" title="<spring:message code='comDamPer.comDamPersonalModify.knoNm'/>" size="60" maxlength="60"/>
-		      	<form:errors path="knoNm"/>
-			</td>
-		</tr>
-		<tr>
-			<th><spring:message code="comDamPer.comDamPersonalModify.knoCn"/> <span class="pilsu">*</span></th><!-- 지식내용 -->
-			<td class="left">
-			    <textarea name="knoCn" class="textarea" title="<spring:message code="comDamPer.comDamPersonalModify.knoCn"/>" cols="300" rows="10">${knoPersonal.knoCn}</textarea><!-- 지식내용 -->
-			</td>
-		</tr>
-		<tr>
-			<th><spring:message code="comDamPer.comDamPersonalModify.colYmd"/> <span class="pilsu">*</span></th><!-- 수집일자 -->
-			<td class="left">
-			    <input type="hidden" name="cal_url" value="<c:url value='/sym/cal/EgovNormalCalPopup.do'/>" />
-		  		<input id="colYmd" name="colYmd" type="text" title="<spring:message code="comDamPer.comDamPersonalModify.colYmdCalendar"/>" value="${knoPersonal.colYmd}"  readonly="readonly" style="width:70px" /><!-- 수집일달력 -->
-	      		
-	      		<div><form:errors path="colYmd"/></div>
-			</td>
-		</tr>
-		<tr>
-			<th><spring:message code="comDamPer.comDamPersonalModify.othbcAt"/></th><!-- 공개여부 -->
-			<td class="left">
-			    <spring:message code="comDamPer.comDamPersonalModify.public" /> : <input type="radio" name="othbcAt" class="radio2" value="Y"
-		     	<c:if test="${knoPersonal.othbcAt == 'Y'}"> checked="checked"</c:if> />&nbsp;
-		     	<spring:message code="comDamPer.comDamPersonalModify.private" /> : <input type="radio" name="othbcAt" class="radio2" value="N"
-		     	<c:if test="${knoPersonal.othbcAt == 'N'}"> checked="checked"</c:if> />
-		     	<br/><form:errors path="othbcAt" />
-			</td>
-		</tr>
-		<!-- 첨부파일 테이블 레이아웃 설정 Start -->
-		<c:if test="${knoPersonal.atchFileId ne ''}">
-			<tr>
-				<th><spring:message code="comDamPer.comDamPersonalModify.atchFileId"/></th><!-- 첨부파일목록 -->
-				<td>
-					<c:import url="/cmm/fms/selectFileInfsForUpdate.do" charEncoding="utf-8">
-						<c:param name="param_atchFileId" value="${egovc:encrypt(knoPersonal.atchFileId)}" />
-					</c:import>
-				</td>
-			</tr>
-		</c:if>
-		<!-- 첨부파일 테이블 레이아웃 End -->
-		<tr>
-			<th><spring:message code="comDamPer.comDamPersonalModify.fileUpload"/></th><!-- 파일첨부 -->
-			<td class="left">
-			    <input name="file_1" id="egovComFileUploader" type="file" multiple title="<spring:message code="comDamPer.comDamPersonalModify.fileUpload"/>"/><!-- 첨부파일명 입력 -->
-			    <div id="egovComFileList"></div>
-			</td>
-		</tr>
-	</table>
-
-	<!-- 하단 버튼 -->
-	<div class="btn">
-		<input class="s_submit" type="submit" value="<spring:message code="button.save" />" onclick="fn_egov_modify_KnoPersonal(); return false;" /><!-- 저장 -->
-		<input class="s_submit" type="submit" value='<spring:message code="button.list" />' onclick="fn_egov_list_KnoPersonal(); return false;" /><!-- 목록 -->
-	</div>
-	<div style="clear:both;"></div>
-	</div>
-
-	<c:if test="${knoPersonal.atchFileId eq '' or knoPersonal.atchFileId eq null}">
- 	<input type="hidden" name="fileListCnt" value="0" />
- 	<input name="atchFileAt" type="hidden" value="N">
- 	</c:if>
-
- 	<c:if test="${knoPersonal.atchFileId ne '' and knoPersonal.atchFileId ne null}">
- 	<input name="atchFileAt" type="hidden" value="Y">
- 	</c:if>
-
-<!-- 첨부파일 개수 설정을 위한 Hidden 설정 -->
-<input type="hidden" name="posblAtchFileNumber" id="posblAtchFileNumber" value="3" />
-<input type="hidden" name="returnUrl" value="<c:url value='/dam/per/EgovComDamPersonalModifyView.do'/>" >
-</form:form>
-	
+        <div class="wTableFrm">
+        	<!-- 타이틀 -->
+        	<h2><spring:message code="comDamPer.comDamPersonalModify.pageTop.title"/></h2><!-- 개인지식 수정 -->
+        
+        	<!-- 등록폼 -->
+        	<table class="wTable">
+        		<colgroup>
+        			<col style="width:16%" />
+        			<col style="" />
+        		</colgroup>
+        		<tr>
+        			<th><spring:message code="comDamPer.comDamPersonalModify.orgnztNm"/> <span class="pilsu">*</span></th><!-- 조직명 -->
+        			<td class="left">
+        			    ${knoPersonal.orgnztNm}
+        			</td>
+        		</tr>
+        		<tr>
+        			<th><spring:message code="comDamPer.comDamPersonalModify.knoTypeNm"/> <span class="pilsu">*</span></th><!-- 지식유형명 -->
+        			<td class="left">
+        			    ${knoPersonal.knoTypeNm}
+        			</td>
+        		</tr>
+        		<tr>
+        			<th><spring:message code="comDamPer.comDamPersonalModify.knoNm"/> <span class="pilsu">*</span></th><!-- 지식명 -->
+        			<td class="left">
+        			    <form:input  path="knoNm" title="<spring:message code='comDamPer.comDamPersonalModify.knoNm'/>" size="60" maxlength="60"/>
+        		      	<form:errors path="knoNm"/>
+        			</td>
+        		</tr>
+        		<tr>
+        			<th><spring:message code="comDamPer.comDamPersonalModify.knoCn"/> <span class="pilsu">*</span></th><!-- 지식내용 -->
+        			<td class="left">
+        			    <textarea name="knoCn" class="textarea" title="<spring:message code="comDamPer.comDamPersonalModify.knoCn"/>" cols="300" rows="10">${knoPersonal.knoCn}</textarea><!-- 지식내용 -->
+        			</td>
+        		</tr>
+        		<tr>
+        			<th><spring:message code="comDamPer.comDamPersonalModify.colYmd"/> <span class="pilsu">*</span></th><!-- 수집일자 -->
+        			<td class="left">
+        			    <input type="hidden" name="cal_url" value="<c:url value='/sym/cal/EgovNormalCalPopup.do'/>" />
+        		  		<input id="colYmd" name="colYmd" type="text" title="<spring:message code="comDamPer.comDamPersonalModify.colYmdCalendar"/>" value="${knoPersonal.colYmd}"  readonly="readonly" style="width:70px" /><!-- 수집일달력 -->
+        	      		
+        	      		<div><form:errors path="colYmd"/></div>
+        			</td>
+        		</tr>
+        		<tr>
+        			<th><spring:message code="comDamPer.comDamPersonalModify.othbcAt"/></th><!-- 공개여부 -->
+        			<td class="left">
+        			    <spring:message code="comDamPer.comDamPersonalModify.public" /> : <input type="radio" name="othbcAt" class="radio2" value="Y"
+        		     	<c:if test="${knoPersonal.othbcAt == 'Y'}"> checked="checked"</c:if> />&nbsp;
+        		     	<spring:message code="comDamPer.comDamPersonalModify.private" /> : <input type="radio" name="othbcAt" class="radio2" value="N"
+        		     	<c:if test="${knoPersonal.othbcAt == 'N'}"> checked="checked"</c:if> />
+        		     	<br/><form:errors path="othbcAt" />
+        			</td>
+        		</tr>
+        		<!-- 첨부파일 테이블 레이아웃 설정 Start -->
+        		<c:if test="${knoPersonal.atchFileId ne ''}">
+        			<tr>
+        				<th><spring:message code="comDamPer.comDamPersonalModify.atchFileId"/></th><!-- 첨부파일목록 -->
+        				<td>
+        					<c:import url="/cmm/fms/selectFileInfsForUpdate.do" charEncoding="utf-8">
+        						<c:param name="param_atchFileId" value="${egovc:encrypt(knoPersonal.atchFileId)}" />
+        					</c:import>
+        				</td>
+        			</tr>
+        		</c:if>
+        		<!-- 첨부파일 테이블 레이아웃 End -->
+        		<tr>
+        			<th><spring:message code="comDamPer.comDamPersonalModify.fileUpload"/></th><!-- 파일첨부 -->
+        			<td class="left">
+        			    <input name="file_1" id="egovComFileUploader" type="file" multiple title="<spring:message code="comDamPer.comDamPersonalModify.fileUpload"/>"/><!-- 첨부파일명 입력 -->
+        			    <div id="egovComFileList"></div>
+        			</td>
+        		</tr>
+        	</table>
+        
+        	<!-- 하단 버튼 -->
+        	<div class="btn">
+        		<input class="s_submit" type="submit" value="<spring:message code="button.save" />" onclick="fn_egov_modify_KnoPersonal(); return false;" /><!-- 저장 -->
+        		<input class="s_submit" type="submit" value='<spring:message code="button.list" />' onclick="fnList(); return false;" /><!-- 목록 -->
+        	</div>
+        	<div style="clear:both;"></div>
+        	</div>
+        
+        	<c:if test="${knoPersonal.atchFileId eq '' or knoPersonal.atchFileId eq null}">
+         	<input type="hidden" name="fileListCnt" value="0" />
+         	<input name="atchFileAt" type="hidden" value="N">
+         	</c:if>
+        
+         	<c:if test="${knoPersonal.atchFileId ne '' and knoPersonal.atchFileId ne null}">
+         	<input name="atchFileAt" type="hidden" value="Y">
+         	</c:if>
+        
+        <!-- 첨부파일 개수 설정을 위한 Hidden 설정 -->
+        <input type="hidden" name="posblAtchFileNumber" id="posblAtchFileNumber" value="3" />
+        <input type="hidden" name="returnUrl" value="<c:url value='/dam/per/EgovComDamPersonalModifyView.do'/>" >
+    </form:form>
+    	
 </body>
 </html>

--- a/src/main/webapp/WEB-INF/jsp/egovframework/com/dam/per/EgovComDamPersonalRegist.jsp
+++ b/src/main/webapp/WEB-INF/jsp/egovframework/com/dam/per/EgovComDamPersonalRegist.jsp
@@ -92,8 +92,10 @@ function fn_egov_initl_knoPersonal(){
 /* ********************************************************
  * 목록 으로 가기
  ******************************************************** */
-function fn_egov_list_KnoPersonal(){
-	location.href = "<c:url value='/dam/per/EgovComDamPersonalList.do'/>";
+function fnList(){
+    var varForm         = document.knoPersonal;
+    varForm.action      = "<c:url value='/dam/per/EgovComDamPersonalList.do'/>";
+    varForm.submit();
 }
 /* ********************************************************
  * 저장처리화면
@@ -122,92 +124,95 @@ function fn_egov_get_CodeId(form){
 
 <body onLoad="fn_egov_initl_knoPersonal();">
 
-<form:form modelAttribute="knoPersonal" name="knoPersonal" method="post" enctype="multipart/form-data">
-
-<div class="wTableFrm">
-	<!-- 타이틀 -->
-<h2><spring:message code="comDamPer.comDamPersonalRegist.pageTop.title"/></h2><!-- 개인지식 등록 -->
-
-<!-- 등록폼 -->
-<table class="wTable">
-	<colgroup>
-		<col style="width:16%" />
-		<col style="" />
-	</colgroup>
-	<tr>
-		<th><spring:message code="comDamPer.comDamPersonalRegist.orgnztNm"/> <span class="pilsu">*</span></th><!-- 조직명 -->
-		<td class="left">
-		    <select name="orgnztId" class="select" >
-			<option value=""><spring:message code="input.cSelect"/></option><!-- 선택 -->
-			<c:forEach var="item" items="${mapTeamList}" varStatus="status">
-			<option value="<c:out value="${item.orgnztId}"/>"<c:if test="${item.orgnztId == knoPersonal.orgnztId}"> selected="selected"</c:if>><c:out value="${item.orgnztNm}"/></option>
-			</c:forEach>
-			</select>
-		</td>
-	</tr>
-	<tr>
-		<th><spring:message code="comDamPer.comDamPersonalRegist.knoTypeNm"/> <span class="pilsu">*</span></th><!-- 지식유형명 -->
-		<td class="left">
-		    <select name="knoTypeCd" class="select">
-			<option value=""><spring:message code="input.cSelect"/></option><!-- 선택 -->
-			<c:forEach var="item" items="${mapMaterialList}" varStatus="status">
-			<option value="<c:out value="${item.knoTypeCd}"/>"<c:if test="${item.knoTypeCd == knoPersonal.knoTypeCd}"> selected="selected"</c:if>><c:out value="${item.knoTypeNm}"/></option>
-			</c:forEach>
-			</select>
-		</td>
-	</tr>
-	<tr>
-		<th><spring:message code="comDamPer.comDamPersonalRegist.knoNm"/> <span class="pilsu">*</span></th><!-- 지식명 -->
-		<td class="left">
-		    <form:input  path="knoNm" title="<spring:message code='comDamPer.comDamPersonalRegist.knoNm'/>" size="60" maxlength="60"/>
-      		<form:errors path="knoNm"/>
-		</td>
-	</tr>
-	<tr>
-		<th><spring:message code="comDamPer.comDamPersonalRegist.knoCn"/> <span class="pilsu">*</span></th><!-- 지식내용 -->
-		<td class="left">
-		    <form:textarea  path="knoCn" title="<spring:message code='comDamPer.comDamPersonalRegist.knoCn'/>" cols="300" rows="10" cssClass="txaClass"/><!-- 지식내용 -->
-      		<form:errors path="knoCn"/>
-		</td>
-	</tr>
-	<tr>
-		<th><spring:message code="comDamPer.comDamPersonalRegist.colYmd"/> <span class="pilsu">*</span></th><!-- 수집일자 -->
-		<td class="left">
-		    <input type="hidden" name="cal_url" value="<c:url value='/sym/cal/EgovNormalCalPopup.do'/>" />
-   			<input id="colYmd" name="colYmd" type="hidden" value=""/>
-			<input id="vcolYmd" name="vcolYmd" type="text" title="<spring:message code="comDamPer.comDamPersonalRegist.colYmd"/>" value="" maxlength="10" readonly="readonly" style="width:70px"/><!-- 수집일자 -->
-		</td>
-	</tr>
-	<tr>
-		<th><spring:message code="comDamPer.comDamPersonalRegist.othbcAt"/></th><!-- 공개여부 -->
-		<td class="left">
-		    <spring:message code="comDamPer.comDamPersonalRegist.public" /> : <input type="radio" name="othbcAt" class="radio2" value="Y">&nbsp;
-	     	<spring:message code="comDamPer.comDamPersonalRegist.private" /> : <input type="radio" name="othbcAt" class="radio2" value="N" checked="checked"/><br/>
-	     	<form:errors path="othbcAt" />
-		</td>
-	</tr>
-	<tr>
-		<th><spring:message code="comDamPer.comDamPersonalRegist.fileUpload"/></th><!-- 파일첨부 -->
-		<td class="left">
-		    <input name="file_1" id="egovComFileUploader" type="file" multiple title="<spring:message code="comDamPer.comDamPersonalRegist.fileUpload"/>" multiple/><!-- 첨부파일명 입력 -->
-		    <div id="egovComFileList"></div>
-		</td>
-	</tr>
-</table>
-
-<!-- 하단 버튼 -->
-<div class="btn">
-	<input class="s_submit" type="submit" value="<spring:message code="button.save" />" onclick="fn_egov_regist_KnoPersonal(document.knoPersonal); return false;" /><!-- 저장 -->
-	<input class="s_submit" type="submit" value='<spring:message code="button.list" />' onclick="fn_egov_list_KnoPersonal(); return false;" /><!-- 목록 -->
-</div>
-<div style="clear:both;"></div>
-</div>
-
-<input type="hidden" name="posblAtchFileNumber" id="posblAtchFileNumber" value="3" />
-<!-- <input name="cmd" type="hidden" value="<c:out value='save'/>"> -->
-<input name="cmd" type="hidden" value="<c:out value='Regist'/>">
-
-</form:form>
+    <form:form modelAttribute="knoPersonal" name="knoPersonal" method="post" enctype="multipart/form-data">
+        <input type="hidden" id="searchCondition" name="searchCondition" value="${knoPersonal.searchCondition}" />
+        <input type="hidden" id="searchKeyword" name="searchKeyword" value="${knoPersonal.searchKeyword}" />
+        <input type="hidden" id="pageIndex" name="pageIndex" value="${knoPersonal.pageIndex}" />
+    
+        <div class="wTableFrm">
+        	<!-- 타이틀 -->
+        <h2><spring:message code="comDamPer.comDamPersonalRegist.pageTop.title"/></h2><!-- 개인지식 등록 -->
+        
+        <!-- 등록폼 -->
+        <table class="wTable">
+        	<colgroup>
+        		<col style="width:16%" />
+        		<col style="" />
+        	</colgroup>
+        	<tr>
+        		<th><spring:message code="comDamPer.comDamPersonalRegist.orgnztNm"/> <span class="pilsu">*</span></th><!-- 조직명 -->
+        		<td class="left">
+        		    <select name="orgnztId" class="select" >
+        			<option value=""><spring:message code="input.cSelect"/></option><!-- 선택 -->
+        			<c:forEach var="item" items="${mapTeamList}" varStatus="status">
+        			<option value="<c:out value="${item.orgnztId}"/>"<c:if test="${item.orgnztId == knoPersonal.orgnztId}"> selected="selected"</c:if>><c:out value="${item.orgnztNm}"/></option>
+        			</c:forEach>
+        			</select>
+        		</td>
+        	</tr>
+        	<tr>
+        		<th><spring:message code="comDamPer.comDamPersonalRegist.knoTypeNm"/> <span class="pilsu">*</span></th><!-- 지식유형명 -->
+        		<td class="left">
+        		    <select name="knoTypeCd" class="select">
+        			<option value=""><spring:message code="input.cSelect"/></option><!-- 선택 -->
+        			<c:forEach var="item" items="${mapMaterialList}" varStatus="status">
+        			<option value="<c:out value="${item.knoTypeCd}"/>"<c:if test="${item.knoTypeCd == knoPersonal.knoTypeCd}"> selected="selected"</c:if>><c:out value="${item.knoTypeNm}"/></option>
+        			</c:forEach>
+        			</select>
+        		</td>
+        	</tr>
+        	<tr>
+        		<th><spring:message code="comDamPer.comDamPersonalRegist.knoNm"/> <span class="pilsu">*</span></th><!-- 지식명 -->
+        		<td class="left">
+        		    <form:input  path="knoNm" title="<spring:message code='comDamPer.comDamPersonalRegist.knoNm'/>" size="60" maxlength="60"/>
+              		<form:errors path="knoNm"/>
+        		</td>
+        	</tr>
+        	<tr>
+        		<th><spring:message code="comDamPer.comDamPersonalRegist.knoCn"/> <span class="pilsu">*</span></th><!-- 지식내용 -->
+        		<td class="left">
+        		    <form:textarea  path="knoCn" title="<spring:message code='comDamPer.comDamPersonalRegist.knoCn'/>" cols="300" rows="10" cssClass="txaClass"/><!-- 지식내용 -->
+              		<form:errors path="knoCn"/>
+        		</td>
+        	</tr>
+        	<tr>
+        		<th><spring:message code="comDamPer.comDamPersonalRegist.colYmd"/> <span class="pilsu">*</span></th><!-- 수집일자 -->
+        		<td class="left">
+        		    <input type="hidden" name="cal_url" value="<c:url value='/sym/cal/EgovNormalCalPopup.do'/>" />
+           			<input id="colYmd" name="colYmd" type="hidden" value=""/>
+        			<input id="vcolYmd" name="vcolYmd" type="text" title="<spring:message code="comDamPer.comDamPersonalRegist.colYmd"/>" value="" maxlength="10" readonly="readonly" style="width:70px"/><!-- 수집일자 -->
+        		</td>
+        	</tr>
+        	<tr>
+        		<th><spring:message code="comDamPer.comDamPersonalRegist.othbcAt"/></th><!-- 공개여부 -->
+        		<td class="left">
+        		    <spring:message code="comDamPer.comDamPersonalRegist.public" /> : <input type="radio" name="othbcAt" class="radio2" value="Y">&nbsp;
+        	     	<spring:message code="comDamPer.comDamPersonalRegist.private" /> : <input type="radio" name="othbcAt" class="radio2" value="N" checked="checked"/><br/>
+        	     	<form:errors path="othbcAt" />
+        		</td>
+        	</tr>
+        	<tr>
+        		<th><spring:message code="comDamPer.comDamPersonalRegist.fileUpload"/></th><!-- 파일첨부 -->
+        		<td class="left">
+        		    <input name="file_1" id="egovComFileUploader" type="file" multiple title="<spring:message code="comDamPer.comDamPersonalRegist.fileUpload"/>" multiple/><!-- 첨부파일명 입력 -->
+        		    <div id="egovComFileList"></div>
+        		</td>
+        	</tr>
+        </table>
+        
+        <!-- 하단 버튼 -->
+        <div class="btn">
+        	<input class="s_submit" type="submit" value="<spring:message code="button.save" />" onclick="fn_egov_regist_KnoPersonal(document.knoPersonal); return false;" /><!-- 저장 -->
+        	<input class="s_submit" type="submit" value='<spring:message code="button.list" />' onclick="fnList(); return false;" /><!-- 목록 -->
+        </div>
+        <div style="clear:both;"></div>
+        </div>
+        
+        <input type="hidden" name="posblAtchFileNumber" id="posblAtchFileNumber" value="3" />
+        <!-- <input name="cmd" type="hidden" value="<c:out value='save'/>"> -->
+        <input name="cmd" type="hidden" value="<c:out value='Regist'/>">
+    
+    </form:form>
 
 </body>
 </html>


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [ ] 버그수정 Bug fixes
- [X] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

- `EgovKnoPersonalController.java`
  - 검색 조건을 이동한 페이지에서 받을 수 있도록 parameter type을 KnoPersonalVO 로 변경
  - model에 검색 조건 추가
  - 등록화면에서 검색 키워드 값을 받을 수 있도록 `@RequestMapping`으로 Annotation 변경
- `EgovComDamPersonalDetail.jsp`
  - 목록 이동 함수 수정
  - form 정보 수정에 따른 다른 함수 내 form 코드 수정
- `EgovComDamPersonalList.jsp`
  - 상세 화면 이동 함수 추가
    - 기존 a 태그 단순 링크를 함수 호출로 변경
  - 등록 화면 이동 함수 추가
- `EgovComDamPersonalModify.jsp`
  - 목록 이동 함수 수정
- `EgovComDamPersonalRegist.jsp`
  - 목록 이동 함수 수정


## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [X] Chrome
- [X] Firefox
- [X] Edge
- [X] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

### 수정 전


https://github.com/user-attachments/assets/09899350-bed7-40b4-9c6a-73c1ed35f581



### 수정 후


https://github.com/user-attachments/assets/e6d6db76-100c-4429-a06f-f3633b035878


