### PR TITLE
[10. 로그인][EgovLoginServiceImpl.actionCrtfctLogin] ServiceImpl 단위 테스트

### DIFF
--- a/src/test/java/egovframework/com/uat/uia/service/impl/EgovLoginServiceImplTestActionCrtfctLoginTest.java
+++ b/src/test/java/egovframework/com/uat/uia/service/impl/EgovLoginServiceImplTestActionCrtfctLoginTest.java
@@ -1,0 +1,119 @@
+package egovframework.com.uat.uia.service.impl;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.ComponentScan.Filter;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.ImportResource;
+import org.springframework.stereotype.Repository;
+import org.springframework.stereotype.Service;
+import org.springframework.test.context.ContextConfiguration;
+
+import egovframework.com.cmm.LoginVO;
+import egovframework.com.cmm.config.EgovLoginConfig;
+import egovframework.com.cop.ems.service.EgovMultiPartEmail;
+import egovframework.com.test.EgovTestAbstractDAO;
+import egovframework.com.uat.uia.service.EgovLoginService;
+import egovframework.com.uss.umt.service.UserManageVO;
+import egovframework.com.uss.umt.service.impl.UserManageDAO;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * [10. 로그인][EgovLoginServiceImpl.actionCrtfctLogin] ServiceImpl 단위 테스트
+ * 
+ * @author 이백행
+ * @since 2024-09-26
+ *
+ */
+@ContextConfiguration(classes = { EgovLoginServiceImplTestActionCrtfctLoginTest.class, EgovTestAbstractDAO.class })
+@Configuration
+@ImportResource({ "classpath*:egovframework/spring/com/idgn/context-idgn-MailMsg.xml",
+		"classpath*:egovframework/spring/com/idgn/context-idgn-UsrCnfrm.xml" })
+@ComponentScan(useDefaultFilters = false, basePackages = { "egovframework.com.uat.uia.service.impl",
+		"egovframework.com.cop.ems.service", "egovframework.com.cmm.config", "egovframework.com.cmm.service",
+		"egovframework.com.uss.umt.service.impl" }, includeFilters = {
+				@Filter(type = FilterType.ANNOTATION, classes = { Repository.class, Service.class }),
+				@Filter(type = FilterType.ASSIGNABLE_TYPE, classes = { EgovLoginService.class, EgovLoginConfig.class,
+						EgovMultiPartEmail.class, UserManageDAO.class, }) })
+@NoArgsConstructor
+@Slf4j
+public class EgovLoginServiceImplTestActionCrtfctLoginTest extends EgovTestAbstractDAO {
+
+	/**
+	 * 일반 로그인, 인증서 로그인을 처리하는 DAO 클래스
+	 */
+	@Autowired
+	private EgovLoginService egovLoginService;
+
+	/**
+	 * 사용자관리에 관한 데이터 접근 클래스를 정의한다.
+	 */
+	@Autowired
+	private UserManageDAO userManageDAO;
+
+	/**
+	 * 테스트
+	 * 
+	 * @throws Exception
+	 */
+	@Test
+	public void test() throws Exception {
+		final UserManageVO testData = testData();
+
+		// given
+		final LoginVO loginVO = new LoginVO();
+
+		// `CRTFC_DN_VALUE` varchar(100) DEFAULT NULL COMMENT '인증DN값',
+		loginVO.setDn(testData.getSubDn());
+
+		// when
+		final LoginVO resultLoginVO = egovLoginService.actionCrtfctLogin(loginVO);
+
+		// then
+		asserts(testData, loginVO, resultLoginVO);
+
+		assertEquals("getUniqId 고유ID", testData.getUniqId(), resultLoginVO.getUniqId());
+	}
+
+	private UserManageVO testData() {
+		final String uniqId = "USRCNFRM_99999999999";
+		final UserManageVO testData = userManageDAO.selectUser(uniqId);
+
+		testData.setSubDn("TEST_DN_" + uniqId);
+		userManageDAO.updateUser(testData);
+
+		return testData;
+	}
+
+	private void asserts(final UserManageVO testData, final LoginVO loginVO, final LoginVO resultLoginVO) {
+		if (log.isDebugEnabled()) {
+			log.debug("testData={}", testData);
+			log.debug("getUniqId={}", testData.getUniqId());
+
+			log.debug("loginVO={}", loginVO);
+			log.debug("getDn={}", loginVO.getDn());
+
+			log.debug("resultLoginVO={}", resultLoginVO);
+			log.debug("getId={}", resultLoginVO.getId());
+			log.debug("getName={}", resultLoginVO.getName());
+			log.debug("getPassword={}", resultLoginVO.getPassword());
+
+			log.debug("getIhidNum={}", resultLoginVO.getIhidNum());
+			log.debug("getEmail={}", resultLoginVO.getEmail());
+			log.debug("getUserSe={}", resultLoginVO.getUserSe());
+			log.debug("getOrgnztId={}", resultLoginVO.getOrgnztId());
+			log.debug("getUniqId={}", resultLoginVO.getUniqId());
+
+			log.debug("assert");
+			log.debug("getUniqId={}, {}", testData.getUniqId(), resultLoginVO.getUniqId());
+		}
+
+		assertEquals("getUniqId 고유ID", testData.getUniqId(), resultLoginVO.getUniqId());
+	}
+
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [x] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

### [10. 로그인][EgovLoginServiceImpl.actionCrtfctLogin] ServiceImpl 단위 테스트

- EsntlId를 이용한 로그인을 처리한다

브랜치 생성
```
2024/test/EgovLoginServiceImpl/actionCrtfctLogin
```

테스트 패키지 생성
```
egovframework.com.uat.uia.service.impl
```

테스트 파일 생성
```
EgovLoginServiceImplTestActionCrtfctLoginTest
```

```java
@ImportResource({ "classpath*:egovframework/spring/com/idgn/context-idgn-MailMsg.xml", })
@ComponentScan(useDefaultFilters = false, basePackages = { "egovframework.com.uat.uia.service.impl",
		"egovframework.com.cop.ems.service", "egovframework.com.cmm.config",
		"egovframework.com.cmm.service", }, includeFilters = {
				@Filter(type = FilterType.ANNOTATION, classes = { Repository.class, Service.class }),
				@Filter(type = FilterType.ASSIGNABLE_TYPE, classes = { EgovLoginService.class, EgovLoginConfig.class,
						EgovMultiPartEmail.class, }) })
```

[2024년 전자정부 표준프레임워크 컨트리뷰션][공통컴포넌트][10. 로그인][EgovLoginServiceImpl.actionCrtfctLogin] ServiceImpl 단위 테스트

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [x] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

https://youtu.be/t1fLNWvQg1M
