### PR TITLE
PMD로 소프트웨어 보안약점 진단하고 제거하기-EgovFileBasePathSecurityValidator

### DIFF
--- a/src/main/java/egovframework/com/cmm/aop/EgovFileBasePathSecurityValidator.java
+++ b/src/main/java/egovframework/com/cmm/aop/EgovFileBasePathSecurityValidator.java
@@ -13,16 +13,21 @@ import lombok.extern.slf4j.Slf4j;
  * EgovFileBasePathSecurityValidator Class 구현
  * 
  * @author 표준프레임워크 신용호
- * @since 2019.04.25
+ * @since 2025.04.01
  * @version 4.3
  * @see
  * 
  *      <pre>
+ *  == 개정이력(Modification Information) ==
  *
- *  수정일         수정자          수정내용
- *  ----------   -----------   ---------------------------
- *  2025.04.01   신용호          최초 생성
- *  
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2025.04.01  신용호          최초 생성
+ *   2025.05.22  이백행          PMD로 소프트웨어 보안약점 진단하고 제거하기-InefficientEmptyStringCheck(비효율적인 빈 문자열 검사), SimplifyBooleanExpressions(부울 표현식 단순화)
+ *
+ *      </pre>
+ * 
+ *      <pre>
  *  - String basePath 파라미터에 대해 보안강화 체크를 한다.
  *  - 보안성을 위해 basePath는 ROOT Path를 지정할수 없다.
  *  - basePath에 대해 다음 경로가 추가되어 화이트리스트 방식으로 점검한다. (필요시 화이트리스트를 추가한다)

--- a/src/main/java/egovframework/com/cmm/aop/EgovFileBasePathSecurityValidator.java
+++ b/src/main/java/egovframework/com/cmm/aop/EgovFileBasePathSecurityValidator.java
@@ -4,6 +4,8 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 
+import org.springframework.util.ObjectUtils;
+
 import egovframework.com.cmm.service.EgovProperties;
 import lombok.extern.slf4j.Slf4j;
 
@@ -47,8 +49,12 @@ public class EgovFileBasePathSecurityValidator {
 		// 테스트용 Base Path - Linux, Mac OS
 		// whiteList.add("/Users/EgovStoredFiles");
 
-		if (basePath == null || basePath.trim().isEmpty()) {
-			log.error("ERROR : The base path is empty.");
+//		if (!StringUtils.hasLength(basePath)) {
+//		if (!StringUtils.hasText(basePath)) {
+		if (ObjectUtils.isEmpty(basePath)) {
+			if (log.isErrorEnabled()) {
+				log.error("ERROR : The base path is empty.");
+			}
 			return false;
 		}
 
@@ -56,7 +62,9 @@ public class EgovFileBasePathSecurityValidator {
 
 		// 루트 경로 제한 (리눅스 / 또는 윈도우 드라이브 루트 경로들)
 		if (normalizedBasePath.matches("(?i)^[a-z]:/$") || normalizedBasePath.equals("/")) {
-			log.error("ERROR : Root base paths are not allowed. basePath = {}", basePath);
+			if (log.isErrorEnabled()) {
+				log.error("ERROR : Root base paths are not allowed. basePath = {}", basePath);
+			}
 			return false;
 		}
 
@@ -72,11 +80,15 @@ public class EgovFileBasePathSecurityValidator {
 				}
 			}
 		} catch (IOException e) {
-			log.debug("Base Path IO Exception!");
+			if (log.isErrorEnabled()) {
+				log.error("Base Path IO Exception!");
+			}
 		}
 
-		if (validateResult == false) {
-			log.error("ERROR : Unacceptable base path: {} ", basePath);
+		if (!validateResult) {
+			if (log.isErrorEnabled()) {
+				log.error("ERROR : Unacceptable base path: {} ", basePath);
+			}
 		}
 
 		return validateResult;

--- a/src/main/java/egovframework/com/cmm/aop/EgovFileBasePathSecurityValidator.java
+++ b/src/main/java/egovframework/com/cmm/aop/EgovFileBasePathSecurityValidator.java
@@ -9,11 +9,13 @@ import lombok.extern.slf4j.Slf4j;
 
 /**
  * EgovFileBasePathSecurityValidator Class 구현
+ * 
  * @author 표준프레임워크 신용호
  * @since 2019.04.25
  * @version 4.3
  * @see
- * <pre>
+ * 
+ *      <pre>
  *
  *  수정일         수정자          수정내용
  *  ----------   -----------   ---------------------------
@@ -25,58 +27,58 @@ import lombok.extern.slf4j.Slf4j;
  *    basePath가 다음 제한된 경로의 하위에 위치하는지 점검한다.
  *    1) Globals.fileStorePath # 파일 업로드 경로
  *    2) Globals.SynchrnServerPath # 파일 동기화 컴포넌트에서 사용할 파일 업로드 경로
- *
+ *      </pre>
  */
 
 @Slf4j
 public class EgovFileBasePathSecurityValidator {
 
-    public static boolean validate(String basePath) {
-    	
-    	boolean validateResult = false;
+	public static boolean validate(String basePath) {
 
-    	ArrayList<String> whiteList = new ArrayList<String>();
-    	// 파일 업로드 경로
-    	whiteList.add(EgovProperties.getProperty("Globals.fileStorePath"));
-    	// 파일 동기화 컴포넌트에서 사용할 파일 업로드 경로
-    	whiteList.add(EgovProperties.getProperty("Globals.SynchrnServerPath"));
-    	// 테스트용 Base Path - Windows OS
-    	//whiteList.add("D:/TEMP/");
-    	// 테스트용 Base Path - Linux, Mac OS
-    	//whiteList.add("/Users/EgovStoredFiles");
-    	
-        if (basePath == null || basePath.trim().isEmpty()) {
-            log.error("ERROR : The base path is empty.");
-            return false;
-        }
-        
+		boolean validateResult = false;
 
-        String normalizedBasePath = basePath.trim().replace("\\", "/"); // 윈도우 경로도 동일하게 처리
+		ArrayList<String> whiteList = new ArrayList<String>();
+		// 파일 업로드 경로
+		whiteList.add(EgovProperties.getProperty("Globals.fileStorePath"));
+		// 파일 동기화 컴포넌트에서 사용할 파일 업로드 경로
+		whiteList.add(EgovProperties.getProperty("Globals.SynchrnServerPath"));
+		// 테스트용 Base Path - Windows OS
+		// whiteList.add("D:/TEMP/");
+		// 테스트용 Base Path - Linux, Mac OS
+		// whiteList.add("/Users/EgovStoredFiles");
 
-        // 루트 경로 제한 (리눅스 / 또는 윈도우 드라이브 루트 경로들)
-        if (normalizedBasePath.matches("(?i)^[a-z]:/$") || normalizedBasePath.equals("/")) {
-            log.error("ERROR : Root base paths are not allowed. basePath = {}", basePath);
-            return false;
-        }
+		if (basePath == null || basePath.trim().isEmpty()) {
+			log.error("ERROR : The base path is empty.");
+			return false;
+		}
+
+		String normalizedBasePath = basePath.trim().replace("\\", "/"); // 윈도우 경로도 동일하게 처리
+
+		// 루트 경로 제한 (리눅스 / 또는 윈도우 드라이브 루트 경로들)
+		if (normalizedBasePath.matches("(?i)^[a-z]:/$") || normalizedBasePath.equals("/")) {
+			log.error("ERROR : Root base paths are not allowed. basePath = {}", basePath);
+			return false;
+		}
 
 		try {
-	        // 입력 경로 정규화 (Canonical Path로 변환)
+			// 입력 경로 정규화 (Canonical Path로 변환)
 			File base = new File(normalizedBasePath).getCanonicalFile();
 
-	        // 허용된 디렉토리 내인지 검증
-	        for (String whiteBasePath : whiteList) {
-	            File file = new File(whiteBasePath).getCanonicalFile();
-	            if (file.getPath().startsWith(base.getPath())) {
-	            	validateResult = true;
-	            }
-	        }
+			// 허용된 디렉토리 내인지 검증
+			for (String whiteBasePath : whiteList) {
+				File file = new File(whiteBasePath).getCanonicalFile();
+				if (file.getPath().startsWith(base.getPath())) {
+					validateResult = true;
+				}
+			}
 		} catch (IOException e) {
 			log.debug("Base Path IO Exception!");
 		}
 
-        if (validateResult == false)
-        	log.error("ERROR : Unacceptable base path: {} " , basePath);
+		if (validateResult == false) {
+			log.error("ERROR : Unacceptable base path: {} ", basePath);
+		}
 
-        return validateResult;
-    }
+		return validateResult;
+	}
 }

--- a/src/test/java/egovframework/com/cmm/aop/EgovFileBasePathSecurityValidatorTest.java
+++ b/src/test/java/egovframework/com/cmm/aop/EgovFileBasePathSecurityValidatorTest.java
@@ -107,4 +107,24 @@ public class EgovFileBasePathSecurityValidatorTest {
 		assertEquals(true, validate);
 	}
 
+	@Test
+	public void test5() {
+		// given
+		String basePath = EgovProperties.getProperty("Globals.SynchrnServerPath") + "/false";
+
+		if (log.isDebugEnabled()) {
+			log.debug("basePath={}", basePath);
+		}
+
+		// when
+		boolean validate = EgovFileBasePathSecurityValidator.validate(basePath);
+
+		if (log.isDebugEnabled()) {
+			log.debug("validate={}", validate);
+		}
+
+		// then
+		assertEquals(false, validate);
+	}
+
 }

--- a/src/test/java/egovframework/com/cmm/aop/EgovFileBasePathSecurityValidatorTest.java
+++ b/src/test/java/egovframework/com/cmm/aop/EgovFileBasePathSecurityValidatorTest.java
@@ -1,0 +1,110 @@
+package egovframework.com.cmm.aop;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import egovframework.com.cmm.service.EgovProperties;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * EgovFileBasePathSecurityValidator Class 구현 단위 테스트
+ * 
+ * @author 이백행
+ * @since 2025.05.22
+ * @version 1.0
+ * @see
+ *
+ *      <pre>
+ *  == 개정이력(Modification Information) ==
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2025.05.22  이백행          최초 생성
+ *
+ *      </pre>
+ */
+@Slf4j
+public class EgovFileBasePathSecurityValidatorTest {
+
+	@Test
+	public void test() {
+		// given
+		String basePath = null;
+
+		if (log.isDebugEnabled()) {
+			log.debug("basePath={}", basePath);
+		}
+
+		// when
+		boolean validate = EgovFileBasePathSecurityValidator.validate(basePath);
+
+		if (log.isDebugEnabled()) {
+			log.debug("validate={}", validate);
+		}
+
+		// then
+		assertEquals(false, validate);
+	}
+
+	@Test
+	public void test2() {
+		// given
+		String basePath = "";
+
+		if (log.isDebugEnabled()) {
+			log.debug("basePath={}", basePath);
+		}
+
+		// when
+		boolean validate = EgovFileBasePathSecurityValidator.validate(basePath);
+
+		if (log.isDebugEnabled()) {
+			log.debug("validate={}", validate);
+		}
+
+		// then
+		assertEquals(false, validate);
+	}
+
+	@Test
+	public void test3() {
+		// given
+		String basePath = EgovProperties.getProperty("Globals.fileStorePath");
+
+		if (log.isDebugEnabled()) {
+			log.debug("basePath={}", basePath);
+		}
+
+		// when
+		boolean validate = EgovFileBasePathSecurityValidator.validate(basePath);
+
+		if (log.isDebugEnabled()) {
+			log.debug("validate={}", validate);
+		}
+
+		// then
+		assertEquals(true, validate);
+	}
+
+	@Test
+	public void test4() {
+		// given
+		String basePath = EgovProperties.getProperty("Globals.SynchrnServerPath");
+
+		if (log.isDebugEnabled()) {
+			log.debug("basePath={}", basePath);
+		}
+
+		// when
+		boolean validate = EgovFileBasePathSecurityValidator.validate(basePath);
+
+		if (log.isDebugEnabled()) {
+			log.debug("validate={}", validate);
+		}
+
+		// then
+		assertEquals(true, validate);
+	}
+
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

<hr>

### 2025-05-22 목 PMD로 소프트웨어 보안약점 진단하고 제거하기-EgovFileBasePathSecurityValidator

#### PMD로 소프트웨어 보안약점 진단 결과

```
src/main/java/egovframework/com/cmm/aop/EgovFileBasePathSecurityValidator.java:48:	InefficientEmptyStringCheck:	InefficientEmptyStringCheck: Empty String 을 체크하기 위해 String.trim().length() /String.trim().isEmpty() 을 사용하는 것은 피하도록 함
src/main/java/egovframework/com/cmm/aop/EgovFileBasePathSecurityValidator.java:77:	SimplifyBooleanExpressions:	SimplifyBooleanExpressions: boolean 사용 시 불필요한 비교 연산을 피하도록 함
```

InefficientEmptyStringCheck 번역
- 비효율적인 빈 문자열 검사
- Inefficient Empty String Check

SimplifyBooleanExpressions 번역
- 부울 표현식 단순화
- Simplify Boolean Expressions

#### 브랜치 생성

```
feature/pmd/EgovFileBasePathSecurityValidator
```

EgovFileBasePathSecurityValidator Class 구현 단위 테스트 추가

#### Commit and Push(커밋 및 푸시) 1

Commit Message(커밋 메시지)
```
이클립스 > Source > Format
```

#### Commit and Push(커밋 및 푸시) 2

Commit Message(커밋 메시지)
```
PMD로 소프트웨어 보안약점 진단하고 제거하기-InefficientEmptyStringCheck(비효율적인 빈 문자열 검사), SimplifyBooleanExpressions(부울 표현식 단순화)
```

#### Commit and Push(커밋 및 푸시) 3

```java
 *   2025.05.22  이백행          PMD로 소프트웨어 보안약점 진단하고 제거하기-InefficientEmptyStringCheck(비효율적인 빈 문자열 검사), SimplifyBooleanExpressions(부울 표현식 단순화)
```

Commit Message(커밋 메시지)
```
개정이력 수정
```

if (log.isErrorEnabled()) { 추가

<hr>

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [x] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

https://youtu.be/8m0WRoJzLp4
