### PR TITLE
PMD로 소프트웨어 보안약점 진단하고 제거하기-EgovQnaController

### DIFF
--- a/src/main/java/egovframework/com/uss/olh/qna/web/EgovQnaController.java
+++ b/src/main/java/egovframework/com/uss/olh/qna/web/EgovQnaController.java
@@ -46,10 +46,33 @@ import egovframework.com.utl.fcc.service.EgovStringUtil;
 *
 *   수정일     	수정자           			수정내용
 *  ------------   --------    ---------------------------------------------
-*   2009.04.01  	박정규          최초 생성
-*   2011.08.26		정진오			IncludedInfo annotation 추가
-*   2011.10.21		이기하			삭제시 비밀번호 확인 추가(최종감리 반영)
-*   2016.08.05		김연호			표준프레임워크 3.6 개선
+
+ *
+ *      </pre>
+ */
+/**
+ * 사용자 계정을 처리하는 비즈니스 구현 클래스
+ * <p>
+ * <b>NOTE:</b> Exception 종류를 EgovBizException, RuntimeException 에서만 동작한다.
+ * fail.common.msg 메세지키가 Message Resource 에 정의 되어 있어야 한다.
+ * 
+ * @author 공통컴포넌트 개발팀 홍길동
+ * @since 2009.06.01
+ * @version 1.0
+ * @see
+ *
+ *      <pre>
+ *  == 개정이력(Modification Information) ==
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2009.04.01  박정규          최초 생성
+ *   2011.08.26  정진오          IncludedInfo annotation 추가
+ *   2011.10.21  이기하          삭제시 비밀번호 확인 추가(최종감리 반영)
+ *   2016.08.05  김연호          표준프레임워크 3.6 개선
+ *   2025.08.22  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-LocalVariableNamingConventions(final이 아닌 변수는 밑줄을 포함할 수 없음)
+ *   2025.08.22  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-UnnecessarySemicolon(필요없는 ; 문장 존재)
+ *   2025.08.22  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-AvoidReassigningParameters(넘겨받는 메소드 parameter 값을 직접 변경하는 코드 탐지)
  *
  *      </pre>
  */


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

<hr>

### 2025-08-22 금 PMD로 소프트웨어 보안약점 진단하고 제거하기-EgovQnaController

`QnaList` 를 `resultList` 로 이름 바꾸기

필요없는 ; 문장 제거
- `QnaVO vo = egovQnaService.selectQnaDetail(qnaVO);;`

`QnaAnswerList` 를 `resultList` 로 이름 바꾸기

`_result` 를 `qnaProcessSttusCode` 로 이름 바꾸기

`qnaVO` 를 `resultVO` 로 이름 바꾸기
```java
//qnaVO = egovQnaService.selectQnaDetail(qnaVO);
QnaVO resultVO = egovQnaService.selectQnaDetail(qnaVO);
````

<hr>

1. PMD로 소프트웨어 보안약점 진단 결과

```
src/main/java/egovframework/com/uss/olh/qna/web/EgovQnaController.java:102:	LocalVariableNamingConventions:	LocalVariableNamingConventions: 'local variable' 의 변수 'QnaList' 이  '[a-z][a-zA-Z0-9]*'  로 시작함
src/main/java/egovframework/com/uss/olh/qna/web/EgovQnaController.java:274:	UnnecessarySemicolon:	UnnecessarySemicolon: 필요없는 문장 (;)이 있음
src/main/java/egovframework/com/uss/olh/qna/web/EgovQnaController.java:321:	UnnecessarySemicolon:	UnnecessarySemicolon: 필요없는 문장 (;)이 있음
src/main/java/egovframework/com/uss/olh/qna/web/EgovQnaController.java:360:	LocalVariableNamingConventions:	LocalVariableNamingConventions: 'local variable' 의 변수 'QnaAnswerList' 이  '[a-z][a-zA-Z0-9]*'  로 시작함
src/main/java/egovframework/com/uss/olh/qna/web/EgovQnaController.java:403:	LocalVariableNamingConventions:	LocalVariableNamingConventions: 'local variable' 의 변수 '_result' 이  '[a-z][a-zA-Z0-9]*'  로 시작함
src/main/java/egovframework/com/uss/olh/qna/web/EgovQnaController.java:406:	AvoidReassigningParameters:	AvoidReassigningParameters: 'qnaVO' 처럼 파라미터 값을 직접 변경하지 말 것
```

2. 브랜치 생성

```
feature/pmd/EgovQnaController
```

3. 이클립스 > Source > Format

4. 개정이력 수정

```java
 *   2025.08.22  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-LocalVariableNamingConventions(final이 아닌 변수는 밑줄을 포함할 수 없음)
 *   2025.08.22  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-UnnecessarySemicolon(필요없는 ; 문장 존재)
 *   2025.08.22  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-AvoidReassigningParameters(넘겨받는 메소드 parameter 값을 직접 변경하는 코드 탐지)
```

<hr>

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

https://youtu.be/of-xlyCrSa8
