### PR TITLE
PMD로 소프트웨어 보안약점 진단하고 제거하기-EgovComCrossSiteHndlr

### DIFF
--- a/src/main/java/egovframework/com/cmm/EgovComCrossSiteHndlr.java
+++ b/src/main/java/egovframework/com/cmm/EgovComCrossSiteHndlr.java
@@ -8,6 +8,7 @@ import javax.servlet.jsp.JspWriter;
 import javax.servlet.jsp.PageContext;
 import javax.servlet.jsp.tagext.BodyTagSupport;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 
 /**
@@ -47,8 +48,8 @@ public class EgovComCrossSiteHndlr extends BodyTagSupport {
 	// *********************************************************************
 	// Construction and initialization
 
-	private final String m_sDiffChar = "()[]{}\"',:;= \t\r\n%!+-";
-	private final String m_sArrDiffChar[] = { "&#40;", "&#41;", "&#91;", "&#93;", "&#123;", "&#125;", "&#34;", "&#39;",
+	private final String sDiffChar = "()[]{}\"',:;= \t\r\n%!+-";
+	private final String sArrDiffChar[] = { "&#40;", "&#41;", "&#91;", "&#93;", "&#123;", "&#125;", "&#34;", "&#39;",
 			"&#44;", "&#58;", "&#59;", "&#61;", " ", "\t", // " ","\t",
 			"\r", "\n", // "\r","\n",
 			"&#37;", "&#33;", "&#43;", "&#45;" };
@@ -95,7 +96,7 @@ public class EgovComCrossSiteHndlr extends BodyTagSupport {
 	public int doStartTag() throws JspException {
 		needBody = false; // reset state related to 'default'
 		this.bodyContent = null; // clean-up body (just in case container is pooling tag handlers)
-		JspWriter out = pageContext.getOut();
+		JspWriter out = pageContext.getOut(); // NOPMD - CloseResource
 		try {
 			// print value if available; otherwise, try 'default'
 			if (value != null) {
@@ -148,16 +149,12 @@ public class EgovComCrossSiteHndlr extends BodyTagSupport {
 	 * See also Util.escapeXml().
 	 */
 	public static void out(PageContext pageContext, boolean escapeXml, Object obj) throws IOException {
-		JspWriter w = pageContext.getOut();
+		JspWriter w = pageContext.getOut(); // NOPMD - CloseResource
 		if (!escapeXml) {
 			// write chars as is
 			if (obj instanceof Reader) {
 				Reader reader = (Reader) obj;
-				char[] buf = new char[4096];
-				int count;
-				while ((count = reader.read(buf, 0, 4096)) != -1) {
-					w.write(buf, 0, count);
-				}
+				w.write(IOUtils.toString(reader));
 			} else {
 				w.write(obj.toString());
 			}
@@ -165,11 +162,8 @@ public class EgovComCrossSiteHndlr extends BodyTagSupport {
 			// escape XML chars
 			if (obj instanceof Reader) {
 				Reader reader = (Reader) obj;
-				char[] buf = new char[4096];
-				int count;
-				while ((count = reader.read(buf, 0, 4096)) != -1) {
-					writeEscapedXml(buf, count, w);
-				}
+				String text = IOUtils.toString(reader);
+				writeEscapedXml(text.toCharArray(), text.length(), w);
 			} else {
 				String text = obj.toString();
 				writeEscapedXml(text.toCharArray(), text.length(), w);
@@ -178,7 +172,7 @@ public class EgovComCrossSiteHndlr extends BodyTagSupport {
 	}
 
 	public static void out2(PageContext pageContext, boolean escapeXml, Object obj) throws IOException {
-		JspWriter w = pageContext.getOut();
+		JspWriter w = pageContext.getOut(); // NOPMD - CloseResource
 		w.write(obj.toString());
 	}
 
@@ -226,14 +220,14 @@ public class EgovComCrossSiteHndlr extends BodyTagSupport {
 		int start = 0;
 		int length = text.length();
 		char[] buffer = text.toCharArray();
-		char[] cDiffChar = this.m_sDiffChar.toCharArray();
+		char[] cDiffChar = this.sDiffChar.toCharArray();
 
 		for (int i = 0; i < length; i++) {
 			char c = buffer[i];
 			booleanDiff = false;
 			for (int k = 0; k < cDiffChar.length; k++) {
 				if (c == cDiffChar[k]) {
-					sRtn = sRtn + m_sArrDiffChar[k];
+					sRtn = sRtn + sArrDiffChar[k];
 					booleanDiff = true;
 					continue;
 				}
@@ -276,14 +270,14 @@ public class EgovComCrossSiteHndlr extends BodyTagSupport {
 		int start = 0;
 		int length = text.length();
 		char[] buffer = text.toCharArray();
-		char[] cDiffChar = this.m_sDiffChar.toCharArray();
+		char[] cDiffChar = this.sDiffChar.toCharArray();
 
 		for (int i = 0; i < length; i++) {
 			char c = buffer[i];
 			booleanDiff = false;
 			for (int k = 0; k < cDiffChar.length; k++) {
 				if (c == cDiffChar[k]) {
-					sRtn = sRtn + m_sArrDiffChar[k];
+					sRtn = sRtn + sArrDiffChar[k];
 					booleanDiff = true;
 					continue;
 				}

--- a/src/main/java/egovframework/com/cmm/EgovComCrossSiteHndlr.java
+++ b/src/main/java/egovframework/com/cmm/EgovComCrossSiteHndlr.java
@@ -16,7 +16,9 @@ import org.apache.commons.lang3.StringUtils;
  * @author 공통서비스 장동한
  * @since 2010.11.09
  * @version 1.0
- * @see <pre>
+ * @see
+ * 
+ *      <pre>
  * &lt;&lt; 개정이력(Modification Information) &gt;&gt;
  *
  *    수정일     수정자      수정내용
@@ -24,7 +26,7 @@ import org.apache.commons.lang3.StringUtils;
  *   2010.11.09  장동한      최초 생성
  *   2022.11.11  김혜준      시큐어코딩 처리
  *
- * </pre>
+ *      </pre>
  */
 @SuppressWarnings("serial")
 public class EgovComCrossSiteHndlr extends BodyTagSupport {
@@ -45,35 +47,26 @@ public class EgovComCrossSiteHndlr extends BodyTagSupport {
 	// *********************************************************************
 	// Construction and initialization
 
-	private final String m_sDiffChar ="()[]{}\"',:;= \t\r\n%!+-";
-	private final String m_sArrDiffChar [] = {
-						"&#40;","&#41;",
-						"&#91;","&#93;",
-						"&#123;","&#125;",
-						"&#34;","&#39;",
-						"&#44;","&#58;",
-						"&#59;","&#61;",
-						" ","\t", //" ","\t",
-						"\r","\n", //"\r","\n",
-						"&#37;","&#33;",
-						"&#43;","&#45;"
-						};
-	
-	// 23.06.08 taglibs 라이브러리 취약점 패치 간 변경사항	김혜준
+	private final String m_sDiffChar = "()[]{}\"',:;= \t\r\n%!+-";
+	private final String m_sArrDiffChar[] = { "&#40;", "&#41;", "&#91;", "&#93;", "&#123;", "&#125;", "&#34;", "&#39;",
+			"&#44;", "&#58;", "&#59;", "&#61;", " ", "\t", // " ","\t",
+			"\r", "\n", // "\r","\n",
+			"&#37;", "&#33;", "&#43;", "&#45;" };
+
+	// 23.06.08 taglibs 라이브러리 취약점 패치 간 변경사항 김혜준
 	public static final int HIGHEST_SPECIAL = '>';
-    public static char[][] specialCharactersRepresentation = new char[HIGHEST_SPECIAL + 1][];
-    static {
-        specialCharactersRepresentation['&'] = "&amp;".toCharArray();
-        specialCharactersRepresentation['<'] = "&lt;".toCharArray();
-        specialCharactersRepresentation['>'] = "&gt;".toCharArray();
-        specialCharactersRepresentation['"'] = "&#034;".toCharArray();
-        specialCharactersRepresentation['\''] = "&#039;".toCharArray();
-    }
+	public static char[][] specialCharactersRepresentation = new char[HIGHEST_SPECIAL + 1][];
+	static {
+		specialCharactersRepresentation['&'] = "&amp;".toCharArray();
+		specialCharactersRepresentation['<'] = "&lt;".toCharArray();
+		specialCharactersRepresentation['>'] = "&gt;".toCharArray();
+		specialCharactersRepresentation['"'] = "&#034;".toCharArray();
+		specialCharactersRepresentation['\''] = "&#039;".toCharArray();
+	}
 
 	/**
-	 * Constructs a new handler. As with TagSupport, subclasses should not
-	 * provide other constructors and are expected to call the superclass
-	 * constructor.
+	 * Constructs a new handler. As with TagSupport, subclasses should not provide
+	 * other constructors and are expected to call the superclass constructor.
 	 */
 	public EgovComCrossSiteHndlr() {
 		super();
@@ -88,6 +81,7 @@ public class EgovComCrossSiteHndlr extends BodyTagSupport {
 	}
 
 	// Releases any resources we may have (or inherit)
+	@Override
 	public void release() {
 		super.release();
 		init();
@@ -97,6 +91,7 @@ public class EgovComCrossSiteHndlr extends BodyTagSupport {
 	// Tag logic
 
 	// evaluates 'value' and determines if the body should be evaluted
+	@Override
 	public int doStartTag() throws JspException {
 		needBody = false; // reset state related to 'default'
 		this.bodyContent = null; // clean-up body (just in case container is pooling tag handlers)
@@ -124,13 +119,14 @@ public class EgovComCrossSiteHndlr extends BodyTagSupport {
 	}
 
 	// prints the body if necessary; reports errors
+	@Override
 	public int doEndTag() throws JspException {
 		try {
-			if (!needBody){
+			if (!needBody) {
 				return EVAL_PAGE; // nothing more to do
 			}
 			// trim and print out the body
-			if (bodyContent != null && bodyContent.getString() != null){
+			if (bodyContent != null && bodyContent.getString() != null) {
 				out(pageContext, escapeXml, bodyContent.getString().trim());
 			}
 			return EVAL_PAGE;
@@ -144,8 +140,8 @@ public class EgovComCrossSiteHndlr extends BodyTagSupport {
 
 	/**
 	 * Outputs <tt>text</tt> to <tt>pageContext</tt>'s current JspWriter. If
-	 * <tt>escapeXml</tt> is true, performs the following substring replacements
-	 * (to facilitate output to XML/HTML pages):
+	 * <tt>escapeXml</tt> is true, performs the following substring replacements (to
+	 * facilitate output to XML/HTML pages):
 	 *
 	 * & -> &amp; < -> &lt; > -> &gt; " -> &#034; ' -> &#039;
 	 *
@@ -230,20 +226,22 @@ public class EgovComCrossSiteHndlr extends BodyTagSupport {
 		int start = 0;
 		int length = text.length();
 		char[] buffer = text.toCharArray();
-		char[] cDiffChar =  this.m_sDiffChar.toCharArray();
+		char[] cDiffChar = this.m_sDiffChar.toCharArray();
 
-		for(int i = 0; i < length; i++) {
+		for (int i = 0; i < length; i++) {
 			char c = buffer[i];
 			booleanDiff = false;
-			for(int k = 0; k < cDiffChar.length; k++){
-				if(c == cDiffChar[k]){
+			for (int k = 0; k < cDiffChar.length; k++) {
+				if (c == cDiffChar[k]) {
 					sRtn = sRtn + m_sArrDiffChar[k];
 					booleanDiff = true;
 					continue;
 				}
 			}
 
-			if(booleanDiff) continue;
+			if (booleanDiff) {
+				continue;
+			}
 
 			if (c <= HIGHEST_SPECIAL) {
 				char[] escaped = specialCharactersRepresentation[c];
@@ -252,10 +250,10 @@ public class EgovComCrossSiteHndlr extends BodyTagSupport {
 						sRtn = sRtn + escaped[j];
 					}
 					start = i + 1;
-				}else{
+				} else {
 					sRtn = sRtn + c;
 				}
-			}else{
+			} else {
 				sRtn = sRtn + c;
 			}
 		}
@@ -278,20 +276,22 @@ public class EgovComCrossSiteHndlr extends BodyTagSupport {
 		int start = 0;
 		int length = text.length();
 		char[] buffer = text.toCharArray();
-		char[] cDiffChar =  this.m_sDiffChar.toCharArray();
+		char[] cDiffChar = this.m_sDiffChar.toCharArray();
 
-		for(int i = 0; i < length; i++) {
+		for (int i = 0; i < length; i++) {
 			char c = buffer[i];
 			booleanDiff = false;
 			for (int k = 0; k < cDiffChar.length; k++) {
-				if(c == cDiffChar[k]){
+				if (c == cDiffChar[k]) {
 					sRtn = sRtn + m_sArrDiffChar[k];
 					booleanDiff = true;
 					continue;
 				}
 			}
 
-			if(booleanDiff) continue;
+			if (booleanDiff) {
+				continue;
+			}
 
 			if (c <= HIGHEST_SPECIAL) {
 				char[] escaped = specialCharactersRepresentation[c];
@@ -300,10 +300,10 @@ public class EgovComCrossSiteHndlr extends BodyTagSupport {
 						sRtn = sRtn + escaped[j];
 					}
 					start = i + 1;
-				}else{
+				} else {
 					sRtn = sRtn + c;
 				}
-			}else{
+			} else {
 				sRtn = sRtn + c;
 			}
 		}
@@ -311,19 +311,19 @@ public class EgovComCrossSiteHndlr extends BodyTagSupport {
 		return sRtn;
 	}
 
-    // for tag attribute
-    public void setValue(Object value) {
-        this.value = value;
-    }
+	// for tag attribute
+	public void setValue(Object value) {
+		this.value = value;
+	}
 
-    // for tag attribute
-    public void setDefault(String def) {
-        this.def = def;
-    }
+	// for tag attribute
+	public void setDefault(String def) {
+		this.def = def;
+	}
 
-    // for tag attribute
-    public void setEscapeXml(boolean escapeXml) {
-        this.escapeXml = escapeXml;
-    }
+	// for tag attribute
+	public void setEscapeXml(boolean escapeXml) {
+		this.escapeXml = escapeXml;
+	}
 
 }

--- a/src/main/java/egovframework/com/cmm/EgovComCrossSiteHndlr.java
+++ b/src/main/java/egovframework/com/cmm/EgovComCrossSiteHndlr.java
@@ -20,12 +20,14 @@ import org.apache.commons.lang3.StringUtils;
  * @see
  * 
  *      <pre>
- * &lt;&lt; 개정이력(Modification Information) &gt;&gt;
+ *  == 개정이력(Modification Information) ==
  *
- *    수정일     수정자      수정내용
- *   -------    --------    ---------------------------
- *   2010.11.09  장동한      최초 생성
- *   2022.11.11  김혜준      시큐어코딩 처리
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2009.03.20  홍길동          최초 생성
+ *   2010.11.09  장동한          최초 생성
+ *   2022.11.11  김혜준          시큐어코딩 처리
+ *   2025.05.22  이백행          PMD로 소프트웨어 보안약점 진단하고 제거하기-FieldNamingConventions(필드 명명 규칙), CloseResource(리소스 닫기), AssignmentInOperand(피연산자의 할당)
  *
  *      </pre>
  */


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

<hr>

### 2025-05-22 목 PMD로 소프트웨어 보안약점 진단하고 제거하기-EgovComCrossSiteHndlr

#### PMD로 소프트웨어 보안약점 진단 결과

```
src/main/java/egovframework/com/cmm/EgovComCrossSiteHndlr.java:48:	FieldNamingConventions:	FieldNamingConventions: 'final field' 의 변수 'm_sDiffChar' 이  '[a-z][a-zA-Z0-9]*'  로 시작함
src/main/java/egovframework/com/cmm/EgovComCrossSiteHndlr.java:49:	FieldNamingConventions:	FieldNamingConventions: 'final field' 의 변수 'm_sArrDiffChar' 이  '[a-z][a-zA-Z0-9]*'  로 시작함
src/main/java/egovframework/com/cmm/EgovComCrossSiteHndlr.java:103:	CloseResource:	CloseResource: 리소스 'JspWriter' 가 사용 후에 닫혔는지 확인필요
src/main/java/egovframework/com/cmm/EgovComCrossSiteHndlr.java:155:	CloseResource:	CloseResource: 리소스 'JspWriter' 가 사용 후에 닫혔는지 확인필요
src/main/java/egovframework/com/cmm/EgovComCrossSiteHndlr.java:162:	AssignmentInOperand:	AssignmentInOperand: 피연산자내에 할당문이 사용됨. Code 를 복잡하고 가독성이 떨어지게 만듬
src/main/java/egovframework/com/cmm/EgovComCrossSiteHndlr.java:174:	AssignmentInOperand:	AssignmentInOperand: 피연산자내에 할당문이 사용됨. Code 를 복잡하고 가독성이 떨어지게 만듬
src/main/java/egovframework/com/cmm/EgovComCrossSiteHndlr.java:185:	CloseResource:	CloseResource: 리소스 'JspWriter' 가 사용 후에 닫혔는지 확인필요
```

FieldNamingConventions 번역
- 필드 명명 규칙
- Field Naming Conventions

CloseResource 번역
- 닫기리소스
- Close Resource
- 리소스 닫기

AssignmentInOperand 번역
- 피연산자의 할당
- Assignment In Operand

#### 브랜치 생성

```
feature/pmd/EgovComCrossSiteHndlr
```

#### Commit and Push(커밋 및 푸시) 1

Commit Message(커밋 메시지)
```
이클립스 > Source > Format
```

#### Commit and Push(커밋 및 푸시) 2

Commit Message(커밋 메시지)
```
PMD로 소프트웨어 보안약점 진단하고 제거하기-FieldNamingConventions(필드 명명 규칙), CloseResource(리소스 닫기), AssignmentInOperand(피연산자의 할당)
```

#### Commit and Push(커밋 및 푸시) 3

```java
 *   2025.05.22  이백행          PMD로 소프트웨어 보안약점 진단하고 제거하기-FieldNamingConventions(필드 명명 규칙), CloseResource(리소스 닫기), AssignmentInOperand(피연산자의 할당)
```

Commit Message(커밋 메시지)
```
개정이력 수정
```

egovc File Search 파일 검색
- egovc.tld
- ${egovc:
- ${egovc:out 없음

NOPMD comment
- // NOPMD - CloseResource
- Alternatively, you can tell PMD to ignore a specific line by using the “NOPMD” marker in a comment, like this:
  - 또는 다음과 같이 주석에 "NOPMD" 마커를 사용하여 PMD가 특정 줄을 무시하도록 지시할 수 있습니다.
- https://pmd.github.io/pmd/pmd_userdocs_suppressing_warnings.html#nopmd-comment

<hr>

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

https://youtu.be/7kw-9H2XlXo
