### PR TITLE
[버그수정] 1060. 시스템이력관리 > Uncaught ReferenceError 오류 수정

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/egovframework/com/sym/log/slg/EgovSysHistList.jsp
+++ b/src/main/webapp/WEB-INF/jsp/egovframework/com/sym/log/slg/EgovSysHistList.jsp
@@ -47,6 +47,12 @@ function fn_egov_inqire_sysHist(histId){
 	document.frm.action = "<c:url value='/sym/log/slg/InqireSysHistory.do'/>";
 	document.frm.submit();
 }
+
+function press(event) {
+	if (event.keyCode == 13) {
+		fn_egov_select_sysHist(1);
+	}
+}
 </script>
 </head>
 <body>
@@ -67,7 +73,7 @@ function fn_egov_inqire_sysHist(histId){
 				<option value="0" <c:if test="${searchVO.searchCnd == '0'}">selected="selected"</c:if> ><spring:message code="comSymLogSlg.sysHistList.sysNm"/></option><!-- 시스템명 -->
 				<option value="1" <c:if test="${searchVO.searchCnd == '1'}">selected="selected"</c:if> ><spring:message code="comSymLogSlg.sysHistList.histSeCodeNm"/></option><!-- 이력구분 -->
 				</select>
-				<input id="searchWrd" class="s_input2 vat" name="searchWrd" type="text" value='<c:out value='${searchVO.searchWrd}'/>' maxlength="35" size="35" onkeypress="press();" title="<spring:message code="title.search"/>" /><!-- 사용자명검색 -->
+				<input id="searchWrd" class="s_input2 vat" name="searchWrd" type="text" value='<c:out value='${searchVO.searchWrd}'/>' maxlength="35" size="35" onkeypress="press(event);" title="<spring:message code="title.search"/>" /><!-- 사용자명검색 -->
 				
 				<span class="btn_b"><a href="" onclick="fn_egov_select_sysHist('1'); return false;" title="<spring:message code="title.inquire"/>"><spring:message code="button.inquire" /></a></span><!-- 조회 -->
 				<input class="s_btn" type="submit" value="<spring:message code="button.create" />" title="<spring:message code="title.create" />" onclick="fn_egov_insert_sysHist(); return false;" /><!-- 등록 -->


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

### 수정된 파일

- EgovSysHistList.jsp

### 수정 내용

- searchKeyword의 onkeypress 이벤트에서 존재하지 않는 press 함수를 호출하여 Uncaught ReferenceError 에러가 발생하는 점을 수정했습니다.

AS-IS
```html
<input id="searchKeyword" class="s_input2 vat" name="searchKeyword" type="text" value="" maxlength="35" size="35" onkeypress="press();" title="검색어" />
```

TO-BE
```html
<input id="searchKeyword" class="s_input2 vat" name="searchKeyword" type="text" value="" maxlength="35" size="35" onkeypress="press(event);" title="검색어" />
```

- onkeypress에서 호출 할 press 함수를 페이지에 추가했습니다.
```javascript
function press(event) {
    if (event.keyCode == 13) {
        fn_egov_select_sysHist(1);
    }
}
```


## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [X] Chrome
- [X] Firefox
- [X] Edge
- [X] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

### 수정 전

![image](https://github.com/user-attachments/assets/7a18133e-896a-499a-af84-004f6d813b5f)


### 수정 후

![image](https://github.com/user-attachments/assets/8c6b0779-f7d9-4828-8267-915cc09b4a3e)

