### PR TITLE
PMD로 소프트웨어 보안약점 진단하고 제거하기-MenuSiteMapVO

### DIFF
--- a/src/main/java/egovframework/com/sym/mnu/mcm/service/MenuSiteMapVO.java
+++ b/src/main/java/egovframework/com/sym/mnu/mcm/service/MenuSiteMapVO.java
@@ -228,7 +228,7 @@ public class MenuSiteMapVO {
 	}
 
 	/**
-	 * tmp_Id attribute를 리턴한다.
+	 * tmpId attribute를 리턴한다.
 	 * 
 	 * @return String
 	 */
@@ -237,16 +237,16 @@ public class MenuSiteMapVO {
 	}
 
 	/**
-	 * tmp_Id attribute 값을 설정한다.
+	 * tmpId attribute 값을 설정한다.
 	 * 
-	 * @param tmp_Id String
+	 * @param tmpId String
 	 */
-	public void setTmpId(String tmp_Id) {
-		this.tmpId = tmp_Id;
+	public void setTmpId(String tmpId) {
+		this.tmpId = tmpId;
 	}
 
 	/**
-	 * tmp_Password attribute를 리턴한다.
+	 * tmpPassword attribute를 리턴한다.
 	 * 
 	 * @return String
 	 */
@@ -255,16 +255,16 @@ public class MenuSiteMapVO {
 	}
 
 	/**
-	 * tmp_Password attribute 값을 설정한다.
+	 * tmpPassword attribute 값을 설정한다.
 	 * 
-	 * @param tmp_Password String
+	 * @param tmpPassword String
 	 */
-	public void setTmpPassword(String tmp_Password) {
-		this.tmpPassword = tmp_Password;
+	public void setTmpPassword(String tmpPassword) {
+		this.tmpPassword = tmpPassword;
 	}
 
 	/**
-	 * tmp_Name attribute를 리턴한다.
+	 * tmpName attribute를 리턴한다.
 	 * 
 	 * @return String
 	 */
@@ -273,16 +273,16 @@ public class MenuSiteMapVO {
 	}
 
 	/**
-	 * tmp_Name attribute 값을 설정한다.
+	 * tmpName attribute 값을 설정한다.
 	 * 
-	 * @param tmp_Name String
+	 * @param tmpName String
 	 */
-	public void setTmpName(String tmp_Name) {
-		this.tmpName = tmp_Name;
+	public void setTmpName(String tmpName) {
+		this.tmpName = tmpName;
 	}
 
 	/**
-	 * tmp_UserSe attribute를 리턴한다.
+	 * tmpUserSe attribute를 리턴한다.
 	 * 
 	 * @return String
 	 */
@@ -291,16 +291,16 @@ public class MenuSiteMapVO {
 	}
 
 	/**
-	 * tmp_UserSe attribute 값을 설정한다.
+	 * tmpUserSe attribute 값을 설정한다.
 	 * 
-	 * @param tmp_UserSe String
+	 * @param tmpUserSe String
 	 */
-	public void setTmpUserSe(String tmp_UserSe) {
-		this.tmpUserSe = tmp_UserSe;
+	public void setTmpUserSe(String tmpUserSe) {
+		this.tmpUserSe = tmpUserSe;
 	}
 
 	/**
-	 * tmp_Email attribute를 리턴한다.
+	 * tmpEmail attribute를 리턴한다.
 	 * 
 	 * @return String
 	 */
@@ -309,16 +309,16 @@ public class MenuSiteMapVO {
 	}
 
 	/**
-	 * tmp_Email attribute 값을 설정한다.
+	 * tmpEmail attribute 값을 설정한다.
 	 * 
-	 * @param tmp_Email String
+	 * @param tmpEmail String
 	 */
-	public void setTmpEmail(String tmp_Email) {
-		this.tmpEmail = tmp_Email;
+	public void setTmpEmail(String tmpEmail) {
+		this.tmpEmail = tmpEmail;
 	}
 
 	/**
-	 * tmp_OrgnztId attribute를 리턴한다.
+	 * tmpOrgnztId attribute를 리턴한다.
 	 * 
 	 * @return String
 	 */
@@ -327,16 +327,16 @@ public class MenuSiteMapVO {
 	}
 
 	/**
-	 * tmp_OrgnztId attribute 값을 설정한다.
+	 * tmpOrgnztId attribute 값을 설정한다.
 	 * 
-	 * @param tmp_OrgnztId String
+	 * @param tmpOrgnztId String
 	 */
-	public void setTmpOrgnztId(String tmp_OrgnztId) {
-		this.tmpOrgnztId = tmp_OrgnztId;
+	public void setTmpOrgnztId(String tmpOrgnztId) {
+		this.tmpOrgnztId = tmpOrgnztId;
 	}
 
 	/**
-	 * tmp_UniqId attribute를 리턴한다.
+	 * tmpUniqId attribute를 리턴한다.
 	 * 
 	 * @return String
 	 */
@@ -345,16 +345,16 @@ public class MenuSiteMapVO {
 	}
 
 	/**
-	 * tmp_UniqId attribute 값을 설정한다.
+	 * tmpUniqId attribute 값을 설정한다.
 	 * 
-	 * @param tmp_UniqId String
+	 * @param tmpUniqId String
 	 */
-	public void setTmpUniqId(String tmp_UniqId) {
-		this.tmpUniqId = tmp_UniqId;
+	public void setTmpUniqId(String tmpUniqId) {
+		this.tmpUniqId = tmpUniqId;
 	}
 
 	/**
-	 * tmp_Cmd attribute를 리턴한다.
+	 * tmpCmd attribute를 리턴한다.
 	 * 
 	 * @return String
 	 */
@@ -363,16 +363,16 @@ public class MenuSiteMapVO {
 	}
 
 	/**
-	 * tmp_Cmd attribute 값을 설정한다.
+	 * tmpCmd attribute 값을 설정한다.
 	 * 
-	 * @param tmp_Cmd String
+	 * @param tmpCmd String
 	 */
-	public void setTmpCmd(String tmp_Cmd) {
-		this.tmpCmd = tmp_Cmd;
+	public void setTmpCmd(String tmpCmd) {
+		this.tmpCmd = tmpCmd;
 	}
 
 	/**
-	 * tmp_rootPath attribute를 리턴한다.
+	 * tmprootPath attribute를 리턴한다.
 	 * 
 	 * @return String
 	 */
@@ -381,12 +381,12 @@ public class MenuSiteMapVO {
 	}
 
 	/**
-	 * tmp_rootPath attribute 값을 설정한다.
+	 * tmprootPath attribute 값을 설정한다.
 	 * 
-	 * @param tmp_rootPath String
+	 * @param tmprootPath String
 	 */
-	public void setTmpRootPath(String tmp_rootPath) {
-		this.tmpRootPath = tmp_rootPath;
+	public void setTmpRootPath(String tmprootPath) {
+		this.tmpRootPath = tmprootPath;
 	}
 
 }

--- a/src/main/java/egovframework/com/sym/mnu/mcm/service/MenuSiteMapVO.java
+++ b/src/main/java/egovframework/com/sym/mnu/mcm/service/MenuSiteMapVO.java
@@ -9,15 +9,15 @@ package egovframework.com.sym.mnu.mcm.service;
  * @see
  *
  *      <pre>
- * << 개정이력(Modification Information) >>
- *   
+ *  == 개정이력(Modification Information) ==
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
- *   2009.03.20  이  용          최초 생성
+ *   2009.03.20  이용           최초 생성
+ *   2025.07.16  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-FormalParameterNamingConventions(변수명에 밑줄 사용)
  *
  *      </pre>
  */
-
 public class MenuSiteMapVO {
 
 	/** 메뉴번호 */

--- a/src/main/java/egovframework/com/sym/mnu/mcm/service/MenuSiteMapVO.java
+++ b/src/main/java/egovframework/com/sym/mnu/mcm/service/MenuSiteMapVO.java
@@ -1,189 +1,226 @@
 package egovframework.com.sym.mnu.mcm.service;
-/** 
+
+/**
  * 사이트맵/메인메뉴 처리를 위한 VO 클래스르를 정의한다
+ * 
  * @author 개발환경 개발팀 이용
  * @since 2009.06.01
  * @version 1.0
  * @see
  *
- * <pre>
+ *      <pre>
  * << 개정이력(Modification Information) >>
  *   
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.03.20  이  용          최초 생성
  *
- * </pre>
+ *      </pre>
  */
 
-public class MenuSiteMapVO{
-	
-   /** 메뉴번호 */
-   private   int      menuNo;
-   
-   /* 사이트맵 */
-   /** 생성자ID **/
-   private   String   creatPersonId;
-   /** 맵생성ID */
-   private   String   mapCreatId;
-   /** 맵파일명 */
-   private   String   bndeFileNm;
-   /** 맵파일경로 */
-   private   String   bndeFilePath;
+public class MenuSiteMapVO {
 
-   /* 권한정보설정 */
-   /** 권한코드 */
-   private   String   authorCode;
-   /** 권한명 */
-   private   String   authorNm;
-   /** 권한설명 */
-   private   String   authorDc;
-   /** 권한생성일자 */
-   private   String   authorCreatDe;
+	/** 메뉴번호 */
+	private int menuNo;
 
-   /* 기타VO변수 */
-   /** rootPath Temp */
-   private   String   tmpRootPath;
+	/* 사이트맵 */
+	/** 생성자ID **/
+	private String creatPersonId;
+	/** 맵생성ID */
+	private String mapCreatId;
+	/** 맵파일명 */
+	private String bndeFileNm;
+	/** 맵파일경로 */
+	private String bndeFilePath;
 
-/* Login 메뉴관련 VO변수 */
-   /** tmp_Id */
-   private   String   tmpId;
-   /** tmp_Password */
-   private   String   tmpPassword;
-   /** tmp_Name */
-   private   String   tmpName;
-   /** tmp_UserSe */
-   private   String   tmpUserSe;
-   /** tmp_Email */
-   private   String   tmpEmail;
-   /** tmp_OrgnztId */
-   private   String   tmpOrgnztId;
-   /** tmp_UniqId */
-   private   String   tmpUniqId;
-   /** tmp_Cmd */
-   private   String   tmpCmd;
-   
+	/* 권한정보설정 */
+	/** 권한코드 */
+	private String authorCode;
+	/** 권한명 */
+	private String authorNm;
+	/** 권한설명 */
+	private String authorDc;
+	/** 권한생성일자 */
+	private String authorCreatDe;
+
+	/* 기타VO변수 */
+	/** rootPath Temp */
+	private String tmpRootPath;
+
+	/* Login 메뉴관련 VO변수 */
+	/** tmp_Id */
+	private String tmpId;
+	/** tmp_Password */
+	private String tmpPassword;
+	/** tmp_Name */
+	private String tmpName;
+	/** tmp_UserSe */
+	private String tmpUserSe;
+	/** tmp_Email */
+	private String tmpEmail;
+	/** tmp_OrgnztId */
+	private String tmpOrgnztId;
+	/** tmp_UniqId */
+	private String tmpUniqId;
+	/** tmp_Cmd */
+	private String tmpCmd;
+
 	/**
 	 * menuNo attribute를 리턴한다.
+	 * 
 	 * @return int
 	 */
 	public int getMenuNo() {
 		return menuNo;
 	}
+
 	/**
 	 * menuNo attribute 값을 설정한다.
+	 * 
 	 * @param menuNo int
 	 */
 	public void setMenuNo(int menuNo) {
 		this.menuNo = menuNo;
 	}
+
 	/**
 	 * creatPersonId attribute를 리턴한다.
+	 * 
 	 * @return String
 	 */
 	public String getCreatPersonId() {
 		return creatPersonId;
 	}
+
 	/**
 	 * creatPersonId attribute 값을 설정한다.
+	 * 
 	 * @param creatPersonId String
 	 */
 	public void setCreatPersonId(String creatPersonId) {
 		this.creatPersonId = creatPersonId;
 	}
+
 	/**
 	 * mapCreatId attribute를 리턴한다.
+	 * 
 	 * @return String
 	 */
 	public String getMapCreatId() {
 		return mapCreatId;
 	}
+
 	/**
 	 * mapCreatId attribute 값을 설정한다.
+	 * 
 	 * @param mapCreatId String
 	 */
 	public void setMapCreatId(String mapCreatId) {
 		this.mapCreatId = mapCreatId;
 	}
+
 	/**
 	 * bndeFileNm attribute를 리턴한다.
+	 * 
 	 * @return String
 	 */
 	public String getBndeFileNm() {
 		return bndeFileNm;
 	}
+
 	/**
 	 * bndeFileNm attribute 값을 설정한다.
+	 * 
 	 * @param bndeFileNm String
 	 */
 	public void setBndeFileNm(String bndeFileNm) {
 		this.bndeFileNm = bndeFileNm;
 	}
+
 	/**
 	 * bndeFilePath attribute를 리턴한다.
+	 * 
 	 * @return String
 	 */
 	public String getBndeFilePath() {
 		return bndeFilePath;
 	}
+
 	/**
 	 * bndeFilePath attribute 값을 설정한다.
+	 * 
 	 * @param bndeFilePath String
 	 */
 	public void setBndeFilePath(String bndeFilePath) {
 		this.bndeFilePath = bndeFilePath;
 	}
+
 	/**
 	 * authorCode attribute를 리턴한다.
+	 * 
 	 * @return String
 	 */
 	public String getAuthorCode() {
 		return authorCode;
 	}
+
 	/**
 	 * authorCode attribute 값을 설정한다.
+	 * 
 	 * @param authorCode String
 	 */
 	public void setAuthorCode(String authorCode) {
 		this.authorCode = authorCode;
 	}
+
 	/**
 	 * authorNm attribute를 리턴한다.
+	 * 
 	 * @return String
 	 */
 	public String getAuthorNm() {
 		return authorNm;
 	}
+
 	/**
 	 * authorNm attribute 값을 설정한다.
+	 * 
 	 * @param authorNm String
 	 */
 	public void setAuthorNm(String authorNm) {
 		this.authorNm = authorNm;
 	}
+
 	/**
 	 * authorDc attribute를 리턴한다.
+	 * 
 	 * @return String
 	 */
 	public String getAuthorDc() {
 		return authorDc;
 	}
+
 	/**
 	 * authorDc attribute 값을 설정한다.
+	 * 
 	 * @param authorDc String
 	 */
 	public void setAuthorDc(String authorDc) {
 		this.authorDc = authorDc;
 	}
+
 	/**
 	 * authorCreatDe attribute를 리턴한다.
+	 * 
 	 * @return String
 	 */
 	public String getAuthorCreatDe() {
 		return authorCreatDe;
 	}
+
 	/**
 	 * authorCreatDe attribute 값을 설정한다.
+	 * 
 	 * @param authorCreatDe String
 	 */
 	public void setAuthorCreatDe(String authorCreatDe) {
@@ -192,111 +229,142 @@ public class MenuSiteMapVO{
 
 	/**
 	 * tmp_Id attribute를 리턴한다.
+	 * 
 	 * @return String
 	 */
 	public String getTmpId() {
 		return tmpId;
 	}
+
 	/**
 	 * tmp_Id attribute 값을 설정한다.
+	 * 
 	 * @param tmp_Id String
 	 */
 	public void setTmpId(String tmp_Id) {
 		this.tmpId = tmp_Id;
 	}
+
 	/**
 	 * tmp_Password attribute를 리턴한다.
+	 * 
 	 * @return String
 	 */
 	public String getTmpPassword() {
 		return tmpPassword;
 	}
+
 	/**
 	 * tmp_Password attribute 값을 설정한다.
+	 * 
 	 * @param tmp_Password String
 	 */
 	public void setTmpPassword(String tmp_Password) {
 		this.tmpPassword = tmp_Password;
 	}
+
 	/**
 	 * tmp_Name attribute를 리턴한다.
+	 * 
 	 * @return String
 	 */
 	public String getTmpName() {
 		return tmpName;
 	}
+
 	/**
 	 * tmp_Name attribute 값을 설정한다.
+	 * 
 	 * @param tmp_Name String
 	 */
 	public void setTmpName(String tmp_Name) {
 		this.tmpName = tmp_Name;
 	}
+
 	/**
 	 * tmp_UserSe attribute를 리턴한다.
+	 * 
 	 * @return String
 	 */
 	public String getTmpUserSe() {
 		return tmpUserSe;
 	}
+
 	/**
 	 * tmp_UserSe attribute 값을 설정한다.
+	 * 
 	 * @param tmp_UserSe String
 	 */
 	public void setTmpUserSe(String tmp_UserSe) {
 		this.tmpUserSe = tmp_UserSe;
 	}
+
 	/**
 	 * tmp_Email attribute를 리턴한다.
+	 * 
 	 * @return String
 	 */
 	public String getTmpEmail() {
 		return tmpEmail;
 	}
+
 	/**
 	 * tmp_Email attribute 값을 설정한다.
+	 * 
 	 * @param tmp_Email String
 	 */
 	public void setTmpEmail(String tmp_Email) {
 		this.tmpEmail = tmp_Email;
 	}
+
 	/**
 	 * tmp_OrgnztId attribute를 리턴한다.
+	 * 
 	 * @return String
 	 */
 	public String getTmpOrgnztId() {
 		return tmpOrgnztId;
 	}
+
 	/**
 	 * tmp_OrgnztId attribute 값을 설정한다.
+	 * 
 	 * @param tmp_OrgnztId String
 	 */
 	public void setTmpOrgnztId(String tmp_OrgnztId) {
 		this.tmpOrgnztId = tmp_OrgnztId;
 	}
+
 	/**
 	 * tmp_UniqId attribute를 리턴한다.
+	 * 
 	 * @return String
 	 */
 	public String getTmpUniqId() {
 		return tmpUniqId;
 	}
+
 	/**
 	 * tmp_UniqId attribute 값을 설정한다.
+	 * 
 	 * @param tmp_UniqId String
 	 */
 	public void setTmpUniqId(String tmp_UniqId) {
 		this.tmpUniqId = tmp_UniqId;
 	}
+
 	/**
 	 * tmp_Cmd attribute를 리턴한다.
+	 * 
 	 * @return String
 	 */
 	public String getTmpCmd() {
 		return tmpCmd;
 	}
+
 	/**
 	 * tmp_Cmd attribute 값을 설정한다.
+	 * 
 	 * @param tmp_Cmd String
 	 */
 	public void setTmpCmd(String tmp_Cmd) {
@@ -305,13 +373,16 @@ public class MenuSiteMapVO{
 
 	/**
 	 * tmp_rootPath attribute를 리턴한다.
+	 * 
 	 * @return String
 	 */
 	public String getTmpRootPath() {
 		return tmpRootPath;
 	}
+
 	/**
 	 * tmp_rootPath attribute 값을 설정한다.
+	 * 
 	 * @param tmp_rootPath String
 	 */
 	public void setTmpRootPath(String tmp_rootPath) {


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

<hr>

### 2025-07-16 수 PMD로 소프트웨어 보안약점 진단하고 제거하기-MenuSiteMapVO

`tmp_Id` 를 `tmpId` 로 이름 바꾸기

`tmp_Password` 를 `tmpPassword` 로 이름 바꾸기

`tmp_Name` 를 `tmpName` 로 이름 바꾸기

`tmp_UserSe` 를 `tmpUserSe` 로 이름 바꾸기

`tmp_Email` 를 `tmpEmail` 로 이름 바꾸기

`tmp_OrgnztId` 를 `tmpOrgnztId` 로 이름 바꾸기

`tmp_UniqId` 를 `tmpUniqId` 로 이름 바꾸기

`tmp_Cmd` 를 `tmpCmd` 로 이름 바꾸기

`tmp_rootPath` 를 `tmprootPath` 로 이름 바꾸기

<hr>

1. PMD로 소프트웨어 보안약점 진단 결과

```
src/main/java/egovframework/com/sym/mnu/mcm/service/MenuSiteMapVO.java:204:	FormalParameterNamingConventions:	FormalParameterNamingConventions: 'method parameter' 의 변수 'tmp_Id' 이  '[a-z][a-zA-Z0-9]*'  로 시작함
src/main/java/egovframework/com/sym/mnu/mcm/service/MenuSiteMapVO.java:218:	FormalParameterNamingConventions:	FormalParameterNamingConventions: 'method parameter' 의 변수 'tmp_Password' 이  '[a-z][a-zA-Z0-9]*'  로 시작함
src/main/java/egovframework/com/sym/mnu/mcm/service/MenuSiteMapVO.java:232:	FormalParameterNamingConventions:	FormalParameterNamingConventions: 'method parameter' 의 변수 'tmp_Name' 이  '[a-z][a-zA-Z0-9]*'  로 시작함
src/main/java/egovframework/com/sym/mnu/mcm/service/MenuSiteMapVO.java:246:	FormalParameterNamingConventions:	FormalParameterNamingConventions: 'method parameter' 의 변수 'tmp_UserSe' 이  '[a-z][a-zA-Z0-9]*'  로 시작함
src/main/java/egovframework/com/sym/mnu/mcm/service/MenuSiteMapVO.java:260:	FormalParameterNamingConventions:	FormalParameterNamingConventions: 'method parameter' 의 변수 'tmp_Email' 이  '[a-z][a-zA-Z0-9]*'  로 시작함
src/main/java/egovframework/com/sym/mnu/mcm/service/MenuSiteMapVO.java:274:	FormalParameterNamingConventions:	FormalParameterNamingConventions: 'method parameter' 의 변수 'tmp_OrgnztId' 이  '[a-z][a-zA-Z0-9]*'  로 시작함
src/main/java/egovframework/com/sym/mnu/mcm/service/MenuSiteMapVO.java:288:	FormalParameterNamingConventions:	FormalParameterNamingConventions: 'method parameter' 의 변수 'tmp_UniqId' 이  '[a-z][a-zA-Z0-9]*'  로 시작함
src/main/java/egovframework/com/sym/mnu/mcm/service/MenuSiteMapVO.java:302:	FormalParameterNamingConventions:	FormalParameterNamingConventions: 'method parameter' 의 변수 'tmp_Cmd' 이  '[a-z][a-zA-Z0-9]*'  로 시작함
src/main/java/egovframework/com/sym/mnu/mcm/service/MenuSiteMapVO.java:317:	FormalParameterNamingConventions:	FormalParameterNamingConventions: 'method parameter' 의 변수 'tmp_rootPath' 이  '[a-z][a-zA-Z0-9]*'  로 시작함
```

2. 브랜치 생성

```
feature/pmd/MenuSiteMapVO
```

3. 이클립스 > Source > Format

4. 개정이력 수정

```java
 *   2025.07.16  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-FormalParameterNamingConventions(변수명에 밑줄 사용)
```

<hr>

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

https://youtu.be/gapv-mNswLM
