### PR TITLE
PMD로 소프트웨어 보안약점 진단하고 제거하기-EgovAdministrationWordController

### DIFF
--- a/src/main/java/egovframework/com/uss/olh/awm/web/EgovAdministrationWordController.java
+++ b/src/main/java/egovframework/com/uss/olh/awm/web/EgovAdministrationWordController.java
@@ -198,8 +198,8 @@ public class EgovAdministrationWordController {
 		ComDefaultCodeVO vo = new ComDefaultCodeVO();
 		vo.setCodeId("COM102");
 
-		List<?> _result = cmmUseService.selectCmmCodeDetail(vo);
-		model.addAttribute("wordSeCode", _result);
+		List<?> wordSeCode = cmmUseService.selectCmmCodeDetail(vo);
+		model.addAttribute("wordSeCode", wordSeCode);
 
 		model.addAttribute("administrationWordVO", new AdministrationWordVO());
 
@@ -256,8 +256,8 @@ public class EgovAdministrationWordController {
 		ComDefaultCodeVO vo = new ComDefaultCodeVO();
 		vo.setCodeId("COM102");
 
-		List<?> _result = cmmUseService.selectCmmCodeDetail(vo);
-		model.addAttribute("wordSeCode", _result);
+		List<?> wordSeCode = cmmUseService.selectCmmCodeDetail(vo);
+		model.addAttribute("wordSeCode", wordSeCode);
 
 		AdministrationWordVO administrationWordVO = new AdministrationWordVO();
 		administrationWordVO.setAdministWordId(administWordId);

--- a/src/main/java/egovframework/com/uss/olh/awm/web/EgovAdministrationWordController.java
+++ b/src/main/java/egovframework/com/uss/olh/awm/web/EgovAdministrationWordController.java
@@ -28,10 +28,13 @@ import egovframework.com.utl.fcc.service.EgovStringUtil;
 
 /**
  * 행정전문용어사전관리를 처리하는 Controller Class 구현
+ * 
  * @author 공통서비스 장동한
  * @since 2009.07.03
  * @version 1.0
- * @see <pre>
+ * @see
+ * 
+ *      <pre>
  * &lt;&lt; 개정이력(Modification Information) &gt;&gt;
  *
  *   수정일      수정자           수정내용
@@ -40,209 +43,217 @@ import egovframework.com.utl.fcc.service.EgovStringUtil;
  *   2011.8.26	 정진오			IncludedInfo annotation 추가
  *   2011.09.19  서준식          삭제 후 리스트 상세조회시 다시 삭제되는 문제 수정
  *   2016.08.10  김연호          표준프레임워크 3.6
- *   
- * </pre>
+ * 
+ *      </pre>
  */
 
 @Controller
 public class EgovAdministrationWordController {
 
-    @Autowired
-    private DefaultBeanValidator beanValidator;
+	@Autowired
+	private DefaultBeanValidator beanValidator;
 
-    /** EgovMessageSource */
-    @Resource(name = "egovMessageSource")
-    EgovMessageSource egovMessageSource;
+	/** EgovMessageSource */
+	@Resource(name = "egovMessageSource")
+	EgovMessageSource egovMessageSource;
 
-    /** egovOnlinePollService */
-    @Resource(name = "EgovAdministrationWordService")
-    private EgovAdministrationWordService egovAdministrationWordService;
-    
-    @Resource(name="EgovCmmUseService")
+	/** egovOnlinePollService */
+	@Resource(name = "EgovAdministrationWordService")
+	private EgovAdministrationWordService egovAdministrationWordService;
+
+	@Resource(name = "EgovCmmUseService")
 	private EgovCmmUseService cmmUseService;
 
-    /** EgovPropertyService */
-    @Resource(name = "propertiesService")
-    protected EgovPropertyService propertiesService;
-    
-    
-    /**
-     * 행정전문용어사전 목록을 조회한다.
-     * @param searchVO
-     * @param administrationWord
-     * @param model
-     * @return "egovframework/com/uss/olh/awm/EgovAdministrationWordList"
-     * @throws Exception
-     */
-	@IncludedInfo(name="행정전문용어사전", order = 560 ,gid = 50)
-    @RequestMapping(value = "/uss/olh/awm/selectAdministrationWordList.do")
-    public String egovAdministrationWordList(@ModelAttribute("searchVO") AdministrationWordVO searchVO, ModelMap model) throws Exception {
+	/** EgovPropertyService */
+	@Resource(name = "propertiesService")
+	protected EgovPropertyService propertiesService;
 
-        /** EgovPropertyService.sample */
-        searchVO.setPageUnit(propertiesService.getInt("pageUnit"));
-        searchVO.setPageSize(propertiesService.getInt("pageSize"));
+	/**
+	 * 행정전문용어사전 목록을 조회한다.
+	 * 
+	 * @param searchVO
+	 * @param administrationWord
+	 * @param model
+	 * @return "egovframework/com/uss/olh/awm/EgovAdministrationWordList"
+	 * @throws Exception
+	 */
+	@IncludedInfo(name = "행정전문용어사전", order = 560, gid = 50)
+	@RequestMapping(value = "/uss/olh/awm/selectAdministrationWordList.do")
+	public String egovAdministrationWordList(@ModelAttribute("searchVO") AdministrationWordVO searchVO, ModelMap model)
+			throws Exception {
 
-        /** pageing */
-        PaginationInfo paginationInfo = new PaginationInfo();
-        paginationInfo.setCurrentPageNo(searchVO.getPageIndex());
-        paginationInfo.setRecordCountPerPage(searchVO.getPageUnit());
-        paginationInfo.setPageSize(searchVO.getPageSize());
+		/** EgovPropertyService.sample */
+		searchVO.setPageUnit(propertiesService.getInt("pageUnit"));
+		searchVO.setPageSize(propertiesService.getInt("pageSize"));
 
-        searchVO.setFirstIndex(paginationInfo.getFirstRecordIndex());
-        searchVO.setLastIndex(paginationInfo.getLastRecordIndex());
-        searchVO.setRecordCountPerPage(paginationInfo.getRecordCountPerPage());
+		/** pageing */
+		PaginationInfo paginationInfo = new PaginationInfo();
+		paginationInfo.setCurrentPageNo(searchVO.getPageIndex());
+		paginationInfo.setRecordCountPerPage(searchVO.getPageUnit());
+		paginationInfo.setPageSize(searchVO.getPageSize());
 
-        List<AdministrationWordVO> resultList = egovAdministrationWordService.selectAdministrationWordList(searchVO);
-        model.addAttribute("resultList", resultList);
+		searchVO.setFirstIndex(paginationInfo.getFirstRecordIndex());
+		searchVO.setLastIndex(paginationInfo.getLastRecordIndex());
+		searchVO.setRecordCountPerPage(paginationInfo.getRecordCountPerPage());
 
-        int totCnt = egovAdministrationWordService.selectAdministrationWordListCnt(searchVO);
-        paginationInfo.setTotalRecordCount(totCnt);
-        model.addAttribute("paginationInfo", paginationInfo);
+		List<AdministrationWordVO> resultList = egovAdministrationWordService.selectAdministrationWordList(searchVO);
+		model.addAttribute("resultList", resultList);
 
-        return "egovframework/com/uss/olh/awm/EgovAdministrationWordList";
-    }
-    
-    /**
-     * 행정전문용어사전 목록을 상세조회 조회한다.
-     * @param searchVO
-     * @param administrationWord
-     * @param commandMap
-     * @param model
-     * @return
-     *         "/uss/olh/awm/EgovAdministrationWordDetail"
-     * @throws Exception
-     */
+		int totCnt = egovAdministrationWordService.selectAdministrationWordListCnt(searchVO);
+		paginationInfo.setTotalRecordCount(totCnt);
+		model.addAttribute("paginationInfo", paginationInfo);
+
+		return "egovframework/com/uss/olh/awm/EgovAdministrationWordList";
+	}
+
+	/**
+	 * 행정전문용어사전 목록을 상세조회 조회한다.
+	 * 
+	 * @param searchVO
+	 * @param administrationWord
+	 * @param commandMap
+	 * @param model
+	 * @return "/uss/olh/awm/EgovAdministrationWordDetail"
+	 * @throws Exception
+	 */
 	@RequestMapping(value = "/uss/olh/awm/selectAdministrationWordDetail.do")
-    public String selectAdministrationWordDetail(@ModelAttribute("searchVO") AdministrationWordVO searchVO, AdministrationWordVO administrationWord, ModelMap model) throws Exception {
+	public String selectAdministrationWordDetail(@ModelAttribute("searchVO") AdministrationWordVO searchVO,
+			AdministrationWordVO administrationWord, ModelMap model) throws Exception {
 
-        AdministrationWordVO result = egovAdministrationWordService.selectAdministrationWordDetail(administrationWord);
-        model.addAttribute("result", result);
+		AdministrationWordVO result = egovAdministrationWordService.selectAdministrationWordDetail(administrationWord);
+		model.addAttribute("result", result);
 
-        return "egovframework/com/uss/olh/awm/EgovAdministrationWordDetail";
-    }
-    
-    /**
-     * 행정전문용어사전관리 목록을 조회한다.
-     * @param searchVO
-     * @param model
-     * @return "egovframework/com/uss/olh/awm/EgovAdministrationWordManageList"
-     * @throws Exception
-     */
-	@IncludedInfo(name="행정전문용어사전관리", order = 561 ,gid = 50)
-    @RequestMapping(value = "/uss/olh/awm/selectAdministrationWordManageList.do")
-    public String egovAdministrationWordManageList(@ModelAttribute("searchVO") AdministrationWordVO searchVO, ModelMap model) throws Exception {
+		return "egovframework/com/uss/olh/awm/EgovAdministrationWordDetail";
+	}
 
-        searchVO.setPageUnit(propertiesService.getInt("pageUnit"));
-        searchVO.setPageSize(propertiesService.getInt("pageSize"));
+	/**
+	 * 행정전문용어사전관리 목록을 조회한다.
+	 * 
+	 * @param searchVO
+	 * @param model
+	 * @return "egovframework/com/uss/olh/awm/EgovAdministrationWordManageList"
+	 * @throws Exception
+	 */
+	@IncludedInfo(name = "행정전문용어사전관리", order = 561, gid = 50)
+	@RequestMapping(value = "/uss/olh/awm/selectAdministrationWordManageList.do")
+	public String egovAdministrationWordManageList(@ModelAttribute("searchVO") AdministrationWordVO searchVO,
+			ModelMap model) throws Exception {
 
-        /** pageing */
-        PaginationInfo paginationInfo = new PaginationInfo();
-        paginationInfo.setCurrentPageNo(searchVO.getPageIndex());
-        paginationInfo.setRecordCountPerPage(searchVO.getPageUnit());
-        paginationInfo.setPageSize(searchVO.getPageSize());
+		searchVO.setPageUnit(propertiesService.getInt("pageUnit"));
+		searchVO.setPageSize(propertiesService.getInt("pageSize"));
 
-        searchVO.setFirstIndex(paginationInfo.getFirstRecordIndex());
-        searchVO.setLastIndex(paginationInfo.getLastRecordIndex());
-        searchVO.setRecordCountPerPage(paginationInfo.getRecordCountPerPage());
+		/** pageing */
+		PaginationInfo paginationInfo = new PaginationInfo();
+		paginationInfo.setCurrentPageNo(searchVO.getPageIndex());
+		paginationInfo.setRecordCountPerPage(searchVO.getPageUnit());
+		paginationInfo.setPageSize(searchVO.getPageSize());
 
-        List<AdministrationWordVO> resultList = egovAdministrationWordService.selectAdministrationWordList(searchVO);
-        model.addAttribute("resultList", resultList);
+		searchVO.setFirstIndex(paginationInfo.getFirstRecordIndex());
+		searchVO.setLastIndex(paginationInfo.getLastRecordIndex());
+		searchVO.setRecordCountPerPage(paginationInfo.getRecordCountPerPage());
 
-        int totCnt = egovAdministrationWordService.selectAdministrationWordListCnt(searchVO);
-        paginationInfo.setTotalRecordCount(totCnt);
-        model.addAttribute("paginationInfo", paginationInfo);
+		List<AdministrationWordVO> resultList = egovAdministrationWordService.selectAdministrationWordList(searchVO);
+		model.addAttribute("resultList", resultList);
 
-        return "egovframework/com/uss/olh/awm/EgovAdministrationWordManageList";
-    }
-    
-    /**
-     * 행정전문용어사전관리 목록을 상세조회 조회한다.
-     * @param searchVO
-     * @param administrationWord
-     * @param commandMap
-     * @param model
-     * @return
-     *         "/uss/olh/awm/EgovAdministrationWordDetail"
-     * @throws Exception
-     */
+		int totCnt = egovAdministrationWordService.selectAdministrationWordListCnt(searchVO);
+		paginationInfo.setTotalRecordCount(totCnt);
+		model.addAttribute("paginationInfo", paginationInfo);
+
+		return "egovframework/com/uss/olh/awm/EgovAdministrationWordManageList";
+	}
+
+	/**
+	 * 행정전문용어사전관리 목록을 상세조회 조회한다.
+	 * 
+	 * @param searchVO
+	 * @param administrationWord
+	 * @param commandMap
+	 * @param model
+	 * @return "/uss/olh/awm/EgovAdministrationWordDetail"
+	 * @throws Exception
+	 */
 	@RequestMapping(value = "/uss/olh/awm/selectAdministrationWordManageDetail.do")
-    public String selectAdministrationWordManageDetail(@ModelAttribute("searchVO") AdministrationWordVO searchVO, AdministrationWordVO administrationWord, ModelMap model) throws Exception {
+	public String selectAdministrationWordManageDetail(@ModelAttribute("searchVO") AdministrationWordVO searchVO,
+			AdministrationWordVO administrationWord, ModelMap model) throws Exception {
 
-        AdministrationWordVO result = egovAdministrationWordService.selectAdministrationWordDetail(administrationWord);
-        model.addAttribute("result", result);
+		AdministrationWordVO result = egovAdministrationWordService.selectAdministrationWordDetail(administrationWord);
+		model.addAttribute("result", result);
 
-        return "egovframework/com/uss/olh/awm/EgovAdministrationWordManageDetail";
-    }
-    
-    /**
-     * 행정전문용어사전을 등록하기 위한 전 처리(공통코드 처리)
-     * @param searchVO
-     * @param model
-     * @return	"/uss/olh/awm/EgovAdministrationWordRegist"
-     * @throws Exception
-     */
-    @RequestMapping("/uss/olh/awm/insertAdministrationWordView.do")
-    public String insertAdministrationWordView(@ModelAttribute("searchVO") AdministrationWordVO searchVO, Model model) throws Exception {
+		return "egovframework/com/uss/olh/awm/EgovAdministrationWordManageDetail";
+	}
 
-    	// 공통코드를 가져오기 위한 Vo
-    	ComDefaultCodeVO vo = new ComDefaultCodeVO();
+	/**
+	 * 행정전문용어사전을 등록하기 위한 전 처리(공통코드 처리)
+	 * 
+	 * @param searchVO
+	 * @param model
+	 * @return "/uss/olh/awm/EgovAdministrationWordRegist"
+	 * @throws Exception
+	 */
+	@RequestMapping("/uss/olh/awm/insertAdministrationWordView.do")
+	public String insertAdministrationWordView(@ModelAttribute("searchVO") AdministrationWordVO searchVO, Model model)
+			throws Exception {
+
+		// 공통코드를 가져오기 위한 Vo
+		ComDefaultCodeVO vo = new ComDefaultCodeVO();
 		vo.setCodeId("COM102");
 
 		List<?> _result = cmmUseService.selectCmmCodeDetail(vo);
 		model.addAttribute("wordSeCode", _result);
 
-        model.addAttribute("administrationWordVO", new AdministrationWordVO());
+		model.addAttribute("administrationWordVO", new AdministrationWordVO());
 
-        return "egovframework/com/uss/olh/awm/EgovAdministrationWordRegist";
+		return "egovframework/com/uss/olh/awm/EgovAdministrationWordRegist";
 
-    }
-    
-    /**
-     * 행정전문용어사전을 등록한다.
-     * @param searchVO
-     * @param administrationWordVO
-     * @param bindingResult
-     * @return	"forward:/uss/olh/awm/selectAdministrationWordManageList.do"
-     * @throws Exception
-     */
-    @RequestMapping("/uss/olh/awm/insertAdministrationWord.do")
-    public String insertAdministrationWord(
-            @ModelAttribute("searchVO") AdministrationWordVO searchVO,  @ModelAttribute("administrationWordVO") AdministrationWordVO administrationWordVO,
-            BindingResult bindingResult) throws Exception {
+	}
 
-    	beanValidator.validate(administrationWordVO, bindingResult);
-		if(bindingResult.hasErrors()){
+	/**
+	 * 행정전문용어사전을 등록한다.
+	 * 
+	 * @param searchVO
+	 * @param administrationWordVO
+	 * @param bindingResult
+	 * @return "forward:/uss/olh/awm/selectAdministrationWordManageList.do"
+	 * @throws Exception
+	 */
+	@RequestMapping("/uss/olh/awm/insertAdministrationWord.do")
+	public String insertAdministrationWord(@ModelAttribute("searchVO") AdministrationWordVO searchVO,
+			@ModelAttribute("administrationWordVO") AdministrationWordVO administrationWordVO,
+			BindingResult bindingResult) throws Exception {
+
+		beanValidator.validate(administrationWordVO, bindingResult);
+		if (bindingResult.hasErrors()) {
 			return "egovframework/com/uss/olh/awm/EgovAdministrationWordRegist";
 		}
 
-    	// 로그인VO에서  사용자 정보 가져오기
-    	LoginVO	loginVO = (LoginVO)EgovUserDetailsHelper.getAuthenticatedUser();
+		// 로그인VO에서 사용자 정보 가져오기
+		LoginVO loginVO = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();
 
-    	String frstRegisterId = loginVO == null ? "" : EgovStringUtil.isNullToString(loginVO.getUniqId());
+		String frstRegisterId = loginVO == null ? "" : EgovStringUtil.isNullToString(loginVO.getUniqId());
 
-    	administrationWordVO.setFrstRegisterId(frstRegisterId);		// 최초등록자ID
-    	administrationWordVO.setLastUpdusrId(frstRegisterId);    	// 최종수정자ID
+		administrationWordVO.setFrstRegisterId(frstRegisterId); // 최초등록자ID
+		administrationWordVO.setLastUpdusrId(frstRegisterId); // 최종수정자ID
 
-        egovAdministrationWordService.insertAdministrationWord(administrationWordVO);
+		egovAdministrationWordService.insertAdministrationWord(administrationWordVO);
 
-        return "forward:/uss/olh/awm/selectAdministrationWordManageList.do";
-    }
-    
-    /**
-     * 행정전문용어사전을 수정하기 위한 전 처리(공통코드 처리)
-     * @param administWordId
-     * @param searchVO
-     * @param model
-     * @return	"/uss/olh/hpc/EgovAdministrationWordUpdt"
-     * @throws Exception
-     */
-    @RequestMapping("/uss/olh/awm/updateAdministrationWordView.do")
-    public String updateAdministrationWordView(@RequestParam("administWordId") String administWordId ,
-            @ModelAttribute("searchVO") AdministrationWordVO searchVO, ModelMap model)
-            throws Exception {
+		return "forward:/uss/olh/awm/selectAdministrationWordManageList.do";
+	}
 
-    	// 공통코드를 가져오기 위한 Vo
-    	ComDefaultCodeVO vo = new ComDefaultCodeVO();
+	/**
+	 * 행정전문용어사전을 수정하기 위한 전 처리(공통코드 처리)
+	 * 
+	 * @param administWordId
+	 * @param searchVO
+	 * @param model
+	 * @return "/uss/olh/hpc/EgovAdministrationWordUpdt"
+	 * @throws Exception
+	 */
+	@RequestMapping("/uss/olh/awm/updateAdministrationWordView.do")
+	public String updateAdministrationWordView(@RequestParam("administWordId") String administWordId,
+			@ModelAttribute("searchVO") AdministrationWordVO searchVO, ModelMap model) throws Exception {
+
+		// 공통코드를 가져오기 위한 Vo
+		ComDefaultCodeVO vo = new ComDefaultCodeVO();
 		vo.setCodeId("COM102");
 
 		List<?> _result = cmmUseService.selectCmmCodeDetail(vo);
@@ -251,56 +262,57 @@ public class EgovAdministrationWordController {
 		AdministrationWordVO administrationWordVO = new AdministrationWordVO();
 		administrationWordVO.setAdministWordId(administWordId);
 
-        model.addAttribute("administrationWordVO", egovAdministrationWordService.selectAdministrationWordDetail(administrationWordVO));
+		model.addAttribute("administrationWordVO",
+				egovAdministrationWordService.selectAdministrationWordDetail(administrationWordVO));
 
-        return "egovframework/com/uss/olh/awm/EgovAdministrationWordUpdt";
-    }
-    
-    /**
-     * 행정전문용어사전을 수정한다.
-     * @param searchVO
-     * @param administrationWordVO
-     * @param bindingResult
-     * @return	"forward:/uss/olh/awm/selectAdministrationWordManageList.do"
-     * @throws Exception
-     */
-    @RequestMapping("/uss/olh/awm/updateAdministrationWord.do")
-    public String updateAdministrationWord(
-            @ModelAttribute("searchVO") AdministrationWordVO searchVO,
-            @ModelAttribute("administrationWordVO") AdministrationWordVO administrationWordVO,
-            BindingResult bindingResult)
-            throws Exception {
+		return "egovframework/com/uss/olh/awm/EgovAdministrationWordUpdt";
+	}
 
-    	// Validation
-    	beanValidator.validate(administrationWordVO, bindingResult);
-		if(bindingResult.hasErrors()){
+	/**
+	 * 행정전문용어사전을 수정한다.
+	 * 
+	 * @param searchVO
+	 * @param administrationWordVO
+	 * @param bindingResult
+	 * @return "forward:/uss/olh/awm/selectAdministrationWordManageList.do"
+	 * @throws Exception
+	 */
+	@RequestMapping("/uss/olh/awm/updateAdministrationWord.do")
+	public String updateAdministrationWord(@ModelAttribute("searchVO") AdministrationWordVO searchVO,
+			@ModelAttribute("administrationWordVO") AdministrationWordVO administrationWordVO,
+			BindingResult bindingResult) throws Exception {
+
+		// Validation
+		beanValidator.validate(administrationWordVO, bindingResult);
+		if (bindingResult.hasErrors()) {
 			return "egovframework/com/uss/olh/awm/EgovAdministrationWordUpdt";
 		}
 
-    	LoginVO	loginVO = (LoginVO)EgovUserDetailsHelper.getAuthenticatedUser();
-    	String	lastUpdusrId = loginVO == null ? "" : EgovStringUtil.isNullToString(loginVO.getUniqId());
+		LoginVO loginVO = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();
+		String lastUpdusrId = loginVO == null ? "" : EgovStringUtil.isNullToString(loginVO.getUniqId());
 
-    	administrationWordVO.setLastUpdusrId(lastUpdusrId);    	// 최종수정자ID
-    	egovAdministrationWordService.updateAdministrationWord(administrationWordVO);
+		administrationWordVO.setLastUpdusrId(lastUpdusrId); // 최종수정자ID
+		egovAdministrationWordService.updateAdministrationWord(administrationWordVO);
 
+		return "forward:/uss/olh/awm/selectAdministrationWordManageList.do";
 
-        return "forward:/uss/olh/awm/selectAdministrationWordManageList.do";
+	}
 
-    }
-    
-    /**
-     * 행정전문용어사전을 삭제한다.
-     * @param hpcmVO
-     * @param searchVO
-     * @return	"forward:/uss/olh/awm/selectAdministrationWordManageList.do"
-     * @throws Exception
-     */
-    @RequestMapping("/uss/olh/awm/deleteAdministrationWord.do")
-    public String deleteAdministrationWord(AdministrationWordVO administrationWordVO, @ModelAttribute("searchVO") AdministrationWordVO searchVO)  throws Exception {
+	/**
+	 * 행정전문용어사전을 삭제한다.
+	 * 
+	 * @param hpcmVO
+	 * @param searchVO
+	 * @return "forward:/uss/olh/awm/selectAdministrationWordManageList.do"
+	 * @throws Exception
+	 */
+	@RequestMapping("/uss/olh/awm/deleteAdministrationWord.do")
+	public String deleteAdministrationWord(AdministrationWordVO administrationWordVO,
+			@ModelAttribute("searchVO") AdministrationWordVO searchVO) throws Exception {
 
-    	egovAdministrationWordService.deleteAdministrationWord(administrationWordVO);
+		egovAdministrationWordService.deleteAdministrationWord(administrationWordVO);
 
-        return "forward:/uss/olh/awm/selectAdministrationWordManageList.do";
-    }
-    
+		return "forward:/uss/olh/awm/selectAdministrationWordManageList.do";
+	}
+
 }

--- a/src/main/java/egovframework/com/uss/olh/awm/web/EgovAdministrationWordController.java
+++ b/src/main/java/egovframework/com/uss/olh/awm/web/EgovAdministrationWordController.java
@@ -33,20 +33,20 @@ import egovframework.com.utl.fcc.service.EgovStringUtil;
  * @since 2009.07.03
  * @version 1.0
  * @see
- * 
+ *
  *      <pre>
- * &lt;&lt; 개정이력(Modification Information) &gt;&gt;
+ *  == 개정이력(Modification Information) ==
  *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.07.03  장동한          최초 생성
- *   2011.8.26	 정진오			IncludedInfo annotation 추가
+ *   2011.08.26  정진오          IncludedInfo annotation 추가
  *   2011.09.19  서준식          삭제 후 리스트 상세조회시 다시 삭제되는 문제 수정
  *   2016.08.10  김연호          표준프레임워크 3.6
- * 
+ *   2025.08.20  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-LocalVariableNamingConventions(final이 아닌 변수는 밑줄을 포함할 수 없음)
+ *
  *      </pre>
  */
-
 @Controller
 public class EgovAdministrationWordController {
 


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

<hr>

### 2025-08-20 수 PMD로 소프트웨어 보안약점 진단하고 제거하기-EgovAdministrationWordController

`_result` 를 `wordSeCode` 로 이름 바꾸기

<hr>

1. PMD로 소프트웨어 보안약점 진단 결과

```
src/main/java/egovframework/com/uss/olh/awm/web/EgovAdministrationWordController.java:201:	LocalVariableNamingConventions:	LocalVariableNamingConventions: 'local variable' 의 변수 '_result' 이  '[a-z][a-zA-Z0-9]*'  로 시작함
src/main/java/egovframework/com/uss/olh/awm/web/EgovAdministrationWordController.java:248:	LocalVariableNamingConventions:	LocalVariableNamingConventions: 'local variable' 의 변수 '_result' 이  '[a-z][a-zA-Z0-9]*'  로 시작함
```

2. 브랜치 생성

```
feature/pmd/EgovAdministrationWordController
```

3. 이클립스 > Source > Format

4. 개정이력 수정

```java
 *   2025.08.20  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-LocalVariableNamingConventions(final이 아닌 변수는 밑줄을 포함할 수 없음)
```

<hr>

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

https://youtu.be/QuBKCxXLcYk
