### PR TITLE
[10. 로그인][EgovLoginServiceImpl.searchPassword] ServiceImpl 단위 테스트

### DIFF
--- a/src/test/java/egovframework/com/cop/ems/service/EgovTestMultiPartEmail.java
+++ b/src/test/java/egovframework/com/cop/ems/service/EgovTestMultiPartEmail.java
@@ -1,0 +1,41 @@
+package egovframework.com.cop.ems.service;
+
+import org.apache.commons.mail.EmailAttachment;
+import org.apache.commons.mail.EmailException;
+
+/**
+ * 발송메일에 첨부파일용으로 사용되는 VO 테스트 클래스
+ * 
+ * @author 이백행
+ * @since 2024.09.28
+ * @version 1.0
+ * @see
+ *
+ *      <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *    수정일      	수정자          수정내용
+ *  ----------     --------    ---------------------------
+ *   2024.09.28  이백행          컨트리뷰션 최초 생성
+ *
+ *      </pre>
+ */
+
+public class EgovTestMultiPartEmail extends EgovMultiPartEmail {
+
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = 4771117818240167794L;
+
+	@Override
+	public String send() throws EmailException {
+		return null;
+	}
+
+	@Override
+	public String send(String addTo, String subject, String msg, EmailAttachment attachment) throws EmailException {
+		return null;
+	}
+
+}

--- a/src/test/java/egovframework/com/uat/uia/service/impl/EgovLoginServiceImplTestSearchPasswordTest.java
+++ b/src/test/java/egovframework/com/uat/uia/service/impl/EgovLoginServiceImplTestSearchPasswordTest.java
@@ -1,0 +1,117 @@
+package egovframework.com.uat.uia.service.impl;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.ComponentScan.Filter;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.ImportResource;
+import org.springframework.stereotype.Repository;
+import org.springframework.stereotype.Service;
+import org.springframework.test.context.ContextConfiguration;
+
+import egovframework.com.cmm.LoginVO;
+import egovframework.com.cmm.config.EgovLoginConfig;
+import egovframework.com.test.EgovTestAbstractDAO;
+import egovframework.com.uat.uia.service.EgovLoginService;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * [10. 로그인][EgovLoginServiceImpl.searchPassword] ServiceImpl 단위 테스트
+ * 
+ * @author 이백행
+ * @since 2024-09-28
+ *
+ */
+@ContextConfiguration(classes = { EgovLoginServiceImplTestSearchPasswordTest.class, EgovTestAbstractDAO.class })
+@Configuration
+@ImportResource({ "classpath*:egovframework/spring/com/idgn/context-idgn-MailMsg.xml",
+		"classpath*:egovframework/spring/com/test-context-mail.xml", })
+@ComponentScan(useDefaultFilters = false, basePackages = { "egovframework.com.uat.uia.service.impl",
+		"egovframework.com.cop.ems.service", "egovframework.com.cmm.config",
+		"egovframework.com.cmm.service", }, includeFilters = {
+				@Filter(type = FilterType.ANNOTATION, classes = { Repository.class, Service.class, }),
+				@Filter(type = FilterType.ASSIGNABLE_TYPE, classes = { EgovLoginService.class,
+						EgovLoginConfig.class, }) })
+@NoArgsConstructor
+@Slf4j
+public class EgovLoginServiceImplTestSearchPasswordTest extends EgovTestAbstractDAO {
+
+	/**
+	 * 일반 로그인, 인증서 로그인을 처리하는 비즈니스 인터페이스 클래스
+	 */
+	@Autowired
+	private EgovLoginService egovLoginService;
+
+	/**
+	 * 테스트
+	 * 
+	 * @throws Exception
+	 */
+	@Test
+	public void test() throws Exception {
+		// given
+		final LoginVO loginVO = new LoginVO();
+		// 일반회원
+		loginVO.setUserSe("GNR");
+
+		loginVO.setId("USER");
+		loginVO.setName("일반회원");
+		loginVO.setEmail("egovframesupport@gmail.com");
+		loginVO.setPasswordHint("P01");
+		loginVO.setPasswordCnsr("전자정부표준프레임워크센터");
+
+		loginVO.setPassword("6TAJYwhKCgkgzPXDb83ZUiHi2/TKHhD7t5Ba6RN2qoo=");
+
+//		// 기업회원
+//		loginVO.setUserSe("ENT");
+//
+//		loginVO.setId("ENTERPRISE");
+//		loginVO.setName("NIA");
+//		loginVO.setEmail("egovframesupport@gmail.com");
+//		loginVO.setPasswordHint("P01");
+//		loginVO.setPasswordCnsr("전자정부표준프레임워크센터");
+//
+//		loginVO.setPassword("ZQhr3oB5QWjBnBO0kbFF7bvQDLkk+Em0ExjTq5JtVTo=");
+
+//		// 업무사용자
+//		loginVO.setUserSe("USR");
+//
+//		loginVO.setId("TEST1");
+//		loginVO.setName("테스트1");
+//		loginVO.setEmail("egovframesupport@gmail.com");
+//		loginVO.setPasswordHint("P01");
+//		loginVO.setPasswordCnsr("전자정부표준프레임워크센터");
+//
+//		loginVO.setPassword("raHLBnHFcunwNzcDcfad4PhD11hHgXSUr7fc1Jk9uoQ=");
+
+		// when
+		final boolean result = egovLoginService.searchPassword(loginVO);
+
+		// then
+		debug(loginVO, result);
+
+		assertEquals("비밀번호를 찾는다.", true, result);
+	}
+
+	private void debug(final LoginVO loginVO, final boolean result) {
+		if (log.isDebugEnabled()) {
+			log.debug("loginVO={}", loginVO);
+			log.debug("getId={}", loginVO.getId());
+			log.debug("getName={}", loginVO.getName());
+			log.debug("getEmail={}", loginVO.getEmail());
+			log.debug("getPasswordHint={}", loginVO.getPasswordHint());
+			log.debug("getPasswordCnsr={}", loginVO.getPasswordCnsr());
+
+			log.debug("result={}", result);
+
+			log.debug("assert");
+			log.debug("비밀번호를 찾는다.={}, {}", true, result);
+		}
+	}
+
+}

--- a/src/test/resources/egovframework/spring/com/test-context-mail.xml
+++ b/src/test/resources/egovframework/spring/com/test-context-mail.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+    xmlns:p="http://www.springframework.org/schema/p"  
+    xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd"> 
+     
+    <!-- 일반용   
+    <bean id="mntrngMailSender" class="org.springframework.mail.javamail.JavaMailSenderImpl" 
+        p:host="STMP서버주소"  
+        p:username="아이디" 
+        p:password="비밀번호" /> 
+    --> 
+    
+    <!-- 메일 연동 인터페이스에서 첨부파일 미사용 -->
+    <bean id="EMSMailSender" class="org.springframework.mail.javamail.JavaMailSenderImpl" 
+        p:host="STMP서버주소" 
+        p:port="465"  
+        p:protocol="smtps" 
+        p:username="아이디" 
+        p:password="비밀번호"> 
+        <property name="javaMailProperties"> 
+            <props> 
+                <prop key="mail.smtps.auth">true</prop> 
+                <prop key="mail.smtps.startls.enable">true</prop> 
+                <prop key="mail.smtps.debug">true</prop> 
+            </props> 
+        </property> 
+    </bean>
+     
+    <!-- 메일 연동 인터페이스에서 첨부파일 사용 -->
+	<bean id="egovMultiPartEmail" class="egovframework.com.cop.ems.service.EgovTestMultiPartEmail"
+		p:host="이메일SMTP주소"
+		p:port="587"
+		p:id="아이디"
+		p:password="비밀번호"
+		p:senderName="System"
+		p:emailAddress="이메일주소" />
+	  
+    <!-- 모니터링 서비스에서 사용 gmail, hanmail 용 -->
+    <bean id="mntrngMailSender" class="org.springframework.mail.javamail.JavaMailSenderImpl" 
+        p:host="이메일SMTP주소"
+        p:port="587"
+        p:protocol="smtp"
+        p:username="아이디" 
+        p:password="비밀번호">
+        <property name="javaMailProperties"> 
+            <props>
+                <prop key="mail.smtps.auth">true</prop> 
+                <prop key="mail.smtps.startls.enable">true</prop> 
+                <prop key="mail.smtps.debug">true</prop> 
+            </props> 
+        </property> 
+    </bean>
+    
+    <!-- 스케줄러에서 메일발송시 설정 -->
+    <bean id="mntrngMessage" class="org.springframework.mail.SimpleMailMessage" 
+        p:from="SYSTEM &lt; orgpig@naver.com &gt;"   
+        p:subject="{모니터링종류} 상태통보." 
+        p:text="* {모니터링종류}  상태통보.&#13;{에러내용}"/> 
+
+</beans> 


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [x] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

### [10. 로그인][EgovLoginServiceImpl.searchPassword] ServiceImpl 단위 테스트

- 비밀번호를 찾는다.
- EgovTestMultiPartEmail 테스트 클래스 추가
- send 는 실제 메일 발송하지 않고 return null 로 함

브랜치 생성
```
2024/test/EgovLoginServiceImpl/searchPassword
```

테스트 패키지 생성
```
egovframework.com.uat.uia.service.impl
```

테스트 파일 생성
```
EgovLoginServiceImplTestSearchPasswordTest
```

```java
@ImportResource({ "classpath*:egovframework/spring/com/idgn/context-idgn-MailMsg.xml",
		"classpath*:egovframework/spring/com/test-context-mail.xml", })
@ComponentScan(useDefaultFilters = false, basePackages = { "egovframework.com.uat.uia.service.impl",
		"egovframework.com.cop.ems.service", "egovframework.com.cmm.config",
		"egovframework.com.cmm.service", }, includeFilters = {
				@Filter(type = FilterType.ANNOTATION, classes = { Repository.class, Service.class, }),
				@Filter(type = FilterType.ASSIGNABLE_TYPE, classes = { EgovLoginService.class, EgovLoginConfig.class,
						EgovMultiPartEmail.class, }) })
```

/egovframe-common-components-2024/src/test/java/egovframework/com/cop/ems/service/EgovTestMultiPartEmail.java
```java
	@Override
	public String send() throws EmailException {
		return null;
	}

	@Override
	public String send(String addTo, String subject, String msg, EmailAttachment attachment) throws EmailException {
		return null;
	}
```

/egovframe-common-components-2024/src/test/resources/egovframework/spring/com/test-context-mail.xml
```xml
    <!-- 메일 연동 인터페이스에서 첨부파일 사용 -->
	<bean id="egovMultiPartEmail" class="egovframework.com.cop.ems.service.EgovTestMultiPartEmail"
		p:host="이메일SMTP주소"
		p:port="587"
		p:id="아이디"
		p:password="비밀번호"
		p:senderName="System"
		p:emailAddress="이메일주소" />
```

[2024년 전자정부 표준프레임워크 컨트리뷰션][공통컴포넌트][10. 로그인][EgovLoginServiceImpl.searchPassword] ServiceImpl 단위 테스트

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [x] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

https://youtu.be/q405I5zIB3c
