### PR TITLE
[버그수정] 1010. 행정코드관리 > Uncaught ReferenceError 오류 수정, 미 사용 함수 제거

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/egovframework/com/sym/ccm/adc/EgovCcmAdministCodeList.jsp
+++ b/src/main/webapp/WEB-INF/jsp/egovframework/com/sym/ccm/adc/EgovCcmAdministCodeList.jsp
@@ -68,11 +68,10 @@ function fnDetail(administZoneSe,administZoneCode){
 	varForm.administZoneCode.value = administZoneCode;
 	varForm.submit();
 }
-/* ********************************************************
- * 삭제 처리 함수
- ******************************************************** */
-function fnDelete(){
-	//
+function press(event) {
+	if (event.keyCode == 13) {
+		linkPage(1);
+	}
 }
 -->
 </script>
@@ -93,7 +92,7 @@ function fnDelete(){
 					<option value='1' <c:if test="${searchVO.searchCondition == '1'}">selected="selected"</c:if>><spring:message code="comSymCcmAdc.ccmAdministCode.lawAddrName" /></option> <!-- 법정동 지역명 -->
 					<option value='2' <c:if test="${searchVO.searchCondition == '2'}">selected="selected"</c:if>><spring:message code="comSymCcmAdc.ccmAdministCode.admAddrName" /></option> <!-- 행정동 지역명 -->
 				</select>
-				<input id="searchKeyword" class="s_input2 vat" name="searchKeyword" type="text" value="${searchVO.searchKeyword}" size="25" onkeypress="press();" title="사용자명검색" />
+				<input id="searchKeyword" class="s_input2 vat" name="searchKeyword" type="text" value="${searchVO.searchKeyword}" size="25" onkeypress="press(event);" title="사용자명검색" />
 				
 				<input class="s_btn" type="submit" value="<spring:message code="title.inquire" />" title="<spring:message code="title.inquire" />" onclick="fnSearch(); return false;" /> <!-- 조회 -->
 				<input class="s_btn" type="submit" value="<spring:message code="title.create" />" title="<spring:message code="title.create" />" onclick="fnRegist(); return false;" /> <!-- 등록 -->


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [X] 버그수정 Bug fixes
- [X] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

### 수정된 파일

- EgovCcmAdministCodeList.jsp


### 수정 내용

- searchKeyword의 onkeypress 이벤트에서 존재하지 않는 press 함수를 호출하여 Uncaught ReferenceError 에러가 발생하는 점을 수정했습니다.
- 페이지에서 사용하지 않고 있는 **fnDelete** 함수를 제거했습니다.

AS-IS
```html
<input id="searchKeyword" class="s_input2 vat" name="searchKeyword" type="text" value="" maxlength="25" size="25" onkeypress="press();" />
```

TO-BE
```html
<input id="searchKeyword" class="s_input2 vat" name="searchKeyword" type="text" value="" maxlength="25" size="25" onkeypress="press(event);" />
```

- onkeypress에서 호출 할 press 함수를 페이지에 추가했습니다.
```javascript
function press(event) {
    if (event.keyCode == 13) {
        linkPage(1);
    }
}
```



## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [X] Chrome
- [X] Firefox
- [X] Edge
- [X] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

### 수정 전

![image](https://github.com/user-attachments/assets/8b16f26f-d077-45d8-9ef0-48ca7aa0dc18)


### 수정 후

![image](https://github.com/user-attachments/assets/d80c06cb-3a3f-40c8-87f9-fe745a05538b)

