### PR TITLE
[기능개선] 100. 부서권한관리 > readonly 속성의 inputbox에서 사용하지 않는 이벤트 속성 제거

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/egovframework/com/sec/drm/EgovDeptAuthorManage.jsp
+++ b/src/main/webapp/WEB-INF/jsp/egovframework/com/sec/drm/EgovDeptAuthorManage.jsp
@@ -198,14 +198,6 @@ function fncSelectDeptAuthorPop() {
     window.open(url,"<spring:message code="comCopSecDrm.list.searchDept" />",'width=500,height=485,scrollbars=no,resizable=no,status=no,center:yes'); //부서검색
 
 }
-
-function press() {
-
-    if (event.keyCode==13) {
-    	fncSelectDeptAuthorList('1');
-    }
-}
-
 </script>
 <script type="text/javascript">
     $(document).ready(function () {
@@ -243,8 +235,8 @@ function press() {
 			<li><div style="line-height:4px;">&nbsp;</div><div><spring:message code="comCopSecDrm.searchCondition.searchKeywordText" /> : </div></li><!-- 부서권한관리 -->
 			<!-- 검색키워드 및 조회버튼 -->
 			<li>
-				<input name="deptCode" type="text" value="<c:out value='${deptAuthorVO.deptCode}' />" size="22" title="<spring:message code="comCopSecDrm.list.deptCd" />" onkeypress="press();" readonly="readonly" /><!-- 부서코드 -->
-				<input name="deptNm" type="text" value="<c:out value='${deptAuthorVO.deptNm}'/>" size="15" title="<spring:message code="comCopSecDrm.list.deptNm" />" onkeypress="press();" readonly="readonly" /><!-- 부서명 -->
+				<input name="deptCode" type="text" value="<c:out value='${deptAuthorVO.deptCode}' />" size="22" title="<spring:message code="comCopSecDrm.list.deptCd" />" readonly="readonly" /><!-- 부서코드 -->
+				<input name="deptNm" type="text" value="<c:out value='${deptAuthorVO.deptNm}'/>" size="15" title="<spring:message code="comCopSecDrm.list.deptNm" />" readonly="readonly" /><!-- 부서명 -->
 				<input id="deptSelectPopup" type="button" class="s_btn" value="<spring:message code="comCopSecDrm.btn.deptSelectPopup" />" title="<spring:message code="comCopSecDrm.btn.deptSelectPopup" /> <spring:message code="input.button" />" /><!-- 부서조회팝업 -->
 				<input type="submit" class="s_btn" value="<spring:message code="button.inquire" />" title="<spring:message code="button.inquire" /> <spring:message code="input.button" />" /><!-- 조회 -->
 				<input type="button" class="s_btn" onClick="fncDeptAuthorDeleteList();return false;" value="<spring:message code="button.delete" />" title="<spring:message code="button.delete" /> <spring:message code="input.button" />" /><!-- 삭제 -->


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [ ] 버그수정 Bug fixes
- [X] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

### 수정된 파일
- EgovDeptAuthorManage.jsp

### 수정 내용
- 부서권한관리 페이지는 팝업에서 값을 선택하여 이용하는 방식으로 input box에 readonly 속성이 부여되어있습니다.
- 사용자 입력이 불가함에도 onkeypress 이벤트가 input box에 부여되어있어 이를 제거하였습니다.
- 해당 이벤트에서 호출하는 press 함수도 함께 제거하였습니다.



## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [X] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

![image](https://github.com/user-attachments/assets/a334ad5e-b2a5-49a4-93ff-29fd35635c77)
