### PR TITLE
[기능개선] 1010. 행정코드관리 > 공공데이터 법정동코드 수신 시 사용여부 기본값 적용

### DIFF
--- a/src/main/java/egovframework/com/sym/ccm/acr/service/impl/EgovAdministCodeRecptnServiceImpl.java
+++ b/src/main/java/egovframework/com/sym/ccm/acr/service/impl/EgovAdministCodeRecptnServiceImpl.java
@@ -84,6 +84,7 @@ public class EgovAdministCodeRecptnServiceImpl extends EgovAbstractServiceImpl i
 			administCodeRecptn.setAblEnnc(""); // 폐지유무 >> x
 			administCodeRecptn.setFrstRegisterId("Batch System"); // 등록자 Batch System
 			administCodeRecptn.setLastUpdusrId("Batch System"); // 수정자 Batch System
+			administCodeRecptn.setUseAt("Y"); // 사용여부 >> Y
 
 			AdministCodeRecptnVO vo = new AdministCodeRecptnVO();
 			vo.setSearchCondition("CodeList");


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [ ] 버그수정 Bug fixes
- [X] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

### 수정된 파일
- EgovAdministCodeRecptnServiceImpl.java

### 수정 내용
- [법정동 공공데이터](https://www.data.go.kr/tcs/dss/selectApiDataDetailView.do?publicDataPk=15077871) 수신 데이터를 DB에 저장할 때 사용여부가 빈 값으로 저장되는 점을 기본 값을 세팅하여 개선하였습니다.



## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [X] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

### 수정 전 - 사용여부 값 비어있음

![image](https://github.com/user-attachments/assets/7a01aa3b-b747-4a68-97e2-db4ff80b43fa)


### 수정 후 - 사용여부 값 적용됨

![image](https://github.com/user-attachments/assets/8e6d3430-1c85-460f-be89-27eeb11592bb)

