### PR TITLE
PMD로 소프트웨어 보안약점 진단하고 제거하기-EgovImageProcessController

### DIFF
--- a/src/main/java/egovframework/com/cmm/web/EgovImageProcessController.java
+++ b/src/main/java/egovframework/com/cmm/web/EgovImageProcessController.java
@@ -29,24 +29,26 @@ import egovframework.com.cmm.service.FileVO;
 import egovframework.com.cmm.util.EgovResourceCloseHelper;
 
 /**
- * @Class Name : EgovImageProcessController.java
- * @Description :
- * @Modification Information
- * 
- *               <pre>
- *    수정일       	      수정자                수정내용
- *    ----------   ---------     -------------------
- *    2009.04.02      이삼섭			 최초생성
- *    2014.03.31      유지보수		 fileSn 오류수정
- *    2018.08.31      이정은		     MimeType 중복설정 제거
- *    2019.11.29      신용호	         KISA 보안약점 조치 : HTTP응답분할(HTTP_Response_Splitting,CRLF)취약점 조치
- *               </pre>
+ * EgovImageProcessController.java
  * 
  * @author 공통 서비스 개발팀 이삼섭
  * @since 2009. 4. 2.
  * @version
  * @see
+ * 
+ *      <pre>
+ *  == 개정이력(Modification Information) ==
  *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2009.03.20  홍길동          최초 생성
+ *   2009.04.02  이삼섭          최초생성
+ *   2014.03.31  유지보수         fileSn 오류수정
+ *   2018.08.31  이정은          MimeType 중복설정 제거
+ *   2019.11.29  신용호          KISA 보안약점 조치 : HTTP응답분할(HTTP_Response_Splitting,CRLF)취약점 조치
+ *   2025.06.03  이백행          PMD로 소프트웨어 보안약점 진단하고 제거하기-LocalVariableNamingConventions(지역 변수 명명 규칙), CloseResource(리소스 닫기), AssignmentInOperand(피연산자의 할당)
+ *
+ *      </pre>
  */
 @SuppressWarnings("serial")
 @Controller

--- a/src/main/java/egovframework/com/cmm/web/EgovImageProcessController.java
+++ b/src/main/java/egovframework/com/cmm/web/EgovImageProcessController.java
@@ -27,19 +27,20 @@ import egovframework.com.cmm.service.EgovFileMngService;
 import egovframework.com.cmm.service.FileVO;
 import egovframework.com.cmm.util.EgovResourceCloseHelper;
 
-
 /**
  * @Class Name : EgovImageProcessController.java
  * @Description :
  * @Modification Information
- *
+ * 
+ *               <pre>
  *    수정일       	      수정자                수정내용
  *    ----------   ---------     -------------------
  *    2009.04.02      이삼섭			 최초생성
  *    2014.03.31      유지보수		 fileSn 오류수정
  *    2018.08.31      이정은		     MimeType 중복설정 제거
  *    2019.11.29      신용호	         KISA 보안약점 조치 : HTTP응답분할(HTTP_Response_Splitting,CRLF)취약점 조치
- *
+ *               </pre>
+ * 
  * @author 공통 서비스 개발팀 이삼섭
  * @since 2009. 4. 2.
  * @version
@@ -53,34 +54,36 @@ public class EgovImageProcessController extends HttpServlet {
 	/** 암호화서비스 */
 	@Resource(name = "egovEnvCryptoService")
 	EgovEnvCryptoService cryptoService;
-	
-    @Resource(name = "EgovFileMngService")
-    private EgovFileMngService fileService;
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(EgovImageProcessController.class);
+	@Resource(name = "EgovFileMngService")
+	private EgovFileMngService fileService;
 
-    /**
-     * 첨부된 이미지에 대한 미리보기 기능을 제공한다.
-     *
-     * @param atchFileId
-     * @param fileSn
-     * @param sessionVO
-     * @param model
-     * @param response
-     * @throws Exception
-     */
-    @RequestMapping("/cmm/fms/getImage.do")
-    public void getImageInf(SessionVO sessionVO, ModelMap model, @RequestParam Map<String, Object> commandMap, HttpServletRequest request, HttpServletResponse response) throws Exception {
+	private static final Logger LOGGER = LoggerFactory.getLogger(EgovImageProcessController.class);
 
-		// 암호화된 atchFileId 를 복호화하고 동일한 세션인 경우만 다운로드할 수 있다. (2022.12.06 추가) - 파일아이디가 유추 불가능하도록 조치
-    	String param_atchFileId = (String) commandMap.get("atchFileId");
-    	param_atchFileId = param_atchFileId.replaceAll(" ", "+");
+	/**
+	 * 첨부된 이미지에 대한 미리보기 기능을 제공한다.
+	 *
+	 * @param atchFileId
+	 * @param fileSn
+	 * @param sessionVO
+	 * @param model
+	 * @param response
+	 * @throws Exception
+	 */
+	@RequestMapping("/cmm/fms/getImage.do")
+	public void getImageInf(SessionVO sessionVO, ModelMap model, @RequestParam Map<String, Object> commandMap,
+			HttpServletRequest request, HttpServletResponse response) throws Exception {
+
+		// 암호화된 atchFileId 를 복호화하고 동일한 세션인 경우만 다운로드할 수 있다. (2022.12.06 추가) - 파일아이디가 유추
+		// 불가능하도록 조치
+		String param_atchFileId = (String) commandMap.get("atchFileId");
+		param_atchFileId = param_atchFileId.replaceAll(" ", "+");
 		byte[] decodedBytes = Base64.getDecoder().decode(param_atchFileId);
 		String decodedString = cryptoService.decrypt(new String(decodedBytes));
 		String decodedSessionId = StringUtils.substringBefore(decodedString, "|");
 		String decodedFileId = StringUtils.substringAfter(decodedString, "|");
 
-		String fileSn = (String)commandMap.get("fileSn");
+		String fileSn = (String) commandMap.get("fileSn");
 
 		String sessionId = request.getSession().getId();
 
@@ -89,55 +92,55 @@ public class EgovImageProcessController extends HttpServlet {
 		if (!isSameSessionId) {
 			throw new Exception();
 		}
-		
+
 		FileVO vo = new FileVO();
 
 		vo.setAtchFileId(decodedFileId);
 		vo.setFileSn(fileSn);
 
-		//------------------------------------------------------------
+		// ------------------------------------------------------------
 		// fileSn이 없는 경우 마지막 파일 참조
-		//------------------------------------------------------------
+		// ------------------------------------------------------------
 		if (fileSn == null || fileSn.equals("")) {
 			int newMaxFileSN = fileService.getMaxFileSN(vo);
 			vo.setFileSn(Integer.toString(newMaxFileSN - 1));
 		}
-		//------------------------------------------------------------
+		// ------------------------------------------------------------
 
 		FileVO fvo = fileService.selectFileInf(vo);
 
-		//String fileLoaction = fvo.getFileStreCours() + fvo.getStreFileNm();
+		// String fileLoaction = fvo.getFileStreCours() + fvo.getStreFileNm();
 
 		File file = null;
 		FileInputStream fis = null;
 
 		BufferedInputStream in = null;
 		ByteArrayOutputStream bStream = null;
-		
+
 		String fileStreCours = EgovWebUtil.filePathBlackList(fvo.getFileStreCours());
 		String streFileNm = EgovWebUtil.filePathBlackList(fvo.getStreFileNm());
 
 		try {
-		    file = new File(fileStreCours, streFileNm);
-		    fis = new FileInputStream(file);
+			file = new File(fileStreCours, streFileNm);
+			fis = new FileInputStream(file);
 
-		    in = new BufferedInputStream(fis);
-		    bStream = new ByteArrayOutputStream();
+			in = new BufferedInputStream(fis);
+			bStream = new ByteArrayOutputStream();
 
-		    int imgByte;
-		    while ((imgByte = in.read()) != -1) {
-		    	bStream.write(imgByte);
-		    }
+			int imgByte;
+			while ((imgByte = in.read()) != -1) {
+				bStream.write(imgByte);
+			}
 
 			String type = "";
 
 			if (fvo.getFileExtsn() != null && !"".equals(fvo.getFileExtsn())) {
-			    if ("jpg".equals(fvo.getFileExtsn().toLowerCase())) {
-				type = "image/jpeg";
-			    } else {
-			    	type = "image/" + fvo.getFileExtsn().toLowerCase();
-			    }
-			    /*type = "image/" + fvo.getFileExtsn().toLowerCase();*/
+				if ("jpg".equals(fvo.getFileExtsn().toLowerCase())) {
+					type = "image/jpeg";
+				} else {
+					type = "image/" + fvo.getFileExtsn().toLowerCase();
+				}
+				/* type = "image/" + fvo.getFileExtsn().toLowerCase(); */
 
 			} else {
 				LOGGER.debug("Image fileType is null.");
@@ -154,5 +157,5 @@ public class EgovImageProcessController extends HttpServlet {
 		} finally {
 			EgovResourceCloseHelper.close(bStream, in, fis);
 		}
-    }
+	}
 }


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

<hr>

### 2025-06-03 토 PMD로 소프트웨어 보안약점 진단하고 제거하기-EgovImageProcessController

#### PMD로 소프트웨어 보안약점 진단 결과

```
src/main/java/egovframework/com/cmm/web/EgovImageProcessController.java:76:	LocalVariableNamingConventions:	LocalVariableNamingConventions: 'local variable' 의 변수 'param_atchFileId' 이  '[a-z][a-zA-Z0-9]*'  로 시작함
src/main/java/egovframework/com/cmm/web/EgovImageProcessController.java:112:	CloseResource:	CloseResource: 리소스 'FileInputStream' 가 사용 후에 닫혔는지 확인필요
src/main/java/egovframework/com/cmm/web/EgovImageProcessController.java:114:	CloseResource:	CloseResource: 리소스 'BufferedInputStream' 가 사용 후에 닫혔는지 확인필요
src/main/java/egovframework/com/cmm/web/EgovImageProcessController.java:128:	AssignmentInOperand:	AssignmentInOperand: 피연산자내에 할당문이 사용됨. Code 를 복잡하고 가독성이 떨어지게 만듬
```

LocalVariableNamingConventions 번역
- 로컬 변수 명명 규칙
- Local Variable Naming Conventions
- 지역 변수 명명 규칙

CloseResource 번역
- 닫기 리소스
- Close Resource
- 리소스 닫기

AssignmentInOperand 번역
- Assignment In Operand
- 피연산자의 할당

#### 브랜치 생성

```
feature/pmd/EgovImageProcessController
```

#### Commit and Push(커밋 및 푸시) 1

Commit Message(커밋 메시지)
```
이클립스 > Source > Format
```

#### Commit and Push(커밋 및 푸시) 2

Commit Message(커밋 메시지)
```
PMD로 소프트웨어 보안약점 진단하고 제거하기-LocalVariableNamingConventions(지역 변수 명명 규칙), CloseResource(리소스 닫기), AssignmentInOperand(피연산자의 할당)
```

#### Commit and Push(커밋 및 푸시) 3

```java
 *   2025.06.03  이백행          PMD로 소프트웨어 보안약점 진단하고 제거하기-LocalVariableNamingConventions(지역 변수 명명 규칙), CloseResource(리소스 닫기), AssignmentInOperand(피연산자의 할당)
```

Commit Message(커밋 메시지)
```
개정이력 수정
```

<hr>

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [x] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

https://youtu.be/e6S_0GQMWIE
