### PR TITLE
[버그수정] 1260. 지식맵관리(유형) > 등록 페이지 마크업 개선

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/egovframework/com/dam/map/mat/EgovComDamMapMaterialRegist.jsp
+++ b/src/main/webapp/WEB-INF/jsp/egovframework/com/dam/map/mat/EgovComDamMapMaterialRegist.jsp
@@ -196,7 +196,7 @@
 			<!-- 하단 버튼 -->
 			<div class="btn">
 				<input class="s_submit" type="submit" value="<spring:message code="button.save" />" onclick="fn_egov_regist_MapMaterial(document.mapMaterial); return false;" /><!-- 저장 -->
-				<input class="s_submit" type="submit" value='<spring:message code="button.list" />' onclick="fn_egov_list_MapMaterial(); return false;" /><!-- 목록 -->
+				<input class="s_submit" type="button" value='<spring:message code="button.list" />' onclick="fn_egov_list_MapMaterial(); return false;" /><!-- 목록 -->
 			</div>
 			<div style="clear:both;"></div>
 		</div>

--- a/src/main/webapp/WEB-INF/jsp/egovframework/com/dam/map/mat/EgovComDamMapMaterialRegist.jsp
+++ b/src/main/webapp/WEB-INF/jsp/egovframework/com/dam/map/mat/EgovComDamMapMaterialRegist.jsp
@@ -152,9 +152,9 @@
 					<col style="" />
 				</colgroup>
 				<tr>
-					<th><spring:message code="comDamMapMat.comDamMapMaterialRegist.orgnztNm"/> <span class="pilsu">*</span></th><!-- 조직명 -->
+					<th><label for="orgnztId"><spring:message code="comDamMapMat.comDamMapMaterialRegist.orgnztNm"/></label> <span class="pilsu">*</span></th><!-- 조직명 -->
 					<td class="left">
-					    <select name="orgnztId" class="select" title="<spring:message code="comDamMapMat.comDamMapMaterialRegist.orgnztNm"/>"><!-- 조직명 -->
+					    <select id="orgnztId" name="orgnztId" class="select" title="<spring:message code="comDamMapMat.comDamMapMaterialRegist.orgnztNm"/>"><!-- 조직명 -->
 						<c:forEach var="mapMaterial" items="${mapTeam}" varStatus="status">
 						<option value='<c:out value="${mapMaterial.orgnztId}"/>'><c:out value="${mapMaterial.orgnztNm}"/></option>
 						</c:forEach>			  		   
@@ -162,29 +162,29 @@
 					</td>
 				</tr>
 				<tr>
-					<th><spring:message code="comDamMapMat.comDamMapMaterialRegist.knoTypeCd"/> <span class="pilsu">*</span></th><!-- 지식유형코드 -->
+					<th><label for="knoTypeCd"><spring:message code="comDamMapMat.comDamMapMaterialRegist.knoTypeCd"/></label> <span class="pilsu">*</span></th><!-- 지식유형코드 -->
 					<td class="left">
-					    <form:input  path="knoTypeCd" title="<spring:message code='comDamMapMat.comDamMapMaterialRegist.knoTypeCd'/>" maxlength="3" style="width:200px"/><!-- 지식유형코드 -->
+					    <form:input path="knoTypeCd" title="<spring:message code='comDamMapMat.comDamMapMaterialRegist.knoTypeCd'/>" maxlength="3" style="width:200px"/><!-- 지식유형코드 -->
 						<form:errors path="knoTypeCd"/>
 						<button id="btnKnoTypeCd" class="btn_s2" onclick="return false;" title="지식유형코드 중복확인">중복확인</button>
 					</td>
 				</tr>
 				<tr>
-					<th><spring:message code="comDamMapMat.comDamMapMaterialRegist.knoTypeNm"/> <span class="pilsu">*</span></th><!-- 지식유형명 -->
+					<th><label for="knoTypeNm"><spring:message code="comDamMapMat.comDamMapMaterialRegist.knoTypeNm"/></label> <span class="pilsu">*</span></th><!-- 지식유형명 -->
 					<td class="left">
 					    <form:input  path="knoTypeNm" title="<spring:message code='comDamMapMat.comDamMapMaterialRegist.knoTypeNm'/>" size="60" maxlength="20"/><!-- 지식유형명 -->
 						<form:errors path="knoTypeNm"/>
 					</td>
 				</tr>
 				<tr>
-					<th><spring:message code="comDamMapMat.comDamMapMaterialRegist.knoUrl"/> <span class="pilsu">*</span></th><!-- 지식URL -->
+					<th><label for="knoUrl"><spring:message code="comDamMapMat.comDamMapMaterialRegist.knoUrl"/></label> <span class="pilsu">*</span></th><!-- 지식URL -->
 					<td class="left">
 					    <form:input  path="knoUrl" title="<spring:message code='comDamMapMat.comDamMapMaterialRegist.knoUrl'/>" size="60" maxlength="100"/><!-- 지식URL -->
 						<form:errors path="knoUrl"/>
 					</td>
 				</tr>
 				<tr>
-					<th><spring:message code="comDamMapMat.comDamMapMaterialRegist.clYmd"/> <span class="pilsu">*</span></th><!-- 분류일자 -->
+					<th><label for="vclYmd"><spring:message code="comDamMapMat.comDamMapMaterialRegist.clYmd"/></label> <span class="pilsu">*</span></th><!-- 분류일자 -->
 					<td class="left">
 					    <input type="hidden" name="cal_url" value="<c:url value='/sym/cal/EgovNormalCalPopup.do'/>" />
 						<input id="clYmd" name="clYmd" type="hidden" value=""/>


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

### 수정된 파일
- EgovComDamMapMaterialRegist.jsp

### 수정 내용
- 조직명, 지식유형코드, 지식유형명, 지식URL, 분류일자 입력 항목에 대해 label 태그 누락을 수정했습니다.
- 목록 버튼이 `fn_egov_list_MapMaterial` 함수를 호출하는 역할만 담당하므로 역할에 맞는 type으로 변경하였습니다.
  - `type='submit'` → `type='button'`

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [X] Chrome
- [X] Firefox
- [X] Edge
- [X] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

### 수정 전

![image](https://github.com/user-attachments/assets/1ea1a07b-8044-458a-ae87-5563b46a0116)


### 수정 후

![image](https://github.com/user-attachments/assets/05be2a6f-a462-41c6-8646-32f1cfdb7737)


