### PR TITLE
지식맵관리(조직) > 등록 시 조직 ID가 중복되었을 때 SQLIntegrityConstraintViolationException 수정

### DIFF
--- a/src/main/java/egovframework/com/dam/map/tea/web/EgovMapTeamController.java
+++ b/src/main/java/egovframework/com/dam/map/tea/web/EgovMapTeamController.java
@@ -126,13 +126,10 @@ public class EgovMapTeamController {
 			return "egovframework/com/dam/map/tea/EgovComDamMapTeamRegist";
 		}
 
-		beanValidator.validate(mapTeam, bindingResult);
-		if (bindingResult.hasErrors()){
-			return "egovframework/com/dam/map/tea/EgovComDamMapTeamRegist";
-		}
-
-		if (mapTeamService.selectMapTeamDetail(mapTeam) != null) {
-			bindingResult.rejectValue("orgnztId", "error.orgnztId", "이미 등록된 조직ID입니다.");
+		if (bindingResult.hasErrors() || mapTeamService.selectMapTeamDetail(mapTeam) != null) {
+			if (!bindingResult.hasErrors()) {
+				bindingResult.rejectValue("orgnztId", "error.orgnztId", "이미 등록된 조직ID입니다.");
+			}
 			return "egovframework/com/dam/map/tea/EgovComDamMapTeamRegist";
 		}
 


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

데이터 등록 시 조직 ID가 중복되면 Duplicate 에러로 에러 페이지가 표시되는 증상을 개선하였습니다.

`EgovMapTeamController` 에서 데이터 저장 전 기존에 등록된 데이터가 있는지 확인하고 에러 메시지를 표시하도록 수정하였습니다.

```java
if (mapTeamService.selectMapTeamDetail(mapTeam) != null) {
	bindingResult.rejectValue("orgnztId", "error.orgnztId", "이미 등록된 조직ID입니다.");
	return "egovframework/com/dam/map/tea/EgovComDamMapTeamRegist";
}
```



## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [] JUnit 테스트 JUnit tests
- [x] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [] Chrome
- [ ] Firefox
- [ ] Edge
- [x] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

### 개선 전

https://github.com/user-attachments/assets/712709d3-9ed2-4d10-b16c-1992355e96d0


### 개선 후

https://github.com/user-attachments/assets/297100e4-8cf4-4e5c-b287-7c4948926023






