### PR TITLE
[버그수정] 1020. 기관코드수신 > Uncaught ReferenceError 오류 수정

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/egovframework/com/sym/ccm/icr/EgovInsttCodeRecptnList.jsp
+++ b/src/main/webapp/WEB-INF/jsp/egovframework/com/sym/ccm/icr/EgovInsttCodeRecptnList.jsp
@@ -57,6 +57,12 @@ function fn_egov_detail_InsttCodeRecptn(insttCode){
     varForm.insttCode.value  = insttCode;
     varForm.submit();
 }
+
+function press(event) {
+    if (event.keyCode == 13) {
+        fn_egov_pageview(1);
+    }
+}
 -->
 </script>
 </head>
@@ -77,7 +83,7 @@ function fn_egov_detail_InsttCodeRecptn(insttCode){
 					<option value='1' <c:if test="${searchVO.searchCondition == '1'}">selected="selected"</c:if>><spring:message code="comSymCcmIcr.insttCodeRecptn.orgNm"/></option> <!-- 기관명 -->
 				</select>
 				
-				<input class="s_input2 vat" name="searchKeyword" type="text" value='<c:out value="${searchVO.searchKeyword}"/>' size="25" onkeypress="press();" title="<spring:message code="title.search"/>" />
+				<input class="s_input2 vat" name="searchKeyword" type="text" value='<c:out value="${searchVO.searchKeyword}"/>' size="25" onkeypress="press(event);" title="<spring:message code="title.search"/>" />
 				<input class="s_btn" type="submit" value='<spring:message code="button.inquire" />' title='<spring:message code="button.inquire" />' onclick="fn_egov_search_InsttCodeRecptn(); return false;" />
 			</li>
 		</ul>


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

### 수정된 파일
- EgovInsttCodeRecptnList.jsp

### 수정 내용
- searchKeyword의 onkeypress에서 존재하지 않는 press 함수를 호출하여 Uncaught ReferenceError 에러가 발생하는 점을 수정했습니다.

AS-IS
```html
<input id="searchKeyword" class="s_input2 vat" name="searchKeyword" type="text" value="" maxlength="35" size="35" onkeypress="press();" />
```

TO-BE
```html
<input id="searchKeyword" class="s_input2 vat" name="searchKeyword" type="text" value="" maxlength="35" size="35" onkeypress="press(event);" />
```

- onkeypress에서 호출 할 press 함수를 페이지에 추가했습니다.
```javascript
function press(event) {
    if (event.keyCode == 13) {
        fn_egov_pageview(1);
    }
}
```

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [X] Chrome
- [X] Firefox
- [X] Edge
- [X] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

### 수정 전

![image](https://github.com/user-attachments/assets/75ced089-6c21-4ae7-a427-4665d4780449)


### 수정 후

![image](https://github.com/user-attachments/assets/e147edd0-6728-4458-99c0-d094ca707d38)

