### PR TITLE
PMD로 소프트웨어 보안약점 진단하고 제거하기-EgovCnsltManageController

### DIFF
--- a/src/main/java/egovframework/com/uss/olp/cns/web/EgovCnsltManageController.java
+++ b/src/main/java/egovframework/com/uss/olp/cns/web/EgovCnsltManageController.java
@@ -299,19 +299,19 @@ public class EgovCnsltManageController {
 		}
 
 		// 첨부파일 관련 첨부파일ID 생성
-		List<FileVO> _result = null;
-		String _atchFileId = "";
+		List<FileVO> fvoList = null;
+		String atchFileId = "";
 
 		// final Map<String, MultipartFile> files = multiRequest.getFileMap();
 		final List<MultipartFile> files = multiRequest.getFiles("file_1");
 
 		if (!files.isEmpty()) {
-			_result = fileUtil.parseFileInf(files, "CNSLT_", 0, "", "");
-			_atchFileId = fileMngService.insertFileInfs(_result); // 파일이 생성되고나면 생성된 첨부파일 ID를 리턴한다.
+			fvoList = fileUtil.parseFileInf(files, "CNSLT_", 0, "", "");
+			atchFileId = fileMngService.insertFileInfs(fvoList); // 파일이 생성되고나면 생성된 첨부파일 ID를 리턴한다.
 		}
 
 		// 리턴받은 첨부파일ID를 셋팅한다..
-		cnsltManageVO.setAtchFileId(_atchFileId); // 첨부파일 ID
+		cnsltManageVO.setAtchFileId(atchFileId); // 첨부파일 ID
 
 		// 로그인VO에서 사용자 정보 가져오기
 		LoginVO loginVO = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();
@@ -453,7 +453,7 @@ public class EgovCnsltManageController {
 		}
 
 		// 첨부파일 관련 ID 생성 start....
-		String _atchFileId = cnsltManageVO.getAtchFileId();
+		String atchFileId = cnsltManageVO.getAtchFileId();
 
 		// final Map<String, MultipartFile> files = multiRequest.getFileMap();
 		final List<MultipartFile> files = multiRequest.getFiles("file_1");
@@ -461,18 +461,18 @@ public class EgovCnsltManageController {
 		if (!files.isEmpty()) {
 
 			if ("N".equals(atchFileAt)) {
-				List<FileVO> _result = fileUtil.parseFileInf(files, "CNSLT_", 0, _atchFileId, "");
-				_atchFileId = fileMngService.insertFileInfs(_result);
+				List<FileVO> fvoList = fileUtil.parseFileInf(files, "CNSLT_", 0, atchFileId, "");
+				atchFileId = fileMngService.insertFileInfs(fvoList);
 
 				// 첨부파일 ID 셋팅
-				cnsltManageVO.setAtchFileId(_atchFileId); // 첨부파일 ID
+				cnsltManageVO.setAtchFileId(atchFileId); // 첨부파일 ID
 
 			} else {
 				FileVO fvo = new FileVO();
-				fvo.setAtchFileId(_atchFileId);
-				int _cnt = fileMngService.getMaxFileSN(fvo);
-				List<FileVO> _result = fileUtil.parseFileInf(files, "CNSLT_", _cnt, _atchFileId, "");
-				fileMngService.updateFileInfs(_result);
+				fvo.setAtchFileId(atchFileId);
+				int fileKeyParam = fileMngService.getMaxFileSN(fvo);
+				List<FileVO> fvoList = fileUtil.parseFileInf(files, "CNSLT_", fileKeyParam, atchFileId, "");
+				fileMngService.updateFileInfs(fvoList);
 			}
 		}
 		// 첨부파일 관련 ID 생성 end...
@@ -514,7 +514,6 @@ public class EgovCnsltManageController {
 		// param1 : 사용자고유ID(uniqId,esntlId)
 		// --------------------------------------------------------
 		LOGGER.debug("@ XSS 권한체크 START ----------------------------------------------");
-		;
 
 		// step1 DB에서 해당 게시물의 uniqId 조회
 		CnsltManageVO vo = cnsltManageService.selectCnsltListDetail(cnsltManageVO);
@@ -527,13 +526,13 @@ public class EgovCnsltManageController {
 		// --------------------------------------------------------------------------------------------
 
 		// 첨부파일 삭제를 위한 ID 생성 start....
-		String _atchFileId = cnsltManageVO.getAtchFileId();
+		String atchFileId = cnsltManageVO.getAtchFileId();
 
 		cnsltManageService.deleteCnsltDtls(cnsltManageVO);
 
 		// 첨부파일을 삭제하기 위한 Vo
 		FileVO fvo = new FileVO();
-		fvo.setAtchFileId(_atchFileId);
+		fvo.setAtchFileId(atchFileId);
 
 		fileMngService.deleteAllFileInf(fvo);
 		// 첨부파일 삭제 End.............
@@ -568,8 +567,8 @@ public class EgovCnsltManageController {
 		searchVO.setLastIndex(paginationInfo.getLastRecordIndex());
 		searchVO.setRecordCountPerPage(paginationInfo.getRecordCountPerPage());
 
-		List<EgovMap> CnsltAnswerList = cnsltManageService.selectCnsltAnswerList(searchVO);
-		model.addAttribute("resultList", CnsltAnswerList);
+		List<EgovMap> resultList = cnsltManageService.selectCnsltAnswerList(searchVO);
+		model.addAttribute("resultList", resultList);
 
 		int totCnt = cnsltManageService.selectCnsltAnswerListTotCnt(searchVO);
 		paginationInfo.setTotalRecordCount(totCnt);
@@ -615,8 +614,8 @@ public class EgovCnsltManageController {
 		ComDefaultCodeVO comDefaultCodeVO = new ComDefaultCodeVO();
 		comDefaultCodeVO.setCodeId("COM028");
 
-		List<CmmnDetailCode> _result = cmmUseService.selectCmmCodeDetail(comDefaultCodeVO);
-		model.addAttribute("resultList", _result);
+		List<CmmnDetailCode> resultList = cmmUseService.selectCmmCodeDetail(comDefaultCodeVO);
+		model.addAttribute("resultList", resultList);
 
 		// 변수명은 CoC 에 따라
 		model.addAttribute(selectCnsltAnswerListDetail(cnsltManageVO, searchVO, model));

--- a/src/main/java/egovframework/com/uss/olp/cns/web/EgovCnsltManageController.java
+++ b/src/main/java/egovframework/com/uss/olp/cns/web/EgovCnsltManageController.java
@@ -40,7 +40,6 @@ import egovframework.com.utl.fcc.service.EgovStringUtil;
 import egovframework.com.utl.sim.service.EgovFileScrty;
 
 /**
- *
  * 상담내용을 처리하는 컨트롤러 클래스
  * 
  * @author 공통서비스 개발팀 박정규
@@ -49,16 +48,17 @@ import egovframework.com.utl.sim.service.EgovFileScrty;
  * @see
  *
  *      <pre>
- * << 개정이력(Modification Information) >>
+ *  == 개정이력(Modification Information) ==
  *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.04.01  박정규          최초 생성
- *   2011.8.26	정진오			IncludedInfo annotation 추가
+ *   2011.08.26  정진오          IncludedInfo annotation 추가
+ *   2025.08.22  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-LocalVariableNamingConventions(final이 아닌 변수는 밑줄을 포함할 수 없음)
+ *   2025.08.22  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-UnnecessarySemicolon(필요없는 ; 문장 존재)
  *
  *      </pre>
  */
-
 @Controller
 public class EgovCnsltManageController {
 


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

<hr>

### 2025-08-22 금 PMD로 소프트웨어 보안약점 진단하고 제거하기-EgovCnsltManageController

`_result` 를 `fvoList` 로 이름 바꾸기

`_atchFileId` 를 `atchFileId` 로 이름 바꾸기

`_cnt` 를 `fileKeyParam` 로 이름 바꾸기

필요없는 ; 문장 제거
- `LOGGER.debug("@ XSS 권한체크 START ----------------------------------------------");`

`CnsltAnswerList` 를 `resultList` 로 이름 바꾸기

`_result` 를 `resultList` 로 이름 바꾸기

<hr>

1. PMD로 소프트웨어 보안약점 진단 결과

```
src/main/java/egovframework/com/uss/olp/cns/web/EgovCnsltManageController.java:302:	LocalVariableNamingConventions:	LocalVariableNamingConventions: 'local variable' 의 변수 '_result' 이  '[a-z][a-zA-Z0-9]*'  로 시작함
src/main/java/egovframework/com/uss/olp/cns/web/EgovCnsltManageController.java:303:	LocalVariableNamingConventions:	LocalVariableNamingConventions: 'local variable' 의 변수 '_atchFileId' 이  '[a-z][a-zA-Z0-9]*'  로 시작함
src/main/java/egovframework/com/uss/olp/cns/web/EgovCnsltManageController.java:456:	LocalVariableNamingConventions:	LocalVariableNamingConventions: 'local variable' 의 변수 '_atchFileId' 이  '[a-z][a-zA-Z0-9]*'  로 시작함
src/main/java/egovframework/com/uss/olp/cns/web/EgovCnsltManageController.java:464:	LocalVariableNamingConventions:	LocalVariableNamingConventions: 'local variable' 의 변수 '_result' 이  '[a-z][a-zA-Z0-9]*'  로 시작함
src/main/java/egovframework/com/uss/olp/cns/web/EgovCnsltManageController.java:473:	LocalVariableNamingConventions:	LocalVariableNamingConventions: 'local variable' 의 변수 '_cnt' 이  '[a-z][a-zA-Z0-9]*'  로 시작함
src/main/java/egovframework/com/uss/olp/cns/web/EgovCnsltManageController.java:474:	LocalVariableNamingConventions:	LocalVariableNamingConventions: 'local variable' 의 변수 '_result' 이  '[a-z][a-zA-Z0-9]*'  로 시작함
src/main/java/egovframework/com/uss/olp/cns/web/EgovCnsltManageController.java:517:	UnnecessarySemicolon:	UnnecessarySemicolon: 필요없는 문장 (;)이 있음
src/main/java/egovframework/com/uss/olp/cns/web/EgovCnsltManageController.java:530:	LocalVariableNamingConventions:	LocalVariableNamingConventions: 'local variable' 의 변수 '_atchFileId' 이  '[a-z][a-zA-Z0-9]*'  로 시작함
src/main/java/egovframework/com/uss/olp/cns/web/EgovCnsltManageController.java:571:	LocalVariableNamingConventions:	LocalVariableNamingConventions: 'local variable' 의 변수 'CnsltAnswerList' 이  '[a-z][a-zA-Z0-9]*'  로 시작함
src/main/java/egovframework/com/uss/olp/cns/web/EgovCnsltManageController.java:618:	LocalVariableNamingConventions:	LocalVariableNamingConventions: 'local variable' 의 변수 '_result' 이  '[a-z][a-zA-Z0-9]*'  로 시작함
```

2. 브랜치 생성

```
feature/pmd/EgovCnsltManageController
```

3. 이클립스 > Source > Format

4. 개정이력 수정

```java
 *   2025.08.22  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-LocalVariableNamingConventions(final이 아닌 변수는 밑줄을 포함할 수 없음)
 *   2025.08.22  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-UnnecessarySemicolon(필요없는 ; 문장 존재)
```

<hr>

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

https://youtu.be/TNq_wqdQIK0
