### PR TITLE
PMD로 소프트웨어 보안약점 진단하고 제거하기-EgovMybatisUtil

### DIFF
--- a/src/main/java/egovframework/com/cmm/util/EgovMybatisUtil.java
+++ b/src/main/java/egovframework/com/cmm/util/EgovMybatisUtil.java
@@ -15,7 +15,7 @@ import org.slf4j.LoggerFactory;
  * @version 1.0
  * @see
  *
- * <pre>
+ *      <pre>
  * << 개정이력(Modification Information) >>
  *
  *   수정일        수정자           수정내용
@@ -23,50 +23,52 @@ import org.slf4j.LoggerFactory;
  *   2016.06.07  장동한           최초 생성
  *   2017.03.03     조성원 	  시큐어코딩(ES)-오류 메시지를 통한 정보노출[CWE-209]
  *   2017.07.21  장동한 			isEquals에서 String Character 비교 가능하도록
- *   
- * </pre>
+ * 
+ *      </pre>
  */
-
-
 public class EgovMybatisUtil {
-	
-	private static final Logger logger = LoggerFactory.getLogger(EgovMybatisUtil.class); 
-	
-    /**
+
+	private static final Logger logger = LoggerFactory.getLogger(EgovMybatisUtil.class);
+
+	/**
 	 * Empty 여부를 확인한다.
+	 * 
 	 * @param o Object
 	 * @return boolean
 	 * @exception IllegalArgumentException
 	 */
 	public static boolean isEmpty(Object o) {
 		logger.debug("o={}", o);
-		if(o == null) return true;
-		
-		if(o instanceof String) {
-			if(((String)o).length() == 0){
+		if (o == null) {
+			return true;
+		}
+
+		if (o instanceof String) {
+			if (((String) o).length() == 0) {
 				return true;
 			}
-		} else if(o instanceof Collection) {
-			if(((Collection<?>)o).isEmpty()){
-			return true;
+		} else if (o instanceof Collection) {
+			if (((Collection<?>) o).isEmpty()) {
+				return true;
 			}
-		} else if(o.getClass().isArray()) {
-			if(Array.getLength(o) == 0){
-			return true;
+		} else if (o.getClass().isArray()) {
+			if (Array.getLength(o) == 0) {
+				return true;
 			}
-		} else if(o instanceof Map) {
-			if(((Map<?, ?>)o).isEmpty()){
-			return true;
+		} else if (o instanceof Map) {
+			if (((Map<?, ?>) o).isEmpty()) {
+				return true;
 			}
-		}else {
+		} else {
 			return false;
 		}
-	
+
 		return false;
 	}
 
-    /**
+	/**
 	 * Not Empty 여부를 확인한다.
+	 * 
 	 * @param o Object
 	 * @return boolean
 	 * @exception IllegalArgumentException
@@ -75,53 +77,59 @@ public class EgovMybatisUtil {
 		return !isEmpty(o);
 	}
 
-    /**
+	/**
 	 * Equal 여부를 확인한다.
+	 * 
 	 * @param obj Object, obj Object
 	 * @return boolean
 	 */
-	
-    public static boolean isEquals(Object obj, Object obj2){
-    	if(isEmpty(obj)) return false;
 
-    	if(obj instanceof String && obj2 instanceof String) {
-    		if( (String.valueOf(obj)).equals( String.valueOf(obj2) )){
+	public static boolean isEquals(Object obj, Object obj2) {
+		if (isEmpty(obj)) {
+			return false;
+		}
+
+		if (obj instanceof String && obj2 instanceof String) {
+			if ((String.valueOf(obj)).equals(String.valueOf(obj2))) {
 				return true;
 			}
-    	}else if(obj instanceof String && obj2 instanceof Character) {
-     		if( (String.valueOf(obj) ).equals( String.valueOf(obj2) )){
-     			return true;
-     		}
-    	}else if(obj instanceof String && obj2 instanceof Integer) {
-    		if( (String.valueOf(obj)).equals( String.valueOf((Integer)obj2) )){
+		} else if (obj instanceof String && obj2 instanceof Character) {
+			if ((String.valueOf(obj)).equals(String.valueOf(obj2))) {
 				return true;
 			}
-    		
-    	}else if(obj instanceof Integer && obj2 instanceof String) {
-    		if( (String.valueOf(obj2)).equals( String.valueOf((Integer)obj) )){
+		} else if (obj instanceof String && obj2 instanceof Integer) {
+			if ((String.valueOf(obj)).equals(String.valueOf(obj2))) {
 				return true;
 			}
-		} else if(obj instanceof Integer && obj instanceof Integer) {
-    		if((Integer)obj == (Integer)obj2){
+
+		} else if (obj instanceof Integer && obj2 instanceof String) {
+			if ((String.valueOf(obj2)).equals(String.valueOf(obj))) {
+				return true;
+			}
+		} else if (obj instanceof Integer && obj instanceof Integer) {
+			if ((Integer) obj == (Integer) obj2) {
 				return true;
 			}
 		}
-    	
-        return false;	
-    }
-    
-    /**
+
+		return false;
+	}
+
+	/**
 	 * String의 Equal 여부를 확인한다.
+	 * 
 	 * @param obj Object, obj Object
 	 * @return boolean
 	 */
-    public static boolean isEqualsStr(Object obj, String s){
-    	if(isEmpty(obj)) return false;
-    	
-    	if(s.equals(String.valueOf(obj))){
-    		 return true;
-    	}
-        return false;
-    }
-    
+	public static boolean isEqualsStr(Object obj, String s) {
+		if (isEmpty(obj)) {
+			return false;
+		}
+
+		if (s.equals(String.valueOf(obj))) {
+			return true;
+		}
+		return false;
+	}
+
 }

--- a/src/main/java/egovframework/com/cmm/util/EgovMybatisUtil.java
+++ b/src/main/java/egovframework/com/cmm/util/EgovMybatisUtil.java
@@ -4,9 +4,6 @@ import java.lang.reflect.Array;
 import java.util.Collection;
 import java.util.Map;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /**
  * EgovMybatisUtil 클래스
  *
@@ -28,8 +25,6 @@ import org.slf4j.LoggerFactory;
  */
 public class EgovMybatisUtil {
 
-	private static final Logger logger = LoggerFactory.getLogger(EgovMybatisUtil.class);
-
 	/**
 	 * Empty 여부를 확인한다.
 	 * 
@@ -38,7 +33,6 @@ public class EgovMybatisUtil {
 	 * @exception IllegalArgumentException
 	 */
 	public static boolean isEmpty(Object o) {
-		logger.debug("o={}", o);
 		if (o == null) {
 			return true;
 		}
@@ -90,20 +84,20 @@ public class EgovMybatisUtil {
 		}
 
 		if (obj instanceof String && obj2 instanceof String) {
-			if ((String.valueOf(obj)).equals(String.valueOf(obj2))) {
+			if (String.valueOf(obj).equals(String.valueOf(obj2))) {
 				return true;
 			}
 		} else if (obj instanceof String && obj2 instanceof Character) {
-			if ((String.valueOf(obj)).equals(String.valueOf(obj2))) {
+			if (String.valueOf(obj).equals(String.valueOf(obj2))) {
 				return true;
 			}
 		} else if (obj instanceof String && obj2 instanceof Integer) {
-			if ((String.valueOf(obj)).equals(String.valueOf(obj2))) {
+			if (String.valueOf(obj).equals(String.valueOf(obj2))) {
 				return true;
 			}
 
 		} else if (obj instanceof Integer && obj2 instanceof String) {
-			if ((String.valueOf(obj2)).equals(String.valueOf(obj))) {
+			if (String.valueOf(obj2).equals(String.valueOf(obj))) {
 				return true;
 			}
 		} else if (obj instanceof Integer && obj instanceof Integer) {

--- a/src/main/java/egovframework/com/cmm/util/EgovMybatisUtil.java
+++ b/src/main/java/egovframework/com/cmm/util/EgovMybatisUtil.java
@@ -11,16 +11,18 @@ import java.util.Map;
  * @since 2016.06.07
  * @version 1.0
  * @see
- *
- *      <pre>
- * << 개정이력(Modification Information) >>
- *
- *   수정일        수정자           수정내용
- *  -------      -------------  ----------------------
- *   2016.06.07  장동한           최초 생성
- *   2017.03.03     조성원 	  시큐어코딩(ES)-오류 메시지를 통한 정보노출[CWE-209]
- *   2017.07.21  장동한 			isEquals에서 String Character 비교 가능하도록
  * 
+ *      <pre>
+ *  == 개정이력(Modification Information) ==
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2016.06.07  장동한          최초 생성
+ *   2017.03.03  조성원          시큐어코딩(ES)-오류 메시지를 통한 정보노출[CWE-209]
+ *   2017.07.21  장동한          isEquals에서 String Character 비교 가능하도록
+ *   2023.05.01  이백행          컬렉션은 원시 유형입니다. 일반 유형 컬렉션 <e>에 대한 참조는 매개 변수화되어야합니다
+ *   2025.05.28  이백행          PMD로 소프트웨어 보안약점 진단하고 제거하기-FieldNamingConventions(필드 명명 규칙), UselessParentheses(쓸모없는 괄호)
+ *
  *      </pre>
  */
 public class EgovMybatisUtil {


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

<hr>

### 2025-05-28 수 PMD로 소프트웨어 보안약점 진단하고 제거하기-EgovMybatisUtil

#### PMD로 소프트웨어 보안약점 진단 결과

```
src/main/java/egovframework/com/cmm/util/EgovMybatisUtil.java:33:	FieldNamingConventions:	FieldNamingConventions: 'constant' 의 변수 'logger' 이  '[A-Z][A-Z_0-9]*'  로 시작함
src/main/java/egovframework/com/cmm/util/EgovMybatisUtil.java:88:	UselessParentheses:	UselessParentheses: 괄호가 없어도 되는 상황에서 불필요한 괄호를 사용할 경우 마치 메소드 호출처럼 보여서 소스 코드의 가독성을 떨어뜨릴 수 있음
src/main/java/egovframework/com/cmm/util/EgovMybatisUtil.java:92:	UselessParentheses:	UselessParentheses: 괄호가 없어도 되는 상황에서 불필요한 괄호를 사용할 경우 마치 메소드 호출처럼 보여서 소스 코드의 가독성을 떨어뜨릴 수 있음
src/main/java/egovframework/com/cmm/util/EgovMybatisUtil.java:96:	UselessParentheses:	UselessParentheses: 괄호가 없어도 되는 상황에서 불필요한 괄호를 사용할 경우 마치 메소드 호출처럼 보여서 소스 코드의 가독성을 떨어뜨릴 수 있음
src/main/java/egovframework/com/cmm/util/EgovMybatisUtil.java:101:	UselessParentheses:	UselessParentheses: 괄호가 없어도 되는 상황에서 불필요한 괄호를 사용할 경우 마치 메소드 호출처럼 보여서 소스 코드의 가독성을 떨어뜨릴 수 있음
```

FieldNamingConventions 번역
- 필드 명명 규칙
- Field Naming Conventions

UselessParentheses 번역
- 쓸모없는 괄호
- Useless Parentheses

#### 브랜치 생성

```
feature/pmd/EgovMybatisUtil
```

#### Commit and Push(커밋 및 푸시) 1

Commit Message(커밋 메시지)
```
이클립스 > Source > Format
```

#### Commit and Push(커밋 및 푸시) 2

Commit Message(커밋 메시지)
```
PMD로 소프트웨어 보안약점 진단하고 제거하기-FieldNamingConventions(필드 명명 규칙), UselessParentheses(쓸모없는 괄호)
```

#### Commit and Push(커밋 및 푸시) 3

```java
 *   2025.05.28  이백행          PMD로 소프트웨어 보안약점 진단하고 제거하기-FieldNamingConventions(필드 명명 규칙), UselessParentheses(쓸모없는 괄호)
```

Commit Message(커밋 메시지)
```
개정이력 수정
```

<hr>

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [x] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

EgovMybatisUtilTest

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

https://youtu.be/ViTCmA0KTtc
