### PR TITLE
일지관리 > HTML5 표준에 맞게 summary 속성 제거

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/egovframework/com/cop/smt/dsm/EgovDiaryManageList.jsp
+++ b/src/main/webapp/WEB-INF/jsp/egovframework/com/cop/smt/dsm/EgovDiaryManageList.jsp
@@ -101,7 +101,7 @@ function fn_egov_search_DiaryManage(){
 	</form>
 
 	<!-- 목록영역 -->
-	<table class="board_list" summary="<spring:message code="common.summary.list" arguments="${pageTitle}" />">
+	<table class="board_list">
 	<caption>${pageTitle} <spring:message code="title.list" /></caption>
 	<colgroup>
 		<col style="width: 9%;">


### PR DESCRIPTION
table 태그에서 caption과 summary를 혼용하고 있고, HTML5에 맞게 summary를 제거

## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

table 태그를 설명하는 summary와 caption와 혼용되고 있어서

HTML5에서 비표준이 된 summary 속성을 제거하였습니다.


## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [X] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

### 개선 전

![1](https://github.com/user-attachments/assets/2a14d04f-b2ce-4a92-9ccf-4952f4aad688)


### 개선 후

![2](https://github.com/user-attachments/assets/f4410242-8118-4700-8b1e-d44a3305a013)




