### PR TITLE
PMD로 소프트웨어 보안약점 진단하고 제거하기-MainImageVO

### DIFF
--- a/src/main/java/egovframework/com/uss/ion/msi/service/MainImageVO.java
+++ b/src/main/java/egovframework/com/uss/ion/msi/service/MainImageVO.java
@@ -13,20 +13,27 @@ package egovframework.com.uss.ion.msi.service;
 
 import java.util.List;
 
+import lombok.Getter;
+import lombok.Setter;
+
 public class MainImageVO extends MainImage {
 
 	/**
 	 * serialVersionUID
 	 */
 	private static final long serialVersionUID = 1L;
+
 	/**
 	 * 메인화면이미지 목록
 	 */
-	List<MainImageVO> mainImageList;
+	private List<MainImageVO> mainImageList;
+
 	/**
 	 * 삭제대상 목록
 	 */
-	String[] delYn;
+	@Getter
+	@Setter
+	private String[] delYn;
 
 	/**
 	 * @return the mainImageList
@@ -40,20 +47,6 @@ public class MainImageVO extends MainImage {
 	 */
 	public void setMainImageList(List<MainImageVO> mainImageList) {
 		this.mainImageList = mainImageList;
-	}
-
-	/**
-	 * @return the delYn
-	 */
-	public String[] getDelYn() {
-		return delYn;
-	}
-
-	/**
-	 * @param delYn the delYn to set
-	 */
-	public void setDelYn(String[] delYn) {
-		this.delYn = delYn;
 	}
 
 }

--- a/src/main/java/egovframework/com/uss/ion/msi/service/MainImageVO.java
+++ b/src/main/java/egovframework/com/uss/ion/msi/service/MainImageVO.java
@@ -1,14 +1,3 @@
-/**
- * 개요
- * - 메인화면이미지에 대한 Vo 클래스를 정의한다.
- * 
- * 상세내용
- * - 메인화면이미지의 목록 항목을 관리한다.
- * @author 이문준
- * @version 1.0
- * @created 03-8-2009 오후 2:08:58
- */
-
 package egovframework.com.uss.ion.msi.service;
 
 import java.util.List;
@@ -16,6 +5,31 @@ import java.util.List;
 import lombok.Getter;
 import lombok.Setter;
 
+/**
+ * <pre>
+ * 개요
+ * - 메인화면이미지에 대한 Vo 클래스를 정의한다.
+ * 
+ * 상세내용
+ * - 메인화면이미지의 목록 항목을 관리한다.
+ * </pre>
+ * 
+ * @author 이문준
+ * @since 2010.08.03
+ * @version 1.0
+ * @see
+ *
+ *      <pre>
+ *  == 개정이력(Modification Information) ==
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2010.08.03  이문준          최초 생성
+ *   2025.08.07  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-MethodReturnsInternalArray(Private 배열에 Public 데이터 할당)
+ *   2025.08.07  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-ArrayIsStoredDirectly(Public 메소드부터 반환된 Private 배열)
+ *
+ *      </pre>
+ */
 public class MainImageVO extends MainImage {
 
 	/**

--- a/src/main/java/egovframework/com/uss/ion/msi/service/MainImageVO.java
+++ b/src/main/java/egovframework/com/uss/ion/msi/service/MainImageVO.java
@@ -21,12 +21,12 @@ public class MainImageVO extends MainImage {
 	private static final long serialVersionUID = 1L;
 	/**
 	 * 메인화면이미지 목록
-	 */	
+	 */
 	List<MainImageVO> mainImageList;
 	/**
 	 * 삭제대상 목록
-	 */		
-    String[] delYn;
+	 */
+	String[] delYn;
 
 	/**
 	 * @return the mainImageList
@@ -34,25 +34,26 @@ public class MainImageVO extends MainImage {
 	public List<MainImageVO> getMainImageList() {
 		return mainImageList;
 	}
+
 	/**
 	 * @param mainImageList the mainImageList to set
 	 */
 	public void setMainImageList(List<MainImageVO> mainImageList) {
 		this.mainImageList = mainImageList;
 	}
+
 	/**
 	 * @return the delYn
 	 */
 	public String[] getDelYn() {
 		return delYn;
 	}
+
 	/**
 	 * @param delYn the delYn to set
 	 */
 	public void setDelYn(String[] delYn) {
 		this.delYn = delYn;
 	}
-    
-    
-    
+
 }


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

<hr>

### 2025-08-07 목 PMD로 소프트웨어 보안약점 진단하고 제거하기-MainImageVO

`getDelYn, setDelYn` 메서드를 제거하고 `private, @Getter, @Setter` 추가

<hr>

1. PMD로 소프트웨어 보안약점 진단 결과

```
src/main/java/egovframework/com/uss/ion/msi/service/MainImageVO.java:47:	MethodReturnsInternalArray:	MethodReturnsInternalArray: 'delYn'을 반환하면 내부 배열이 노출될 수 있음
src/main/java/egovframework/com/uss/ion/msi/service/MainImageVO.java:53:	ArrayIsStoredDirectly:	ArrayIsStoredDirectly: 배열 'delYn' 이 직접 저장되어 있음
```

2. 브랜치 생성

```
feature/pmd/MainImageVO
```

3. 이클립스 > Source > Format

4. 개정이력 수정

```java
 *   2025.08.07  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-MethodReturnsInternalArray(Private 배열에 Public 데이터 할당)
 *   2025.08.07  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-ArrayIsStoredDirectly(Public 메소드부터 반환된 Private 배열)
```

<hr>

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

https://youtu.be/0Jmcz2qlLJI
