### PR TITLE
[버그수정] 2180. 주소정보연계 > 주소가져오기 XML 응답결과 수정

### DIFF
--- a/src/main/java/egovframework/com/sym/adr/web/EgovAdressCntcController.java
+++ b/src/main/java/egovframework/com/sym/adr/web/EgovAdressCntcController.java
@@ -63,7 +63,7 @@ public class EgovAdressCntcController {
 
 			response.setCharacterEncoding("UTF-8");
 			response.setContentType("text/xml");
-			response.getWriter().write(EgovWebUtil.clearXSSMaximum(sb.toString()));
+			response.getWriter().write(sb.toString());
 		}
 	}
 


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

### 수정된 파일
- EgovAdressCntcController.java

### 수정 내용
- **주소가져오기(Controller)** 버튼을 통해 주소를 가져올 때 `/sym/adr/getAdressCntcApi.do`의 XML 응답 결과가 XML 포맷에 맞지 않아 javascript에서 파싱을 못하고 오류가 발생
- Controller에서 www.juso.go.kr API 결과를 반환할 때 clearXSSMaximum 메서드로 반환 값을 replace하는 코드를 제거하였습니다.


## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [x] JUnit 테스트 JUnit tests
- [x] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [X] Chrome
- [X] Firefox
- [X] Edge
- [X] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

### 수정 전
![image](https://github.com/user-attachments/assets/438b52f7-5d6a-4cee-a444-d2a2c87d8b74)
![image](https://github.com/user-attachments/assets/d01f7083-642e-46c1-94fc-4c2c3fad3aa3)


### 수정 후
![image](https://github.com/user-attachments/assets/183bbeca-2e81-4cce-964a-c02a9849b338)
![image](https://github.com/user-attachments/assets/ca042a58-415b-418a-9e50-33c9a4d2fa57)


