### PR TITLE
PMD로 소프트웨어 보안약점 진단하고 제거하기-EgovTwitterController

### DIFF
--- a/src/main/java/egovframework/com/uss/ion/tir/web/EgovTwitterController.java
+++ b/src/main/java/egovframework/com/uss/ion/tir/web/EgovTwitterController.java
@@ -36,18 +36,19 @@ import twitter4j.CreateTweetResponse;
  * @since 2010.10.04
  * @version 1.0
  * @see
- * 
+ *
  *      <pre>
- * &lt;&lt; 개정이력(Modification Information) &gt;&gt;
+ *  == 개정이력(Modification Information) ==
  *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2010.10.04  장동한          최초 생성
- *   2011.8.26	정진오			IncludedInfo annotation 추가
+ *   2011.08.26  정진오          IncludedInfo annotation 추가
+ *   2025.08.16  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-LocalVariableNamingConventions(final이 아닌 변수는 밑줄을 포함할 수 없음)
+ *   2025.08.16  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-AvoidReassigningParameters(넘겨받는 메소드 parameter 값을 직접 변경하는 코드 탐지)
  *
  *      </pre>
  */
-
 @Controller
 public class EgovTwitterController {
 

--- a/src/main/java/egovframework/com/uss/ion/tir/web/EgovTwitterController.java
+++ b/src/main/java/egovframework/com/uss/ion/tir/web/EgovTwitterController.java
@@ -31,11 +31,13 @@ import twitter4j.CreateTweetResponse;
 
 /**
  * 트위터 수신, 송신를 처리하는 Controller Class 구현
+ * 
  * @author 공통서비스 장동한
  * @since 2010.10.04
  * @version 1.0
  * @see
- * <pre>
+ * 
+ *      <pre>
  * &lt;&lt; 개정이력(Modification Information) &gt;&gt;
  *
  *   수정일      수정자           수정내용
@@ -43,7 +45,7 @@ import twitter4j.CreateTweetResponse;
  *   2010.10.04  장동한          최초 생성
  *   2011.8.26	정진오			IncludedInfo annotation 추가
  *
- * </pre>
+ *      </pre>
  */
 
 @Controller
@@ -63,14 +65,15 @@ public class EgovTwitterController {
 	/** 트위터 송신(목록) 서비스 */
 	@Resource(name = "egovTwitterTrnsmitService")
 	private EgovTwitterTrnsmitService egovTwitterTrnsmitService;
-	
+
 	private static final Logger LOGGER = LoggerFactory.getLogger(EgovTwitterController.class);
 
 	/**
 	 * 트위터를 메인 인증 페이지조회
-	 * @param commandMap 	-Request  Variable
-	 * @return String 		-리턴 URL
-	 * @throws Exception	-Exception Throws
+	 * 
+	 * @param commandMap -Request Variable
+	 * @return String -리턴 URL
+	 * @throws Exception -Exception Throws
 	 */
 	@IncludedInfo(name = "Twitter연동", order = 830, gid = 50)
 	@RequestMapping(value = "/uss/ion/tir/selectTwitterMain.do")
@@ -80,9 +83,10 @@ public class EgovTwitterController {
 
 	/**
 	 * 트위터를 인증키 관리 페이지를 조회한다.
-	 * @param model 		-Spring 제공하는 ModelMap
-	 * @return String 		-리턴 URL
-	 * @throws Exception	-Exception Throws
+	 * 
+	 * @param model -Spring 제공하는 ModelMap
+	 * @return String -리턴 URL
+	 * @throws Exception -Exception Throws
 	 */
 	@RequestMapping(value = "/uss/ion/tir/selectTwitterAccount.do", method = RequestMethod.GET)
 	public String EgovTwitterAccountGet(ModelMap model) throws Exception {
@@ -102,7 +106,7 @@ public class EgovTwitterController {
 
 		Map<?, ?> mapResult = egovTwitterTrnsmitService.selectTwitterAccount(hmPram);
 
-		//Consumer key/Consumer secret 키 값 조회
+		// Consumer key/Consumer secret 키 값 조회
 		if (mapResult == null) {
 			model.addAttribute("consumerKey", "");
 			model.addAttribute("consumerSecret", "");
@@ -115,14 +119,16 @@ public class EgovTwitterController {
 	}
 
 	/**
-	 * 트위터를 인증키 관리 페이지를  수정한다.
-	 * @param model 		-Spring 제공하는 ModelMap
-	 * @return String 		-리턴 URL
-	 * @throws Exception	-Exception Throws
+	 * 트위터를 인증키 관리 페이지를 수정한다.
+	 * 
+	 * @param model -Spring 제공하는 ModelMap
+	 * @return String -리턴 URL
+	 * @throws Exception -Exception Throws
 	 */
 	@SuppressWarnings("unused")
 	@RequestMapping(value = "/uss/ion/tir/selectTwitterAccount.do", method = RequestMethod.POST)
-	public String EgovTwitterAccountPost(HttpServletRequest request, HttpServletResponse response, ModelMap model) throws Exception {
+	public String EgovTwitterAccountPost(HttpServletRequest request, HttpServletResponse response, ModelMap model)
+			throws Exception {
 
 		// Spring Security 사용자권한 처리
 		Boolean isAuthenticated = EgovUserDetailsHelper.isAuthenticated();
@@ -134,8 +140,10 @@ public class EgovTwitterController {
 		// 로그인 객체 선언
 		LoginVO loginVO = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();
 
-		String sConsumerKey = request.getParameter("ConsumerKey") == null ? "" : (String) request.getParameter("ConsumerKey");
-		String sConsumerSecret = request.getParameter("ConsumerSecret") == null ? "" : (String) request.getParameter("ConsumerSecret");
+		String sConsumerKey = request.getParameter("ConsumerKey") == null ? ""
+				: (String) request.getParameter("ConsumerKey");
+		String sConsumerSecret = request.getParameter("ConsumerSecret") == null ? ""
+				: (String) request.getParameter("ConsumerSecret");
 
 		HashMap<String, String> hmPram = new HashMap<String, String>();
 		hmPram.put("usid", loginVO == null ? "" : EgovStringUtil.isNullToString(loginVO.getUniqId()));
@@ -154,17 +162,17 @@ public class EgovTwitterController {
 			egovTwitterTrnsmitService.insertTwitterAccount(hmPram);
 		}
 
-		//저장된키 키 Attribute 설정
+		// 저장된키 키 Attribute 설정
 		model.addAttribute("consumerKey", sConsumerKey);
 		model.addAttribute("consumerSecret", sConsumerSecret);
 
-		//트위터 세션정보 삭제
+		// 트위터 세션정보 삭제
 		WebUtils.setSessionAttribute(request, "sCONSUMER_KEY", null);
 		WebUtils.setSessionAttribute(request, "sCONSUMER_SECRET", null);
 		WebUtils.setSessionAttribute(request, "atoken", null);
 		WebUtils.setSessionAttribute(request, "astoken", null);
 
-		//저장메세지 설정
+		// 저장메세지 설정
 		String ReusltScript = "";
 
 		ReusltScript += "<script type='text/javaScript' language='javascript'>";
@@ -178,9 +186,10 @@ public class EgovTwitterController {
 
 	/**
 	 * 트위터를 인증 페이지를 조회한다.
-	 * @param model 		-Spring 제공하는 ModelMap
-	 * @return String 		-리턴 URL
-	 * @throws Exception	-Exception Throws
+	 * 
+	 * @param model -Spring 제공하는 ModelMap
+	 * @return String -리턴 URL
+	 * @throws Exception -Exception Throws
 	 */
 	@RequestMapping(value = "/uss/ion/tir/selectTwitterPopup.do")
 	public String EgovTwitterPopupGet(ModelMap model) throws Exception {
@@ -200,7 +209,7 @@ public class EgovTwitterController {
 
 		Map<?, ?> mapResult = egovTwitterTrnsmitService.selectTwitterAccount(hmPram);
 
-		//Consumer key/Consumer secret 키 값 조회
+		// Consumer key/Consumer secret 키 값 조회
 		if (mapResult == null) {
 			model.addAttribute("consumerKey", "");
 			model.addAttribute("consumerSecret", "");
@@ -214,12 +223,13 @@ public class EgovTwitterController {
 
 	/**
 	 * 트위터를 인증 페이지를 조회한다.
-	 * @param searchVO 		-트위터 Model
-	 * @param commandMap 	-Request  Variable
-	 * @param twitterInfo 	-트위터 Model
-	 * @param model 		-Spring 제공하는 ModelMap
-	 * @return String 		-리턴 URL
-	 * @throws Exception	-Exception Throws
+	 * 
+	 * @param searchVO    -트위터 Model
+	 * @param commandMap  -Request Variable
+	 * @param twitterInfo -트위터 Model
+	 * @param model       -Spring 제공하는 ModelMap
+	 * @return String -리턴 URL
+	 * @throws Exception -Exception Throws
 	 */
 	@RequestMapping(value = "/uss/ion/tir/selectTwitterPopupActor.do")
 	public String EgovTwitterPopupPost(@RequestParam Map<?, ?> commandMap, ModelMap model) throws Exception {
@@ -227,7 +237,8 @@ public class EgovTwitterController {
 		String sCheckKey = commandMap.get("chkKey") == null ? "" : (String) commandMap.get("chkKey");
 
 		String sConsumerKey = commandMap.get("ConsumerKey") == null ? "" : (String) commandMap.get("ConsumerKey");
-		String sConsumerSecret = commandMap.get("ConsumerSecret") == null ? "" : (String) commandMap.get("ConsumerSecret");
+		String sConsumerSecret = commandMap.get("ConsumerSecret") == null ? ""
+				: (String) commandMap.get("ConsumerSecret");
 
 		// Spring Security 사용자권한 처리
 		Boolean isAuthenticated = EgovUserDetailsHelper.isAuthenticated();
@@ -249,7 +260,7 @@ public class EgovTwitterController {
 		LOGGER.info("EgovTwitterPopupPost>");
 		LOGGER.info("selectTwitterAccountCheck>" + egovTwitterTrnsmitService.selectTwitterAccountCheck(hmPram));
 
-		//Consumer key/Consumer secret 키 값 저장 체크시
+		// Consumer key/Consumer secret 키 값 저장 체크시
 		if (sCheckKey.equals("1")) {
 			if (egovTwitterTrnsmitService.selectTwitterAccountCheck(hmPram) > 0) {
 				egovTwitterTrnsmitService.updtTwitterAccount(hmPram);
@@ -266,25 +277,26 @@ public class EgovTwitterController {
 
 	/**
 	 * 트위터를 인증 페이지를 조회한다.
-	 * @param model 		-Spring 제공하는 ModelMap
-	 * @return String 		-리턴 URL
-	 * @throws Exception	-Exception Throws
+	 * 
+	 * @param model -Spring 제공하는 ModelMap
+	 * @return String -리턴 URL
+	 * @throws Exception -Exception Throws
 	 */
 	@RequestMapping(value = "/uss/ion/tir/selectTwitterPopupProcess.do")
 	public String EgovTwitterPopupProcess(ModelMap model) throws Exception {
 		return "egovframework/com/uss/ion/tir/EgovTwitterPopupProcess";
 	}
 
-
 	/**
 	 * 트위터를 송신 페이지를 조회 한다.
-	 * @param model 		-Spring 제공하는 ModelMap
-	 * @return String 		-리턴 URL
-	 * @throws Exception	-Exception Throws
+	 * 
+	 * @param model -Spring 제공하는 ModelMap
+	 * @return String -리턴 URL
+	 * @throws Exception -Exception Throws
 	 */
 	@RequestMapping(value = "/uss/ion/tir/registTwitterTrnsmit.do", method = RequestMethod.GET)
 	public String EgovTwitterTrnsmitGet(ModelMap model, HttpServletRequest request) throws Exception {
-		
+
 		String sCONSUMER_KEY = (String) WebUtils.getSessionAttribute(request, "sCONSUMER_KEY");
 		String sCONSUMER_SECRET = (String) WebUtils.getSessionAttribute(request, "sCONSUMER_SECRET");
 
@@ -309,14 +321,15 @@ public class EgovTwitterController {
 
 	/**
 	 * 트위터를 송신을 등록 처리 한다.
-	 * @param searchVO 		-트위터 Model
-	 * @param commandMap 	-Request Variable
-	 * @param twitterInfo 	-트위터 Model
-	 * @param request -HttpServletRequest 객체
-	 * @param response -HttpServletResponse 객체
-	 * @param model 		-Spring 제공하는 ModelMap
-	 * @return String 		-리턴 URL
-	 * @throws Exception	-Exception Throws
+	 * 
+	 * @param searchVO    -트위터 Model
+	 * @param commandMap  -Request Variable
+	 * @param twitterInfo -트위터 Model
+	 * @param request     -HttpServletRequest 객체
+	 * @param response    -HttpServletResponse 객체
+	 * @param model       -Spring 제공하는 ModelMap
+	 * @return String -리턴 URL
+	 * @throws Exception -Exception Throws
 	 */
 	@RequestMapping(value = "/uss/ion/tir/registTwitterTrnsmit.do", method = RequestMethod.POST)
 	public String EgovTwitterTrnsmitPost(TwitterInfo twitterInfo, HttpServletRequest request,
@@ -355,7 +368,7 @@ public class EgovTwitterController {
 
 		return "egovframework/com/uss/ion/tir/EgovTwitterTrnsmitResult";
 	}
-	
+
 	@RequestMapping(value = "/uss/ion/tir/twitterDelete.do")
 	public String deleteTweet(@RequestParam("tweetID") String tID, HttpServletRequest request) throws Exception {
 
@@ -375,12 +388,12 @@ public class EgovTwitterController {
 		hmParam.put("sCONSUMER_SECRET", sCONSUMER_SECRET);
 		hmParam.put("atoken", atoken);
 		hmParam.put("astoken", astoken);
-		
+
 		boolean deleteResult = egovTwitterTrnsmitService.twitterDelete(hmParam, tID);
 
 		LOGGER.info("트윗 삭제");
 		LOGGER.info("DELETERESULT >>> " + deleteResult);
-		
+
 		return "egovframework/com/uss/ion/tir/EgovTwitterMain";
 
 	}

--- a/src/main/java/egovframework/com/uss/ion/tir/web/EgovTwitterController.java
+++ b/src/main/java/egovframework/com/uss/ion/tir/web/EgovTwitterController.java
@@ -173,13 +173,13 @@ public class EgovTwitterController {
 		WebUtils.setSessionAttribute(request, "astoken", null);
 
 		// 저장메세지 설정
-		String ReusltScript = "";
+		String reusltScript = "";
 
-		ReusltScript += "<script type='text/javaScript' language='javascript'>";
-		ReusltScript += "alert(' 작성된  트위터 인증키(ConsumerKey/ConsumerSecret)를 저장 하였습니다!  ');";
-		ReusltScript += "</script>";
+		reusltScript += "<script type='text/javaScript' language='javascript'>";
+		reusltScript += "alert(' 작성된  트위터 인증키(ConsumerKey/ConsumerSecret)를 저장 하였습니다!  ');";
+		reusltScript += "</script>";
 
-		model.addAttribute("reusltScript", ReusltScript);
+		model.addAttribute("reusltScript", reusltScript);
 
 		return "egovframework/com/uss/ion/tir/EgovTwitterAccount";
 	}
@@ -297,16 +297,16 @@ public class EgovTwitterController {
 	@RequestMapping(value = "/uss/ion/tir/registTwitterTrnsmit.do", method = RequestMethod.GET)
 	public String EgovTwitterTrnsmitGet(ModelMap model, HttpServletRequest request) throws Exception {
 
-		String sCONSUMER_KEY = (String) WebUtils.getSessionAttribute(request, "sCONSUMER_KEY");
-		String sCONSUMER_SECRET = (String) WebUtils.getSessionAttribute(request, "sCONSUMER_SECRET");
+		String consumerKey = (String) WebUtils.getSessionAttribute(request, "sCONSUMER_KEY");
+		String consumerSecret = (String) WebUtils.getSessionAttribute(request, "sCONSUMER_SECRET");
 
 		String atoken = (String) WebUtils.getSessionAttribute(request, "atoken");
 		String astoken = (String) WebUtils.getSessionAttribute(request, "astoken");
 
 		HashMap<String, Object> hmParam = new HashMap<String, Object>();
 		// 인증키값 설정
-		hmParam.put("sCONSUMER_KEY", sCONSUMER_KEY);
-		hmParam.put("sCONSUMER_SECRET", sCONSUMER_SECRET);
+		hmParam.put("sCONSUMER_KEY", consumerKey);
+		hmParam.put("sCONSUMER_SECRET", consumerSecret);
 		hmParam.put("atoken", atoken);
 		hmParam.put("astoken", astoken);
 
@@ -335,8 +335,8 @@ public class EgovTwitterController {
 	public String EgovTwitterTrnsmitPost(TwitterInfo twitterInfo, HttpServletRequest request,
 			HttpServletResponse response, ModelMap model) throws Exception {
 
-		String sCONSUMER_KEY = (String) WebUtils.getSessionAttribute(request, "sCONSUMER_KEY");
-		String sCONSUMER_SECRET = (String) WebUtils.getSessionAttribute(request, "sCONSUMER_SECRET");
+		String consumerKey = (String) WebUtils.getSessionAttribute(request, "sCONSUMER_KEY");
+		String consumerSecret = (String) WebUtils.getSessionAttribute(request, "sCONSUMER_SECRET");
 
 		String atoken = (String) WebUtils.getSessionAttribute(request, "atoken");
 		String astoken = (String) WebUtils.getSessionAttribute(request, "astoken");
@@ -344,8 +344,8 @@ public class EgovTwitterController {
 		HashMap<String, Object> hmParam = new HashMap<String, Object>();
 
 		// 인증키값 설정
-		hmParam.put("sCONSUMER_KEY", sCONSUMER_KEY);
-		hmParam.put("sCONSUMER_SECRET", sCONSUMER_SECRET);
+		hmParam.put("sCONSUMER_KEY", consumerKey);
+		hmParam.put("sCONSUMER_SECRET", consumerSecret);
 		hmParam.put("atoken", atoken);
 		hmParam.put("astoken", astoken);
 		LOGGER.info("[Controller]===>>> atoken = " + atoken);
@@ -372,11 +372,11 @@ public class EgovTwitterController {
 	@RequestMapping(value = "/uss/ion/tir/twitterDelete.do")
 	public String deleteTweet(@RequestParam("tweetID") String tID, HttpServletRequest request) throws Exception {
 
-		tID = tID.replace("&quot;", "");
-		LOGGER.info("트윗 아이디 >>> " + tID);
+		String tID2 = tID.replace("&quot;", "");
+		LOGGER.info("트윗 아이디 >>> " + tID2);
 
-		String sCONSUMER_KEY = (String) WebUtils.getSessionAttribute(request, "sCONSUMER_KEY");
-		String sCONSUMER_SECRET = (String) WebUtils.getSessionAttribute(request, "sCONSUMER_SECRET");
+		String consumerKey = (String) WebUtils.getSessionAttribute(request, "sCONSUMER_KEY");
+		String consumerSecret = (String) WebUtils.getSessionAttribute(request, "sCONSUMER_SECRET");
 
 		String atoken = (String) WebUtils.getSessionAttribute(request, "atoken");
 		String astoken = (String) WebUtils.getSessionAttribute(request, "astoken");
@@ -384,12 +384,12 @@ public class EgovTwitterController {
 		HashMap<String, Object> hmParam = new HashMap<String, Object>();
 
 		// 인증키값 설정
-		hmParam.put("sCONSUMER_KEY", sCONSUMER_KEY);
-		hmParam.put("sCONSUMER_SECRET", sCONSUMER_SECRET);
+		hmParam.put("sCONSUMER_KEY", consumerKey);
+		hmParam.put("sCONSUMER_SECRET", consumerSecret);
 		hmParam.put("atoken", atoken);
 		hmParam.put("astoken", astoken);
 
-		boolean deleteResult = egovTwitterTrnsmitService.twitterDelete(hmParam, tID);
+		boolean deleteResult = egovTwitterTrnsmitService.twitterDelete(hmParam, tID2);
 
 		LOGGER.info("트윗 삭제");
 		LOGGER.info("DELETERESULT >>> " + deleteResult);


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

<hr>

### 2025-08-16 토 PMD로 소프트웨어 보안약점 진단하고 제거하기-EgovTwitterController

`ReusltScript` 를 `reusltScript` 로 이름 바꾸기

`sCONSUMER_KEY` 를 `consumerKey` 로 이름 바꾸기

`sCONSUMER_SECRET` 을 `consumerSecret` 로 이름 바꾸기

`String tID2 = tID.replace("&quot;", "");` 로 수정

<hr>

1. PMD로 소프트웨어 보안약점 진단 결과

```
src/main/java/egovframework/com/uss/ion/tir/web/EgovTwitterController.java:168:	LocalVariableNamingConventions:	LocalVariableNamingConventions: 'local variable' 의 변수 'ReusltScript' 이  '[a-z][a-zA-Z0-9]*'  로 시작함
src/main/java/egovframework/com/uss/ion/tir/web/EgovTwitterController.java:288:	LocalVariableNamingConventions:	LocalVariableNamingConventions: 'local variable' 의 변수 'sCONSUMER_KEY' 이  '[a-z][a-zA-Z0-9]*'  로 시작함
src/main/java/egovframework/com/uss/ion/tir/web/EgovTwitterController.java:289:	LocalVariableNamingConventions:	LocalVariableNamingConventions: 'local variable' 의 변수 'sCONSUMER_SECRET' 이  '[a-z][a-zA-Z0-9]*'  로 시작함
src/main/java/egovframework/com/uss/ion/tir/web/EgovTwitterController.java:325:	LocalVariableNamingConventions:	LocalVariableNamingConventions: 'local variable' 의 변수 'sCONSUMER_KEY' 이  '[a-z][a-zA-Z0-9]*'  로 시작함
src/main/java/egovframework/com/uss/ion/tir/web/EgovTwitterController.java:326:	LocalVariableNamingConventions:	LocalVariableNamingConventions: 'local variable' 의 변수 'sCONSUMER_SECRET' 이  '[a-z][a-zA-Z0-9]*'  로 시작함
src/main/java/egovframework/com/uss/ion/tir/web/EgovTwitterController.java:362:	AvoidReassigningParameters:	AvoidReassigningParameters: 'tID' 처럼 파라미터 값을 직접 변경하지 말 것
src/main/java/egovframework/com/uss/ion/tir/web/EgovTwitterController.java:365:	LocalVariableNamingConventions:	LocalVariableNamingConventions: 'local variable' 의 변수 'sCONSUMER_KEY' 이  '[a-z][a-zA-Z0-9]*'  로 시작함
src/main/java/egovframework/com/uss/ion/tir/web/EgovTwitterController.java:366:	LocalVariableNamingConventions:	LocalVariableNamingConventions: 'local variable' 의 변수 'sCONSUMER_SECRET' 이  '[a-z][a-zA-Z0-9]*'  로 시작함
```

2. 브랜치 생성

```
feature/pmd/EgovTwitterController
```

3. 이클립스 > Source > Format

4. 개정이력 수정

```java
 *   2025.08.16  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-LocalVariableNamingConventions(final이 아닌 변수는 밑줄을 포함할 수 없음)
 *   2025.08.16  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-AvoidReassigningParameters(넘겨받는 메소드 parameter 값을 직접 변경하는 코드 탐지)
```

<hr>

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

https://youtu.be/8_4jkH2p-Tw
