### PR TITLE
[기능개선] 140. 접속통계 > 개인별 통계의 데이터가 없는 경우 안내 메시지 추가

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/egovframework/com/sts/cst/EgovConectStats.jsp
+++ b/src/main/webapp/WEB-INF/jsp/egovframework/com/sts/cst/EgovConectStats.jsp
@@ -277,42 +277,49 @@ function getNextWeek(v,t){
 
 	<!-- 개인별 결과 -->
 	<c:if test='${statsInfo.statsKind == "PRSONAL" }'>
-	<h3><spring:message code="comStsCst.conectStats.subTitle1" /></h3> <!-- 그래프 (단위, 횟수) -->
-	<table class="e001 mb10">
-		<colgroup>
-			<col style="width:14%" />
-			<col style="" />
-		</colgroup>
-		        <c:forEach items="${conectStats}" var="resultInfo" varStatus="status">
-			      <tr>
-			        <td width="100" height="10" class="lt_text3" nowrap>${resultInfo.statsDate}</td>
-			        <td width="560" height="10">
-					  <img src="<c:url value='/images/egovframework/com/cmm/left_bg.gif' />" width="<c:out value='${resultInfo.statsCo * statsInfo.maxUnit}' />" height="10" align="left" alt="">&nbsp;&nbsp;${resultInfo.statsCo}&nbsp;<spring:message code="comStsCst.conectStats.results.unit"/> <!-- 회 -->
+		<h3><spring:message code="comStsCst.conectStats.subTitle1" /></h3> <!-- 그래프 (단위, 횟수) -->
+		<table class="e001 mb10">
+			<colgroup>
+				<col style="width:14%" />
+				<col style="" />
+			</colgroup>
+			<c:forEach items="${conectStats}" var="resultInfo" varStatus="status">
+				<tr>
+					<td width="100" height="10" class="lt_text3" nowrap>${resultInfo.statsDate}</td>
+					<td width="560" height="10">
+						<img src="<c:url value='/images/egovframework/com/cmm/left_bg.gif' />" width="<c:out value='${resultInfo.statsCo * statsInfo.maxUnit}' />" height="10" align="left" alt="">&nbsp;&nbsp;${resultInfo.statsCo}&nbsp;<spring:message code="comStsCst.conectStats.results.unit"/> <!-- 회 -->
 					</td>
-			      </tr>
-			    </c:forEach>
-	    <c:if test="${fn:length(userStatsList) == 0}">
-	    <tr><td></td></tr>
-	    </c:if>
-	</table>
-
-	<h3><spring:message code="comStsCst.conectStats.subTitle2" /></h3> <!-- 텍스트 (단위, 횟수) -->
-	<table class="e001">
-		<colgroup>
-			<col style="width:14%" />
-			<col style="" />
-		</colgroup>
-		        <c:forEach items="${conectStats}" var="resultInfo" varStatus="status">
-		        <tr>
-		          <td>${resultInfo.statsDate} &nbsp;&nbsp;&nbsp;${resultInfo.statsCo}&nbsp;<spring:message code="comStsCst.conectStats.results.unit"/></td> <!-- 회 -->
-		        </tr>
-		        </c:forEach>
-		        <c:if test="${fn:length(userStatsList) == 0}">
-			    <tr><td></td></tr>
-			    </c:if>
-	</table>
+				</tr>
+			</c:forEach>
+			<c:if test="${fn:length(userStatsList) == 0}">
+				<tr>
+					<td>
+						<spring:message code="ussIonLsi.loginScrinImageList.failInquire"/>
+					</td>
+				</tr>
+			</c:if>
+		</table>
+	
+		<h3><spring:message code="comStsCst.conectStats.subTitle2" /></h3> <!-- 텍스트 (단위, 횟수) -->
+		<table class="e001">
+			<colgroup>
+				<col style="width:14%" />
+				<col style="" />
+			</colgroup>
+			<c:forEach items="${conectStats}" var="resultInfo" varStatus="status">
+				<tr>
+					<td>${resultInfo.statsDate} &nbsp;&nbsp;&nbsp;${resultInfo.statsCo}&nbsp;<spring:message code="comStsCst.conectStats.results.unit"/></td> <!-- 회 -->
+				</tr>
+			</c:forEach>
+			<c:if test="${fn:length(userStatsList) == 0}">
+				<tr>
+					<td>
+						<spring:message code="ussIonLsi.loginScrinImageList.failInquire"/>
+					</td>
+				</tr>
+			</c:if>
+		</table>
 	</c:if>
-
 	</form>
 	
 </div>


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [ ] 버그수정 Bug fixes
- [X] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

### 수정된 파일
- EgovConectStats.jsp

### 수정 내용
- 개인별 통계 데이터가 없는 경우 결과가 흰 화면으로만 보여 사용자가 조회 결과를 인지할 수 없어 안내 메시지를 추가했습니다.

AS-IS

```jsp
<c:if test="${fn:length(userStatsList) == 0}">
<tr><td></td></tr>
</c:if>
```

TO-BE

```jsp
<c:if test="${fn:length(userStatsList) == 0}">
	<tr>
		<td>
			<spring:message code="ussIonLsi.loginScrinImageList.failInquire"/>
		</td>
	</tr>
</c:if>
```



## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [X] Chrome
- [ ] Firefox
- [ ] Edge
- [X] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

### 수정 전


https://github.com/user-attachments/assets/459d34f4-6ce2-4a00-b7d9-2a964cc09c44



### 수정 후


https://github.com/user-attachments/assets/704dce18-5f8d-4aeb-8c71-6e0932585543


