### PR TITLE
PMD로 소프트웨어 보안약점 진단하고 제거하기-EgovFileMngUtil

### DIFF
--- a/src/main/java/egovframework/com/cmm/service/EgovFileMngUtil.java
+++ b/src/main/java/egovframework/com/cmm/service/EgovFileMngUtil.java
@@ -38,10 +38,11 @@ import egovframework.com.cmm.util.EgovResourceCloseHelper;
 /**
  * @author 공통 서비스 개발팀 이삼섭
  * @version 1.0
- * @Class Name  : EgovFileMngUtil.java
+ * @Class Name : EgovFileMngUtil.java
  * @Description : 메시지 처리 관련 유틸리티
  * @Modification Information
- *
+ * 
+ *               <pre>
  *   수정일               수정자            수정내용
  *   ----------   --------   ---------------------------
  *   2009.02.13   이삼섭            최초 생성
@@ -50,7 +51,8 @@ import egovframework.com.cmm.util.EgovResourceCloseHelper;
  *   2020.10.26   신용호            parseFileInf(List<MultipartFile> files ...) 추가
  *   2022.11.11   김혜준            시큐어코딩 처리
  *   2024.12.04   신용호            downFile() KISA 시큐어코딩 처리
- *
+ *               </pre>
+ * 
  * @see
  * @since 2009. 02. 13
  *
@@ -73,7 +75,8 @@ public class EgovFileMngUtil {
 	 * @return
 	 * @throws Exception
 	 */
-	public List<FileVO> parseFileInf(Map<String, MultipartFile> files, String KeyStr, int fileKeyParam, String atchFileId, String storePath) throws Exception {
+	public List<FileVO> parseFileInf(Map<String, MultipartFile> files, String KeyStr, int fileKeyParam,
+			String atchFileId, String storePath) throws Exception {
 		int fileKey = fileKeyParam;
 
 		String storePathString = "";
@@ -94,7 +97,7 @@ public class EgovFileMngUtil {
 		File saveFolder = new File(EgovWebUtil.filePathBlackList(storePathString));
 
 		if (!saveFolder.exists() || saveFolder.isFile()) {
-			//2017.03.03 	조성원 	시큐어코딩(ES)-부적절한 예외 처리[CWE-253, CWE-440, CWE-754]
+			// 2017.03.03 조성원 시큐어코딩(ES)-부적절한 예외 처리[CWE-253, CWE-440, CWE-754]
 			if (saveFolder.mkdirs()) {
 				LOGGER.debug("[file.mkdirs] saveFolder : Creation Success ");
 			} else {
@@ -145,7 +148,8 @@ public class EgovFileMngUtil {
 	 * @return
 	 * @throws Exception
 	 */
-	public List<FileVO> parseFileInf(List<MultipartFile> files, String KeyStr, int fileKeyParam, String atchFileId, String storePath) throws Exception {
+	public List<FileVO> parseFileInf(List<MultipartFile> files, String KeyStr, int fileKeyParam, String atchFileId,
+			String storePath) throws Exception {
 		int fileKey = fileKeyParam;
 
 		String storePathString = "";
@@ -231,7 +235,8 @@ public class EgovFileMngUtil {
 				}
 			}
 
-			String writeFilePath = EgovWebUtil.filePathBlackList(FILE_STORE_PATH + File.separator + FilenameUtils.getName(newName));
+			String writeFilePath = EgovWebUtil
+					.filePathBlackList(FILE_STORE_PATH + File.separator + FilenameUtils.getName(newName));
 			bos = new FileOutputStream(writeFilePath);
 
 			int bytesRead = 0;
@@ -272,7 +277,8 @@ public class EgovFileMngUtil {
 		orgFileName = orgFileName.replaceAll("\r", "").replaceAll("\n", "");
 
 		File file = new File(EgovWebUtil.filePathBlackList(FILE_STORE_PATH + downFileName));
-		//File file = new File(EgovWebUtil.filePathBlackList(downFileName,FILE_STORE_PATH));
+		// File file = new
+		// File(EgovWebUtil.filePathBlackList(downFileName,FILE_STORE_PATH));
 
 		if (!file.exists()) {
 			throw new FileNotFoundException(downFileName);
@@ -282,10 +288,11 @@ public class EgovFileMngUtil {
 			throw new FileNotFoundException(downFileName);
 		}
 
-		byte[] buffer = new byte[BUFF_SIZE]; //buffer size 2K.
+		byte[] buffer = new byte[BUFF_SIZE]; // buffer size 2K.
 
 		response.setContentType("application/x-msdownload");
-		response.setHeader("Content-Disposition:", "attachment; filename=" + new String(orgFileName.getBytes(), "UTF-8"));
+		response.setHeader("Content-Disposition:",
+				"attachment; filename=" + new String(orgFileName.getBytes(), "UTF-8"));
 		response.setHeader("Content-Transfer-Encoding", "binary");
 		response.setHeader("Pragma", "no-cache");
 		response.setHeader("Expires", "0");
@@ -331,7 +338,7 @@ public class EgovFileMngUtil {
 		map.put(Globals.ORIGIN_FILE_NM, orginFileName);
 		map.put(Globals.UPLOAD_FILE_NM, newName);
 		map.put(Globals.FILE_EXT, fileExt);
-		map.put(Globals.FILE_PATH, FILE_STORE_PATH );
+		map.put(Globals.FILE_PATH, FILE_STORE_PATH);
 		map.put(Globals.FILE_SIZE, String.valueOf(size));
 
 		return map;
@@ -351,18 +358,19 @@ public class EgovFileMngUtil {
 
 		try {
 			stream = file.getInputStream();
-			File cFile = new File(EgovWebUtil.filePathBlackList(FILE_STORE_PATH ));
+			File cFile = new File(EgovWebUtil.filePathBlackList(FILE_STORE_PATH));
 
 			if (!cFile.isDirectory()) {
-				//2017.03.03 	조성원 	시큐어코딩(ES)-부적절한 예외 처리[CWE-253, CWE-440, CWE-754]
-				if (cFile.mkdirs()){
+				// 2017.03.03 조성원 시큐어코딩(ES)-부적절한 예외 처리[CWE-253, CWE-440, CWE-754]
+				if (cFile.mkdirs()) {
 					LOGGER.debug("[file.mkdirs] saveFolder : Creation Success ");
 				} else {
 					LOGGER.error("[file.mkdirs] saveFolder : Creation Fail ");
 				}
 			}
 
-			bos = new FileOutputStream(EgovWebUtil.filePathBlackList(FILE_STORE_PATH  + File.separator + FilenameUtils.getName(newName)));
+			bos = new FileOutputStream(
+					EgovWebUtil.filePathBlackList(FILE_STORE_PATH + File.separator + FilenameUtils.getName(newName)));
 
 			int bytesRead = 0;
 			byte[] buffer = new byte[BUFF_SIZE];
@@ -379,13 +387,14 @@ public class EgovFileMngUtil {
 	 * 서버 파일에 대하여 다운로드를 처리한다.
 	 *
 	 * @param response
-	 * @param streFileNm 파일된 파일명
+	 * @param streFileNm  파일된 파일명
 	 * @param orignFileNm
 	 * @throws Exception
 	 */
 	public void downFile(HttpServletResponse response, String streFileNm, String orignFileNm) throws Exception {
 		String downFilePath = EgovWebUtil.filePathBlackList(FILE_STORE_PATH + streFileNm);
-		//String downFilePath = EgovWebUtil.filePathBlackList(streFileNm,FILE_STORE_PATH);
+		// String downFilePath =
+		// EgovWebUtil.filePathBlackList(streFileNm,FILE_STORE_PATH);
 		String orgFileName = orignFileNm;
 
 		File file = new File(downFilePath);
@@ -407,13 +416,13 @@ public class EgovFileMngUtil {
 
 				String mimetype = "application/x-msdownload";
 
-				//response.setBufferSize(fSize);
+				// response.setBufferSize(fSize);
 				response.setContentType(mimetype);
 				response.setHeader("Content-Disposition:", "attachment; filename=" + orgFileName);
 				response.setContentLength(fSize);
-				//response.setHeader("Content-Transfer-Encoding","binary");
-				//response.setHeader("Pragma","no-cache");
-				//response.setHeader("Expires","0");
+				// response.setHeader("Content-Transfer-Encoding","binary");
+				// response.setHeader("Pragma","no-cache");
+				// response.setHeader("Expires","0");
 				FileCopyUtils.copy(in, response.getOutputStream());
 			} finally {
 				EgovResourceCloseHelper.close(in);
@@ -423,62 +432,54 @@ public class EgovFileMngUtil {
 		}
 
 		/*
-		String uploadPath = propertiesService.getString("fileDir");
-
-		File uFile = new File(uploadPath, requestedFile);
-		int fSize = (int) uFile.length();
-
-		if (fSize > 0) {
-		    BufferedInputStream in = new BufferedInputStream(new FileInputStream(uFile));
-
-		    String mimetype = "text/html";
-
-		    //response.setBufferSize(fSize);
-		    response.setContentType(mimetype);
-		    response.setHeader("Content-Disposition", "attachment; filename=\"" + requestedFile + "\"");
-		    response.setContentLength(fSize);
-
-		    FileCopyUtils.copy(in, response.getOutputStream());
-		    in.close();
-		    response.getOutputStream().flush();
-		    response.getOutputStream().close();
-		} else {
-		    response.setContentType("text/html");
-		    PrintWriter printwriter = response.getWriter();
-		    printwriter.println("<html>");
-		    printwriter.println("<br><br><br><h2>Could not get file name:<br>" + requestedFile + "</h2>");
-		    printwriter.println("<br><br><br><center><h3><a href='javascript: history.go(-1)'>Back</a></h3></center>");
-		    printwriter.println("<br><br><br>&copy; webAccess");
-		    printwriter.println("</html>");
-		    printwriter.flush();
-		    printwriter.close();
-		}
-		//*/
+		 * String uploadPath = propertiesService.getString("fileDir");
+		 * 
+		 * File uFile = new File(uploadPath, requestedFile); int fSize = (int)
+		 * uFile.length();
+		 * 
+		 * if (fSize > 0) { BufferedInputStream in = new BufferedInputStream(new
+		 * FileInputStream(uFile));
+		 * 
+		 * String mimetype = "text/html";
+		 * 
+		 * //response.setBufferSize(fSize); response.setContentType(mimetype);
+		 * response.setHeader("Content-Disposition", "attachment; filename=\"" +
+		 * requestedFile + "\""); response.setContentLength(fSize);
+		 * 
+		 * FileCopyUtils.copy(in, response.getOutputStream()); in.close();
+		 * response.getOutputStream().flush(); response.getOutputStream().close(); }
+		 * else { response.setContentType("text/html"); PrintWriter printwriter =
+		 * response.getWriter(); printwriter.println("<html>");
+		 * printwriter.println("<br><br><br><h2>Could not get file name:<br>" +
+		 * requestedFile + "</h2>"); printwriter.
+		 * println("<br><br><br><center><h3><a href='javascript: history.go(-1)'>Back</a></h3></center>"
+		 * ); printwriter.println("<br><br><br>&copy; webAccess");
+		 * printwriter.println("</html>"); printwriter.flush(); printwriter.close(); }
+		 * //
+		 */
 
 		/*
-		response.setContentType("application/x-msdownload");
-		response.setHeader("Content-Disposition:", "attachment; filename=" + new String(orgFileName.getBytes(),"UTF-8" ));
-		response.setHeader("Content-Transfer-Encoding","binary");
-		response.setHeader("Pragma","no-cache");
-		response.setHeader("Expires","0");
-
-		BufferedInputStream fin = new BufferedInputStream(new FileInputStream(file));
-		BufferedOutputStream outs = new BufferedOutputStream(response.getOutputStream());
-		int read = 0;
-
-		while ((read = fin.read(b)) != -1) {
-		    outs.write(b,0,read);
-		}
-		log.debug(this.getClass().getName()+" BufferedOutputStream Write Complete!!! ");
-
-		outs.close();
-		fin.close();
-		//*/
+		 * response.setContentType("application/x-msdownload");
+		 * response.setHeader("Content-Disposition:", "attachment; filename=" + new
+		 * String(orgFileName.getBytes(),"UTF-8" ));
+		 * response.setHeader("Content-Transfer-Encoding","binary");
+		 * response.setHeader("Pragma","no-cache"); response.setHeader("Expires","0");
+		 * 
+		 * BufferedInputStream fin = new BufferedInputStream(new FileInputStream(file));
+		 * BufferedOutputStream outs = new
+		 * BufferedOutputStream(response.getOutputStream()); int read = 0;
+		 * 
+		 * while ((read = fin.read(b)) != -1) { outs.write(b,0,read); }
+		 * log.debug(this.getClass().getName()
+		 * +" BufferedOutputStream Write Complete!!! ");
+		 * 
+		 * outs.close(); fin.close(); //
+		 */
 	}
 
 	/**
-	 * 공통 컴포넌트 utl.fcc 패키지와 Dependency 제거를 위해 내부 메서드로 추가 정의함
-	 * 응용어플리케이션에서 고유값을 사용하기 위해 시스템에서 17자리의 TIMESTAMP값을 구하는 기능
+	 * 공통 컴포넌트 utl.fcc 패키지와 Dependency 제거를 위해 내부 메서드로 추가 정의함 응용어플리케이션에서 고유값을 사용하기 위해
+	 * 시스템에서 17자리의 TIMESTAMP값을 구하는 기능
 	 *
 	 * @param
 	 * @return Timestamp 값

--- a/src/main/java/egovframework/com/cmm/service/EgovFileMngUtil.java
+++ b/src/main/java/egovframework/com/cmm/service/EgovFileMngUtil.java
@@ -35,26 +35,27 @@ import org.springframework.web.multipart.MultipartFile;
 import egovframework.com.cmm.EgovWebUtil;
 
 /**
+ * 파일 관리 유틸리티
+ * 
  * @author 공통 서비스 개발팀 이삼섭
- * @version 1.0
- * @Class Name : EgovFileMngUtil.java
- * @Description : 메시지 처리 관련 유틸리티
- * @Modification Information
- * 
- *               <pre>
- *   수정일               수정자            수정내용
- *   ----------   --------   ---------------------------
- *   2009.02.13   이삼섭            최초 생성
- *   2011.08.09   서준식            utl.fcc패키지와 Dependency제거를 위해 getTimeStamp()메서드 추가
- *   2017.03.03   조성원            시큐어코딩(ES)-부적절한 예외 처리[CWE-253, CWE-440, CWE-754]
- *   2020.10.26   신용호            parseFileInf(List<MultipartFile> files ...) 추가
- *   2022.11.11   김혜준            시큐어코딩 처리
- *   2024.12.04   신용호            downFile() KISA 시큐어코딩 처리
- *               </pre>
- * 
- * @see
  * @since 2009. 02. 13
+ * @version 1.0
+ * @see
+ * 
+ *      <pre>
+ *  == 개정이력(Modification Information) ==
  *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2009.02.13  이삼섭          최초 생성
+ *   2011.08.09  서준식          utl.fcc패키지와 Dependency제거를 위해 getTimeStamp()메서드 추가
+ *   2017.03.03  조성원          시큐어코딩(ES)-부적절한 예외 처리[CWE-253, CWE-440, CWE-754]
+ *   2020.10.26  신용호          parseFileInf(List<MultipartFile> files ...) 추가
+ *   2022.11.11  김혜준          시큐어코딩 처리
+ *   2024.12.04  신용호          downFile() KISA 시큐어코딩 처리
+ *   2025.05.26  이백행          PMD로 소프트웨어 보안약점 진단하고 제거하기-FormalParameterNamingConventions(공식 매개변수 명명 규칙), CloseResource(리소스 닫기), LocalVariableNamingConventions(지역 변수 명명 규칙), AssignmentInOperand(피연산자의 할당)
+ * 
+ *      </pre>
  */
 @Component("EgovFileMngUtil")
 public class EgovFileMngUtil {

--- a/src/main/java/egovframework/com/cmm/service/EgovFileMngUtil.java
+++ b/src/main/java/egovframework/com/cmm/service/EgovFileMngUtil.java
@@ -33,7 +33,6 @@ import org.springframework.util.FileCopyUtils;
 import org.springframework.web.multipart.MultipartFile;
 
 import egovframework.com.cmm.EgovWebUtil;
-import egovframework.com.cmm.util.EgovResourceCloseHelper;
 
 /**
  * @author 공통 서비스 개발팀 이삼섭
@@ -63,8 +62,6 @@ public class EgovFileMngUtil {
 	private static final Logger LOGGER = LoggerFactory.getLogger(EgovFileMngUtil.class);
 	private static final String FILE_STORE_PATH = EgovProperties.getProperty("Globals.fileStorePath");
 
-	public static final int BUFF_SIZE = 2048;
-
 	@Resource(name = "egovFileIdGnrService")
 	private EgovIdGnrService idgenService;
 
@@ -75,7 +72,7 @@ public class EgovFileMngUtil {
 	 * @return
 	 * @throws Exception
 	 */
-	public List<FileVO> parseFileInf(Map<String, MultipartFile> files, String KeyStr, int fileKeyParam,
+	public List<FileVO> parseFileInf(Map<String, MultipartFile> files, String keyStr, int fileKeyParam,
 			String atchFileId, String storePath) throws Exception {
 		int fileKey = fileKeyParam;
 
@@ -120,7 +117,7 @@ public class EgovFileMngUtil {
 
 			// 2022.11.11 시큐어코딩 처리
 			String fileExt = FilenameUtils.getExtension(orginFileName).toUpperCase();
-			String newName = KeyStr + getTimeStamp() + fileKey;
+			String newName = keyStr + getTimeStamp() + fileKey;
 			long size = file.getSize();
 			String filePath = storePathString + File.separator + newName;
 			file.transferTo(new File(EgovWebUtil.filePathBlackList(filePath)));
@@ -148,7 +145,7 @@ public class EgovFileMngUtil {
 	 * @return
 	 * @throws Exception
 	 */
-	public List<FileVO> parseFileInf(List<MultipartFile> files, String KeyStr, int fileKeyParam, String atchFileId,
+	public List<FileVO> parseFileInf(List<MultipartFile> files, String keyStr, int fileKeyParam, String atchFileId,
 			String storePath) throws Exception {
 		int fileKey = fileKeyParam;
 
@@ -190,7 +187,7 @@ public class EgovFileMngUtil {
 
 			// 2022.11.11 시큐어코딩 처리
 			String fileExt = FilenameUtils.getExtension(orginFileName).toUpperCase();
-			String newName = KeyStr + getTimeStamp() + fileKey;
+			String newName = keyStr + getTimeStamp() + fileKey;
 			long size = file.getSize();
 			String filePath = storePathString + File.separator + newName;
 			file.transferTo(new File(EgovWebUtil.filePathBlackList(filePath)));
@@ -221,32 +218,20 @@ public class EgovFileMngUtil {
 	 * @throws Exception
 	 */
 	protected void writeUploadedFile(MultipartFile file, String newName) throws Exception {
-		InputStream stream = null;
-		OutputStream bos = null;
+		File cFile = new File(FILE_STORE_PATH);
 
-		try {
-			stream = file.getInputStream();
-			File cFile = new File(FILE_STORE_PATH);
-
-			if (!cFile.isDirectory()) {
-				boolean _flag = cFile.mkdir();
-				if (!_flag) {
-					throw new IOException("Directory creation Failed ");
-				}
+		if (!cFile.isDirectory()) {
+			boolean flag = cFile.mkdir();
+			if (!flag) {
+				throw new IOException("Directory creation Failed ");
 			}
+		}
 
-			String writeFilePath = EgovWebUtil
-					.filePathBlackList(FILE_STORE_PATH + File.separator + FilenameUtils.getName(newName));
-			bos = new FileOutputStream(writeFilePath);
+		String writeFilePath = EgovWebUtil
+				.filePathBlackList(FILE_STORE_PATH + File.separator + FilenameUtils.getName(newName));
 
-			int bytesRead = 0;
-			byte[] buffer = new byte[BUFF_SIZE];
-
-			while ((bytesRead = stream.read(buffer, 0, BUFF_SIZE)) != -1) {
-				bos.write(buffer, 0, bytesRead);
-			}
-		} finally {
-			EgovResourceCloseHelper.close(bos, stream);
+		try (InputStream stream = file.getInputStream(); OutputStream bos = new FileOutputStream(writeFilePath);) {
+			FileCopyUtils.copy(stream, bos);
 		}
 	}
 
@@ -288,8 +273,6 @@ public class EgovFileMngUtil {
 			throw new FileNotFoundException(downFileName);
 		}
 
-		byte[] buffer = new byte[BUFF_SIZE]; // buffer size 2K.
-
 		response.setContentType("application/x-msdownload");
 		response.setHeader("Content-Disposition:",
 				"attachment; filename=" + new String(orgFileName.getBytes(), "UTF-8"));
@@ -297,19 +280,9 @@ public class EgovFileMngUtil {
 		response.setHeader("Pragma", "no-cache");
 		response.setHeader("Expires", "0");
 
-		BufferedInputStream fin = null;
-		BufferedOutputStream outs = null;
-
-		try {
-			fin = new BufferedInputStream(new FileInputStream(file));
-			outs = new BufferedOutputStream(response.getOutputStream());
-			int read = 0;
-
-			while ((read = fin.read(buffer)) != -1) {
-				outs.write(buffer, 0, read);
-			}
-		} finally {
-			EgovResourceCloseHelper.close(outs, fin);
+		try (BufferedInputStream fin = new BufferedInputStream(new FileInputStream(file));
+				BufferedOutputStream outs = new BufferedOutputStream(response.getOutputStream());) {
+			FileCopyUtils.copy(fin, outs);
 		}
 	}
 
@@ -353,33 +326,22 @@ public class EgovFileMngUtil {
 	 * @throws Exception
 	 */
 	protected static void writeFile(MultipartFile file, String newName) throws Exception {
-		InputStream stream = null;
-		OutputStream bos = null;
+		File cFile = new File(EgovWebUtil.filePathBlackList(FILE_STORE_PATH));
 
-		try {
-			stream = file.getInputStream();
-			File cFile = new File(EgovWebUtil.filePathBlackList(FILE_STORE_PATH));
-
-			if (!cFile.isDirectory()) {
-				// 2017.03.03 조성원 시큐어코딩(ES)-부적절한 예외 처리[CWE-253, CWE-440, CWE-754]
-				if (cFile.mkdirs()) {
-					LOGGER.debug("[file.mkdirs] saveFolder : Creation Success ");
-				} else {
-					LOGGER.error("[file.mkdirs] saveFolder : Creation Fail ");
-				}
+		if (!cFile.isDirectory()) {
+			// 2017.03.03 조성원 시큐어코딩(ES)-부적절한 예외 처리[CWE-253, CWE-440, CWE-754]
+			if (cFile.mkdirs()) {
+				LOGGER.debug("[file.mkdirs] saveFolder : Creation Success ");
+			} else {
+				LOGGER.error("[file.mkdirs] saveFolder : Creation Fail ");
 			}
+		}
 
-			bos = new FileOutputStream(
-					EgovWebUtil.filePathBlackList(FILE_STORE_PATH + File.separator + FilenameUtils.getName(newName)));
+		try (InputStream stream = file.getInputStream();
+				OutputStream bos = new FileOutputStream(EgovWebUtil
+						.filePathBlackList(FILE_STORE_PATH + File.separator + FilenameUtils.getName(newName)));) {
 
-			int bytesRead = 0;
-			byte[] buffer = new byte[BUFF_SIZE];
-
-			while ((bytesRead = stream.read(buffer, 0, BUFF_SIZE)) != -1) {
-				bos.write(buffer, 0, bytesRead);
-			}
-		} finally {
-			EgovResourceCloseHelper.close(bos, stream);
+			FileCopyUtils.copy(stream, bos);
 		}
 	}
 
@@ -409,11 +371,7 @@ public class EgovFileMngUtil {
 
 		int fSize = (int) file.length();
 		if (fSize > 0) {
-			BufferedInputStream in = null;
-
-			try {
-				in = new BufferedInputStream(new FileInputStream(file));
-
+			try (BufferedInputStream in = new BufferedInputStream(new FileInputStream(file));) {
 				String mimetype = "application/x-msdownload";
 
 				// response.setBufferSize(fSize);
@@ -424,8 +382,6 @@ public class EgovFileMngUtil {
 				// response.setHeader("Pragma","no-cache");
 				// response.setHeader("Expires","0");
 				FileCopyUtils.copy(in, response.getOutputStream());
-			} finally {
-				EgovResourceCloseHelper.close(in);
 			}
 			response.getOutputStream().flush();
 			response.getOutputStream().close();


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

<hr>

### 2025-05-26 월 PMD로 소프트웨어 보안약점 진단하고 제거하기-EgovFileMngUtil

#### PMD로 소프트웨어 보안약점 진단 결과

```
src/main/java/egovframework/com/cmm/service/EgovFileMngUtil.java:76:	FormalParameterNamingConventions:	FormalParameterNamingConventions: 'method parameter' 의 변수 'KeyStr' 이  '[a-z][a-zA-Z0-9]*'  로 시작함
src/main/java/egovframework/com/cmm/service/EgovFileMngUtil.java:148:	FormalParameterNamingConventions:	FormalParameterNamingConventions: 'method parameter' 의 변수 'KeyStr' 이  '[a-z][a-zA-Z0-9]*'  로 시작함
src/main/java/egovframework/com/cmm/service/EgovFileMngUtil.java:220:	CloseResource:	CloseResource: 리소스 'InputStream' 가 사용 후에 닫혔는지 확인필요
src/main/java/egovframework/com/cmm/service/EgovFileMngUtil.java:221:	CloseResource:	CloseResource: 리소스 'OutputStream' 가 사용 후에 닫혔는지 확인필요
src/main/java/egovframework/com/cmm/service/EgovFileMngUtil.java:228:	LocalVariableNamingConventions:	LocalVariableNamingConventions: 'local variable' 의 변수 '_flag' 이  '[a-z][a-zA-Z0-9]*'  로 시작함
src/main/java/egovframework/com/cmm/service/EgovFileMngUtil.java:240:	AssignmentInOperand:	AssignmentInOperand: 피연산자내에 할당문이 사용됨. Code 를 복잡하고 가독성이 떨어지게 만듬
src/main/java/egovframework/com/cmm/service/EgovFileMngUtil.java:293:	CloseResource:	CloseResource: 리소스 'BufferedInputStream' 가 사용 후에 닫혔는지 확인필요
src/main/java/egovframework/com/cmm/service/EgovFileMngUtil.java:294:	CloseResource:	CloseResource: 리소스 'BufferedOutputStream' 가 사용 후에 닫혔는지 확인필요
src/main/java/egovframework/com/cmm/service/EgovFileMngUtil.java:301:	AssignmentInOperand:	AssignmentInOperand: 피연산자내에 할당문이 사용됨. Code 를 복잡하고 가독성이 떨어지게 만듬
src/main/java/egovframework/com/cmm/service/EgovFileMngUtil.java:349:	CloseResource:	CloseResource: 리소스 'InputStream' 가 사용 후에 닫혔는지 확인필요
src/main/java/egovframework/com/cmm/service/EgovFileMngUtil.java:350:	CloseResource:	CloseResource: 리소스 'OutputStream' 가 사용 후에 닫혔는지 확인필요
src/main/java/egovframework/com/cmm/service/EgovFileMngUtil.java:370:	AssignmentInOperand:	AssignmentInOperand: 피연산자내에 할당문이 사용됨. Code 를 복잡하고 가독성이 떨어지게 만듬
src/main/java/egovframework/com/cmm/service/EgovFileMngUtil.java:403:	CloseResource:	CloseResource: 리소스 'BufferedInputStream' 가 사용 후에 닫혔는지 확인필요
```

FormalParameterNamingConventions 번역
- 형식 매개변수 명명 규칙
- Formal Parameter Naming Conventions
- 공식 매개변수 명명 규칙

CloseResource 번역
- 닫기 리소스
- Close Resource
- 리소스 닫기

LocalVariableNamingConventions 번역
- 로컬 변수 명명 규칙
- Local Variable Naming Conventions
- 지역 변수 명명 규칙

AssignmentInOperand 번역
- Assignment In Operand
- 피연산자의 할당

#### 브랜치 생성

```
feature/pmd/EgovFileMngUtil
```

#### Commit and Push(커밋 및 푸시) 1

Commit Message(커밋 메시지)
```
이클립스 > Source > Format
```

#### Commit and Push(커밋 및 푸시) 2

Commit Message(커밋 메시지)
```
PMD로 소프트웨어 보안약점 진단하고 제거하기-FormalParameterNamingConventions(공식 매개변수 명명 규칙), CloseResource(리소스 닫기), LocalVariableNamingConventions(지역 변수 명명 규칙), AssignmentInOperand(피연산자의 할당)
```

#### Commit and Push(커밋 및 푸시) 3

```java
 *   2025.05.26  이백행          PMD로 소프트웨어 보안약점 진단하고 제거하기-FormalParameterNamingConventions(공식 매개변수 명명 규칙), CloseResource(리소스 닫기), LocalVariableNamingConventions(지역 변수 명명 규칙), AssignmentInOperand(피연산자의 할당)
```

Commit Message(커밋 메시지)
```
개정이력 수정
```

<hr>

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

https://youtu.be/hRu1nHvmtQw
