### PR TITLE
PMD로 소프트웨어 보안약점 진단하고 제거하기-EgovRecentSrchwrdController

### DIFF
--- a/src/main/java/egovframework/com/uss/ion/rsm/web/EgovRecentSrchwrdController.java
+++ b/src/main/java/egovframework/com/uss/ion/rsm/web/EgovRecentSrchwrdController.java
@@ -36,10 +36,13 @@ import net.sourceforge.ajaxtags.xml.AjaxXmlBuilder;
 
 /**
  * 최근검색어를 처리하는 Controller Class 구현
+ * 
  * @author 공통서비스 장동한
  * @since 2009.07.03
  * @version 1.0
- * @see <pre>
+ * @see
+ * 
+ *      <pre>
  * &lt;&lt; 개정이력(Modification Information) &gt;&gt;
  *
  *   수정일      수정자           수정내용
@@ -47,8 +50,8 @@ import net.sourceforge.ajaxtags.xml.AjaxXmlBuilder;
  *   2009.07.03  장동한          최초 생성
  *   2011.12.15  이기하          검색어 없을 시 미저장, 사용자 검색여부 'N'일 때 자동검색 미사용 수정
  *   2020.10.29  권태성          등록 화면과 데이터를 처리하는 method 분리
- *   
- * </pre>
+ * 
+ *      </pre>
  */
 
 @Controller
@@ -73,6 +76,7 @@ public class EgovRecentSrchwrdController {
 
 	/**
 	 * 최근검색어관리 목록을 조회한다.
+	 * 
 	 * @param searchVO
 	 * @param commandMap
 	 * @param recentSrchwrdVO
@@ -83,12 +87,10 @@ public class EgovRecentSrchwrdController {
 	@SuppressWarnings("unused")
 	@IncludedInfo(name = "최근검색어 조회", order = 760, gid = 50)
 	@RequestMapping(value = "/uss/ion/rsm/listRecentSrchwrd.do")
-	public String egovRecentSrchwrdList(
-		@ModelAttribute("searchVO") RecentSrchwrd searchVO, @RequestParam Map<?, ?> commandMap,
-		RecentSrchwrd recentSrchwrdVO, ModelMap model)
-		throws Exception {
+	public String egovRecentSrchwrdList(@ModelAttribute("searchVO") RecentSrchwrd searchVO,
+			@RequestParam Map<?, ?> commandMap, RecentSrchwrd recentSrchwrdVO, ModelMap model) throws Exception {
 
-		String sSearchMode = commandMap.get("searchMode") == null ? "" : (String)commandMap.get("searchMode");
+		String sSearchMode = commandMap.get("searchMode") == null ? "" : (String) commandMap.get("searchMode");
 
 		/** EgovPropertyService.sample */
 		searchVO.setPageUnit(propertiesService.getInt("pageUnit"));
@@ -108,9 +110,9 @@ public class EgovRecentSrchwrdController {
 		model.addAttribute("resultList", reusltList);
 
 		model.addAttribute("searchKeyword",
-			commandMap.get("searchKeyword") == null ? "" : (String)commandMap.get("searchKeyword"));
+				commandMap.get("searchKeyword") == null ? "" : (String) commandMap.get("searchKeyword"));
 		model.addAttribute("searchCondition",
-			commandMap.get("searchCondition") == null ? "" : (String)commandMap.get("searchCondition"));
+				commandMap.get("searchCondition") == null ? "" : (String) commandMap.get("searchCondition"));
 
 		int totCnt = egovRecentSrchwrdService.selectRecentSrchwrdListCnt(searchVO);
 		paginationInfo.setTotalRecordCount(totCnt);
@@ -121,6 +123,7 @@ public class EgovRecentSrchwrdController {
 
 	/**
 	 * 최근검색어관리 목록을 상세조회 조회한다.
+	 * 
 	 * @param searchVO
 	 * @param recentSrchwrdVO
 	 * @param commandMap
@@ -129,14 +132,12 @@ public class EgovRecentSrchwrdController {
 	 * @throws Exception
 	 */
 	@RequestMapping(value = "/uss/ion/rsm/detailRecentSrchwrd.do")
-	public String egovRecentSrchwrdDetail(
-		@ModelAttribute("searchVO") ComDefaultVO searchVO,
-		RecentSrchwrd recentSrchwrd, @RequestParam Map<?, ?> commandMap,
-		ModelMap model) throws Exception {
+	public String egovRecentSrchwrdDetail(@ModelAttribute("searchVO") ComDefaultVO searchVO,
+			RecentSrchwrd recentSrchwrd, @RequestParam Map<?, ?> commandMap, ModelMap model) throws Exception {
 
 		String sLocationUrl = "egovframework/com/uss/ion/rsm/EgovRecentSrchwrdDetail";
 
-		String sCmd = commandMap.get("cmd") == null ? "" : (String)commandMap.get("cmd");
+		String sCmd = commandMap.get("cmd") == null ? "" : (String) commandMap.get("cmd");
 
 		if (sCmd.equals("del")) {
 			egovRecentSrchwrdService.deleteRecentSrchwrd(recentSrchwrd);
@@ -151,6 +152,7 @@ public class EgovRecentSrchwrdController {
 
 	/**
 	 * 최근검색어관리 수정화면
+	 * 
 	 * @param searchVO
 	 * @param recentSrchwrdVO
 	 * @param model
@@ -174,6 +176,7 @@ public class EgovRecentSrchwrdController {
 
 	/**
 	 * 최근검색어관리를 수정한다.
+	 * 
 	 * @param searchVO
 	 * @param recentSrchwrdVO
 	 * @param bindingResult
@@ -209,14 +212,14 @@ public class EgovRecentSrchwrdController {
 
 		return "redirect:/uss/ion/rsm/listRecentSrchwrd.do";
 	}
-	
+
 	/**
 	 * 최근검색어관리 등록 화면
+	 * 
 	 * @param searchVO
 	 * @param recentSrchwrdVO
 	 * @param model
-	 * @return
-	 *         "/uss/ion/rsm/EgovOnlinePollRegist"
+	 * @return "/uss/ion/rsm/EgovOnlinePollRegist"
 	 * @throws Exception
 	 */
 	@RequestMapping(value = "/uss/ion/rsm/registRecentSrchwrdView.do")
@@ -231,15 +234,15 @@ public class EgovRecentSrchwrdController {
 
 		return "egovframework/com/uss/ion/rsm/EgovRecentSrchwrdRegist";
 	}
-	
+
 	/**
 	 * 최근검색어관리를 등록한다.
+	 * 
 	 * @param searchVO
 	 * @param recentSrchwrdVO
 	 * @param bindingResult
 	 * @param model
-	 * @return
-	 *         "redirect:/uss/ion/rsm/listRecentSrchwrd.do"
+	 * @return "redirect:/uss/ion/rsm/listRecentSrchwrd.do"
 	 * @throws Exception
 	 */
 	@RequestMapping(value = "/uss/ion/rsm/registRecentSrchwrd.do")
@@ -274,6 +277,7 @@ public class EgovRecentSrchwrdController {
 
 	/**
 	 * 최근검색어결과 목록을 조회한다.
+	 * 
 	 * @param searchVO
 	 * @param commandMap
 	 * @param recentSrchwrdVO
@@ -283,14 +287,11 @@ public class EgovRecentSrchwrdController {
 	 */
 	@SuppressWarnings("unused")
 	@RequestMapping(value = "/uss/ion/rsm/listRecentSrchwrdResult.do")
-	public String egovRecentSrchwrdResultList(
-		@ModelAttribute("searchVO") RecentSrchwrd searchVO,
-		@RequestParam Map<?, ?> commandMap,
-		ModelMap model)
-		throws Exception {
+	public String egovRecentSrchwrdResultList(@ModelAttribute("searchVO") RecentSrchwrd searchVO,
+			@RequestParam Map<?, ?> commandMap, ModelMap model) throws Exception {
 
-		String sSearchMode = commandMap.get("searchMode") == null ? "" : (String)commandMap.get("searchMode");
-		String sCmd = commandMap.get("cmd") == null ? "" : (String)commandMap.get("cmd");
+		String sSearchMode = commandMap.get("searchMode") == null ? "" : (String) commandMap.get("searchMode");
+		String sCmd = commandMap.get("cmd") == null ? "" : (String) commandMap.get("cmd");
 
 		/** EgovPropertyService.sample */
 		searchVO.setPageUnit(propertiesService.getInt("pageUnit"));
@@ -306,10 +307,10 @@ public class EgovRecentSrchwrdController {
 		searchVO.setLastIndex(paginationInfo.getLastRecordIndex());
 		searchVO.setRecordCountPerPage(paginationInfo.getRecordCountPerPage());
 
-		//건별삭제
+		// 건별삭제
 		if (sCmd.equals("del")) {
 			egovRecentSrchwrdService.deleteRecentSrchwrdResult(searchVO);
-			//관리별삭제
+			// 관리별삭제
 		} else if (sCmd.equals("delAll")) {
 			egovRecentSrchwrdService.deleteRecentSrchwrdResultAll(searchVO);
 		}
@@ -318,12 +319,12 @@ public class EgovRecentSrchwrdController {
 		model.addAttribute("resultList", reusltList);
 
 		model.addAttribute("searchKeyword",
-			commandMap.get("searchKeyword") == null ? "" : (String)commandMap.get("searchKeyword"));
+				commandMap.get("searchKeyword") == null ? "" : (String) commandMap.get("searchKeyword"));
 		model.addAttribute("searchCondition",
-			commandMap.get("searchCondition") == null ? "" : (String)commandMap.get("searchCondition"));
+				commandMap.get("searchCondition") == null ? "" : (String) commandMap.get("searchCondition"));
 
 		model.addAttribute("srchwrdManageId",
-			commandMap.get("srchwrdManageId") == null ? "" : (String)commandMap.get("srchwrdManageId"));
+				commandMap.get("srchwrdManageId") == null ? "" : (String) commandMap.get("srchwrdManageId"));
 
 		int totCnt = egovRecentSrchwrdService.selectRecentSrchwrdResultListCnt(searchVO);
 		paginationInfo.setTotalRecordCount(totCnt);
@@ -334,15 +335,15 @@ public class EgovRecentSrchwrdController {
 
 	/**
 	 * 최근검색어 결과를 조회한다.
+	 * 
 	 * @param searchVO
 	 * @param model
 	 * @return "model"
 	 * @throws Exception
 	 */
 	@RequestMapping(value = "/uss/ion/rsm/listRecentSrchwrdResultSerach.do")
-	protected ModelAndView egovRecentSrchwrdResultSerachList(
-		@RequestParam("searchKeyword") String searchKeyword,
-		RecentSrchwrd recentSrchwrd) throws Exception {
+	protected ModelAndView egovRecentSrchwrdResultSerachList(@RequestParam("searchKeyword") String searchKeyword,
+			RecentSrchwrd recentSrchwrd) throws Exception {
 
 		recentSrchwrd.setQ(searchKeyword);
 		LOGGER.debug("recentSrchwrd : {}", recentSrchwrd);
@@ -364,9 +365,9 @@ public class EgovRecentSrchwrdController {
 
 		EgovMap emResult = new EgovMap();
 		for (int i = 0; i < reusltList.size(); i++) {
-			emResult = (EgovMap)reusltList.get(i);
-			ajaxXmlBuilder.addItem((String)emResult.get("recentSrchwrdNm"), (String)emResult.get("recentSrchwrdNm"),
-				false);
+			emResult = reusltList.get(i);
+			ajaxXmlBuilder.addItem((String) emResult.get("recentSrchwrdNm"), (String) emResult.get("recentSrchwrdNm"),
+					false);
 		}
 
 		model.addObject("ajaxXml", ajaxXmlBuilder.toString());
@@ -376,6 +377,7 @@ public class EgovRecentSrchwrdController {
 
 	/**
 	 * 최근검색어를 등록한다.
+	 * 
 	 * @param commandMap
 	 * @param recentSrchwrd
 	 * @param model
@@ -383,10 +385,8 @@ public class EgovRecentSrchwrdController {
 	 * @throws Exception
 	 */
 	@RequestMapping(value = "/uss/ion/rsm/registRecentSrchwrdResult.do")
-	public void egovRecentSrchwrdRegist(
-		@RequestParam Map<?, ?> commandMap,
-		HttpServletResponse response,
-		RecentSrchwrd recentSrchwrd) throws Exception {
+	public void egovRecentSrchwrdRegist(@RequestParam Map<?, ?> commandMap, HttpServletResponse response,
+			RecentSrchwrd recentSrchwrd) throws Exception {
 
 		response.setHeader("Content-Type", "text/html;charset=utf-8");
 		PrintWriter out = new PrintWriter(new OutputStreamWriter(response.getOutputStream(), "UTF-8"));
@@ -395,15 +395,16 @@ public class EgovRecentSrchwrdController {
 		LOGGER.debug("recentSrchwrd : {}", recentSrchwrd);
 
 		// 로그인 객체 선언
-		LoginVO loginVO = (LoginVO)EgovUserDetailsHelper.getAuthenticatedUser();
+		LoginVO loginVO = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();
 
-		//아이디 설정
+		// 아이디 설정
 		recentSrchwrd.setFrstRegisterId(loginVO == null ? "" : EgovStringUtil.isNullToString(loginVO.getUniqId()));
 		recentSrchwrd.setLastUpdusrId(loginVO == null ? "" : EgovStringUtil.isNullToString(loginVO.getUniqId()));
 
-		//       System.out.println("recentSrchwrd.getSrchwrdNm() : "+ recentSrchwrd.getSrchwrdNm());
+		// System.out.println("recentSrchwrd.getSrchwrdNm() : "+
+		// recentSrchwrd.getSrchwrdNm());
 
-		//검색어가 없을 시 미저장
+		// 검색어가 없을 시 미저장
 		if (recentSrchwrd.getSrchwrdNm() != null && !recentSrchwrd.getSrchwrdNm().equals("")) {
 			egovRecentSrchwrdService.insertRecentSrchwrdResult(recentSrchwrd);
 		}

--- a/src/main/java/egovframework/com/uss/ion/rsm/web/EgovRecentSrchwrdController.java
+++ b/src/main/java/egovframework/com/uss/ion/rsm/web/EgovRecentSrchwrdController.java
@@ -41,19 +41,20 @@ import net.sourceforge.ajaxtags.xml.AjaxXmlBuilder;
  * @since 2009.07.03
  * @version 1.0
  * @see
- * 
+ *
  *      <pre>
- * &lt;&lt; 개정이력(Modification Information) &gt;&gt;
+ *  == 개정이력(Modification Information) ==
  *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.07.03  장동한          최초 생성
  *   2011.12.15  이기하          검색어 없을 시 미저장, 사용자 검색여부 'N'일 때 자동검색 미사용 수정
  *   2020.10.29  권태성          등록 화면과 데이터를 처리하는 method 분리
- * 
+ *   2025.08.13  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-UselessParentheses(불필요한 괄호사용)
+ *   2025.08.13  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-CloseResource(부적절한 자원 해제)
+ *
  *      </pre>
  */
-
 @Controller
 public class EgovRecentSrchwrdController {
 

--- a/src/main/java/egovframework/com/uss/ion/rsm/web/EgovRecentSrchwrdController.java
+++ b/src/main/java/egovframework/com/uss/ion/rsm/web/EgovRecentSrchwrdController.java
@@ -2,6 +2,7 @@ package egovframework.com.uss.ion.rsm.web;
 
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
+import java.io.Writer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -31,7 +32,6 @@ import egovframework.com.cmm.annotation.IncludedInfo;
 import egovframework.com.cmm.util.EgovUserDetailsHelper;
 import egovframework.com.uss.ion.rsm.service.EgovRecentSrchwrdService;
 import egovframework.com.uss.ion.rsm.service.RecentSrchwrd;
-import egovframework.com.utl.fcc.service.EgovStringUtil;
 import net.sourceforge.ajaxtags.xml.AjaxXmlBuilder;
 
 /**
@@ -203,9 +203,10 @@ public class EgovRecentSrchwrdController {
 		// 로그인 객체 선언
 		LoginVO loginVO = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();
 		// 아이디 설정
-		String uniqId = (loginVO == null ? "" : EgovStringUtil.isNullToString(loginVO.getUniqId()));
-		recentSrchwrd.setFrstRegisterId(uniqId);
-		recentSrchwrd.setLastUpdusrId(uniqId);
+		if (loginVO != null) {
+			recentSrchwrd.setFrstRegisterId(loginVO.getUniqId());
+			recentSrchwrd.setLastUpdusrId(loginVO.getUniqId());
+		}
 
 		// 저장
 		egovRecentSrchwrdService.updateRecentSrchwrd(recentSrchwrd);
@@ -265,9 +266,10 @@ public class EgovRecentSrchwrdController {
 		// 로그인 객체 선언
 		LoginVO loginVO = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();
 		// 아이디 설정
-		String uniqId = (loginVO == null ? "" : EgovStringUtil.isNullToString(loginVO.getUniqId()));
-		recentSrchwrd.setFrstRegisterId(uniqId);
-		recentSrchwrd.setLastUpdusrId(uniqId);
+		if (loginVO != null) {
+			recentSrchwrd.setFrstRegisterId(loginVO.getUniqId());
+			recentSrchwrd.setLastUpdusrId(loginVO.getUniqId());
+		}
 
 		// 저장
 		egovRecentSrchwrdService.insertRecentSrchwrd(recentSrchwrd);
@@ -389,7 +391,8 @@ public class EgovRecentSrchwrdController {
 			RecentSrchwrd recentSrchwrd) throws Exception {
 
 		response.setHeader("Content-Type", "text/html;charset=utf-8");
-		PrintWriter out = new PrintWriter(new OutputStreamWriter(response.getOutputStream(), "UTF-8"));
+		Writer writer = new OutputStreamWriter(response.getOutputStream(), "UTF-8"); // NOPMD - CloseResource 규칙 무시
+		PrintWriter out = new PrintWriter(writer); // NOPMD - CloseResource 규칙 무시
 
 		LOGGER.debug("commandMap : {}", commandMap);
 		LOGGER.debug("recentSrchwrd : {}", recentSrchwrd);
@@ -398,8 +401,10 @@ public class EgovRecentSrchwrdController {
 		LoginVO loginVO = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();
 
 		// 아이디 설정
-		recentSrchwrd.setFrstRegisterId(loginVO == null ? "" : EgovStringUtil.isNullToString(loginVO.getUniqId()));
-		recentSrchwrd.setLastUpdusrId(loginVO == null ? "" : EgovStringUtil.isNullToString(loginVO.getUniqId()));
+		if (loginVO != null) {
+			recentSrchwrd.setFrstRegisterId(loginVO.getUniqId());
+			recentSrchwrd.setLastUpdusrId(loginVO.getUniqId());
+		}
 
 		// System.out.println("recentSrchwrd.getSrchwrdNm() : "+
 		// recentSrchwrd.getSrchwrdNm());

--- a/src/main/java/egovframework/com/uss/ion/rsm/web/EgovRecentSrchwrdController.java
+++ b/src/main/java/egovframework/com/uss/ion/rsm/web/EgovRecentSrchwrdController.java
@@ -32,6 +32,7 @@ import egovframework.com.cmm.annotation.IncludedInfo;
 import egovframework.com.cmm.util.EgovUserDetailsHelper;
 import egovframework.com.uss.ion.rsm.service.EgovRecentSrchwrdService;
 import egovframework.com.uss.ion.rsm.service.RecentSrchwrd;
+import egovframework.com.utl.fcc.service.EgovStringUtil;
 import net.sourceforge.ajaxtags.xml.AjaxXmlBuilder;
 
 /**
@@ -203,11 +204,10 @@ public class EgovRecentSrchwrdController {
 
 		// 로그인 객체 선언
 		LoginVO loginVO = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();
+		String uniqId = loginVO == null ? "" : EgovStringUtil.isNullToString(loginVO.getUniqId());
 		// 아이디 설정
-		if (loginVO != null) {
-			recentSrchwrd.setFrstRegisterId(loginVO.getUniqId());
-			recentSrchwrd.setLastUpdusrId(loginVO.getUniqId());
-		}
+		recentSrchwrd.setFrstRegisterId(uniqId);
+		recentSrchwrd.setLastUpdusrId(uniqId);
 
 		// 저장
 		egovRecentSrchwrdService.updateRecentSrchwrd(recentSrchwrd);
@@ -266,11 +266,10 @@ public class EgovRecentSrchwrdController {
 
 		// 로그인 객체 선언
 		LoginVO loginVO = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();
+		String uniqId = loginVO == null ? "" : EgovStringUtil.isNullToString(loginVO.getUniqId());
 		// 아이디 설정
-		if (loginVO != null) {
-			recentSrchwrd.setFrstRegisterId(loginVO.getUniqId());
-			recentSrchwrd.setLastUpdusrId(loginVO.getUniqId());
-		}
+		recentSrchwrd.setFrstRegisterId(uniqId);
+		recentSrchwrd.setLastUpdusrId(uniqId);
 
 		// 저장
 		egovRecentSrchwrdService.insertRecentSrchwrd(recentSrchwrd);
@@ -400,12 +399,10 @@ public class EgovRecentSrchwrdController {
 
 		// 로그인 객체 선언
 		LoginVO loginVO = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();
-
+		String uniqId = loginVO == null ? "" : EgovStringUtil.isNullToString(loginVO.getUniqId());
 		// 아이디 설정
-		if (loginVO != null) {
-			recentSrchwrd.setFrstRegisterId(loginVO.getUniqId());
-			recentSrchwrd.setLastUpdusrId(loginVO.getUniqId());
-		}
+		recentSrchwrd.setFrstRegisterId(uniqId);
+		recentSrchwrd.setLastUpdusrId(uniqId);
 
 		// System.out.println("recentSrchwrd.getSrchwrdNm() : "+
 		// recentSrchwrd.getSrchwrdNm());


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

<hr>

### 2025-08-13 수 PMD로 소프트웨어 보안약점 진단하고 제거하기-EgovRecentSrchwrdController

아이디 설정을 수정
```java
		// 로그인 객체 선언
		LoginVO loginVO = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();
		// 아이디 설정
//		String uniqId = (loginVO == null ? "" : EgovStringUtil.isNullToString(loginVO.getUniqId()));
//		recentSrchwrd.setFrstRegisterId(uniqId);
//		recentSrchwrd.setLastUpdusrId(uniqId);
		if (loginVO != null) {
			recentSrchwrd.setFrstRegisterId(loginVO.getUniqId());
			recentSrchwrd.setLastUpdusrId(loginVO.getUniqId());
		}
```

`PrintWriter` 에 `// NOPMD - CloseResource 규칙 무시` 특정 규칙 무시 주석 추가

<hr>

1. PMD로 소프트웨어 보안약점 진단 결과

```
src/main/java/egovframework/com/uss/ion/rsm/web/EgovRecentSrchwrdController.java:203:	UselessParentheses:	UselessParentheses: 괄호가 없어도 되는 상황에서 불필요한 괄호를 사용할 경우 마치 메소드 호출처럼 보여서 소스 코드의 가독성을 떨어뜨릴 수 있음
src/main/java/egovframework/com/uss/ion/rsm/web/EgovRecentSrchwrdController.java:265:	UselessParentheses:	UselessParentheses: 괄호가 없어도 되는 상황에서 불필요한 괄호를 사용할 경우 마치 메소드 호출처럼 보여서 소스 코드의 가독성을 떨어뜨릴 수 있음
src/main/java/egovframework/com/uss/ion/rsm/web/EgovRecentSrchwrdController.java:392:	CloseResource:	CloseResource: 리소스 'PrintWriter' 가 사용 후에 닫혔는지 확인필요
```

2. 브랜치 생성

```
feature/pmd/EgovRecentSrchwrdController
```

3. 이클립스 > Source > Format

4. 개정이력 수정

```java
 *   2025.08.13  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-UselessParentheses(불필요한 괄호사용)
 *   2025.08.13  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-CloseResource(부적절한 자원 해제)
```

<hr>

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

https://youtu.be/J7dO0p_6ahI
