### PR TITLE
[버그수정] 1010. 행정코드관리 > 공공데이터 법정동코드 저장 시 NullPointerException 수정

### DIFF
--- a/src/main/java/egovframework/com/sym/ccm/acr/service/impl/AdministCodeRecptnDAO.java
+++ b/src/main/java/egovframework/com/sym/ccm/acr/service/impl/AdministCodeRecptnDAO.java
@@ -47,19 +47,19 @@ public class AdministCodeRecptnDAO extends EgovComAbstractDAO {
 	public void insertAdministCode(AdministCodeRecptn administCodeRecptn) throws Exception {
 		AdministCodeRecptn beforeData = (AdministCodeRecptn) selectOne("AdministCodeRecptnDAO.selectAdministCodeDetail", administCodeRecptn);
 
-		if (beforeData.getAdministZoneCode().equals(administCodeRecptn.getAdministZoneCode())
-		&&  beforeData.getAdministZoneSe()  .equals(administCodeRecptn.getAdministZoneSe()  )
-		) {
+		if (beforeData != null
+			&& beforeData.getAdministZoneCode().equals(administCodeRecptn.getAdministZoneCode())
+			&& beforeData.getAdministZoneSe().equals(administCodeRecptn.getAdministZoneSe())) {
 			// 기등록 자료
-        	administCodeRecptn.setProcessSe("10");
+			administCodeRecptn.setProcessSe("10");
 		} else {
 			int rtnValue = update("AdministCodeRecptnDAO.insertAdministCode", administCodeRecptn);
-	        if (rtnValue != 1) {
-	        	// 등록 오류
-	        	administCodeRecptn.setProcessSe("11");
-	        }
-        }
-    	update("AdministCodeRecptnDAO.updateAdministCodeRecptn", administCodeRecptn);
+			if (rtnValue != 1) {
+				// 등록 오류
+				administCodeRecptn.setProcessSe("11");
+			}
+		}
+		update("AdministCodeRecptnDAO.updateAdministCodeRecptn", administCodeRecptn);
 	}
 
 	/**


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

### 수정된 파일
- AdministCodeRecptnDAO.java

### 수정 내용
- [법정동 공공데이터](https://www.data.go.kr/tcs/dss/selectApiDataDetailView.do?publicDataPk=15077871) 데이터를 수신하여 저장할 때 이전 데이터 확인 과정에서 null 체크를 하지 않아 발생하는 NullPointerException  오류 수정

에러 내용
```shell
[log4j]2024-09-22 19:12:24,386 ERROR [egovframework.com.cmm.EgovComOthersExcepHndlr] egovframework.com.sym.ccm.acr.service.impl.EgovAdministCodeRecptnServiceImpl.insertAdministCodeRecptn
java.lang.NullPointerException: null
	at egovframework.com.sym.ccm.acr.service.impl.AdministCodeRecptnDAO.insertAdministCode(AdministCodeRecptnDAO.java:50) ~[classes/:?]
	at egovframework.com.sym.ccm.acr.service.impl.EgovAdministCodeRecptnServiceImpl.insertAdministCodeRecptn(EgovAdministCodeRecptnServiceImpl.java:97) ~[classes/:?]
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:?]
	at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
	at java.lang.reflect.Method.invoke(Method.java:566) ~[?:?]
```



AS-IS

```java
public void insertAdministCode(AdministCodeRecptn administCodeRecptn) throws Exception {
	AdministCodeRecptn beforeData = (AdministCodeRecptn) selectOne("AdministCodeRecptnDAO.selectAdministCodeDetail", administCodeRecptn);

	if (beforeData.getAdministZoneCode().equals(administCodeRecptn.getAdministZoneCode())
		&&  beforeData.getAdministZoneSe()  .equals(administCodeRecptn.getAdministZoneSe()  )
		) {
		// 기등록 자료
		administCodeRecptn.setProcessSe("10");
	} else {
		int rtnValue = update("AdministCodeRecptnDAO.insertAdministCode", administCodeRecptn);
		if (rtnValue != 1) {
			// 등록 오류
			administCodeRecptn.setProcessSe("11");
		}
	}
	update("AdministCodeRecptnDAO.updateAdministCodeRecptn", administCodeRecptn);
}

```

TO-BE

```java
public void insertAdministCode(AdministCodeRecptn administCodeRecptn) throws Exception {
	AdministCodeRecptn beforeData = (AdministCodeRecptn) selectOne("AdministCodeRecptnDAO.selectAdministCodeDetail", administCodeRecptn);

	if (beforeData != null
		&& beforeData.getAdministZoneCode().equals(administCodeRecptn.getAdministZoneCode())
		&& beforeData.getAdministZoneSe().equals(administCodeRecptn.getAdministZoneSe())) {
		// 기등록 자료
		administCodeRecptn.setProcessSe("10");
	} else {
		int rtnValue = update("AdministCodeRecptnDAO.insertAdministCode", administCodeRecptn);
		if (rtnValue != 1) {
			// 등록 오류
			administCodeRecptn.setProcessSe("11");
		}
	}
	update("AdministCodeRecptnDAO.updateAdministCodeRecptn", administCodeRecptn);
}
```

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [X] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

### 수정후 저장된 데이터 목록

![image](https://github.com/user-attachments/assets/d344bb1a-9f58-469a-b39c-4539a153c6e5)
