### PR TITLE
프로그램관리 > 등록 시 프로그램파일명이 중복되었을 때 발생하는 SQLIntegrityConstraintViolationException 수정

### DIFF
--- a/src/main/java/egovframework/com/sym/prm/web/EgovProgrmManageController.java
+++ b/src/main/java/egovframework/com/sym/prm/web/EgovProgrmManageController.java
@@ -212,7 +212,11 @@ public class EgovProgrmManageController {
 		}
 
 		beanValidator.validate(progrmManageVO, bindingResult);
-		if (bindingResult.hasErrors()) {
+		if (bindingResult.hasErrors() ||
+		    progrmManageService.selectProgrm(progrmManageVO) != null) {
+		    if (!bindingResult.hasErrors()) {
+				bindingResult.rejectValue("progrmFileNm", "error.progrmFileNm", "이미 등록된 프로그램파일명입니다.");
+		    }
 			return "egovframework/com/sym/prm/EgovProgramListRegist";
 		}
 		if (progrmManageVO.getProgrmDc() == null || progrmManageVO.getProgrmDc().equals("")) {

--- a/src/main/java/egovframework/com/sym/prm/web/EgovProgrmManageController.java
+++ b/src/main/java/egovframework/com/sym/prm/web/EgovProgrmManageController.java
@@ -44,6 +44,7 @@ import egovframework.com.utl.fcc.service.EgovStringUtil;
  *   2011.08.22  서준식			selectProgrmChangRequstProcess() 메서드 처리일자 trim 처리
  *   2011.08.26	 정진오			IncludedInfo annotation 추가
  *   2024.09.04  권태성			등록 화면과 데이터를 처리하는 method 분리, validation 적용
+ *   2025.07.15  권태성			프로그램파일명 등록 시 중복 체크 로직 추가
  * </pre>
  */
 


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

데이터 등록 시 프로그램파일명이 중복되면 Duplicate 에러로 에러 페이지가 표시되는 증상을 개선하였습니다.

`EgovProgrmManageController` 에서 데이터 저장 전 기존에 등록된 데이터가 있는지 확인하고 에러 메시지를 표시하도록 수정하였습니다.

```java
beanValidator.validate(progrmManageVO, bindingResult);
if (bindingResult.hasErrors() ||
    progrmManageService.selectProgrm(progrmManageVO) != null) {
    if (!bindingResult.hasErrors()) {
		bindingResult.rejectValue("progrmFileNm", "error.progrmFileNm", "이미 등록된 프로그램파일명입니다.");
    }
	return "egovframework/com/sym/prm/EgovProgramListRegist";
}
```


## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [] JUnit 테스트 JUnit tests
- [x] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

### 개선 전

https://github.com/user-attachments/assets/ee56e548-61a5-4bf6-8020-290ec66f96f0





### 개선 후


https://github.com/user-attachments/assets/1e942d7e-b04e-4beb-a958-44a85a21a2cf




