### PR TITLE
부서업무정보 > 목록 > TypeError: null is not an object 에러 수정

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/egovframework/com/cop/smt/djm/EgovDeptJobList.jsp
+++ b/src/main/webapp/WEB-INF/jsp/egovframework/com/cop/smt/djm/EgovDeptJobList.jsp
@@ -35,10 +35,17 @@
 <link href="<c:url value="/css/egovframework/com/button.css"/>" rel="stylesheet" type="text/css">
 <script type="text/javascript">
 
+	// display 속성 변경 시 null 체크와 HTMLElement 타입 체크를 수행하는 함수로 수정
+	function setDisplayById(id, displayValue) {
+		var el = document.getElementById(id);
+		if (el && el instanceof HTMLElement) {
+			el.style.display = displayValue;
+		}
+	}
+
 	function fn_egov_init_deptjob(){
 		fn_egov_hide_ListStyle();
-		var idsrc = document.getElementById(document.frm.searchDeptId.value);
-		idsrc.style.display="";
+		setDisplayById(document.frm.searchDeptId.value, "");
 	}
 
 	function press(event) {
@@ -83,17 +90,14 @@
 
 	function fn_egov_change_ListStyle(list){
 		fn_egov_hide_ListStyle();
-
-		var idsrc = document.getElementById(list);
-		idsrc.style.display="";
+		setDisplayById(list, "");
 	}
 
 	function fn_egov_hide_ListStyle(){
 		<c:forEach var="resultBxFn" items="${resultBxList}" varStatus="st">
 		<c:if test="${tmpDeptId != resultBxFn.deptId}">
 		<c:set var="tmpDeptId" value="${resultBxFn.deptId}"/>
-		var idsrc${st.count} = document.getElementById("${resultBxFn.deptId}");
-		idsrc${st.count}.style.display="none";
+		setDisplayById("${resultBxFn.deptId}", "none");
 		</c:if>
 		</c:forEach>	 
 	}


### PR DESCRIPTION
idsrc.style 코드에서 null 체크를 하지 않고 호출하여 발생하는 TypeError: null is not an object 에러 개선

## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

부서업무정보 목록 페이지인 EgovDeptJobList.jsp 의

```javascript
function fn_egov_init_deptjob(){
	fn_egov_hide_ListStyle();
	var idsrc = document.getElementById(document.frm.searchDeptId.value);
	idsrc.style.display="";
}
```

위 코드에서 idsrc 의 null 체크를 하지 않고 코드를 실행하여 TypeError: null is not an object 에러가 발생했습니다.


```javascript
// null 체크 후 코드 실행
function setDisplayById(id, displayValue) {
	var el = document.getElementById(id);
	if (el && el instanceof HTMLElement) {
		el.style.display = displayValue;
	}
}

function fn_egov_init_deptjob(){
	fn_egov_hide_ListStyle();
	setDisplayById(document.frm.searchDeptId.value, "");
}
```

위와 같이 null 체크 후 display를 지정하는 setDisplayById 함수를 추가하고 해당 함수를 통해 동작하도록 수정하였습니다.

같은 페이지 내에 같은 동작을 하는 코드도 같은 함수를 사용하도록 수정하였습니다.




## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [] JUnit 테스트 JUnit tests
- [x] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [x] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

### 개선 전

https://github.com/user-attachments/assets/c4fb1281-9421-4c5e-9a61-6c05b02cb875




### 개선 후


https://github.com/user-attachments/assets/cd0c8972-088e-44f7-b6e5-da9b33bfef62







