### PR TITLE
context-datasource-hikari.xml 추가

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -576,6 +576,13 @@
 			</exclusions>
 		</dependency>
 
+		<!-- https://mvnrepository.com/artifact/p6spy/p6spy -->
+		<dependency>
+			<groupId>p6spy</groupId>
+			<artifactId>p6spy</artifactId>
+			<version>3.9.1</version>
+		</dependency>
+
 	</dependencies>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@
 		</dependency>
 		<!-- 실행환경 라이브러리 끝 -->
 
-		<dependency>
+		<!--<dependency>
 			<groupId>com.googlecode.log4jdbc</groupId>
 			<artifactId>log4jdbc</artifactId>
 			<version>1.2</version>
@@ -144,7 +144,8 @@
 					<groupId>org.slf4j</groupId>
 				</exclusion>
 			</exclusions>
-		</dependency>
+		</dependency>-->
+
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-dbcp2</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -220,6 +220,10 @@
 					<artifactId>slf4j-api</artifactId>
 					<groupId>org.slf4j</groupId>
 				</exclusion>
+				<exclusion>
+					<groupId>com.zaxxer</groupId>
+					<artifactId>HikariCP-java7</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 		<dependency>
@@ -557,6 +561,19 @@
 			<groupId>javax.faces</groupId>
 			<artifactId>javax.faces-api</artifactId>
 			<version>2.3</version>
+		</dependency>
+
+		<!-- https://mvnrepository.com/artifact/com.zaxxer/HikariCP -->
+		<dependency>
+			<groupId>com.zaxxer</groupId>
+			<artifactId>HikariCP</artifactId>
+			<version>4.0.3</version>
+			<exclusions>
+				<exclusion>
+					<groupId>*</groupId>
+					<artifactId>*</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 	</dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
 	<groupId>egovframework</groupId>
 	<artifactId>common</artifactId>
 	<packaging>war</packaging>
@@ -50,9 +51,9 @@
 		</repository>
 	</repositories>
 
-    <dependencies>
-        <!-- 실행환경 라이브러리 -->
-        <!--
+	<dependencies>
+		<!-- 실행환경 라이브러리 -->
+		<!--
         mybatis를 사용하는 데 jdk1.5로 컴파일 할 경우 아래와 같이 변경해 주시기 바랍니다.
         (3.2.X 버전에서 부터 jdk1.6으로 컴파일 되어 발생하는 현상)
           <dependency>
@@ -72,126 +73,126 @@
 			<version>3.5.16</version>
           </dependency>
         -->
-        <dependency>
-            <groupId>org.egovframe.rte</groupId>
-            <artifactId>org.egovframe.rte.fdl.idgnr</artifactId>
-            <version>${org.egovframe.rte.version}</version>
-        </dependency>
+		<dependency>
+			<groupId>org.egovframe.rte</groupId>
+			<artifactId>org.egovframe.rte.fdl.idgnr</artifactId>
+			<version>${org.egovframe.rte.version}</version>
+		</dependency>
 
-        <!--
+		<!--
         JBoss의 경우는 <body-context>부분을 empty로 수정하여 적용하시면 되며,
         pom.xml을 아래와 같이 적용하시면 수정된 jar를 참조하실 수 있습니다.
         (기존 org.egovframe.rte.ptl.mvc dependency에 내부적으로 참조되고 있어,
         해당 부분을 exclude 처리해야 함)
         아래 주석을 해제하시면 됩니다.
         -->
-        <dependency>
-            <groupId>org.egovframe.rte</groupId>
-            <artifactId>org.egovframe.rte.ptl.mvc</artifactId>
-            <version>${org.egovframe.rte.version}</version>
-            <!-- <exclusions>
+		<dependency>
+			<groupId>org.egovframe.rte</groupId>
+			<artifactId>org.egovframe.rte.ptl.mvc</artifactId>
+			<version>${org.egovframe.rte.version}</version>
+			<!-- <exclusions>
                 <exclusion>
                     <groupId>org.springmodules</groupId>
                     <artifactId>spring-modules-validation</artifactId>
                 </exclusion>
             <exclusions> -->
-        </dependency>
-        <!-- <dependency>
+		</dependency>
+		<!-- <dependency>
           <groupId>org.egovframe.rte</groupId>
           <artifactId>spring-modules-validation</artifactId>
           <version>0.9</version>
         </dependency> -->
-        <dependency>
-            <groupId>org.egovframe.rte</groupId>
-            <artifactId>org.egovframe.rte.fdl.property</artifactId>
-            <version>${org.egovframe.rte.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.egovframe.rte</groupId>
-            <artifactId>org.egovframe.rte.fdl.security</artifactId>
-            <version>${org.egovframe.rte.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.egovframe.rte</groupId>
-            <artifactId>org.egovframe.rte.fdl.excel</artifactId>
-            <version>${org.egovframe.rte.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.egovframe.rte</groupId>
-            <artifactId>org.egovframe.rte.bat.core</artifactId>
-            <version>${org.egovframe.rte.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.egovframe.rte</groupId>
-            <artifactId>org.egovframe.rte.fdl.crypto</artifactId>
-            <version>${org.egovframe.rte.version}</version>
-        </dependency>
-        <dependency>
+		<dependency>
+			<groupId>org.egovframe.rte</groupId>
+			<artifactId>org.egovframe.rte.fdl.property</artifactId>
+			<version>${org.egovframe.rte.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.egovframe.rte</groupId>
+			<artifactId>org.egovframe.rte.fdl.security</artifactId>
+			<version>${org.egovframe.rte.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.egovframe.rte</groupId>
+			<artifactId>org.egovframe.rte.fdl.excel</artifactId>
+			<version>${org.egovframe.rte.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.egovframe.rte</groupId>
+			<artifactId>org.egovframe.rte.bat.core</artifactId>
+			<version>${org.egovframe.rte.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.egovframe.rte</groupId>
+			<artifactId>org.egovframe.rte.fdl.crypto</artifactId>
+			<version>${org.egovframe.rte.version}</version>
+		</dependency>
+		<dependency>
 			<groupId>org.egovframe.rte</groupId>
 			<artifactId>org.egovframe.rte.fdl.access</artifactId>
 			<version>${org.egovframe.rte.version}</version>
 		</dependency>
-        <!-- 실행환경 라이브러리 끝 -->
+		<!-- 실행환경 라이브러리 끝 -->
 
-        <dependency>
-            <groupId>com.googlecode.log4jdbc</groupId>
-            <artifactId>log4jdbc</artifactId>
-            <version>1.2</version>
-            <exclusions>
-                <exclusion>
-                    <artifactId>slf4j-api</artifactId>
-                    <groupId>org.slf4j</groupId>
-                </exclusion>
-            </exclusions>
-        </dependency>
 		<dependency>
-		    <groupId>org.apache.commons</groupId>
-		    <artifactId>commons-dbcp2</artifactId>
+			<groupId>com.googlecode.log4jdbc</groupId>
+			<artifactId>log4jdbc</artifactId>
+			<version>1.2</version>
+			<exclusions>
+				<exclusion>
+					<artifactId>slf4j-api</artifactId>
+					<groupId>org.slf4j</groupId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-dbcp2</artifactId>
 			<version>2.12.0</version>
 		</dependency>
-        <dependency>
-            <groupId>javax.servlet.jsp.jstl</groupId>
-            <artifactId>jstl-api</artifactId>
-            <version>1.2</version>
-            <exclusions>
-                <exclusion>
-                	<groupId>javax.servlet</groupId>
-                	<artifactId>servlet-api</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.taglibs</groupId>
-            <artifactId>taglibs-standard-impl</artifactId>
-            <version>1.2.5</version>
-        </dependency>
+		<dependency>
+			<groupId>javax.servlet.jsp.jstl</groupId>
+			<artifactId>jstl-api</artifactId>
+			<version>1.2</version>
+			<exclusions>
+				<exclusion>
+					<groupId>javax.servlet</groupId>
+					<artifactId>servlet-api</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.taglibs</groupId>
+			<artifactId>taglibs-standard-impl</artifactId>
+			<version>1.2.5</version>
+		</dependency>
 		<dependency>
 			<groupId>javax.servlet</groupId>
 			<artifactId>javax.servlet-api</artifactId>
 			<version>4.0.1</version>
 		</dependency>
-        <dependency>
-            <groupId>org.jasypt</groupId>
-            <artifactId>jasypt</artifactId>
-            <version>1.9.3</version>
-        </dependency>
-        <dependency>
-            <groupId>cglib</groupId>
-            <artifactId>cglib</artifactId>
-            <version>3.3.0</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-compress</artifactId>
+		<dependency>
+			<groupId>org.jasypt</groupId>
+			<artifactId>jasypt</artifactId>
+			<version>1.9.3</version>
+		</dependency>
+		<dependency>
+			<groupId>cglib</groupId>
+			<artifactId>cglib</artifactId>
+			<version>3.3.0</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-compress</artifactId>
 			<version>1.26.2</version>
-        </dependency>
+		</dependency>
 		<dependency>
 			<groupId>xerces</groupId>
 			<artifactId>xercesImpl</artifactId>
 			<version>2.12.2</version>
 		</dependency>
-        <!-- cache -->
-        <!-- <dependency>
+		<!-- cache -->
+		<!-- <dependency>
             <groupId>net.sf.ehcache</groupId>
             <artifactId>ehcache-core</artifactId>
             <version>2.10.9.2</version>
@@ -207,236 +208,236 @@
 		    <artifactId>ehcache</artifactId>
 		    <version>2.10.9.2</version>
 		</dependency> -->
-        <!-- cache end -->
+		<!-- cache end -->
 
-        <!-- Scheduling -->
-        <dependency>
-            <groupId>org.quartz-scheduler</groupId>
-            <artifactId>quartz</artifactId>
-            <version>2.3.2</version>
-            <exclusions>
-                <exclusion>
-                    <artifactId>slf4j-api</artifactId>
-                    <groupId>org.slf4j</groupId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.quartz-scheduler</groupId>
-            <artifactId>quartz-jobs</artifactId>
-            <version>2.3.2</version>
-        </dependency>
-        <!-- Scheduling end-->
+		<!-- Scheduling -->
+		<dependency>
+			<groupId>org.quartz-scheduler</groupId>
+			<artifactId>quartz</artifactId>
+			<version>2.3.2</version>
+			<exclusions>
+				<exclusion>
+					<artifactId>slf4j-api</artifactId>
+					<groupId>org.slf4j</groupId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>org.quartz-scheduler</groupId>
+			<artifactId>quartz-jobs</artifactId>
+			<version>2.3.2</version>
+		</dependency>
+		<!-- Scheduling end-->
 
-        <!-- 공통컴포넌트 시작 -->
+		<!-- 공통컴포넌트 시작 -->
 
-        <!-- Validation 에서 사용 antlr.TokenStream -->
-        <dependency>
-            <groupId>org.antlr</groupId>
-	        <artifactId>antlr</artifactId>
-	        <version>3.5</version>
-        </dependency>
+		<!-- Validation 에서 사용 antlr.TokenStream -->
+		<dependency>
+			<groupId>org.antlr</groupId>
+			<artifactId>antlr</artifactId>
+			<version>3.5</version>
+		</dependency>
 
-        <!-- 우편번호를 위한 라이브러리 -->
-        <dependency>
-            <groupId>oro</groupId>
-            <artifactId>oro</artifactId>
-            <version>2.0.8</version>
-        </dependency>
+		<!-- 우편번호를 위한 라이브러리 -->
+		<dependency>
+			<groupId>oro</groupId>
+			<artifactId>oro</artifactId>
+			<version>2.0.8</version>
+		</dependency>
 
-        <!-- 요소기술 달력을 위한 라이브러리 -->
-        <dependency>
-            <groupId>com.ibm.icu</groupId>
-            <artifactId>icu4j</artifactId>
+		<!-- 요소기술 달력을 위한 라이브러리 -->
+		<dependency>
+			<groupId>com.ibm.icu</groupId>
+			<artifactId>icu4j</artifactId>
 			<version>75.1</version>
-        </dependency>
+		</dependency>
 
-        <!-- FTP용 3rd party 라이브러리 -->
-        <dependency>
-            <groupId>commons-net</groupId>
-            <artifactId>commons-net</artifactId>
+		<!-- FTP용 3rd party 라이브러리 -->
+		<dependency>
+			<groupId>commons-net</groupId>
+			<artifactId>commons-net</artifactId>
 			<version>3.11.1</version>
-        </dependency>
+		</dependency>
 
-        <!-- Email -->
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-email</artifactId>
-            <version>1.6.0</version>
-        </dependency>
-        <dependency>
-            <groupId>egovframework.com.ems</groupId>
-            <artifactId>sndng-mail</artifactId>
-            <version>1.0</version>
-        </dependency>
+		<!-- Email -->
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-email</artifactId>
+			<version>1.6.0</version>
+		</dependency>
+		<dependency>
+			<groupId>egovframework.com.ems</groupId>
+			<artifactId>sndng-mail</artifactId>
+			<version>1.0</version>
+		</dependency>
 
-        <!-- Cross-Site Scripting -->
-        <dependency>
-            <groupId>javax.servlet.jsp</groupId>
-            <artifactId>javax.servlet.jsp-api</artifactId>
-            <version>2.3.3</version>
-            <scope>provided</scope>
-        </dependency>
+		<!-- Cross-Site Scripting -->
+		<dependency>
+			<groupId>javax.servlet.jsp</groupId>
+			<artifactId>javax.servlet.jsp-api</artifactId>
+			<version>2.3.3</version>
+			<scope>provided</scope>
+		</dependency>
 		<!-- LDAP SDK -->
 		<dependency>
 			<groupId>ldapsdk</groupId>
 			<artifactId>ldapsdk</artifactId>
 			<version>4.1</version>
 		</dependency>
-        <!-- PDF변환용 라이브러리 -->
-        <dependency>
-            <groupId>com.artofsolving</groupId>
-            <artifactId>jodconverter</artifactId>
-            <version>2.2.1</version>
-            <exclusions>
-                <exclusion>
-                    <artifactId>slf4j-api</artifactId>
-                    <groupId>org.slf4j</groupId>
-                </exclusion>
-                <exclusion>
-                    <artifactId>commons-io</artifactId>
-                    <groupId>commons-io</groupId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-        <!-- fileupload -->
-        <dependency>
-            <groupId>commons-fileupload</groupId>
-            <artifactId>commons-fileupload</artifactId>
-            <version>1.5</version>
-            <exclusions>
-                <exclusion>
-                    <artifactId>commons-io</artifactId>
-                    <groupId>commons-io</groupId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-        <!-- Twitter -->
-        <dependency>
-            <groupId>org.twitter4j</groupId>
-            <artifactId>twitter4j-core</artifactId>
-            <version>4.0.7</version>
-        </dependency>
-		<!-- Twitter v2 -->
+		<!-- PDF변환용 라이브러리 -->
 		<dependency>
-		    <groupId>io.github.takke</groupId>
-		    <artifactId>jp.takke.twitter4j-v2</artifactId>
-		    <version>1.4.2</version>
+			<groupId>com.artofsolving</groupId>
+			<artifactId>jodconverter</artifactId>
+			<version>2.2.1</version>
+			<exclusions>
+				<exclusion>
+					<artifactId>slf4j-api</artifactId>
+					<groupId>org.slf4j</groupId>
+				</exclusion>
+				<exclusion>
+					<artifactId>commons-io</artifactId>
+					<groupId>commons-io</groupId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
-        <!-- Ajax -->
-        <dependency>
-            <groupId>net.sourceforge.ajaxtags</groupId>
-            <artifactId>ajaxtags-resources</artifactId>
-            <version>1.5.7</version>
-        </dependency>
+		<!-- fileupload -->
+		<dependency>
+			<groupId>commons-fileupload</groupId>
+			<artifactId>commons-fileupload</artifactId>
+			<version>1.5</version>
+			<exclusions>
+				<exclusion>
+					<artifactId>commons-io</artifactId>
+					<groupId>commons-io</groupId>
+				</exclusion>
+			</exclusions>
+		</dependency>
 
-        <!-- WYSIWYG Editor -->
-        <dependency>
-            <groupId>com.ckeditor</groupId>
-            <artifactId>ckeditor-java-core</artifactId>
-            <version>3.5.3</version>
-        </dependency>
+		<!-- Twitter -->
+		<dependency>
+			<groupId>org.twitter4j</groupId>
+			<artifactId>twitter4j-core</artifactId>
+			<version>4.0.7</version>
+		</dependency>
+		<!-- Twitter v2 -->
+		<dependency>
+			<groupId>io.github.takke</groupId>
+			<artifactId>jp.takke.twitter4j-v2</artifactId>
+			<version>1.4.2</version>
+		</dependency>
 
-        <!-- xmlParserAPI -->
-        <dependency>
-            <groupId>org.apache.xmlgraphics</groupId>
-            <artifactId>batik-ext</artifactId>
+		<!-- Ajax -->
+		<dependency>
+			<groupId>net.sourceforge.ajaxtags</groupId>
+			<artifactId>ajaxtags-resources</artifactId>
+			<version>1.5.7</version>
+		</dependency>
+
+		<!-- WYSIWYG Editor -->
+		<dependency>
+			<groupId>com.ckeditor</groupId>
+			<artifactId>ckeditor-java-core</artifactId>
+			<version>3.5.3</version>
+		</dependency>
+
+		<!-- xmlParserAPI -->
+		<dependency>
+			<groupId>org.apache.xmlgraphics</groupId>
+			<artifactId>batik-ext</artifactId>
 			<version>1.17</version>
-        </dependency>
-        
-        <!-- oauth2 login -->
-	    <dependency>
-              <groupId>com.github.scribejava</groupId>
-              <artifactId>scribejava-apis</artifactId>
-              <version>8.3.3</version>
-        </dependency>
-        <dependency>
-              <groupId>com.github.scribejava</groupId>
-              <artifactId>scribejava-core</artifactId>
-              <version>8.3.3</version>
-        </dependency>
-        
-        <!-- WebSocket Messenger -->
-        <dependency>
-            <groupId>javax.websocket</groupId>
-            <artifactId>javax.websocket-api</artifactId>
-            <version>1.1</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish</groupId>
-            <artifactId>javax.json</artifactId>
-            <version>1.1.4</version>
-        </dependency>
-        
-        <!-- ajax json -->
-        <!-- social에서 참조 하고 있어 임시 주석 처리 -->
-		<dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-			<version>2.17.1</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-annotations</artifactId>
-			<version>2.17.1</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-			<version>2.17.1</version>
-        </dependency>
+		</dependency>
 
-        <!-- LDAP조직도관리 관련 라이브러리  -->
-        <dependency>
-            <groupId>org.springframework.ldap</groupId>
-            <artifactId>spring-ldap-core</artifactId>
-            <version>2.4.1</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.springframework</groupId>
-                    <artifactId>spring-beans</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.springframework</groupId>
-                    <artifactId>spring-core</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.springframework</groupId>
-                    <artifactId>spring-tx</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>jcl-over-slf4j</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-mapper-asl</artifactId>
-            <version>1.9.13</version>
-        </dependency>
-
-        <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.33</version>
-        </dependency>
+		<!-- oauth2 login -->
 		<dependency>
-		    <groupId>org.mariadb.jdbc</groupId>
-		    <artifactId>mariadb-java-client</artifactId>
+			<groupId>com.github.scribejava</groupId>
+			<artifactId>scribejava-apis</artifactId>
+			<version>8.3.3</version>
+		</dependency>
+		<dependency>
+			<groupId>com.github.scribejava</groupId>
+			<artifactId>scribejava-core</artifactId>
+			<version>8.3.3</version>
+		</dependency>
+
+		<!-- WebSocket Messenger -->
+		<dependency>
+			<groupId>javax.websocket</groupId>
+			<artifactId>javax.websocket-api</artifactId>
+			<version>1.1</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.glassfish</groupId>
+			<artifactId>javax.json</artifactId>
+			<version>1.1.4</version>
+		</dependency>
+
+		<!-- ajax json -->
+		<!-- social에서 참조 하고 있어 임시 주석 처리 -->
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-core</artifactId>
+			<version>2.17.1</version>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-annotations</artifactId>
+			<version>2.17.1</version>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+			<version>2.17.1</version>
+		</dependency>
+
+		<!-- LDAP조직도관리 관련 라이브러리  -->
+		<dependency>
+			<groupId>org.springframework.ldap</groupId>
+			<artifactId>spring-ldap-core</artifactId>
+			<version>2.4.1</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.springframework</groupId>
+					<artifactId>spring-beans</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.springframework</groupId>
+					<artifactId>spring-core</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.springframework</groupId>
+					<artifactId>spring-tx</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-api</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>jcl-over-slf4j</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>org.codehaus.jackson</groupId>
+			<artifactId>jackson-mapper-asl</artifactId>
+			<version>1.9.13</version>
+		</dependency>
+
+		<dependency>
+			<groupId>mysql</groupId>
+			<artifactId>mysql-connector-java</artifactId>
+			<version>8.0.33</version>
+		</dependency>
+		<dependency>
+			<groupId>org.mariadb.jdbc</groupId>
+			<artifactId>mariadb-java-client</artifactId>
 			<version>3.4.0</version>
 		</dependency>
 		<dependency>
-		     <groupId>org.postgresql</groupId>
-		     <artifactId>postgresql</artifactId>
+			<groupId>org.postgresql</groupId>
+			<artifactId>postgresql</artifactId>
 			<version>42.7.3</version>
 		</dependency>
 
@@ -447,8 +448,8 @@
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
-		    <groupId>com.github.javaparser</groupId>
-		    <artifactId>javaparser-core</artifactId>
+			<groupId>com.github.javaparser</groupId>
+			<artifactId>javaparser-core</artifactId>
 			<version>3.26.1</version>
 		</dependency>
 		<dependency>
@@ -457,7 +458,7 @@
 			<version>2.6.0</version>
 		</dependency>
 
-        <!-- 3rd party 라이브러리로 별도의 설치 필요 끝 -->
+		<!-- 3rd party 라이브러리로 별도의 설치 필요 끝 -->
 
 		<!-- 법정도코드, 기관코드 연계 -->
 		<dependency>
@@ -466,7 +467,7 @@
 			<version>1.1.1</version>
 		</dependency>
 
-        <!-- 공통컴포넌트 끝 -->
+		<!-- 공통컴포넌트 끝 -->
 
 		<dependency>
 			<groupId>junit</groupId>
@@ -493,56 +494,56 @@
 			<scope>test</scope>
 		</dependency>
 
-        <!-- 3rd party 라이브러리로 별도의 설치 필요 -->
-        <!-- oracle 11g driver -->
-        <dependency>
-            <groupId>project</groupId>
-            <artifactId>ojdbc6</artifactId>
-            <version>11.2.0.3</version>
-        </dependency>
-        <!-- altibase driver -->
-        <dependency>
-        	 <groupId>project</groupId>
-        	 <artifactId>altibase</artifactId>
-        	 <version>7.1.0</version>
-        </dependency>
-        <!-- tibero driver -->
-        <dependency>
-            <groupId>project</groupId>
-            <artifactId>tibero5</artifactId>
-            <version>5.0.0</version>
-        </dependency>
-        <!-- cubrid driver -->
-        <dependency>
-            <groupId>project</groupId>
-            <artifactId>cubrid</artifactId>
-            <version>10.2.0</version>
-        </dependency>
-        <!-- goldilocks driver -->
-        <dependency>
-            <groupId>project</groupId>
-            <artifactId>goldilocks8</artifactId>
-            <version>8.0.0</version>
-        </dependency>
+		<!-- 3rd party 라이브러리로 별도의 설치 필요 -->
+		<!-- oracle 11g driver -->
+		<dependency>
+			<groupId>project</groupId>
+			<artifactId>ojdbc6</artifactId>
+			<version>11.2.0.3</version>
+		</dependency>
+		<!-- altibase driver -->
+		<dependency>
+			<groupId>project</groupId>
+			<artifactId>altibase</artifactId>
+			<version>7.1.0</version>
+		</dependency>
+		<!-- tibero driver -->
+		<dependency>
+			<groupId>project</groupId>
+			<artifactId>tibero5</artifactId>
+			<version>5.0.0</version>
+		</dependency>
+		<!-- cubrid driver -->
+		<dependency>
+			<groupId>project</groupId>
+			<artifactId>cubrid</artifactId>
+			<version>10.2.0</version>
+		</dependency>
+		<!-- goldilocks driver -->
+		<dependency>
+			<groupId>project</groupId>
+			<artifactId>goldilocks8</artifactId>
+			<version>8.0.0</version>
+		</dependency>
 
-        <!--  M-Gov (SMS Service API) -->
-         <dependency>
-            <groupId>project</groupId>
-            <artifactId>smeapi</artifactId>
-            <version>2.7.0</version>
-        </dependency>
-    	   
-        <!-- GPKI인증서 로그인처리 라이브러리 -->
-        <dependency>
-            <groupId>project</groupId>
-            <artifactId>gpkisecureweb</artifactId>
-            <version>1.0.4.9</version>
-        </dependency>        
-        <dependency>
-            <groupId>project</groupId>
-            <artifactId>libgpkiapi</artifactId>
-            <version>1.4.0</version>
-        </dependency>
+		<!--  M-Gov (SMS Service API) -->
+		<dependency>
+			<groupId>project</groupId>
+			<artifactId>smeapi</artifactId>
+			<version>2.7.0</version>
+		</dependency>
+
+		<!-- GPKI인증서 로그인처리 라이브러리 -->
+		<dependency>
+			<groupId>project</groupId>
+			<artifactId>gpkisecureweb</artifactId>
+			<version>1.0.4.9</version>
+		</dependency>
+		<dependency>
+			<groupId>project</groupId>
+			<artifactId>libgpkiapi</artifactId>
+			<version>1.4.0</version>
+		</dependency>
 
 		<!-- 디지털원패스 라이브러리 시작 -->
 		<dependency>
@@ -551,21 +552,21 @@
 			<version>2.0.0</version>
 		</dependency>
 		<!-- 디지털원패스 라이브러리 끝 -->
-		
+
 		<dependency>
-		    <groupId>javax.faces</groupId>
-		    <artifactId>javax.faces-api</artifactId>
-		    <version>2.3</version>
+			<groupId>javax.faces</groupId>
+			<artifactId>javax.faces-api</artifactId>
+			<version>2.3</version>
 		</dependency>
 
-    </dependencies>
+	</dependencies>
 
-    <build>
-        <defaultGoal>install</defaultGoal>
-        <directory>${basedir}/target</directory>
-        <finalName>egovframework-all-in-one</finalName>
-        <pluginManagement>
-            <plugins>
+	<build>
+		<defaultGoal>install</defaultGoal>
+		<directory>${basedir}/target</directory>
+		<finalName>egovframework-all-in-one</finalName>
+		<pluginManagement>
+			<plugins>
 				<plugin>
 					<groupId>org.codehaus.cargo</groupId>
 					<artifactId>cargo-maven3-plugin</artifactId>
@@ -576,73 +577,73 @@
 							<type>embedded</type>
 						</container>
 						<configuration>
-							<property name="cargo.servlet.port" value="8080"/>
+							<property name="cargo.servlet.port" value="8080" />
 						</configuration>
 					</configuration>
 				</plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-compiler-plugin</artifactId>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-compiler-plugin</artifactId>
 					<version>3.13.0</version>
-                    <configuration>
+					<configuration>
 						<source>${java.version}</source>
 						<target>${java.version}</target>
-                    </configuration>
-                </plugin>
-                <plugin>
-                	<groupId>org.apache.maven.plugins</groupId>
-                	<artifactId>maven-war-plugin</artifactId>
+					</configuration>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-war-plugin</artifactId>
 					<version>3.4.0</version>
-                	<configuration>
-                		<failOnMissingWebXml>false</failOnMissingWebXml>
-                	</configuration>
-                </plugin>
-                <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>hibernate3-maven-plugin</artifactId>
-                    <version>3.0</version>
-                    <dependencies>
-                        <dependency>
-                            <groupId>org.hsqldb</groupId>
-                            <artifactId>hsqldb</artifactId>
-                            <version>2.7.2</version>
-                        </dependency>
-                    </dependencies>
-                </plugin>
-                <!-- EMMA   -->
-                <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>emma-maven-plugin</artifactId>
-                    <version>1.0-alpha-3</version>
-                </plugin>
-                <!-- PMD manven plugin -->
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-pmd-plugin</artifactId>
+					<configuration>
+						<failOnMissingWebXml>false</failOnMissingWebXml>
+					</configuration>
+				</plugin>
+				<plugin>
+					<groupId>org.codehaus.mojo</groupId>
+					<artifactId>hibernate3-maven-plugin</artifactId>
+					<version>3.0</version>
+					<dependencies>
+						<dependency>
+							<groupId>org.hsqldb</groupId>
+							<artifactId>hsqldb</artifactId>
+							<version>2.7.2</version>
+						</dependency>
+					</dependencies>
+				</plugin>
+				<!-- EMMA   -->
+				<plugin>
+					<groupId>org.codehaus.mojo</groupId>
+					<artifactId>emma-maven-plugin</artifactId>
+					<version>1.0-alpha-3</version>
+				</plugin>
+				<!-- PMD manven plugin -->
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-pmd-plugin</artifactId>
 					<version>3.23.0</version>
-                </plugin>
-            </plugins>
-        </pluginManagement>
-        <plugins>
-            <!-- EMMA -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
+				</plugin>
+			</plugins>
+		</pluginManagement>
+		<plugins>
+			<!-- EMMA -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
 				<version>3.3.0</version>
-                <configuration>
-                    <skipTests>true</skipTests>
-                    <forkMode>once</forkMode>
-                    <reportFormat>xml</reportFormat>
-                    <excludes>
-                        <exclude>**/Abstract*.java</exclude>
-                        <exclude>**/*Suite.java</exclude>
-                    </excludes>
-                    <includes>
-                        <include>**/*Test.java</include>
-                    </includes>
-                </configuration>
-            </plugin>
-            <!-- docker server 배포 
+				<configuration>
+					<skipTests>true</skipTests>
+					<forkMode>once</forkMode>
+					<reportFormat>xml</reportFormat>
+					<excludes>
+						<exclude>**/Abstract*.java</exclude>
+						<exclude>**/*Suite.java</exclude>
+					</excludes>
+					<includes>
+						<include>**/*Test.java</include>
+					</includes>
+				</configuration>
+			</plugin>
+			<!-- docker server 배포 
             <plugin>
                 <groupId>org.apache.tomcat.maven</groupId>
                 <artifactId>tomcat7-maven-plugin</artifactId>

--- a/src/main/java/egovframework/com/cmm/config/EgovConfigDatasource.java
+++ b/src/main/java/egovframework/com/cmm/config/EgovConfigDatasource.java
@@ -1,0 +1,177 @@
+package egovframework.com.cmm.config;
+
+import org.egovframe.rte.fdl.cryptography.EgovEnvCryptoService;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+
+import egovframework.com.cmm.service.EgovProperties;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Java Config 기반 데이터소스 설정 (HikariCP)
+ * 
+ * <pre>
+ * VM arguments
+ * -Dspring.profiles.active=mysql-java-config,security
+ * -Dspring.profiles.active=oracle-java-config,security
+ * -Dspring.profiles.active=altibase-java-config,security
+ * -Dspring.profiles.active=tibero-java-config,security
+ * -Dspring.profiles.active=cubrid-java-config,security
+ * -Dspring.profiles.active=maria-java-config,security
+ * -Dspring.profiles.active=postgres-java-config,security
+ * -Dspring.profiles.active=goldilocks-java-config,security
+ * </pre>
+ * 
+ * @author 이백행
+ * @since 2025.07.12
+ * @version 4.3.1
+ * @see
+ *
+ *      <pre>
+ *  == 개정이력(Modification Information) ==
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2025.07.12  이백행          2025년 컨트리뷰션 최초 생성
+ *
+ *      </pre>
+ */
+@Configuration
+@RequiredArgsConstructor
+public class EgovConfigDatasource {
+
+	private final EgovEnvCryptoService egovEnvCryptoService;
+
+	@Profile("mysql-java-config")
+	@Bean(name = "dataSource", destroyMethod = "close")
+	public HikariDataSource dataSourceMysql() {
+		HikariConfig config = new HikariConfig();
+		config.setDriverClassName(EgovProperties.getProperty("Globals.mysql.DriverClassName"));
+		config.setJdbcUrl(EgovProperties.getProperty("Globals.mysql.Url"));
+		config.setUsername(EgovProperties.getProperty("Globals.mysql.UserName"));
+		config.setPassword(egovEnvCryptoService.getPassword());
+
+		config.setMaximumPoolSize(100);
+
+		HikariDataSource ds = new HikariDataSource(config);
+
+		return ds;
+	}
+
+	@Profile("oracle-java-config")
+	@Bean(name = "dataSource", destroyMethod = "close")
+	public HikariDataSource dataSourceOracle() {
+		HikariConfig config = new HikariConfig();
+		config.setDriverClassName(EgovProperties.getProperty("Globals.oracle.DriverClassName"));
+		config.setJdbcUrl(EgovProperties.getProperty("Globals.oracle.Url"));
+		config.setUsername(EgovProperties.getProperty("Globals.oracle.UserName"));
+		config.setPassword(egovEnvCryptoService.getPassword());
+
+		config.setMaximumPoolSize(100);
+
+		HikariDataSource ds = new HikariDataSource(config);
+
+		return ds;
+	}
+
+	@Profile("altibase-java-config")
+	@Bean(name = "dataSource", destroyMethod = "close")
+	public HikariDataSource dataSourceAltibase() {
+		HikariConfig config = new HikariConfig();
+		config.setDriverClassName(EgovProperties.getProperty("Globals.altibase.DriverClassName"));
+		config.setJdbcUrl(EgovProperties.getProperty("Globals.altibase.Url"));
+		config.setUsername(EgovProperties.getProperty("Globals.altibase.UserName"));
+		config.setPassword(egovEnvCryptoService.getPassword());
+
+		config.setMaximumPoolSize(100);
+
+		HikariDataSource ds = new HikariDataSource(config);
+
+		return ds;
+	}
+
+	@Profile("tibero-java-config")
+	@Bean(name = "dataSource", destroyMethod = "close")
+	public HikariDataSource dataSourceTibero() {
+		HikariConfig config = new HikariConfig();
+		config.setDriverClassName(EgovProperties.getProperty("Globals.tibero.DriverClassName"));
+		config.setJdbcUrl(EgovProperties.getProperty("Globals.tibero.Url"));
+		config.setUsername(EgovProperties.getProperty("Globals.tibero.UserName"));
+		config.setPassword(egovEnvCryptoService.getPassword());
+
+		config.setMaximumPoolSize(100);
+
+		HikariDataSource ds = new HikariDataSource(config);
+
+		return ds;
+	}
+
+	@Profile("cubrid-java-config")
+	@Bean(name = "dataSource", destroyMethod = "close")
+	public HikariDataSource dataSourceCubrid() {
+		HikariConfig config = new HikariConfig();
+		config.setDriverClassName(EgovProperties.getProperty("Globals.cubrid.DriverClassName"));
+		config.setJdbcUrl(EgovProperties.getProperty("Globals.cubrid.Url"));
+		config.setUsername(EgovProperties.getProperty("Globals.cubrid.UserName"));
+		config.setPassword(egovEnvCryptoService.getPassword());
+
+		config.setMaximumPoolSize(100);
+
+		HikariDataSource ds = new HikariDataSource(config);
+
+		return ds;
+	}
+
+	@Profile("maria-java-config")
+	@Bean(name = "dataSource", destroyMethod = "close")
+	public HikariDataSource dataSourceMaria() {
+		HikariConfig config = new HikariConfig();
+		config.setDriverClassName(EgovProperties.getProperty("Globals.maria.DriverClassName"));
+		config.setJdbcUrl(EgovProperties.getProperty("Globals.maria.Url"));
+		config.setUsername(EgovProperties.getProperty("Globals.maria.UserName"));
+		config.setPassword(egovEnvCryptoService.getPassword());
+
+		config.setMaximumPoolSize(100);
+
+		HikariDataSource ds = new HikariDataSource(config);
+
+		return ds;
+	}
+
+	@Profile("postgres-java-config")
+	@Bean(name = "dataSource", destroyMethod = "close")
+	public HikariDataSource dataSourcePostgres() {
+		HikariConfig config = new HikariConfig();
+		config.setDriverClassName(EgovProperties.getProperty("Globals.postgres.DriverClassName"));
+		config.setJdbcUrl(EgovProperties.getProperty("Globals.postgres.Url"));
+		config.setUsername(EgovProperties.getProperty("Globals.postgres.UserName"));
+		config.setPassword(egovEnvCryptoService.getPassword());
+
+		config.setMaximumPoolSize(100);
+
+		HikariDataSource ds = new HikariDataSource(config);
+
+		return ds;
+	}
+
+	@Profile("goldilocks-java-config")
+	@Bean(name = "dataSource", destroyMethod = "close")
+	public HikariDataSource dataSourceGoldilocks() {
+		HikariConfig config = new HikariConfig();
+		config.setDriverClassName(EgovProperties.getProperty("Globals.goldilocks.DriverClassName"));
+		config.setJdbcUrl(EgovProperties.getProperty("Globals.goldilocks.Url"));
+		config.setUsername(EgovProperties.getProperty("Globals.goldilocks.UserName"));
+		config.setPassword(egovEnvCryptoService.getPassword());
+
+		config.setMaximumPoolSize(100);
+
+		HikariDataSource ds = new HikariDataSource(config);
+
+		return ds;
+	}
+
+}

--- a/src/main/java/egovframework/com/cmm/config/EgovConfigDatasourceJndi.java
+++ b/src/main/java/egovframework/com/cmm/config/EgovConfigDatasourceJndi.java
@@ -10,14 +10,7 @@ import org.springframework.jndi.JndiObjectFactoryBean;
  * 
  * <pre>
  * VM arguments
- * -Dspring.profiles.active=mysql-jndi,security
- * -Dspring.profiles.active=oracle-jndi,security
- * -Dspring.profiles.active=altibase-jndi,security
- * -Dspring.profiles.active=tibero-jndi,security
- * -Dspring.profiles.active=cubrid-jndi,security
- * -Dspring.profiles.active=maria-jndi,security
- * -Dspring.profiles.active=postgres-jndi,security
- * -Dspring.profiles.active=goldilocks-jndi,security
+ * -Dspring.profiles.active=datasource-jndi,security
  * </pre>
  * 
  * @author 이백행
@@ -45,102 +38,17 @@ public class EgovConfigDatasourceJndi {
 //               username="com" password="com01" driverClassName="net.sf.log4jdbc.DriverSpy"
 //               url="jdbc:log4jdbc:mysql://127.0.0.1:3306/com"/>
 // 
+//  <Resource name="jdbc/ComDB" auth="Container" type="javax.sql.DataSource"
+//               maxTotal="100" maxIdle="30" maxWaitMillis="10000"
+//               username="com" password="com01" driverClassName="com.p6spy.engine.spy.P6SpyDriver"
+//               url="jdbc:p6spy:mysql://127.0.0.1:3306/com"/>
+// 
 // https://tomcat.apache.org/tomcat-9.0-doc/jndi-datasource-examples-howto.html
 
-	@Profile("mysql-jndi")
-	@Bean(name = "dataSource")
-	public JndiObjectFactoryBean dataSourceMysql() {
-		JndiObjectFactoryBean jndiObjectFactoryBean = new JndiObjectFactoryBean();
-
-		// Apache Tomcat 9
-		jndiObjectFactoryBean.setJndiName("java:/comp/env/jdbc/ComDB");
-
-//		jndiObjectFactoryBean.setJndiName("jdbc/ComDB");
-
-		return jndiObjectFactoryBean;
-	}
-
-	@Profile("oracle-jndi")
-	@Bean(name = "dataSource")
-	public JndiObjectFactoryBean dataSourceOracle() {
-		JndiObjectFactoryBean jndiObjectFactoryBean = new JndiObjectFactoryBean();
-
-		// Apache Tomcat 9
-		jndiObjectFactoryBean.setJndiName("java:/comp/env/jdbc/ComDB");
-
-//		jndiObjectFactoryBean.setJndiName("jdbc/ComDB");
-
-		return jndiObjectFactoryBean;
-	}
-
-	@Profile("altibase-jndi")
-	@Bean(name = "dataSource")
-	public JndiObjectFactoryBean dataSourceAltibase() {
-		JndiObjectFactoryBean jndiObjectFactoryBean = new JndiObjectFactoryBean();
-
-		// Apache Tomcat 9
-		jndiObjectFactoryBean.setJndiName("java:/comp/env/jdbc/ComDB");
-
-//		jndiObjectFactoryBean.setJndiName("jdbc/ComDB");
-
-		return jndiObjectFactoryBean;
-	}
-
-	@Profile("tibero-jndi")
-	@Bean(name = "dataSource")
-	public JndiObjectFactoryBean dataSourceTibero() {
-		JndiObjectFactoryBean jndiObjectFactoryBean = new JndiObjectFactoryBean();
-
-		// Apache Tomcat 9
-		jndiObjectFactoryBean.setJndiName("java:/comp/env/jdbc/ComDB");
-
-//		jndiObjectFactoryBean.setJndiName("jdbc/ComDB");
-
-		return jndiObjectFactoryBean;
-	}
-
-	@Profile("cubrid-jndi")
-	@Bean(name = "dataSource")
-	public JndiObjectFactoryBean dataSourceCubrid() {
-		JndiObjectFactoryBean jndiObjectFactoryBean = new JndiObjectFactoryBean();
-
-		// Apache Tomcat 9
-		jndiObjectFactoryBean.setJndiName("java:/comp/env/jdbc/ComDB");
-
-//		jndiObjectFactoryBean.setJndiName("jdbc/ComDB");
-
-		return jndiObjectFactoryBean;
-	}
-
-	@Profile("maria-jndi")
-	@Bean(name = "dataSource")
-	public JndiObjectFactoryBean dataSourceMaria() {
-		JndiObjectFactoryBean jndiObjectFactoryBean = new JndiObjectFactoryBean();
-
-		// Apache Tomcat 9
-		jndiObjectFactoryBean.setJndiName("java:/comp/env/jdbc/ComDB");
-
-//		jndiObjectFactoryBean.setJndiName("jdbc/ComDB");
-
-		return jndiObjectFactoryBean;
-	}
-
-	@Profile("postgres-jndi")
-	@Bean(name = "dataSource")
-	public JndiObjectFactoryBean dataSourcePostgres() {
-		JndiObjectFactoryBean jndiObjectFactoryBean = new JndiObjectFactoryBean();
-
-		// Apache Tomcat 9
-		jndiObjectFactoryBean.setJndiName("java:/comp/env/jdbc/ComDB");
-
-//		jndiObjectFactoryBean.setJndiName("jdbc/ComDB");
-
-		return jndiObjectFactoryBean;
-	}
-
-	@Profile("goldilocks-jndi")
-	@Bean(name = "dataSource")
-	public JndiObjectFactoryBean dataSourceGoldilocks() {
+	@Profile("datasource-jndi")
+//	@Bean(name = "dataSource")
+	@Bean
+	public JndiObjectFactoryBean dataSource() {
 		JndiObjectFactoryBean jndiObjectFactoryBean = new JndiObjectFactoryBean();
 
 		// Apache Tomcat 9

--- a/src/main/java/egovframework/com/cmm/config/EgovConfigDatasourceJndi.java
+++ b/src/main/java/egovframework/com/cmm/config/EgovConfigDatasourceJndi.java
@@ -1,0 +1,154 @@
+package egovframework.com.cmm.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.jndi.JndiObjectFactoryBean;
+
+/**
+ * JNDI 데이터소스 설정
+ * 
+ * <pre>
+ * VM arguments
+ * -Dspring.profiles.active=mysql-jndi,security
+ * -Dspring.profiles.active=oracle-jndi,security
+ * -Dspring.profiles.active=altibase-jndi,security
+ * -Dspring.profiles.active=tibero-jndi,security
+ * -Dspring.profiles.active=cubrid-jndi,security
+ * -Dspring.profiles.active=maria-jndi,security
+ * -Dspring.profiles.active=postgres-jndi,security
+ * -Dspring.profiles.active=goldilocks-jndi,security
+ * </pre>
+ * 
+ * @author 이백행
+ * @since 2025.07.12
+ * @version 4.3.1
+ * @see
+ *
+ *      <pre>
+ *  == 개정이력(Modification Information) ==
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2025.07.12  이백행          2025년 컨트리뷰션 최초 생성
+ *
+ *      </pre>
+ */
+@Configuration
+public class EgovConfigDatasourceJndi {
+
+// Apache Tomcat 9
+// JNDI Datasource How-To
+// 
+//  <Resource name="jdbc/ComDB" auth="Container" type="javax.sql.DataSource"
+//               maxTotal="100" maxIdle="30" maxWaitMillis="10000"
+//               username="com" password="com01" driverClassName="net.sf.log4jdbc.DriverSpy"
+//               url="jdbc:log4jdbc:mysql://127.0.0.1:3306/com"/>
+// 
+// https://tomcat.apache.org/tomcat-9.0-doc/jndi-datasource-examples-howto.html
+
+	@Profile("mysql-jndi")
+	@Bean(name = "dataSource")
+	public JndiObjectFactoryBean dataSourceMysql() {
+		JndiObjectFactoryBean jndiObjectFactoryBean = new JndiObjectFactoryBean();
+
+		// Apache Tomcat 9
+		jndiObjectFactoryBean.setJndiName("java:/comp/env/jdbc/ComDB");
+
+//		jndiObjectFactoryBean.setJndiName("jdbc/ComDB");
+
+		return jndiObjectFactoryBean;
+	}
+
+	@Profile("oracle-jndi")
+	@Bean(name = "dataSource")
+	public JndiObjectFactoryBean dataSourceOracle() {
+		JndiObjectFactoryBean jndiObjectFactoryBean = new JndiObjectFactoryBean();
+
+		// Apache Tomcat 9
+		jndiObjectFactoryBean.setJndiName("java:/comp/env/jdbc/ComDB");
+
+//		jndiObjectFactoryBean.setJndiName("jdbc/ComDB");
+
+		return jndiObjectFactoryBean;
+	}
+
+	@Profile("altibase-jndi")
+	@Bean(name = "dataSource")
+	public JndiObjectFactoryBean dataSourceAltibase() {
+		JndiObjectFactoryBean jndiObjectFactoryBean = new JndiObjectFactoryBean();
+
+		// Apache Tomcat 9
+		jndiObjectFactoryBean.setJndiName("java:/comp/env/jdbc/ComDB");
+
+//		jndiObjectFactoryBean.setJndiName("jdbc/ComDB");
+
+		return jndiObjectFactoryBean;
+	}
+
+	@Profile("tibero-jndi")
+	@Bean(name = "dataSource")
+	public JndiObjectFactoryBean dataSourceTibero() {
+		JndiObjectFactoryBean jndiObjectFactoryBean = new JndiObjectFactoryBean();
+
+		// Apache Tomcat 9
+		jndiObjectFactoryBean.setJndiName("java:/comp/env/jdbc/ComDB");
+
+//		jndiObjectFactoryBean.setJndiName("jdbc/ComDB");
+
+		return jndiObjectFactoryBean;
+	}
+
+	@Profile("cubrid-jndi")
+	@Bean(name = "dataSource")
+	public JndiObjectFactoryBean dataSourceCubrid() {
+		JndiObjectFactoryBean jndiObjectFactoryBean = new JndiObjectFactoryBean();
+
+		// Apache Tomcat 9
+		jndiObjectFactoryBean.setJndiName("java:/comp/env/jdbc/ComDB");
+
+//		jndiObjectFactoryBean.setJndiName("jdbc/ComDB");
+
+		return jndiObjectFactoryBean;
+	}
+
+	@Profile("maria-jndi")
+	@Bean(name = "dataSource")
+	public JndiObjectFactoryBean dataSourceMaria() {
+		JndiObjectFactoryBean jndiObjectFactoryBean = new JndiObjectFactoryBean();
+
+		// Apache Tomcat 9
+		jndiObjectFactoryBean.setJndiName("java:/comp/env/jdbc/ComDB");
+
+//		jndiObjectFactoryBean.setJndiName("jdbc/ComDB");
+
+		return jndiObjectFactoryBean;
+	}
+
+	@Profile("postgres-jndi")
+	@Bean(name = "dataSource")
+	public JndiObjectFactoryBean dataSourcePostgres() {
+		JndiObjectFactoryBean jndiObjectFactoryBean = new JndiObjectFactoryBean();
+
+		// Apache Tomcat 9
+		jndiObjectFactoryBean.setJndiName("java:/comp/env/jdbc/ComDB");
+
+//		jndiObjectFactoryBean.setJndiName("jdbc/ComDB");
+
+		return jndiObjectFactoryBean;
+	}
+
+	@Profile("goldilocks-jndi")
+	@Bean(name = "dataSource")
+	public JndiObjectFactoryBean dataSourceGoldilocks() {
+		JndiObjectFactoryBean jndiObjectFactoryBean = new JndiObjectFactoryBean();
+
+		// Apache Tomcat 9
+		jndiObjectFactoryBean.setJndiName("java:/comp/env/jdbc/ComDB");
+
+//		jndiObjectFactoryBean.setJndiName("jdbc/ComDB");
+
+		return jndiObjectFactoryBean;
+	}
+
+}

--- a/src/main/java/egovframework/com/cmm/context/EgovWebServletContextListener.java
+++ b/src/main/java/egovframework/com/cmm/context/EgovWebServletContextListener.java
@@ -7,26 +7,25 @@ import egovframework.com.cmm.service.EgovProperties;
 import lombok.extern.slf4j.Slf4j;
 
 /**
- * EgovWebServletContextListener 클래스
- * <p>
  * 데이터베이스 설정을 spring.profiles.active 방식으로 처리
  * <p>
  * (공통컴포넌트 특성상 데이터베이스별 분리/개발,검증,운영서버로 분리 가능)
- * <p>
- * N/A
- *
+ * 
  * @author 장동한
  * @since 2016.06.23
  * @version 1.0
  * @see
  *
  *      <pre>
- * << 개정이력(Modification Information) >>
+ *  == 개정이력(Modification Information) ==
  *
- *   수정일        수정자           수정내용
- *  -------      -------------  ----------------------
- *   2016.06.23  장동한           최초 생성
- *   2017.03.03     조성원 	시큐어코딩(ES)-오류 메시지를 통한 정보노출[CWE-209]
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2009.03.20  홍길동          최초 생성
+ *   2016.06.23  장동한          최초 생성
+ *   2017.03.03  조성원          시큐어코딩(ES)-오류 메시지를 통한 정보노출[CWE-209]
+ *   2025.07.12  이백행          2025년 컨트리뷰션 `-Dspring.profiles.active=mysql-hikari,security` 동작하지 않아 리팩토링
+ *
  *      </pre>
  */
 @Slf4j

--- a/src/main/java/egovframework/com/cmm/context/EgovWebServletContextListener.java
+++ b/src/main/java/egovframework/com/cmm/context/EgovWebServletContextListener.java
@@ -31,8 +31,16 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class EgovWebServletContextListener implements ServletContextListener {
 
+	public EgovWebServletContextListener() {
+		setEgovProfileSetting();
+	}
+
 	@Override
 	public void contextInitialized(ServletContextEvent event) {
+		setEgovProfileSetting();
+	}
+
+	private void setEgovProfileSetting() {
 		try {
 			if (log.isDebugEnabled()) {
 				log.debug("===========================Start EgovServletContextLoad START ===========");

--- a/src/main/java/egovframework/com/cmm/context/EgovWebServletContextListener.java
+++ b/src/main/java/egovframework/com/cmm/context/EgovWebServletContextListener.java
@@ -3,10 +3,8 @@ package egovframework.com.cmm.context;
 import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import egovframework.com.cmm.service.EgovProperties;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * EgovWebServletContextListener 클래스
@@ -31,40 +29,36 @@ import egovframework.com.cmm.service.EgovProperties;
  *   2017.03.03     조성원 	시큐어코딩(ES)-오류 메시지를 통한 정보노출[CWE-209]
  *      </pre>
  */
-
+@Slf4j
 public class EgovWebServletContextListener implements ServletContextListener {
-	private static final Logger LOGGER = LoggerFactory.getLogger(EgovWebServletContextListener.class);
-
-	public EgovWebServletContextListener() {
-		setEgovProfileSetting();
-	}
 
 	@Override
 	public void contextInitialized(ServletContextEvent event) {
-		if (System.getProperty("spring.profiles.active") == null) {
-			setEgovProfileSetting();
-		}
-	}
-
-	@Override
-	public void contextDestroyed(ServletContextEvent event) {
-		if (System.getProperty("spring.profiles.active") != null) {
-			System.clearProperty("spring.profiles.active");
-		}
-	}
-
-	public void setEgovProfileSetting() {
 		try {
-			LOGGER.debug("===========================Start EgovServletContextLoad START ===========");
-			System.setProperty("spring.profiles.active",
-					EgovProperties.getProperty("Globals.DbType") + "," + EgovProperties.getProperty("Globals.Auth"));
-			LOGGER.debug("Setting spring.profiles.active>" + System.getProperty("spring.profiles.active"));
-			LOGGER.debug("===========================END   EgovServletContextLoad END ===========");
+			if (log.isDebugEnabled()) {
+				log.debug("===========================Start EgovServletContextLoad START ===========");
+				log.debug("Setting spring.profiles.active>" + System.getProperty("spring.profiles.active"));
+			}
+
+			if (System.getProperty("spring.profiles.active") == null) {
+				System.setProperty("spring.profiles.active", EgovProperties.getProperty("Globals.DbType") + ","
+						+ EgovProperties.getProperty("Globals.Auth"));
+			}
+
+			if (log.isDebugEnabled()) {
+				log.debug("Setting spring.profiles.active>" + System.getProperty("spring.profiles.active"));
+				log.debug("===========================END   EgovServletContextLoad END ===========");
+			}
 			// 2017.03.03 조성원 시큐어코딩(ES)-오류 메시지를 통한 정보노출[CWE-209]
 		} catch (IllegalArgumentException e) {
-			LOGGER.error("[IllegalArgumentException] Try/Catch...usingParameters Runing : " + e.getMessage());
+			if (log.isErrorEnabled()) {
+				log.error("[IllegalArgumentException] Try/Catch...usingParameters Runing", e);
+			}
 		} catch (RuntimeException e) {
-			LOGGER.error("[" + e.getClass() + "] search fail : " + e.getMessage());
+			if (log.isErrorEnabled()) {
+				log.error("[" + e.getClass() + "] search fail", e);
+			}
 		}
 	}
+
 }

--- a/src/main/java/egovframework/com/cmm/context/EgovWebServletContextListener.java
+++ b/src/main/java/egovframework/com/cmm/context/EgovWebServletContextListener.java
@@ -10,59 +10,61 @@ import egovframework.com.cmm.service.EgovProperties;
 
 /**
  * EgovWebServletContextListener 클래스
- * <Notice>
- * 	    데이터베이스 설정을 spring.profiles.active 방식으로 처리
- * 		(공통컴포넌트 특성상 데이터베이스별 분리/개발,검증,운영서버로 분리 가능)
- * <Disclaimer>
- *		N/A
+ * <p>
+ * 데이터베이스 설정을 spring.profiles.active 방식으로 처리
+ * <p>
+ * (공통컴포넌트 특성상 데이터베이스별 분리/개발,검증,운영서버로 분리 가능)
+ * <p>
+ * N/A
  *
  * @author 장동한
  * @since 2016.06.23
  * @version 1.0
  * @see
  *
- * <pre>
+ *      <pre>
  * << 개정이력(Modification Information) >>
  *
  *   수정일        수정자           수정내용
  *  -------      -------------  ----------------------
  *   2016.06.23  장동한           최초 생성
  *   2017.03.03     조성원 	시큐어코딩(ES)-오류 메시지를 통한 정보노출[CWE-209]
- * </pre>
+ *      </pre>
  */
 
 public class EgovWebServletContextListener implements ServletContextListener {
-    private static final Logger LOGGER = LoggerFactory.getLogger(EgovWebServletContextListener.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(EgovWebServletContextListener.class);
 
-    public EgovWebServletContextListener(){
-    	setEgovProfileSetting();
-    }
+	public EgovWebServletContextListener() {
+		setEgovProfileSetting();
+	}
 
-    @Override
-	public void contextInitialized(ServletContextEvent event){
-    	if(System.getProperty("spring.profiles.active") == null){
-    		setEgovProfileSetting();
-    	}
-    }
+	@Override
+	public void contextInitialized(ServletContextEvent event) {
+		if (System.getProperty("spring.profiles.active") == null) {
+			setEgovProfileSetting();
+		}
+	}
 
-    @Override
+	@Override
 	public void contextDestroyed(ServletContextEvent event) {
-    	if(System.getProperty("spring.profiles.active") != null){
-    		System.clearProperty("spring.profiles.active");
-    	}
-    }
+		if (System.getProperty("spring.profiles.active") != null) {
+			System.clearProperty("spring.profiles.active");
+		}
+	}
 
-    public void setEgovProfileSetting(){
-        try {
-            LOGGER.debug("===========================Start EgovServletContextLoad START ===========");
-            System.setProperty("spring.profiles.active", EgovProperties.getProperty("Globals.DbType")+","+EgovProperties.getProperty("Globals.Auth"));
-            LOGGER.debug("Setting spring.profiles.active>"+System.getProperty("spring.profiles.active"));
-            LOGGER.debug("===========================END   EgovServletContextLoad END ===========");
-        //2017.03.03 	조성원 	시큐어코딩(ES)-오류 메시지를 통한 정보노출[CWE-209]
-        } catch(IllegalArgumentException e) {
-    		LOGGER.error("[IllegalArgumentException] Try/Catch...usingParameters Runing : "+ e.getMessage());
-        } catch (RuntimeException e) {
-        	LOGGER.error("[" + e.getClass() +"] search fail : " + e.getMessage());
-        }
-    }
+	public void setEgovProfileSetting() {
+		try {
+			LOGGER.debug("===========================Start EgovServletContextLoad START ===========");
+			System.setProperty("spring.profiles.active",
+					EgovProperties.getProperty("Globals.DbType") + "," + EgovProperties.getProperty("Globals.Auth"));
+			LOGGER.debug("Setting spring.profiles.active>" + System.getProperty("spring.profiles.active"));
+			LOGGER.debug("===========================END   EgovServletContextLoad END ===========");
+			// 2017.03.03 조성원 시큐어코딩(ES)-오류 메시지를 통한 정보노출[CWE-209]
+		} catch (IllegalArgumentException e) {
+			LOGGER.error("[IllegalArgumentException] Try/Catch...usingParameters Runing : " + e.getMessage());
+		} catch (RuntimeException e) {
+			LOGGER.error("[" + e.getClass() + "] search fail : " + e.getMessage());
+		}
+	}
 }

--- a/src/main/resources/egovframework/egovProps/globals.properties
+++ b/src/main/resources/egovframework/egovProps/globals.properties
@@ -35,8 +35,8 @@ Globals.MainPage  = /EgovContent.do
 # Globals.mysql.Password = com01 \ucc98\ub7fc \ud3c9\ubb38\uc744 \uc0ac\uc6a9\ud558\ub824\uba74 context-crypto.xml \uc5d0\uc11c initial="false" crypto="false" \ub85c \uc124\uc815\ud558\uace0, 
 # context-datasource.xml \uc5d0\uc11c <property name="password" value="${Globals.mysql.Password}"/> \ub85c \ubc14\uafb8\uc5b4 \uc8fc\uc5b4\uc57c \ud568
 #mysql
-Globals.mysql.DriverClassName=net.sf.log4jdbc.DriverSpy
-Globals.mysql.Url=jdbc:log4jdbc:mysql://127.0.0.1:3306/com
+Globals.mysql.DriverClassName=com.p6spy.engine.spy.P6SpyDriver
+Globals.mysql.Url=jdbc:p6spy:mysql://127.0.0.1:3306/com
 Globals.mysql.UserName = com
 Globals.mysql.Password = xz4fmrSdr1vGGl6UtwPLwA%3D%3D
 

--- a/src/main/resources/egovframework/egovProps/globals.properties
+++ b/src/main/resources/egovframework/egovProps/globals.properties
@@ -35,6 +35,8 @@ Globals.MainPage  = /EgovContent.do
 # Globals.mysql.Password = com01 \ucc98\ub7fc \ud3c9\ubb38\uc744 \uc0ac\uc6a9\ud558\ub824\uba74 context-crypto.xml \uc5d0\uc11c initial="false" crypto="false" \ub85c \uc124\uc815\ud558\uace0, 
 # context-datasource.xml \uc5d0\uc11c <property name="password" value="${Globals.mysql.Password}"/> \ub85c \ubc14\uafb8\uc5b4 \uc8fc\uc5b4\uc57c \ud568
 #mysql
+#Globals.mysql.DriverClassName=net.sf.log4jdbc.DriverSpy
+#Globals.mysql.Url=jdbc:log4jdbc:mysql://127.0.0.1:3306/com
 Globals.mysql.DriverClassName=com.p6spy.engine.spy.P6SpyDriver
 Globals.mysql.Url=jdbc:p6spy:mysql://127.0.0.1:3306/com
 Globals.mysql.UserName = com

--- a/src/main/resources/egovframework/spring/com/context-datasource-hikari.xml
+++ b/src/main/resources/egovframework/spring/com/context-datasource-hikari.xml
@@ -1,0 +1,160 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:util="http://www.springframework.org/schema/util"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd 
+						http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.0.xsd">
+
+	<!-- VM arguments -->
+	<!-- -Dspring.profiles.active=mysql-hikari,security -->
+	<!-- -Dspring.profiles.active=oracle-hikari,security -->
+	<!-- -Dspring.profiles.active=altibase-hikari,security -->
+	<!-- -Dspring.profiles.active=tibero-hikari,security -->
+	<!-- -Dspring.profiles.active=cubrid-hikari,security -->
+	<!-- -Dspring.profiles.active=maria-hikari,security -->
+	<!-- -Dspring.profiles.active=postgres-hikari,security -->
+	<!-- -Dspring.profiles.active=goldilocks-hikari,security -->
+
+	<!-- MySQL -->
+	<beans profile="mysql-hikari">
+		<bean id="dataSource" class="com.zaxxer.hikari.HikariDataSource"
+			destroy-method="close">
+			<property name="driverClassName"
+				value="${Globals.mysql.DriverClassName}" />
+			<property name="jdbcUrl" value="${Globals.mysql.Url}" />
+			<property name="username" value="${Globals.mysql.UserName}" />
+			<!-- 암호화(Crypto) 관련 서비스 https://www.egovframe.go.kr/wiki/doku.php?id=egovframework:rte2:fdl:crypto_simplify_v3_8 
+				참조 -->
+			<property name="password"
+				value="#{egovEnvCryptoService.getPassword()}" />
+
+			<property name="maximumPoolSize" value="100" />
+		</bean>
+	</beans>
+
+	<!-- oracle -->
+	<beans profile="oracle-hikari">
+		<bean id="dataSource" class="com.zaxxer.hikari.HikariDataSource"
+			destroy-method="close">
+			<property name="driverClassName"
+				value="${Globals.oracle.DriverClassName}" />
+			<property name="jdbcUrl" value="${Globals.oracle.Url}" />
+			<property name="username" value="${Globals.oracle.UserName}" />
+			<property name="password"
+				value="#{egovEnvCryptoService.getPassword()}" />
+
+			<property name="maximumPoolSize" value="100" />
+		</bean>
+	</beans>
+
+	<!-- altibase -->
+	<beans profile="altibase-hikari">
+		<bean id="dataSource" class="com.zaxxer.hikari.HikariDataSource"
+			destroy-method="close">
+			<property name="driverClassName"
+				value="${Globals.altibase.DriverClassName}" />
+			<property name="jdbcUrl" value="${Globals.altibase.Url}" />
+			<property name="username"
+				value="${Globals.altibase.UserName}" />
+			<property name="password"
+				value="#{egovEnvCryptoService.getPassword()}" />
+
+			<property name="maximumPoolSize" value="100" />
+
+			<property name="validationQuery" value="select 1" />
+			<property name="testWhileIdle" value="true" />
+		</bean>
+	</beans>
+
+	<!-- tibero -->
+	<beans profile="tibero-hikari">
+		<bean id="dataSource" class="com.zaxxer.hikari.HikariDataSource"
+			destroy-method="close">
+			<property name="driverClassName"
+				value="${Globals.tibero.DriverClassName}" />
+			<property name="jdbcUrl" value="${Globals.tibero.Url}" />
+			<property name="username" value="${Globals.tibero.UserName}" />
+			<property name="password"
+				value="#{egovEnvCryptoService.getPassword()}" />
+
+			<property name="maximumPoolSize" value="100" />
+		</bean>
+	</beans>
+
+	<!-- cubrid -->
+	<beans profile="cubrid-hikari">
+		<bean id="dataSource" class="com.zaxxer.hikari.HikariDataSource"
+			destroy-method="close">
+			<property name="driverClassName"
+				value="${Globals.cubrid.DriverClassName}" />
+			<property name="jdbcUrl" value="${Globals.cubrid.Url}" />
+			<property name="username" value="${Globals.cubrid.UserName}" />
+			<property name="password"
+				value="#{egovEnvCryptoService.getPassword()}" />
+
+			<property name="maximumPoolSize" value="100" />
+
+			<property name="validationQuery" value="select 1" />
+			<property name="testOnBorrow" value="false" />
+		</bean>
+	</beans>
+	<!-- CUBRID 가이드 참조 https://www.cubrid.com/tutorial/3794188 * DBCP를 통해 최초 
+		connection 시 해당 connection이 유효한지 체크하는 isValid를 호출 -->
+
+	<!-- MariaDB -->
+	<beans profile="maria-hikari">
+		<bean id="dataSource" class="com.zaxxer.hikari.HikariDataSource"
+			destroy-method="close">
+			<property name="driverClassName"
+				value="${Globals.maria.DriverClassName}" />
+			<property name="jdbcUrl" value="${Globals.maria.Url}" />
+			<property name="username" value="${Globals.maria.UserName}" />
+			<property name="password"
+				value="#{egovEnvCryptoService.getPassword()}" />
+
+			<property name="maximumPoolSize" value="100" />
+		</bean>
+	</beans>
+
+	<!-- PostresSQL -->
+	<beans profile="postgres-hikari">
+		<bean id="dataSource" class="com.zaxxer.hikari.HikariDataSource"
+			destroy-method="close">
+			<property name="driverClassName"
+				value="${Globals.postgres.DriverClassName}" />
+			<property name="jdbcUrl" value="${Globals.postgres.Url}" />
+			<property name="username"
+				value="${Globals.postgres.UserName}" />
+			<property name="password"
+				value="#{egovEnvCryptoService.getPassword()}" />
+
+			<property name="maximumPoolSize" value="100" />
+		</bean>
+	</beans>
+
+	<!-- GOLDILOCKS -->
+	<beans profile="goldilocks-hikari">
+		<bean id="dataSource" class="com.zaxxer.hikari.HikariDataSource"
+			destroy-method="close">
+			<property name="driverClassName"
+				value="${Globals.goldilocks.DriverClassName}" />
+			<property name="jdbcUrl" value="${Globals.goldilocks.Url}" />
+			<property name="username"
+				value="${Globals.goldilocks.UserName}" />
+			<property name="password"
+				value="#{egovEnvCryptoService.getPassword()}" />
+
+			<property name="maximumPoolSize" value="100" />
+		</bean>
+	</beans>
+
+	<!-- DB Pool이 생성이 되더라고 특정 시간 호출되지 않으면 DBMS 설정에 따라 연결을 끊어질 때 이 경우 DBCP를 사용하셨다면.. 
+		다음과 같은 설정을 추가하시면 연결을 유지시켜 줍니다. -->
+	<!-- <property name="validationQuery" value="select 1 from dual" /> <property 
+		name="testWhileIdle" value="true" /> <property name="timeBetweenEvictionRunsMillis" 
+		value="60000" /> -->  <!-- 1분 -->
+
+	<!-- DBCP가 아닌 WAS의 DataSource를 사용하시는 경우도 WAS별로 동일한 설정을 하실 수 있습니다. (WAS별 
+		구체적인 설정은 WAS document 확인) -->
+
+</beans>

--- a/src/main/resources/spy.properties
+++ b/src/main/resources/spy.properties
@@ -1,0 +1,5 @@
+driverlist=com.mysql.cj.jdbc.Driver,com.mysql.jdbc.Driver,oracle.jdbc.driver.OracleDriver,Altibase.jdbc.driver.AltibaseDriver,com.tmax.tibero.jdbc.TbDriver,cubrid.jdbc.driver.CUBRIDDriver,org.mariadb.jdbc.Driver,org.postgresql.Driver,sunje.goldilocks.jdbc.GoldilocksDriver
+
+appender=com.p6spy.engine.spy.appender.StdoutLogger
+
+logMessageFormat=com.p6spy.engine.spy.appender.MultiLineFormat


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.
데이터소스를 HikariCP도 사용할 수 있게 함

현재는 -Dspring.profiles.active=mysql-hikari,security 해도 동작하지 않아 리팩토링 했습니다.

`EgovWebServletContextListener` 생성자 제거

`contextDestroyed` 메서드 제거

`setEgovProfileSetting` 메서드 제거하고 `contextInitialized` 메서드로 이동

`LOGGER` 를 `@Slf4j` 로 변경

context-datasource-hikari.xml 추가
- mysql-hikari
```xml
	<!-- VM arguments -->
	<!-- -Dspring.profiles.active=mysql-hikari,security -->
	<!-- -Dspring.profiles.active=oracle-hikari,security -->
	<!-- -Dspring.profiles.active=altibase-hikari,security -->
	<!-- -Dspring.profiles.active=tibero-hikari,security -->
	<!-- -Dspring.profiles.active=cubrid-hikari,security -->
	<!-- -Dspring.profiles.active=maria-hikari,security -->
	<!-- -Dspring.profiles.active=postgres-hikari,security -->
	<!-- -Dspring.profiles.active=goldilocks-hikari,security -->
```

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [x] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

<img width="1920" height="913" alt="image" src="https://github.com/user-attachments/assets/a60b6878-2bd2-43d1-954c-d2c7542b7e89" />
