### PR TITLE
블로그 관리 > 카테고리 등록 버튼의 ReferenceError: Can't find variable 수정

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/egovframework/com/cop/bbs/EgovArticleBlogList.jsp
+++ b/src/main/webapp/WEB-INF/jsp/egovframework/com/cop/bbs/EgovArticleBlogList.jsp
@@ -226,7 +226,7 @@ $(document).ready(function() {
 			<ul class="gnb r">
 			<c:choose>
 				<c:when test="${loginUserCnt == 1}">
-				<li><a href="<c:url value='/cop/bbs/insertBBSMasterView.do?blogId=${boardMasterVO.blogId}&blogAt=Y' />" onclick="fn_egov_ls()"><spring:message code="comCopBlog.articleBlogList.regCategory" /></a></li><!-- 카테고리등록 -->
+				<li><a href="<c:url value='/cop/bbs/insertBBSMasterView.do?blogId=${boardMasterVO.blogId}&blogAt=Y' />"><spring:message code="comCopBlog.articleBlogList.regCategory" /></a></li><!-- 카테고리등록 -->
 				<li><a href="<c:url value='/cop/bbs/selectBlogListManager.do?blogId=${boardMasterVO.blogId}' />" ><spring:message code="comCopBlog.blogUseMgrMain.btnBoard" /></a></li> <!-- 개인블로그관리  -->
 			</ul>
 				<button class="write" onclick="fn_blog_cn('${boardMasterVO.blogId}')"><spring:message code="button.create" /></button>


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

170. 블로그 관리 컴포넌트의 
/cop/bbs/selectArticleBlogList.do?blogId=BLOG_000000000000000&bbsId=BBSMSTR_000000000001 페이지에서

카테고리 등록 버튼을 클릭 했을 때 발생하는 `ReferenceError: Can't find variable: fn_egov_ls` 에러를 수정했습니다.

해당 함수가 존재하지 않고, 필요하지 않은 상황이라 a 태그의 onclick 속성을 제거하였습니다.



## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [] JUnit 테스트 JUnit tests
- [x] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [x] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

### 개선 전

https://github.com/user-attachments/assets/ca5cf44e-d944-498d-a69c-26b5ca4415d8




### 개선 후


https://github.com/user-attachments/assets/d9d0161e-54ba-404e-a7fb-496c111d7350







