### PR TITLE
PMD로 소프트웨어 보안약점 진단하고 제거하기-EgovMessageUtil

### DIFF
--- a/src/main/java/egovframework/com/utl/cas/service/EgovMessageUtil.java
+++ b/src/main/java/egovframework/com/utl/cas/service/EgovMessageUtil.java
@@ -58,7 +58,7 @@ public class EgovMessageUtil {
 	}
 
 	/**
-	 *해당되는 속성키로부터 정보 메시지(파라미터 변환 포함)를 얻는다.
+	 * 해당되는 속성키로부터 정보 메시지(파라미터 변환 포함)를 얻는다.
 	 *
 	 * @param strCode
 	 * @param arrParam
@@ -114,10 +114,10 @@ public class EgovMessageUtil {
 
 		return getMessage("confirm", strCode, arrParam);
 	}
+
 	/**
-	 * 주어진 작업 코드, 문자열 코드, 그리고 파라미터 배열을 사용하여 메시지를 반환합니다.
-	 * 문자열 코드를 사용하여 메시지 속성 파일에서 메시지를 가져옵니다.
-	 * 파라미터 배열이 제공되면 해당 파라미터로 메시지를 교체합니다.
+	 * 주어진 작업 코드, 문자열 코드, 그리고 파라미터 배열을 사용하여 메시지를 반환합니다. 문자열 코드를 사용하여 메시지 속성 파일에서
+	 * 메시지를 가져옵니다. 파라미터 배열이 제공되면 해당 파라미터로 메시지를 교체합니다.
 	 *
 	 * @param wrkCode  작업을 지정하는 코드
 	 * @param strCode  메시지 속성 파일에서 메시지를 찾는데 사용되는 코드
@@ -131,11 +131,16 @@ public class EgovMessageUtil {
 		String strMsg = "";
 		if (!"".equals(EgovStringUtil.isNullToString(strCode.trim()))) {
 
-			strMsg = EgovProperties.getProperty(EgovProperties.RELATIVE_PATH_PREFIX + "egovProps" + PATH_SEP + "conf" + PATH_SEP + wrkCode + "message.properties", strCode);
+			strMsg = EgovProperties.getProperty(EgovProperties.RELATIVE_PATH_PREFIX + "egovProps" + PATH_SEP + "conf"
+					+ PATH_SEP + wrkCode + "message.properties", strCode);
 
-			if(arrParam != null) {
+			if (arrParam != null) {
 				for (int i = (arrParam.length > 0 ? arrParam.length - 1 : -1); i >= 0; i--) {
-					strMsg = EgovStringUtil.replace(EgovStringUtil.isNullToString(strMsg), "{" + i + "}", arrParam[i]);//KISA 보안약점 조치 (2018-10-29, 윤창원)
+					strMsg = EgovStringUtil.replace(EgovStringUtil.isNullToString(strMsg), "{" + i + "}", arrParam[i]);// KISA
+																														// 보안약점
+																														// 조치
+																														// (2018-10-29,
+																														// 윤창원)
 				}
 			}
 			message = strMsg;

--- a/src/main/java/egovframework/com/utl/cas/service/EgovMessageUtil.java
+++ b/src/main/java/egovframework/com/utl/cas/service/EgovMessageUtil.java
@@ -135,12 +135,9 @@ public class EgovMessageUtil {
 					+ PATH_SEP + wrkCode + "message.properties", strCode);
 
 			if (arrParam != null) {
-				for (int i = (arrParam.length > 0 ? arrParam.length - 1 : -1); i >= 0; i--) {
-					strMsg = EgovStringUtil.replace(EgovStringUtil.isNullToString(strMsg), "{" + i + "}", arrParam[i]);// KISA
-																														// 보안약점
-																														// 조치
-																														// (2018-10-29,
-																														// 윤창원)
+				for (int i = arrParam.length > 0 ? arrParam.length - 1 : -1; i >= 0; i--) {
+					// KISA 보안약점 조치 (2018-10-29, 윤창원)
+					strMsg = EgovStringUtil.replace(EgovStringUtil.isNullToString(strMsg), "{" + i + "}", arrParam[i]);
 				}
 			}
 			message = strMsg;

--- a/src/main/java/egovframework/com/utl/cas/service/EgovMessageUtil.java
+++ b/src/main/java/egovframework/com/utl/cas/service/EgovMessageUtil.java
@@ -1,24 +1,26 @@
-/**
- * @Class Name  : EgovMessageUtil.java
- * @Description : 메시지 처리 관련 유틸리티
- * @Modification Information
- *
- *     수정일         수정자                   수정내용
- *     -------          --------        ---------------------------
- *   2009.02.13       이삼섭                  최초 생성
- *
- * @author 공통 서비스 개발팀 이삼섭
- * @since 2009. 02. 13
- * @version 1.0
- * @see
- *
- */
-
 package egovframework.com.utl.cas.service;
 
 import egovframework.com.cmm.service.EgovProperties;
 import egovframework.com.utl.fcc.service.EgovStringUtil;
 
+/**
+ * 메시지 처리 관련 유틸리티
+ * 
+ * @author 공통 서비스 개발팀 이삼섭
+ * @since 2009.02.13
+ * @version 1.0
+ * @see
+ *
+ *      <pre>
+ *  == 개정이력(Modification Information) ==
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2009.02.13  이삼섭          최초 생성
+ *   2025.08.29  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-UselessParentheses(불필요한 괄호사용)
+ *
+ *      </pre>
+ */
 public class EgovMessageUtil {
 
 	private static final String PATH_SEP = System.getProperty("file.separator");


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

<hr>

### 2025-08-29 금 PMD로 소프트웨어 보안약점 진단하고 제거하기-EgovMessageUtil

불필요한 괄호제거
```java
//for (int i = (arrParam.length > 0 ? arrParam.length - 1 : -1); i >= 0; i--) {
for (int i = arrParam.length > 0 ? arrParam.length - 1 : -1; i >= 0; i--) {
```

<hr>

1. PMD로 소프트웨어 보안약점 진단 결과

```
src/main/java/egovframework/com/utl/cas/service/EgovMessageUtil.java:137:	UselessParentheses:	UselessParentheses: 괄호가 없어도 되는 상황에서 불필요한 괄호를 사용할 경우 마치 메소드 호출처럼 보여서 소스 코드의 가독성을 떨어뜨릴 수 있음
```

2. 브랜치 생성

```
feature/pmd/EgovMessageUtil
```

3. 이클립스 > Source > Format

4. 개정이력 수정

```java
 *   2025.08.29  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-UselessParentheses(불필요한 괄호사용)
```

<hr>

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

https://youtu.be/EmFr7NVHpJU
