### PR TITLE
[버그수정] 390. 간부일정관리 > Uncaught TypeError 오류 수정

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/egovframework/com/cop/smt/lsm/EgovLeaderSchdulList.jsp
+++ b/src/main/webapp/WEB-INF/jsp/egovframework/com/cop/smt/lsm/EgovLeaderSchdulList.jsp
@@ -137,22 +137,6 @@ $(function() {
 	}else{
 		$(".tab01 li:eq(0) a").addClass("on");
 	}
-	
-	
-	if(searchMode == "MONTH"){
-		vFrom.action = "<c:url value='/cop/smt/lsm/usr/selectLeaderSchdulMonthList.do' />";
-		document.getElementById("tabMenu0").bgColor = '#BBBBBB';
-	}else if(searchMode == "WEEK"){
-		vFrom.action = "<c:url value='/cop/smt/lsm/usr/selectLeaderSchdulWeekList.do' />";
-		document.getElementById("tabMenu1").bgColor = '#BBBBBB';
-	}else if(searchMode == "DAILY"){
-		vFrom.action = "<c:url value='/cop/smt/lsm/usr/selectLeaderSchdulDailyList.do' />";
-		document.getElementById("tabMenu2").bgColor = '#BBBBBB';
-	}else{
-		vFrom.action = "<c:url value='/cop/smt/lsm/usr/selectLeaderSchdulMonthList.do' />"; 
-		document.getElementById("tabMenu0").bgColor = '#BBBBBB';
-	}
-	vFrom.submit();
 });
 
 </script>


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

### 수정된 파일
- EgovLeaderSchdulList.jsp


### 수정 내용
- 페이지 로딩 후 실행되는 스크립트에서 발생한 `Uncaught TypeError: Cannot set properties of null (setting 'bgColor')`  오류를 수정했습니다.
- html 코드를 보아 상단 탭 마크업이 변경된 것으로 보이는데 과거 마크업에 사용되었던 스크립트가 남아있는 것으로 판단되어 해당 스크립트를 제거하였습니다.


## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [X] Chrome
- [X] Firefox
- [X] Edge
- [X] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

### 수정 전
![image](https://github.com/user-attachments/assets/73a1f3ce-18e3-4474-bcbb-b4ad8114f77e)


### 수정 후
![image](https://github.com/user-attachments/assets/f79f7088-c6cc-48b4-9fcd-1f2f9c5e4dd1)



