### PR TITLE
PMD로 소프트웨어 보안약점 진단하고 제거하기-EgovSysHistoryController

### DIFF
--- a/src/main/java/egovframework/com/sym/log/slg/web/EgovSysHistoryController.java
+++ b/src/main/java/egovframework/com/sym/log/slg/web/EgovSysHistoryController.java
@@ -32,25 +32,25 @@ import egovframework.com.sym.log.slg.service.SysHistory;
 import egovframework.com.sym.log.slg.service.SysHistoryVO;
 
 /**
- * @Class Name : EgovSysHistoryController.java
- * @Description : 시스템 이력관리를 위한 웹 컨트롤러 클래스
- * @Modification Information
- * 
- *               <pre>
- *    수정일               수정자         수정내용
- *    ----------   -------  -------------------
- *    2009.03.09   이삼섭         최초작성
- *    2011.08.26   정진오         IncludedInfo annotation 추가
- *    2018.09.28   정진오         updateSysHistory validation처리시 예외 수정
- *               </pre>
+ * 시스템 이력관리를 위한 웹 컨트롤러 클래스
  * 
  * @author 공통 서비스 개발팀 이삼섭
- * @since 2009. 3. 9.
- * @version
+ * @since 2009.03.09
+ * @version 1.0
  * @see
  *
+ *      <pre>
+ *  == 개정이력(Modification Information) ==
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2009.03.09  이삼섭          최초 작성
+ *   2011.08.26  정진오          IncludedInfo annotation 추가
+ *   2018.09.28  정진오          updateSysHistory validation처리시 예외 수정
+ *   2025.07.14  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-LocalVariableNamingConventions(final이 아닌 변수는 밑줄을 포함할 수 없음)
+ *
+ *      </pre>
  */
-
 @Controller
 public class EgovSysHistoryController {
 

--- a/src/main/java/egovframework/com/sym/log/slg/web/EgovSysHistoryController.java
+++ b/src/main/java/egovframework/com/sym/log/slg/web/EgovSysHistoryController.java
@@ -85,29 +85,28 @@ public class EgovSysHistoryController {
 			@ModelAttribute("history") SysHistory history, BindingResult bindingResult, SessionStatus status,
 			ModelMap model) throws Exception {
 
-		Boolean isAuthenticated = EgovUserDetailsHelper.isAuthenticated();
-
 		beanValidator.validate(history, bindingResult);
 		if (bindingResult.hasErrors()) {
 			ComDefaultCodeVO vo = new ComDefaultCodeVO();
 			vo.setCodeId("COM002");
-			List<CmmnDetailCode> _result = cmmUseService.selectCmmCodeDetail(vo);
-			model.addAttribute("resultList", _result);
+			List<CmmnDetailCode> resultCOM002List = cmmUseService.selectCmmCodeDetail(vo);
+			model.addAttribute("resultList", resultCOM002List);
 			return "egovframework/com/sym/log/slg/EgovSysHistRegist";
 		}
 
-		if (isAuthenticated) {
-			LoginVO user = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();
-			List<FileVO> _result = null;
-			String _atchFileId = "";
+		LoginVO loginVO = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();
+
+		if (loginVO != null) {
+			List<FileVO> fvoList = null;
+			String atchFileId = "";
 			// final Map<String, MultipartFile> files = multiRequest.getFileMap();
 			final List<MultipartFile> files = multiRequest.getFiles("file_1");
 			if (!files.isEmpty()) {
-				_result = fileUtil.parseFileInf(files, "SHF_", 0, "", "");
-				_atchFileId = fileMngService.insertFileInfs(_result);
+				fvoList = fileUtil.parseFileInf(files, "SHF_", 0, "", "");
+				atchFileId = fileMngService.insertFileInfs(fvoList);
 			}
-			history.setFrstRegisterId((user == null || user.getUniqId() == null) ? "" : user.getUniqId());
-			history.setAtchFileId(_atchFileId);
+			history.setFrstRegisterId(loginVO.getUniqId());
+			history.setAtchFileId(atchFileId);
 			sysHistoryService.insertSysHistory(history);
 		}
 
@@ -126,8 +125,8 @@ public class EgovSysHistoryController {
 
 		ComDefaultCodeVO vo = new ComDefaultCodeVO();
 		vo.setCodeId("COM002");
-		List<CmmnDetailCode> _result = cmmUseService.selectCmmCodeDetail(vo);
-		model.addAttribute("resultList", _result);
+		List<CmmnDetailCode> resultCOM002List = cmmUseService.selectCmmCodeDetail(vo);
+		model.addAttribute("resultList", resultCOM002List);
 		return "egovframework/com/sym/log/slg/EgovSysHistRegist";
 	}
 
@@ -144,34 +143,34 @@ public class EgovSysHistoryController {
 			@ModelAttribute("searchVO") SysHistoryVO historyVO, @ModelAttribute("history") SysHistory history,
 			BindingResult bindingResult, SessionStatus status, ModelMap model) throws Exception {
 
-		Boolean isAuthenticated = EgovUserDetailsHelper.isAuthenticated();
-
 		beanValidator.validate(history, bindingResult);
 		if (bindingResult.hasErrors()) {
 
 			model.addAttribute("history", history);
 			ComDefaultCodeVO vo = new ComDefaultCodeVO();
 			vo.setCodeId("COM002");
-			List<CmmnDetailCode> _result = cmmUseService.selectCmmCodeDetail(vo);
-			model.addAttribute("resultList", _result);
+			List<CmmnDetailCode> resultCOM002List = cmmUseService.selectCmmCodeDetail(vo);
+			model.addAttribute("resultList", resultCOM002List);
 			return "egovframework/com/sym/log/slg/EgovSysHistUpdt";
 		}
 
-		if (isAuthenticated) {
-			String _atchFileId = history.getAtchFileId();
+		LoginVO loginVO = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();
+
+		if (loginVO != null) {
+			String atchFileId = history.getAtchFileId();
 			// final Map<String, MultipartFile> files = multiRequest.getFileMap();
 			final List<MultipartFile> files = multiRequest.getFiles("file_1");
 			if (!files.isEmpty()) {
-				if ("".equals(_atchFileId)) {
-					List<FileVO> _result = fileUtil.parseFileInf(files, "SHF_", 0, _atchFileId, "");
-					_atchFileId = fileMngService.insertFileInfs(_result);
-					history.setAtchFileId(_atchFileId);
+				if ("".equals(atchFileId)) {
+					List<FileVO> fvoList = fileUtil.parseFileInf(files, "SHF_", 0, atchFileId, "");
+					atchFileId = fileMngService.insertFileInfs(fvoList);
+					history.setAtchFileId(atchFileId);
 				} else {
 					FileVO fvo = new FileVO();
-					fvo.setAtchFileId(_atchFileId);
-					int _cnt = fileMngService.getMaxFileSN(fvo);
-					List<FileVO> _result = fileUtil.parseFileInf(files, "SHF_", _cnt, _atchFileId, "");
-					fileMngService.updateFileInfs(_result);
+					fvo.setAtchFileId(atchFileId);
+					int fileKeyParam = fileMngService.getMaxFileSN(fvo);
+					List<FileVO> fvoList = fileUtil.parseFileInf(files, "SHF_", fileKeyParam, atchFileId, "");
+					fileMngService.updateFileInfs(fvoList);
 				}
 			}
 			// model.addAttribute("history", history);
@@ -199,8 +198,8 @@ public class EgovSysHistoryController {
 		model.addAttribute("history", history);
 		ComDefaultCodeVO vo = new ComDefaultCodeVO();
 		vo.setCodeId("COM002");
-		List<CmmnDetailCode> _result = cmmUseService.selectCmmCodeDetail(vo);
-		model.addAttribute("resultList", _result);
+		List<CmmnDetailCode> resultCOM002List = cmmUseService.selectCmmCodeDetail(vo);
+		model.addAttribute("resultList", resultCOM002List);
 		return "egovframework/com/sym/log/slg/EgovSysHistUpdt";
 	}
 
@@ -216,9 +215,9 @@ public class EgovSysHistoryController {
 	public String deleteSysHistory(@ModelAttribute("history") SysHistory history, SessionStatus status, ModelMap model)
 			throws Exception {
 
-		Boolean isAuthenticated = EgovUserDetailsHelper.isAuthenticated();
+		LoginVO loginVO = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();
 
-		if (isAuthenticated) {
+		if (loginVO != null) {
 			sysHistoryService.deleteSysHistory(history);
 		}
 

--- a/src/main/java/egovframework/com/sym/log/slg/web/EgovSysHistoryController.java
+++ b/src/main/java/egovframework/com/sym/log/slg/web/EgovSysHistoryController.java
@@ -35,13 +35,15 @@ import egovframework.com.sym.log.slg.service.SysHistoryVO;
  * @Class Name : EgovSysHistoryController.java
  * @Description : 시스템 이력관리를 위한 웹 컨트롤러 클래스
  * @Modification Information
- *
+ * 
+ *               <pre>
  *    수정일               수정자         수정내용
  *    ----------   -------  -------------------
  *    2009.03.09   이삼섭         최초작성
  *    2011.08.26   정진오         IncludedInfo annotation 추가
  *    2018.09.28   정진오         updateSysHistory validation처리시 예외 수정
- *
+ *               </pre>
+ * 
  * @author 공통 서비스 개발팀 이삼섭
  * @since 2009. 3. 9.
  * @version
@@ -52,19 +54,19 @@ import egovframework.com.sym.log.slg.service.SysHistoryVO;
 @Controller
 public class EgovSysHistoryController {
 
-	@Resource(name="EgovSysHistoryService")
+	@Resource(name = "EgovSysHistoryService")
 	private EgovSysHistoryService sysHistoryService;
 
-	@Resource(name="EgovCmmUseService")
+	@Resource(name = "EgovCmmUseService")
 	private EgovCmmUseService cmmUseService;
 
-	@Resource(name="propertiesService")
+	@Resource(name = "propertiesService")
 	protected EgovPropertyService propertyService;
 
-	@Resource(name="EgovFileMngService")
+	@Resource(name = "EgovFileMngService")
 	private EgovFileMngService fileMngService;
 
-	@Resource(name="EgovFileMngUtil")
+	@Resource(name = "EgovFileMngUtil")
 	private EgovFileMngUtil fileUtil;
 
 	@Autowired
@@ -78,13 +80,10 @@ public class EgovSysHistoryController {
 	 * @return
 	 * @throws Exception
 	 */
-	@RequestMapping(value="/sym/log/slg/InsertSysHistory.do")
-	public String insertSysHistory(
-			final MultipartHttpServletRequest multiRequest,
-			@ModelAttribute("history") SysHistory history,
-			BindingResult bindingResult,
-			SessionStatus status,
-			ModelMap model) throws Exception{
+	@RequestMapping(value = "/sym/log/slg/InsertSysHistory.do")
+	public String insertSysHistory(final MultipartHttpServletRequest multiRequest,
+			@ModelAttribute("history") SysHistory history, BindingResult bindingResult, SessionStatus status,
+			ModelMap model) throws Exception {
 
 		Boolean isAuthenticated = EgovUserDetailsHelper.isAuthenticated();
 
@@ -97,15 +96,15 @@ public class EgovSysHistoryController {
 			return "egovframework/com/sym/log/slg/EgovSysHistRegist";
 		}
 
-		if(isAuthenticated){
-			LoginVO user = (LoginVO)EgovUserDetailsHelper.getAuthenticatedUser();
+		if (isAuthenticated) {
+			LoginVO user = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();
 			List<FileVO> _result = null;
 			String _atchFileId = "";
-			//final Map<String, MultipartFile> files = multiRequest.getFileMap();
+			// final Map<String, MultipartFile> files = multiRequest.getFileMap();
 			final List<MultipartFile> files = multiRequest.getFiles("file_1");
-			if(!files.isEmpty()){
-				 _result = fileUtil.parseFileInf(files, "SHF_", 0, "", "");
-				 _atchFileId = fileMngService.insertFileInfs(_result);
+			if (!files.isEmpty()) {
+				_result = fileUtil.parseFileInf(files, "SHF_", 0, "", "");
+				_atchFileId = fileMngService.insertFileInfs(_result);
 			}
 			history.setFrstRegisterId((user == null || user.getUniqId() == null) ? "" : user.getUniqId());
 			history.setAtchFileId(_atchFileId);
@@ -122,9 +121,8 @@ public class EgovSysHistoryController {
 	 * @return
 	 * @throws Exception
 	 */
-	@RequestMapping(value="/sym/log/slg/AddSysHistory.do")
-	public String addSysHistory(@ModelAttribute("searchVO") SysHistoryVO historyVO,
-			ModelMap model) throws Exception{
+	@RequestMapping(value = "/sym/log/slg/AddSysHistory.do")
+	public String addSysHistory(@ModelAttribute("searchVO") SysHistoryVO historyVO, ModelMap model) throws Exception {
 
 		ComDefaultCodeVO vo = new ComDefaultCodeVO();
 		vo.setCodeId("COM002");
@@ -132,7 +130,6 @@ public class EgovSysHistoryController {
 		model.addAttribute("resultList", _result);
 		return "egovframework/com/sym/log/slg/EgovSysHistRegist";
 	}
-
 
 	/**
 	 * 시스템이력 수정
@@ -142,14 +139,10 @@ public class EgovSysHistoryController {
 	 * @return
 	 * @throws Exception
 	 */
-	@RequestMapping(value="/sym/log/slg/UpdateSysHistory.do")
-	public String updateSysHistory(
-			final MultipartHttpServletRequest multiRequest,
-			@ModelAttribute("searchVO") SysHistoryVO historyVO,
-			@ModelAttribute("history") SysHistory history,
-			BindingResult bindingResult,
-			SessionStatus status,
-			ModelMap model) throws Exception{
+	@RequestMapping(value = "/sym/log/slg/UpdateSysHistory.do")
+	public String updateSysHistory(final MultipartHttpServletRequest multiRequest,
+			@ModelAttribute("searchVO") SysHistoryVO historyVO, @ModelAttribute("history") SysHistory history,
+			BindingResult bindingResult, SessionStatus status, ModelMap model) throws Exception {
 
 		Boolean isAuthenticated = EgovUserDetailsHelper.isAuthenticated();
 
@@ -164,16 +157,16 @@ public class EgovSysHistoryController {
 			return "egovframework/com/sym/log/slg/EgovSysHistUpdt";
 		}
 
-		if(isAuthenticated){
+		if (isAuthenticated) {
 			String _atchFileId = history.getAtchFileId();
-			//final Map<String, MultipartFile> files = multiRequest.getFileMap();
+			// final Map<String, MultipartFile> files = multiRequest.getFileMap();
 			final List<MultipartFile> files = multiRequest.getFiles("file_1");
-			if(!files.isEmpty()){
-				if("".equals(_atchFileId)){
+			if (!files.isEmpty()) {
+				if ("".equals(_atchFileId)) {
 					List<FileVO> _result = fileUtil.parseFileInf(files, "SHF_", 0, _atchFileId, "");
 					_atchFileId = fileMngService.insertFileInfs(_result);
 					history.setAtchFileId(_atchFileId);
-				}else{
+				} else {
 					FileVO fvo = new FileVO();
 					fvo.setAtchFileId(_atchFileId);
 					int _cnt = fileMngService.getMaxFileSN(fvo);
@@ -181,12 +174,11 @@ public class EgovSysHistoryController {
 					fileMngService.updateFileInfs(_result);
 				}
 			}
-			//model.addAttribute("history", history);
+			// model.addAttribute("history", history);
 			sysHistoryService.updateSysHistory(history);
 		}
 
 		status.setComplete();
-
 
 		return "forward:/sym/log/slg/SelectSysHistoryList.do";
 	}
@@ -199,9 +191,9 @@ public class EgovSysHistoryController {
 	 * @return
 	 * @throws Exception
 	 */
-	@RequestMapping(value="/sym/log/slg/ModifySysHistory.do")
-	public String modifySysHistory(@ModelAttribute("searchVO") SysHistoryVO historyVO,
-			ModelMap model) throws Exception{
+	@RequestMapping(value = "/sym/log/slg/ModifySysHistory.do")
+	public String modifySysHistory(@ModelAttribute("searchVO") SysHistoryVO historyVO, ModelMap model)
+			throws Exception {
 
 		SysHistoryVO history = sysHistoryService.selectSysHistory(historyVO);
 		model.addAttribute("history", history);
@@ -220,15 +212,13 @@ public class EgovSysHistoryController {
 	 * @return
 	 * @throws Exception
 	 */
-	@RequestMapping(value="/sym/log/slg/DeleteSysHistory.do")
-	public String deleteSysHistory(
-			@ModelAttribute("history") SysHistory history,
-			SessionStatus status,
-			ModelMap model) throws Exception{
+	@RequestMapping(value = "/sym/log/slg/DeleteSysHistory.do")
+	public String deleteSysHistory(@ModelAttribute("history") SysHistory history, SessionStatus status, ModelMap model)
+			throws Exception {
 
 		Boolean isAuthenticated = EgovUserDetailsHelper.isAuthenticated();
 
-		if(isAuthenticated){
+		if (isAuthenticated) {
 			sysHistoryService.deleteSysHistory(history);
 		}
 
@@ -237,38 +227,38 @@ public class EgovSysHistoryController {
 	}
 
 	/**
-     * 시스템이력 목록 조회
-     *
-     * @param history
-     * @param model
-     * @return
-     * @throws Exception
-     */
-    @IncludedInfo(name = "시스템이력관리", listUrl = "/sym/log/slg/SelectSysHistoryList.do", order = 1060, gid = 60)
-    @RequestMapping(value = "/sym/log/slg/SelectSysHistoryList.do")
-    public String selectSysHistoryList(@ModelAttribute("searchVO") SysHistoryVO historyVO, ModelMap model)
-            throws Exception {
+	 * 시스템이력 목록 조회
+	 *
+	 * @param history
+	 * @param model
+	 * @return
+	 * @throws Exception
+	 */
+	@IncludedInfo(name = "시스템이력관리", listUrl = "/sym/log/slg/SelectSysHistoryList.do", order = 1060, gid = 60)
+	@RequestMapping(value = "/sym/log/slg/SelectSysHistoryList.do")
+	public String selectSysHistoryList(@ModelAttribute("searchVO") SysHistoryVO historyVO, ModelMap model)
+			throws Exception {
 
-        historyVO.setPageUnit(propertyService.getInt("pageUnit"));
-        historyVO.setPageSize(propertyService.getInt("pageSize"));
+		historyVO.setPageUnit(propertyService.getInt("pageUnit"));
+		historyVO.setPageSize(propertyService.getInt("pageSize"));
 
-        PaginationInfo paginationInfo = new PaginationInfo();
-        paginationInfo.setCurrentPageNo(historyVO.getPageIndex());
-        paginationInfo.setRecordCountPerPage(historyVO.getPageUnit());
-        paginationInfo.setPageSize(historyVO.getPageSize());
+		PaginationInfo paginationInfo = new PaginationInfo();
+		paginationInfo.setCurrentPageNo(historyVO.getPageIndex());
+		paginationInfo.setRecordCountPerPage(historyVO.getPageUnit());
+		paginationInfo.setPageSize(historyVO.getPageSize());
 
-        historyVO.setFirstIndex(paginationInfo.getFirstRecordIndex());
-        historyVO.setLastIndex(paginationInfo.getLastRecordIndex());
-        historyVO.setRecordCountPerPage(paginationInfo.getRecordCountPerPage());
+		historyVO.setFirstIndex(paginationInfo.getFirstRecordIndex());
+		historyVO.setLastIndex(paginationInfo.getLastRecordIndex());
+		historyVO.setRecordCountPerPage(paginationInfo.getRecordCountPerPage());
 
-        sysHistoryService.selectSysHistoryList(historyVO, model);
-        int totCnt = (Integer) model.get("resultCnt");
+		sysHistoryService.selectSysHistoryList(historyVO, model);
+		int totCnt = (Integer) model.get("resultCnt");
 
-        paginationInfo.setTotalRecordCount(totCnt);
-        model.addAttribute("paginationInfo", paginationInfo);
+		paginationInfo.setTotalRecordCount(totCnt);
+		model.addAttribute("paginationInfo", paginationInfo);
 
-        return "egovframework/com/sym/log/slg/EgovSysHistList";
-    }
+		return "egovframework/com/sym/log/slg/EgovSysHistList";
+	}
 
 	/**
 	 * 시스템이력 상세 조회
@@ -278,10 +268,9 @@ public class EgovSysHistoryController {
 	 * @return
 	 * @throws Exception
 	 */
-	@RequestMapping(value="/sym/log/slg/InqireSysHistory.do")
+	@RequestMapping(value = "/sym/log/slg/InqireSysHistory.do")
 	public String selectSysHistory(@ModelAttribute("searchVO") SysHistoryVO historyVO,
-			@RequestParam("histId") String histId,
-			ModelMap model) throws Exception{
+			@RequestParam("histId") String histId, ModelMap model) throws Exception {
 
 		historyVO.setHistId(histId.trim());
 


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

<hr>

### 2025-07-14 월 PMD로 소프트웨어 보안약점 진단하고 제거하기-EgovSysHistoryController

`_result, _atchFileId, _cnt` 를 카멜 케이스로 이름 바꾸기

`EgovUserDetailsHelper.isAuthenticated()` 를 `loginVO != null` 로 수정

`user` 를 `loginVO` 로 이름 바꾸기

<hr>

1. PMD로 소프트웨어 보안약점 진단 결과

```
src/main/java/egovframework/com/sym/log/slg/web/EgovSysHistoryController.java:95:	LocalVariableNamingConventions:	LocalVariableNamingConventions: 'local variable' 의 변수 '_result' 이  '[a-z][a-zA-Z0-9]*'  로 시작함
src/main/java/egovframework/com/sym/log/slg/web/EgovSysHistoryController.java:102:	LocalVariableNamingConventions:	LocalVariableNamingConventions: 'local variable' 의 변수 '_result' 이  '[a-z][a-zA-Z0-9]*'  로 시작함
src/main/java/egovframework/com/sym/log/slg/web/EgovSysHistoryController.java:103:	LocalVariableNamingConventions:	LocalVariableNamingConventions: 'local variable' 의 변수 '_atchFileId' 이  '[a-z][a-zA-Z0-9]*'  로 시작함
src/main/java/egovframework/com/sym/log/slg/web/EgovSysHistoryController.java:131:	LocalVariableNamingConventions:	LocalVariableNamingConventions: 'local variable' 의 변수 '_result' 이  '[a-z][a-zA-Z0-9]*'  로 시작함
src/main/java/egovframework/com/sym/log/slg/web/EgovSysHistoryController.java:162:	LocalVariableNamingConventions:	LocalVariableNamingConventions: 'local variable' 의 변수 '_result' 이  '[a-z][a-zA-Z0-9]*'  로 시작함
src/main/java/egovframework/com/sym/log/slg/web/EgovSysHistoryController.java:168:	LocalVariableNamingConventions:	LocalVariableNamingConventions: 'local variable' 의 변수 '_atchFileId' 이  '[a-z][a-zA-Z0-9]*'  로 시작함
src/main/java/egovframework/com/sym/log/slg/web/EgovSysHistoryController.java:173:	LocalVariableNamingConventions:	LocalVariableNamingConventions: 'local variable' 의 변수 '_result' 이  '[a-z][a-zA-Z0-9]*'  로 시작함
src/main/java/egovframework/com/sym/log/slg/web/EgovSysHistoryController.java:179:	LocalVariableNamingConventions:	LocalVariableNamingConventions: 'local variable' 의 변수 '_cnt' 이  '[a-z][a-zA-Z0-9]*'  로 시작함
src/main/java/egovframework/com/sym/log/slg/web/EgovSysHistoryController.java:180:	LocalVariableNamingConventions:	LocalVariableNamingConventions: 'local variable' 의 변수 '_result' 이  '[a-z][a-zA-Z0-9]*'  로 시작함
src/main/java/egovframework/com/sym/log/slg/web/EgovSysHistoryController.java:210:	LocalVariableNamingConventions:	LocalVariableNamingConventions: 'local variable' 의 변수 '_result' 이  '[a-z][a-zA-Z0-9]*'  로 시작함
```

2. 브랜치 생성

```
feature/pmd/EgovSysHistoryController
```

3. 이클립스 > Source > Format

4. 개정이력 수정

```java
 *   2025.07.14  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-LocalVariableNamingConventions(final이 아닌 변수는 밑줄을 포함할 수 없음)
```

<hr>

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

https://youtu.be/cVba60qk_Gw
