### PR TITLE
PMD로 소프트웨어 보안약점 진단하고 제거하기-QustnrTmplatManageVO

### DIFF
--- a/src/main/java/egovframework/com/uss/olp/qtm/service/QustnrTmplatManageVO.java
+++ b/src/main/java/egovframework/com/uss/olp/qtm/service/QustnrTmplatManageVO.java
@@ -14,11 +14,12 @@ import lombok.Setter;
  * @see
  *
  *      <pre>
- * << 개정이력(Modification Information) >>
+ *  == 개정이력(Modification Information) ==
  *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.03.20  장동한          최초 생성
+ *   2025.08.26  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-AvoidArrayLoops(배열의 값을 루프문을 이용하여 복사하는 것 보다, System.arraycopy() 메소드를 이용하여 복사하는 것이 효율적이며 수행 속도가 빠름)
  *
  *      </pre>
  */

--- a/src/main/java/egovframework/com/uss/olp/qtm/service/QustnrTmplatManageVO.java
+++ b/src/main/java/egovframework/com/uss/olp/qtm/service/QustnrTmplatManageVO.java
@@ -1,21 +1,23 @@
 package egovframework.com.uss.olp.qtm.service;
 
 import java.io.Serializable;
+
 /**
  * 설문템플릿 VO Class 구현
+ * 
  * @author 공통서비스 장동한
  * @since 2009.03.20
  * @version 1.0
  * @see
  *
- * <pre>
+ *      <pre>
  * << 개정이력(Modification Information) >>
  *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.03.20  장동한          최초 생성
  *
- * </pre>
+ *      </pre>
  */
 public class QustnrTmplatManageVO implements Serializable {
 
@@ -30,7 +32,7 @@ public class QustnrTmplatManageVO implements Serializable {
 	/** 설문템플 이미지내용 */
 	private byte[] qestnrTmplatImagepathnm;
 
-	/** 설문템플릿  설명 */
+	/** 설문템플릿 설명 */
 	private String qestnrTmplatCn = "";
 
 	/** 설문템플릿경로명 */
@@ -53,6 +55,7 @@ public class QustnrTmplatManageVO implements Serializable {
 
 	/**
 	 * qestnrTmplatId attribute 를 리턴한다.
+	 * 
 	 * @return the String
 	 */
 	public String getQestnrTmplatId() {
@@ -61,6 +64,7 @@ public class QustnrTmplatManageVO implements Serializable {
 
 	/**
 	 * qestnrTmplatId attribute 값을 설정한다.
+	 * 
 	 * @return qestnrTmplatId String
 	 */
 	public void setQestnrTmplatId(String qestnrTmplatId) {
@@ -69,6 +73,7 @@ public class QustnrTmplatManageVO implements Serializable {
 
 	/**
 	 * qestnrTmplatTy attribute 를 리턴한다.
+	 * 
 	 * @return the String
 	 */
 	public String getQestnrTmplatTy() {
@@ -77,6 +82,7 @@ public class QustnrTmplatManageVO implements Serializable {
 
 	/**
 	 * qestnrTmplatTy attribute 값을 설정한다.
+	 * 
 	 * @return qestnrTmplatTy String
 	 */
 	public void setQestnrTmplatTy(String qestnrTmplatTy) {
@@ -85,6 +91,7 @@ public class QustnrTmplatManageVO implements Serializable {
 
 	/**
 	 * qestnrTmplatImagepathnm attribute 를 리턴한다.
+	 * 
 	 * @return the byte[]
 	 */
 	public byte[] getQestnrTmplatImagepathnm() {
@@ -102,18 +109,20 @@ public class QustnrTmplatManageVO implements Serializable {
 
 	/**
 	 * qestnrTmplatImagepathnm attribute 값을 설정한다.
+	 * 
 	 * @return qestnrTmplatImagepathnm byte[]
 	 */
 	public void setQestnrTmplatImagepathnm(byte[] qestnrTmplatImagepathnm) {
 		this.qestnrTmplatImagepathnm = new byte[qestnrTmplatImagepathnm.length];
 
-		for (int i = 0; i <  qestnrTmplatImagepathnm.length; ++i) {
+		for (int i = 0; i < qestnrTmplatImagepathnm.length; ++i) {
 			this.qestnrTmplatImagepathnm[i] = qestnrTmplatImagepathnm[i];
 		}
 	}
 
 	/**
 	 * qestnrTmplatCn attribute 를 리턴한다.
+	 * 
 	 * @return the String
 	 */
 	public String getQestnrTmplatCn() {
@@ -122,6 +131,7 @@ public class QustnrTmplatManageVO implements Serializable {
 
 	/**
 	 * qestnrTmplatCn attribute 값을 설정한다.
+	 * 
 	 * @return qestnrTmplatCn String
 	 */
 	public void setQestnrTmplatCn(String qestnrTmplatCn) {
@@ -130,6 +140,7 @@ public class QustnrTmplatManageVO implements Serializable {
 
 	/**
 	 * qestnrTmplatCours attribute 를 리턴한다.
+	 * 
 	 * @return the String
 	 */
 	public String getQestnrTmplatCours() {
@@ -138,6 +149,7 @@ public class QustnrTmplatManageVO implements Serializable {
 
 	/**
 	 * qestnrTmplatCours attribute 값을 설정한다.
+	 * 
 	 * @return qestnrTmplatCours String
 	 */
 	public void setQestnrTmplatCours(String qestnrTmplatCours) {
@@ -146,6 +158,7 @@ public class QustnrTmplatManageVO implements Serializable {
 
 	/**
 	 * frstRegisterPnttm attribute 를 리턴한다.
+	 * 
 	 * @return the String
 	 */
 	public String getFrstRegisterPnttm() {
@@ -154,6 +167,7 @@ public class QustnrTmplatManageVO implements Serializable {
 
 	/**
 	 * frstRegisterPnttm attribute 값을 설정한다.
+	 * 
 	 * @return frstRegisterPnttm String
 	 */
 	public void setFrstRegisterPnttm(String frstRegisterPnttm) {
@@ -162,6 +176,7 @@ public class QustnrTmplatManageVO implements Serializable {
 
 	/**
 	 * frstRegisterId attribute 를 리턴한다.
+	 * 
 	 * @return the String
 	 */
 	public String getFrstRegisterId() {
@@ -170,6 +185,7 @@ public class QustnrTmplatManageVO implements Serializable {
 
 	/**
 	 * frstRegisterId attribute 값을 설정한다.
+	 * 
 	 * @return frstRegisterId String
 	 */
 	public void setFrstRegisterId(String frstRegisterId) {
@@ -178,6 +194,7 @@ public class QustnrTmplatManageVO implements Serializable {
 
 	/**
 	 * lastUpdusrPnttm attribute 를 리턴한다.
+	 * 
 	 * @return the String
 	 */
 	public String getLastUpdusrPnttm() {
@@ -186,6 +203,7 @@ public class QustnrTmplatManageVO implements Serializable {
 
 	/**
 	 * lastUpdusrPnttm attribute 값을 설정한다.
+	 * 
 	 * @return lastUpdusrPnttm String
 	 */
 	public void setLastUpdusrPnttm(String lastUpdusrPnttm) {
@@ -194,6 +212,7 @@ public class QustnrTmplatManageVO implements Serializable {
 
 	/**
 	 * lastUpdusrId attribute 를 리턴한다.
+	 * 
 	 * @return the String
 	 */
 	public String getLastUpdusrId() {
@@ -202,6 +221,7 @@ public class QustnrTmplatManageVO implements Serializable {
 
 	/**
 	 * lastUpdusrId attribute 값을 설정한다.
+	 * 
 	 * @return lastUpdusrId String
 	 */
 	public void setLastUpdusrId(String lastUpdusrId) {
@@ -210,6 +230,7 @@ public class QustnrTmplatManageVO implements Serializable {
 
 	/**
 	 * cmd attribute 를 리턴한다.
+	 * 
 	 * @return the String
 	 */
 	public String getCmd() {
@@ -218,12 +239,11 @@ public class QustnrTmplatManageVO implements Serializable {
 
 	/**
 	 * cmd attribute 값을 설정한다.
+	 * 
 	 * @return cmd String
 	 */
 	public void setCmd(String cmd) {
 		this.cmd = cmd;
 	}
-
-
 
 }

--- a/src/main/java/egovframework/com/uss/olp/qtm/service/QustnrTmplatManageVO.java
+++ b/src/main/java/egovframework/com/uss/olp/qtm/service/QustnrTmplatManageVO.java
@@ -2,6 +2,9 @@ package egovframework.com.uss.olp.qtm.service;
 
 import java.io.Serializable;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * 설문템플릿 VO Class 구현
  * 
@@ -30,6 +33,8 @@ public class QustnrTmplatManageVO implements Serializable {
 	private String qestnrTmplatTy = "";
 
 	/** 설문템플 이미지내용 */
+	@Getter
+	@Setter
 	private byte[] qestnrTmplatImagepathnm;
 
 	/** 설문템플릿 설명 */
@@ -87,37 +92,6 @@ public class QustnrTmplatManageVO implements Serializable {
 	 */
 	public void setQestnrTmplatTy(String qestnrTmplatTy) {
 		this.qestnrTmplatTy = qestnrTmplatTy;
-	}
-
-	/**
-	 * qestnrTmplatImagepathnm attribute 를 리턴한다.
-	 * 
-	 * @return the byte[]
-	 */
-	public byte[] getQestnrTmplatImagepathnm() {
-		byte[] ret = null;
-
-		if (qestnrTmplatImagepathnm != null) {
-			ret = new byte[qestnrTmplatImagepathnm.length];
-
-			for (int i = 0; i < qestnrTmplatImagepathnm.length; i++) {
-				ret[i] = qestnrTmplatImagepathnm[i];
-			}
-		}
-		return ret;
-	}
-
-	/**
-	 * qestnrTmplatImagepathnm attribute 값을 설정한다.
-	 * 
-	 * @return qestnrTmplatImagepathnm byte[]
-	 */
-	public void setQestnrTmplatImagepathnm(byte[] qestnrTmplatImagepathnm) {
-		this.qestnrTmplatImagepathnm = new byte[qestnrTmplatImagepathnm.length];
-
-		for (int i = 0; i < qestnrTmplatImagepathnm.length; ++i) {
-			this.qestnrTmplatImagepathnm[i] = qestnrTmplatImagepathnm[i];
-		}
 	}
 
 	/**


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

<hr>

### 2025-08-26 화 PMD로 소프트웨어 보안약점 진단하고 제거하기-QustnrTmplatManageVO

`getQestnrTmplatImagepathnm, setQestnrTmplatImagepathnm` 메서드를 제거하고 `@Getter, @Setter` 추가

<hr>

1. PMD로 소프트웨어 보안약점 진단 결과

```
src/main/java/egovframework/com/uss/olp/qtm/service/QustnrTmplatManageVO.java:96:	AvoidArrayLoops:	AvoidArrayLoops: 배열의 값을 루프문을 이용하여 복사하는 것 보다 System.arraycopy() 메소드를 이용하여 복사하는 것이 효율적이며 수행 속도가 빠름
```

2. 브랜치 생성

```
feature/pmd/QustnrTmplatManageVO
```

3. 이클립스 > Source > Format

4. 개정이력 수정

```java
 *   2025.08.26  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-AvoidArrayLoops(배열의 값을 루프문을 이용하여 복사하는 것 보다, System.arraycopy() 메소드를 이용하여 복사하는 것이 효율적이며 수행 속도가 빠름)
```

<hr>

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

https://youtu.be/Z8qWeftP4k4
