### PR TITLE
[버그수정] 750. 로그인화면이미지관리 > Uncaught TypeError 오류 수정

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/egovframework/com/uss/ion/lsi/EgovLoginScrinImageList.jsp
+++ b/src/main/webapp/WEB-INF/jsp/egovframework/com/uss/ion/lsi/EgovLoginScrinImageList.jsp
@@ -149,19 +149,19 @@ function press() {
 	<h1><spring:message code="ussIonLsi.loginScrinImageList.loginScrinImageList"/></h1><!-- 로그인화면이미지 관리 -->
 
 	<form name="listForm" action="<c:url value='/uss/ion/lsi/selectLoginScrinImageList.do'/>" method="post">
-	
-	<div class="search_box" title=<spring:message code="common.searchCondition.msg"/>><!-- 이 레이아웃은 하단 정보를 대한 검색 정보로 구성되어 있습니다. -->
-		<ul>
-			<li>
-				<label for="searchKeyword"><spring:message code="ussIonLsi.loginScrinImageList.imageNm"/> : </label><!-- 이미지 명 -->
-				<input id="searchKeyword" class="s_input2 vat" name="searchKeyword" type="text" value='<c:out value="${loginScrinImageVO.searchKeyword}"/>' size="25" onkeypress="press();" title=<spring:message code="button.search"/> /><!-- 검색 -->
-				
-				<input class="s_btn" type="submit" value='<spring:message code="button.inquire" />' title='<spring:message code="button.inquire" />' onclick="fncSelectLoginScrinImageList('1'); return false;" />
-				<span class="btn_b"><a href="<c:url value='/uss/ion/lsi/addViewLoginScrinImage.do'/>?pageIndex=<c:out value='${loginScrinImageVO.pageIndex}'/>&amp;searchKeyword=<c:out value="${loginScrinImageVO.searchKeyword}"/>&amp;searchCondition=1" onclick="fncAddLoginScrinImageInsert(); return false;" title='<spring:message code="button.create" />'><spring:message code="button.create" /></a></span>
-			</li>
-		</ul>
-	</div>
-	<input type="hidden" name="searchCondition" value="1">
+		<div class="search_box" title=<spring:message code="common.searchCondition.msg"/>><!-- 이 레이아웃은 하단 정보를 대한 검색 정보로 구성되어 있습니다. -->
+			<ul>
+				<li>
+					<label for="searchKeyword"><spring:message code="ussIonLsi.loginScrinImageList.imageNm"/> : </label><!-- 이미지 명 -->
+					<input id="searchKeyword" class="s_input2 vat" name="searchKeyword" type="text" value='<c:out value="${loginScrinImageVO.searchKeyword}"/>' size="25" onkeypress="press();" title=<spring:message code="button.search"/> /><!-- 검색 -->
+
+					<input class="s_btn" type="submit" value='<spring:message code="button.inquire" />' title='<spring:message code="button.inquire" />' onclick="fncSelectLoginScrinImageList('1'); return false;" />
+					<span class="btn_b"><a href="<c:url value='/uss/ion/lsi/addViewLoginScrinImage.do'/>?pageIndex=<c:out value='${loginScrinImageVO.pageIndex}'/>&amp;searchKeyword=<c:out value="${loginScrinImageVO.searchKeyword}"/>&amp;searchCondition=1" onclick="fncAddLoginScrinImageInsert(); return false;" title='<spring:message code="button.create" />'><spring:message code="button.create" /></a></span>
+				</li>
+			</ul>
+		</div>
+		<input type="hidden" name="searchCondition" value="1">
+		<input type="hidden" name="pageIndex" value="<c:out value='${loginScrinImageVO.pageIndex}'/>">
 	</form>
 
 	<table class="board_list">


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

### 수정된 파일
- EgovLoginScrinImageList.jsp

### 수정 내용
- `fncSelectLoginScrinImageList` 함수에서 **Uncaught TypeError** 오류가 발생
- listForm에 pageIndex 요소가 없어 Cannot read properties of undefined가 발생한 것으로 listForm에 pageIndex 요소를 추가하였습니다.
- listForm 내 태그의 formatting을 정리하였습니다.




## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [X] Chrome
- [X] Firefox
- [X] Edge
- [X] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

### 수정 전
![image](https://github.com/user-attachments/assets/5d220b2b-e3ff-4b0d-9ac6-8f92dab344ee)


### 수정 후
![image](https://github.com/user-attachments/assets/dd24dce1-aa36-4415-8a72-627fa54b318d)

