### PR TITLE
PMD로 소프트웨어 보안약점 진단하고 제거하기-EgovDateUtil

### DIFF
--- a/src/main/java/egovframework/com/utl/fcc/service/EgovDateUtil.java
+++ b/src/main/java/egovframework/com/utl/fcc/service/EgovDateUtil.java
@@ -14,7 +14,6 @@ import java.util.TimeZone;
 import com.ibm.icu.util.ChineseCalendar;
 
 /**
- *
  * Date 에 대한 Util 클래스
  * 
  * @author 공통서비스 개발팀 이중호
@@ -23,11 +22,14 @@ import com.ibm.icu.util.ChineseCalendar;
  * @see
  *
  *      <pre>
- * << 개정이력(Modification Information) >>
+ *  == 개정이력(Modification Information) ==
  *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.02.01  이중호          최초 생성
+ *   2025.08.30  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-UselessParentheses(불필요한 괄호사용)
+ *   2025.08.30  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-LocalVariableNamingConventions(final이 아닌 변수는 밑줄을 포함할 수 없음)
+ *   2025.08.30  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-AvoidReassigningParameters(넘겨받는 메소드 parameter 값을 직접 변경하는 코드 탐지)
  *
  *      </pre>
  */

--- a/src/main/java/egovframework/com/utl/fcc/service/EgovDateUtil.java
+++ b/src/main/java/egovframework/com/utl/fcc/service/EgovDateUtil.java
@@ -16,25 +16,28 @@ import com.ibm.icu.util.ChineseCalendar;
 /**
  *
  * Date 에 대한 Util 클래스
+ * 
  * @author 공통서비스 개발팀 이중호
  * @since 2009.02.01
  * @version 1.0
  * @see
  *
- * <pre>
+ *      <pre>
  * << 개정이력(Modification Information) >>
  *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.02.01  이중호          최초 생성
  *
- * </pre>
+ *      </pre>
  */
 public class EgovDateUtil {
 
 	/**
-	 * <p>yyyyMMdd 혹은 yyyy-MM-dd 형식의 날짜 문자열을 입력 받아 년, 월, 일을
-	 * 증감한다. 년, 월, 일은 가감할 수를 의미하며, 음수를 입력할 경우 감한다.</p>
+	 * <p>
+	 * yyyyMMdd 혹은 yyyy-MM-dd 형식의 날짜 문자열을 입력 받아 년, 월, 일을 증감한다. 년, 월, 일은 가감할 수를 의미하며,
+	 * 음수를 입력할 경우 감한다.
+	 * </p>
 	 *
 	 * <pre>
 	 * DateUtil.addYearMonthDay("19810828", 0, 0, 19)  = "19810916"
@@ -49,13 +52,13 @@ public class EgovDateUtil {
 	 * DateUtil.addYearMonthDay("20040229", 2, 0, 1)   = "20060301"
 	 * </pre>
 	 *
-	 * @param  dateStr 날짜 문자열(yyyyMMdd, yyyy-MM-dd의 형식)
-	 * @param  year 가감할 년. 0이 입력될 경우 가감이 없다
-	 * @param  month 가감할 월. 0이 입력될 경우 가감이 없다
-	 * @param  day 가감할 일. 0이 입력될 경우 가감이 없다
-	 * @return  yyyyMMdd 형식의 날짜 문자열
-	 * @throws IllegalArgumentException 날짜 포맷이 정해진 바와 다를 경우.
-	 *         입력 값이 <code>null</code>인 경우.
+	 * @param dateStr 날짜 문자열(yyyyMMdd, yyyy-MM-dd의 형식)
+	 * @param year    가감할 년. 0이 입력될 경우 가감이 없다
+	 * @param month   가감할 월. 0이 입력될 경우 가감이 없다
+	 * @param day     가감할 일. 0이 입력될 경우 가감이 없다
+	 * @return yyyyMMdd 형식의 날짜 문자열
+	 * @throws IllegalArgumentException 날짜 포맷이 정해진 바와 다를 경우. 입력 값이
+	 *                                  <code>null</code>인 경우.
 	 */
 	public static String addYearMonthDay(String sDate, int year, int month, int day) {
 
@@ -78,13 +81,15 @@ public class EgovDateUtil {
 		if (day != 0) {
 			cal.add(Calendar.DATE, day);
 		}
-		
+
 		return sdf.format(cal.getTime());
 	}
 
 	/**
-	 * <p>yyyyMMdd 혹은 yyyy-MM-dd 형식의 날짜 문자열을 입력 받아 년을
-	 * 증감한다. <code>year</code>는 가감할 수를 의미하며, 음수를 입력할 경우 감한다.</p>
+	 * <p>
+	 * yyyyMMdd 혹은 yyyy-MM-dd 형식의 날짜 문자열을 입력 받아 년을 증감한다. <code>year</code>는 가감할 수를
+	 * 의미하며, 음수를 입력할 경우 감한다.
+	 * </p>
 	 *
 	 * <pre>
 	 * DateUtil.addYear("20000201", 62)  = "20620201"
@@ -94,19 +99,21 @@ public class EgovDateUtil {
 	 * DateUtil.addYear("19000101", 200) = "21000101"
 	 * </pre>
 	 *
-	 * @param  dateStr 날짜 문자열(yyyyMMdd, yyyy-MM-dd의 형식)
-	 * @param  year 가감할 년. 0이 입력될 경우 가감이 없다
-	 * @return  yyyyMMdd 형식의 날짜 문자열
-	 * @throws IllegalArgumentException 날짜 포맷이 정해진 바와 다를 경우.
-	 *         입력 값이 <code>null</code>인 경우.
+	 * @param dateStr 날짜 문자열(yyyyMMdd, yyyy-MM-dd의 형식)
+	 * @param year    가감할 년. 0이 입력될 경우 가감이 없다
+	 * @return yyyyMMdd 형식의 날짜 문자열
+	 * @throws IllegalArgumentException 날짜 포맷이 정해진 바와 다를 경우. 입력 값이
+	 *                                  <code>null</code>인 경우.
 	 */
 	public static String addYear(String dateStr, int year) {
 		return addYearMonthDay(dateStr, year, 0, 0);
 	}
 
 	/**
-	 * <p>yyyyMMdd 혹은 yyyy-MM-dd 형식의 날짜 문자열을 입력 받아 월을
-	 * 증감한다. <code>month</code>는 가감할 수를 의미하며, 음수를 입력할 경우 감한다.</p>
+	 * <p>
+	 * yyyyMMdd 혹은 yyyy-MM-dd 형식의 날짜 문자열을 입력 받아 월을 증감한다. <code>month</code>는 가감할 수를
+	 * 의미하며, 음수를 입력할 경우 감한다.
+	 * </p>
 	 *
 	 * <pre>
 	 * DateUtil.addMonth("20010201", 12)  = "20020201"
@@ -117,22 +124,23 @@ public class EgovDateUtil {
 	 * DateUtil.addMonth("20060228", -1)  = "20060128"
 	 * </pre>
 	 *
-	 * @param  dateStr 날짜 문자열(yyyyMMdd, yyyy-MM-dd의 형식)
-	 * @param  month 가감할 월. 0이 입력될 경우 가감이 없다
-	 * @return  yyyyMMdd 형식의 날짜 문자열
-	 * @throws IllegalArgumentException 날짜 포맷이 정해진 바와 다를 경우.
-	 *         입력 값이 <code>null</code>인 경우.
+	 * @param dateStr 날짜 문자열(yyyyMMdd, yyyy-MM-dd의 형식)
+	 * @param month   가감할 월. 0이 입력될 경우 가감이 없다
+	 * @return yyyyMMdd 형식의 날짜 문자열
+	 * @throws IllegalArgumentException 날짜 포맷이 정해진 바와 다를 경우. 입력 값이
+	 *                                  <code>null</code>인 경우.
 	 */
 	public static String addMonth(String dateStr, int month) {
 		return addYearMonthDay(dateStr, 0, month, 0);
 	}
 
 	/**
-	 * <p>yyyyMMdd 혹은 yyyy-MM-dd 형식의 날짜 문자열을 입력 받아 일(day)를
-	 * 증감한다. <code>day</code>는 가감할 수를 의미하며, 음수를 입력할 경우 감한다.
-	 * <br/><br/>
-	 * 위에 정의된 addDays 메서드는 사용자가 ParseException을 반드시 처리해야 하는 불편함이
-	 * 있기 때문에 추가된 메서드이다.</p>
+	 * <p>
+	 * yyyyMMdd 혹은 yyyy-MM-dd 형식의 날짜 문자열을 입력 받아 일(day)를 증감한다. <code>day</code>는 가감할
+	 * 수를 의미하며, 음수를 입력할 경우 감한다. <br/>
+	 * <br/>
+	 * 위에 정의된 addDays 메서드는 사용자가 ParseException을 반드시 처리해야 하는 불편함이 있기 때문에 추가된 메서드이다.
+	 * </p>
 	 *
 	 * <pre>
 	 * DateUtil.addDay("19991201", 62) = "20000201"
@@ -143,21 +151,23 @@ public class EgovDateUtil {
 	 * DateUtil.addDay("20060631", 1) = "20060702"
 	 * </pre>
 	 *
-	 * @param  dateStr 날짜 문자열(yyyyMMdd, yyyy-MM-dd의 형식)
-	 * @param  day 가감할 일. 0이 입력될 경우 가감이 없다
-	 * @return  yyyyMMdd 형식의 날짜 문자열
-	 * @throws IllegalArgumentException 날짜 포맷이 정해진 바와 다를 경우.
-	 *         입력 값이 <code>null</code>인 경우.
+	 * @param dateStr 날짜 문자열(yyyyMMdd, yyyy-MM-dd의 형식)
+	 * @param day     가감할 일. 0이 입력될 경우 가감이 없다
+	 * @return yyyyMMdd 형식의 날짜 문자열
+	 * @throws IllegalArgumentException 날짜 포맷이 정해진 바와 다를 경우. 입력 값이
+	 *                                  <code>null</code>인 경우.
 	 */
 	public static String addDay(String dateStr, int day) {
 		return addYearMonthDay(dateStr, 0, 0, day);
 	}
 
 	/**
-	 * <p>yyyyMMdd 혹은 yyyy-MM-dd 형식의 날짜 문자열 <code>dateStr1</code>과 <code>
+	 * <p>
+	 * yyyyMMdd 혹은 yyyy-MM-dd 형식의 날짜 문자열 <code>dateStr1</code>과 <code>
 	 * dateStr2</code> 사이의 일 수를 구한다.<br>
-	 * <code>dateStr2</code>가 <code>dateStr1</code> 보다 과거 날짜일 경우에는
-	 * 음수를 반환한다. 동일한 경우에는 0을 반환한다.</p>
+	 * <code>dateStr2</code>가 <code>dateStr1</code> 보다 과거 날짜일 경우에는 음수를 반환한다. 동일한
+	 * 경우에는 0을 반환한다.
+	 * </p>
 	 *
 	 * <pre>
 	 * DateUtil.getDaysDiff("20060228","20060310") = 10
@@ -167,11 +177,11 @@ public class EgovDateUtil {
 	 * DateUtil.getDaysDiff("20060801","20060801") = 0
 	 * </pre>
 	 *
-	 * @param  dateStr1 날짜 문자열(yyyyMMdd, yyyy-MM-dd의 형식)
-	 * @param  dateStr2 날짜 문자열(yyyyMMdd, yyyy-MM-dd의 형식)
-	 * @return  일 수 차이.
-	 * @throws IllegalArgumentException 날짜 포맷이 정해진 바와 다를 경우.
-	 *         입력 값이 <code>null</code>인 경우.
+	 * @param dateStr1 날짜 문자열(yyyyMMdd, yyyy-MM-dd의 형식)
+	 * @param dateStr2 날짜 문자열(yyyyMMdd, yyyy-MM-dd의 형식)
+	 * @return 일 수 차이.
+	 * @throws IllegalArgumentException 날짜 포맷이 정해진 바와 다를 경우. 입력 값이
+	 *                                  <code>null</code>인 경우.
 	 */
 	public static int getDaysDiff(String sDate1, String sDate2) {
 		String dateStr1 = validChkDate(sDate1);
@@ -202,7 +212,9 @@ public class EgovDateUtil {
 	}
 
 	/**
-	 * <p>yyyyMMdd 혹은 yyyy-MM-dd 형식의 날짜 문자열을 입력 받아 유효한 날짜인지 검사.</p>
+	 * <p>
+	 * yyyyMMdd 혹은 yyyy-MM-dd 형식의 날짜 문자열을 입력 받아 유효한 날짜인지 검사.
+	 * </p>
 	 *
 	 * <pre>
 	 * DateUtil.checkDate("1999-02-35") = false
@@ -214,8 +226,8 @@ public class EgovDateUtil {
 	 * DateUtil.checkDate("2006-02-28") = true
 	 * </pre>
 	 *
-	 * @param  dateStr 날짜 문자열(yyyyMMdd, yyyy-MM-dd의 형식)
-	 * @return  유효한 날짜인지 여부
+	 * @param dateStr 날짜 문자열(yyyyMMdd, yyyy-MM-dd의 형식)
+	 * @return 유효한 날짜인지 여부
 	 */
 	public static boolean checkDate(String sDate) {
 		String dateStr = validChkDate(sDate);
@@ -228,12 +240,14 @@ public class EgovDateUtil {
 	}
 
 	/**
-	 * <p>입력한 년, 월, 일이 유효한지 검사.</p>
+	 * <p>
+	 * 입력한 년, 월, 일이 유효한지 검사.
+	 * </p>
 	 *
-	 * @param  year 연도
-	 * @param  month 월
-	 * @param  day 일
-	 * @return  유효한 날짜인지 여부
+	 * @param year  연도
+	 * @param month 월
+	 * @param day   일
+	 * @return 유효한 날짜인지 여부
 	 */
 	public static boolean checkDate(String year, String month, String day) {
 		try {
@@ -241,10 +255,11 @@ public class EgovDateUtil {
 
 			Date result = formatter.parse(year + "." + month + "." + day);
 			String resultStr = formatter.format(result);
-			if (resultStr.equalsIgnoreCase(year + "." + month + "." + day))
+			if (resultStr.equalsIgnoreCase(year + "." + month + "." + day)) {
 				return true;
-			else
+			} else {
 				return false;
+			}
 		} catch (ParseException e) {
 			return false;
 		}
@@ -253,11 +268,11 @@ public class EgovDateUtil {
 	/**
 	 * 날짜형태의 String의 날짜 포맷 및 TimeZone을 변경해 주는 메서드
 	 *
-	 * @param  strSource       바꿀 날짜 String
-	 * @param  fromDateFormat  기존의 날짜 형태
-	 * @param  toDateFormat    원하는 날짜 형태
-	 * @param  strTimeZone     변경할 TimeZone(""이면 변경 안함)
-	 * @return  소스 String의 날짜 포맷을 변경한 String
+	 * @param strSource      바꿀 날짜 String
+	 * @param fromDateFormat 기존의 날짜 형태
+	 * @param toDateFormat   원하는 날짜 형태
+	 * @param strTimeZone    변경할 TimeZone(""이면 변경 안함)
+	 * @return 소스 String의 날짜 포맷을 변경한 String
 	 */
 	public static String convertDate(String strSource, String fromDateFormat, String toDateFormat, String strTimeZone) {
 		SimpleDateFormat simpledateformat = null;
@@ -268,10 +283,12 @@ public class EgovDateUtil {
 		if (EgovStringUtil.isNullToString(strSource).trim().equals("")) {
 			return "";
 		}
-		if (EgovStringUtil.isNullToString(fromDateFormat).trim().equals(""))
+		if (EgovStringUtil.isNullToString(fromDateFormat).trim().equals("")) {
 			fromFormat = "yyyyMMddHHmmss"; // default값
-		if (EgovStringUtil.isNullToString(toDateFormat).trim().equals(""))
+		}
+		if (EgovStringUtil.isNullToString(toDateFormat).trim().equals("")) {
 			toFormat = "yyyy-MM-dd HH:mm:ss"; // default값
+		}
 
 		try {
 			simpledateformat = new SimpleDateFormat(fromFormat, Locale.getDefault());
@@ -283,22 +300,23 @@ public class EgovDateUtil {
 		} catch (ParseException exception) {
 			throw new RuntimeException(exception);
 		}
-		
+
 		return simpledateformat.format(date);
 
 	}
 
 	/**
 	 * yyyyMMdd 형식의 날짜문자열을 원하는 캐릭터(ch)로 쪼개 돌려준다<br/>
-	* <pre>
+	 * 
+	 * <pre>
 	* ex) 20030405, ch(.) -> 2003.04.05
 	* ex) 200304, ch(.) -> 2003.04
 	* ex) 20040101,ch(/) --> 2004/01/01 로 리턴
-	* </pre>
-	*
-	* @param date yyyyMMdd 형식의 날짜문자열
-	* @param ch 구분자
-	* @return 변환된 문자열
+	 * </pre>
+	 *
+	 * @param date yyyyMMdd 형식의 날짜문자열
+	 * @param ch   구분자
+	 * @return 변환된 문자열
 	 */
 	public static String formatDate(String sDate, String ch) {
 		String dateStr = validChkDate(sDate);
@@ -323,9 +341,9 @@ public class EgovDateUtil {
 			if (dd.equals("00")) {
 				return yyyy + ch + mm;
 			}
-			
+
 			return yyyy + ch + mm + ch + dd;
-		
+
 		} else if (str.length() == 6) {
 			yyyy = str.substring(0, 4);
 			if (yyyy.equals("0000")) {
@@ -338,7 +356,7 @@ public class EgovDateUtil {
 			}
 
 			return yyyy + ch + mm;
-			
+
 		} else if (str.length() == 4) {
 			yyyy = str.substring(0, 4);
 			if (yyyy.equals("0000")) {
@@ -353,12 +371,13 @@ public class EgovDateUtil {
 
 	/**
 	 * HH24MISS 형식의 시간문자열을 원하는 캐릭터(ch)로 쪼개 돌려준다 <br>
+	 * 
 	 * <pre>
 	 *     ex) 151241, ch(/) -> 15/12/31
 	 * </pre>
 	 *
 	 * @param str HH24MISS 형식의 시간문자열
-	 * @param ch 구분자
+	 * @param ch  구분자
 	 * @return 변환된 문자열
 	 */
 	public static String formatTime(String sTime, String ch) {
@@ -381,7 +400,9 @@ public class EgovDateUtil {
 	}
 
 	/**
-	 * <p>입력받은 연도가 윤년인지 아닌지 검사한다.</p>
+	 * <p>
+	 * 입력받은 연도가 윤년인지 아닌지 검사한다.
+	 * </p>
 	 *
 	 * <pre>
 	 * DateUtil.isLeapYear(2004) = false
@@ -389,8 +410,8 @@ public class EgovDateUtil {
 	 * DateUtil.isLeapYear(2006) = true
 	 * </pre>
 	 *
-	 * @param  year 연도
-	 * @return  윤년 여부
+	 * @param year 연도
+	 * @return 윤년 여부
 	 */
 	public static boolean isLeapYear(int year) {
 		if (year % 4 == 0 && year % 100 != 0 || year % 400 == 0) {
@@ -400,18 +421,20 @@ public class EgovDateUtil {
 	}
 
 	/**
-	 * 현재(한국기준) 날짜정보를 얻는다.                     <BR>
-	 * 표기법은 yyyy-mm-dd                                  <BR>
-	 * @return  String      yyyymmdd형태의 현재 한국시간.   <BR>
+	 * 현재(한국기준) 날짜정보를 얻는다. <BR>
+	 * 표기법은 yyyy-mm-dd <BR>
+	 * 
+	 * @return String yyyymmdd형태의 현재 한국시간. <BR>
 	 */
 	public static String getToday() {
 		return getCurrentDate("");
 	}
 
 	/**
-	 * 현재(한국기준) 날짜정보를 얻는다.                     <BR>
-	 * 표기법은 yyyy-mm-dd                                  <BR>
-	 * @return  String      yyyymmdd형태의 현재 한국시간.   <BR>
+	 * 현재(한국기준) 날짜정보를 얻는다. <BR>
+	 * 표기법은 yyyy-mm-dd <BR>
+	 * 
+	 * @return String yyyymmdd형태의 현재 한국시간. <BR>
 	 */
 	public static String getCurrentDate(String dateType) {
 		Calendar aCalendar = Calendar.getInstance();
@@ -419,7 +442,7 @@ public class EgovDateUtil {
 		int year = aCalendar.get(Calendar.YEAR);
 		int month = aCalendar.get(Calendar.MONTH) + 1;
 		int date = aCalendar.get(Calendar.DATE);
-		String strDate = Integer.toString(year) 
+		String strDate = Integer.toString(year)
 				+ ((month < 10) ? "0" + Integer.toString(month) : Integer.toString(month))
 				+ ((date < 10) ? "0" + Integer.toString(date) : Integer.toString(date));
 
@@ -432,41 +455,28 @@ public class EgovDateUtil {
 
 	/**
 	 * 날짜형태의 String의 날짜 포맷만을 변경해 주는 메서드
-	 * @param sDate 날짜
-	 * @param sTime 시간
+	 * 
+	 * @param sDate      날짜
+	 * @param sTime      시간
 	 * @param sFormatStr 포멧 스트링 문자열
 	 * @return 지정한 날짜/시간을 지정한 포맷으로 출력
-	 * @See Letter  Date or Time Component  Presentation  Examples
-	           G  Era designator  Text  AD
-	           y  Year  Year  1996; 96
-	           M  Month in year  Month  July; Jul; 07
-	           w  Week in year  Number  27
-	           W  Week in month  Number  2
-	           D  Day in year  Number  189
-	           d  Day in month  Number  10
-	           F  Day of week in month  Number  2
-	           E  Day in week  Text  Tuesday; Tue
-	           a  Am/pm marker  Text  PM
-	           H  Hour in day (0-23)  Number  0
-	           k  Hour in day (1-24)  Number  24
-	           K  Hour in am/pm (0-11)  Number  0
-	           h  Hour in am/pm (1-12)  Number  12
-	           m  Minute in hour  Number  30
-	           s  Second in minute  Number  55
-	           S  Millisecond  Number  978
-	           z  Time zone  General time zone  Pacific Standard Time; PST; GMT-08:00
-	           Z  Time zone  RFC 822 time zone  -0800
-
-	           Date and Time Pattern  Result
-	           "yyyy.MM.dd G 'at' HH:mm:ss z"  2001.07.04 AD at 12:08:56 PDT
-	           "EEE, MMM d, ''yy"  Wed, Jul 4, '01
-	           "h:mm a"  12:08 PM
-	           "hh 'o''clock' a, zzzz"  12 o'clock PM, Pacific Daylight Time
-	           "K:mm a, z"  0:08 PM, PDT
-	           "yyyyy.MMMMM.dd GGG hh:mm aaa"  02001.July.04 AD 12:08 PM
-	           "EEE, d MMM yyyy HH:mm:ss Z"  Wed, 4 Jul 2001 12:08:56 -0700
-	           "yyMMddHHmmssZ"  010704120856-0700
-
+	 * @See Letter Date or Time Component Presentation Examples G Era designator
+	 *      Text AD y Year Year 1996; 96 M Month in year Month July; Jul; 07 w Week
+	 *      in year Number 27 W Week in month Number 2 D Day in year Number 189 d
+	 *      Day in month Number 10 F Day of week in month Number 2 E Day in week
+	 *      Text Tuesday; Tue a Am/pm marker Text PM H Hour in day (0-23) Number 0 k
+	 *      Hour in day (1-24) Number 24 K Hour in am/pm (0-11) Number 0 h Hour in
+	 *      am/pm (1-12) Number 12 m Minute in hour Number 30 s Second in minute
+	 *      Number 55 S Millisecond Number 978 z Time zone General time zone Pacific
+	 *      Standard Time; PST; GMT-08:00 Z Time zone RFC 822 time zone -0800
+	 * 
+	 *      Date and Time Pattern Result "yyyy.MM.dd G 'at' HH:mm:ss z" 2001.07.04
+	 *      AD at 12:08:56 PDT "EEE, MMM d, ''yy" Wed, Jul 4, '01 "h:mm a" 12:08 PM
+	 *      "hh 'o''clock' a, zzzz" 12 o'clock PM, Pacific Daylight Time "K:mm a, z"
+	 *      0:08 PM, PDT "yyyyy.MMMMM.dd GGG hh:mm aaa" 02001.July.04 AD 12:08 PM
+	 *      "EEE, d MMM yyyy HH:mm:ss Z" Wed, 4 Jul 2001 12:08:56 -0700
+	 *      "yyMMddHHmmssZ" 010704120856-0700
+	 * 
 	 */
 	public static String convertDate(String sDate, String sTime, String sFormatStr) {
 		String dateStr = validChkDate(sDate);
@@ -488,6 +498,7 @@ public class EgovDateUtil {
 
 	/**
 	 * 입력받은 일자 사이의 임의의 일자를 반환
+	 * 
 	 * @param sDate1 시작일자
 	 * @param sDate2 종료일자
 	 * @return 임의일자
@@ -520,10 +531,11 @@ public class EgovDateUtil {
 
 		r.setSeed(new Date().getTime());
 
-		long rand = ((r.nextLong() >>> 1) % (endDate.getTimeInMillis() - beginDate.getTimeInMillis() + 1)) + beginDate.getTimeInMillis();
+		long rand = ((r.nextLong() >>> 1) % (endDate.getTimeInMillis() - beginDate.getTimeInMillis() + 1))
+				+ beginDate.getTimeInMillis();
 
 		GregorianCalendar cal = new GregorianCalendar();
-		//SimpleDateFormat calformat = new SimpleDateFormat("yyyy-MM-dd");
+		// SimpleDateFormat calformat = new SimpleDateFormat("yyyy-MM-dd");
 		SimpleDateFormat calformat = new SimpleDateFormat("yyyyMMdd", Locale.ENGLISH);
 		cal.setTimeInMillis(rand);
 		randomDate = calformat.format(cal.getTime());
@@ -534,6 +546,7 @@ public class EgovDateUtil {
 
 	/**
 	 * 입력받은 양력일자를 변환하여 음력일자로 반환
+	 * 
 	 * @param sDate 양력일자
 	 * @return 음력일자
 	 */
@@ -582,7 +595,8 @@ public class EgovDateUtil {
 
 	/**
 	 * 입력받은 음력일자를 변환하여 양력일자로 반환
-	 * @param sDate 음력일자
+	 * 
+	 * @param sDate      음력일자
 	 * @param iLeapMonth 음력윤달여부(IS_LEAP_MONTH)
 	 * @return 양력일자
 	 */
@@ -618,6 +632,7 @@ public class EgovDateUtil {
 
 	/**
 	 * 입력받은 요일의 영문명을 국문명의 요일로 반환
+	 * 
 	 * @param sWeek 영문 요일명
 	 * @return 국문 요일명
 	 */
@@ -645,6 +660,7 @@ public class EgovDateUtil {
 
 	/**
 	 * 입력일자의 유효 여부를 확인
+	 * 
 	 * @param sDate 일자
 	 * @return 유효 여부
 	 */
@@ -682,9 +698,10 @@ public class EgovDateUtil {
 
 	/**
 	 * 입력일자, 요일의 유효 여부를 확인
-	 * @param     sDate 일자
-	 * @param     sWeek 요일 (DAY_OF_WEEK)
-	 * @return    유효 여부
+	 * 
+	 * @param sDate 일자
+	 * @param sWeek 요일 (DAY_OF_WEEK)
+	 * @return 유효 여부
 	 */
 	public static boolean validDate(String sDate, int sWeek) {
 		String dateStr = validChkDate(sDate);
@@ -711,8 +728,9 @@ public class EgovDateUtil {
 
 	/**
 	 * 입력시간의 유효 여부를 확인
-	 * @param     sTime 입력시간
-	 * @return    유효 여부
+	 * 
+	 * @param sTime 입력시간
+	 * @return 유효 여부
 	 */
 	public static boolean validTime(String sTime) {
 		String timeStr = validChkTime(sTime);
@@ -744,10 +762,11 @@ public class EgovDateUtil {
 
 	/**
 	 * 입력된 일자에 연, 월, 일을 가감한 날짜의 요일을 반환
+	 * 
 	 * @param sDate 날짜
-	 * @param year 연
+	 * @param year  연
 	 * @param month 월
-	 * @param day 일
+	 * @param day   일
 	 * @return 계산된 일자의 요일(DAY_OF_WEEK)
 	 */
 	public static String addYMDtoWeek(String sDate, int year, int month, int day) {
@@ -770,17 +789,19 @@ public class EgovDateUtil {
 
 	/**
 	 * 입력된 일자에 연, 월, 일, 시간, 분을 가감한 날짜, 시간을 포멧스트링 형식으로 반환
-	 * @param sDate 날짜
-	 * @param sTime 시간
-	 * @param year 연
-	 * @param month 월
-	 * @param day 일
-	 * @param hour 시간
-	 * @param minute 분
+	 * 
+	 * @param sDate     날짜
+	 * @param sTime     시간
+	 * @param year      연
+	 * @param month     월
+	 * @param day       일
+	 * @param hour      시간
+	 * @param minute    분
 	 * @param formatStr 포멧스트링
 	 * @return
 	 */
-	public static String addYMDtoDayTime(String sDate, String sTime, int year, int month, int day, int hour, int minute, String formatStr) {
+	public static String addYMDtoDayTime(String sDate, String sTime, int year, int month, int day, int hour, int minute,
+			String formatStr) {
 		String dateStr = validChkDate(sDate);
 		String timeStr = validChkTime(sTime);
 
@@ -812,6 +833,7 @@ public class EgovDateUtil {
 
 	/**
 	 * 입력된 일자를 int 형으로 반환
+	 * 
 	 * @param sDate 일자
 	 * @return int(일자)
 	 */
@@ -821,6 +843,7 @@ public class EgovDateUtil {
 
 	/**
 	 * 입력된 시간을 int 형으로 반환
+	 * 
 	 * @param sTime 시간
 	 * @return int(시간)
 	 */
@@ -830,6 +853,7 @@ public class EgovDateUtil {
 
 	/**
 	 * 입력된 일자 문자열을 확인하고 8자리로 리턴
+	 * 
 	 * @param sDate
 	 * @return
 	 */
@@ -837,16 +861,17 @@ public class EgovDateUtil {
 		if (dateStr == null || !(dateStr.trim().length() == 8 || dateStr.trim().length() == 10)) {
 			throw new IllegalArgumentException("Invalid date format: " + dateStr);
 		}
-				
+
 		if (dateStr.length() == 10) {
 			return EgovStringUtil.removeMinusChar(dateStr);
 		}
-		
+
 		return dateStr;
 	}
 
 	/**
 	 * 입력된 일자 문자열을 확인하고 8자리로 리턴
+	 * 
 	 * @param sDate
 	 * @return
 	 */
@@ -854,7 +879,7 @@ public class EgovDateUtil {
 		if (timeStr == null || !(timeStr.trim().length() == 4)) {
 			throw new IllegalArgumentException("Invalid time format: " + timeStr);
 		}
-		
+
 		if (timeStr.length() == 5) {
 			timeStr = EgovStringUtil.remove(timeStr, ':');
 		}

--- a/src/main/java/egovframework/com/utl/fcc/service/EgovDateUtil.java
+++ b/src/main/java/egovframework/com/utl/fcc/service/EgovDateUtil.java
@@ -202,8 +202,8 @@ public class EgovDateUtil {
 		}
 
 		if (date1 != null && date2 != null) {
-			int days1 = (int) ((date1.getTime() / 3600000) / 24);
-			int days2 = (int) ((date2.getTime() / 3600000) / 24);
+			int days1 = (int) (date1.getTime() / 3600000) / 24;
+			int days2 = (int) (date2.getTime() / 3600000) / 24;
 			return days2 - days1;
 		} else {
 			return 0;
@@ -585,9 +585,9 @@ public class EgovDateUtil {
 		String retMonth = (pad2Str + month).substring(month.length());
 		String retDay = (pad2Str + day).substring(day.length());
 
-		String SDay = retYear + retMonth + retDay;
+		String sDay = retYear + retMonth + retDay;
 
-		hm.put("day", SDay);
+		hm.put("day", sDay);
 		hm.put("leap", leap);
 
 		return hm;
@@ -715,10 +715,10 @@ public class EgovDateUtil {
 		cal.set(Calendar.MONTH, Integer.parseInt(dateStr.substring(4, 6)) - 1);
 		cal.set(Calendar.DAY_OF_MONTH, Integer.parseInt(dateStr.substring(6, 8)));
 
-		int Week = cal.get(Calendar.DAY_OF_WEEK);
+		int week = cal.get(Calendar.DAY_OF_WEEK);
 
 		if (validDate(sDate)) {
-			if (sWeek == Week) {
+			if (sWeek == week) {
 				ret = true;
 			}
 		}
@@ -743,13 +743,13 @@ public class EgovDateUtil {
 		cal.set(Calendar.HOUR_OF_DAY, Integer.parseInt(timeStr.substring(0, 2)));
 		cal.set(Calendar.MINUTE, Integer.parseInt(timeStr.substring(2, 4)));
 
-		String HH = String.valueOf(cal.get(Calendar.HOUR_OF_DAY));
-		String MM = String.valueOf(cal.get(Calendar.MINUTE));
+		String hh = String.valueOf(cal.get(Calendar.HOUR_OF_DAY));
+		String mm = String.valueOf(cal.get(Calendar.MINUTE));
 
 		String pad2Str = "00";
 
-		String retHH = (pad2Str + HH).substring(HH.length());
-		String retMM = (pad2Str + MM).substring(MM.length());
+		String retHH = (pad2Str + hh).substring(hh.length());
+		String retMM = (pad2Str + mm).substring(mm.length());
 
 		String retTime = retHH + retMM;
 
@@ -881,7 +881,7 @@ public class EgovDateUtil {
 		}
 
 		if (timeStr.length() == 5) {
-			timeStr = EgovStringUtil.remove(timeStr, ':');
+			return EgovStringUtil.remove(timeStr, ':');
 		}
 
 		return timeStr;


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

<hr>

### 2025-08-30 토 PMD로 소프트웨어 보안약점 진단하고 제거하기-EgovDateUtil

불필요한 괄호제거
```java
//			int days1 = (int) ((date1.getTime() / 3600000) / 24);
//			int days2 = (int) ((date2.getTime() / 3600000) / 24);
			int days1 = (int) (date1.getTime() / 3600000) / 24;
			int days2 = (int) (date2.getTime() / 3600000) / 24;
```

`SDay` 를 `sDay` 로 이름 바꾸기

`Week` 를 `week` 로 이름 바꾸기

`HH` 를 `hh` 로 이름 바꾸기

`MM` 를 `mm` 로 이름 바꾸기

파라미터 값을 직접 변경하지 말게 수정
```java
		if (timeStr.length() == 5) {
//			timeStr = EgovStringUtil.remove(timeStr, ':');
			return EgovStringUtil.remove(timeStr, ':');
		}

		return timeStr;
```

<hr>

1. PMD로 소프트웨어 보안약점 진단 결과

```
src/main/java/egovframework/com/utl/fcc/service/EgovDateUtil.java:195:	UselessParentheses:	UselessParentheses: 괄호가 없어도 되는 상황에서 불필요한 괄호를 사용할 경우 마치 메소드 호출처럼 보여서 소스 코드의 가독성을 떨어뜨릴 수 있음
src/main/java/egovframework/com/utl/fcc/service/EgovDateUtil.java:196:	UselessParentheses:	UselessParentheses: 괄호가 없어도 되는 상황에서 불필요한 괄호를 사용할 경우 마치 메소드 호출처럼 보여서 소스 코드의 가독성을 떨어뜨릴 수 있음
src/main/java/egovframework/com/utl/fcc/service/EgovDateUtil.java:575:	LocalVariableNamingConventions:	LocalVariableNamingConventions: 'local variable' 의 변수 'SDay' 이  '[a-z][a-zA-Z0-9]*'  로 시작함
src/main/java/egovframework/com/utl/fcc/service/EgovDateUtil.java:701:	LocalVariableNamingConventions:	LocalVariableNamingConventions: 'local variable' 의 변수 'Week' 이  '[a-z][a-zA-Z0-9]*'  로 시작함
src/main/java/egovframework/com/utl/fcc/service/EgovDateUtil.java:728:	LocalVariableNamingConventions:	LocalVariableNamingConventions: 'local variable' 의 변수 'HH' 이  '[a-z][a-zA-Z0-9]*'  로 시작함
src/main/java/egovframework/com/utl/fcc/service/EgovDateUtil.java:729:	LocalVariableNamingConventions:	LocalVariableNamingConventions: 'local variable' 의 변수 'MM' 이  '[a-z][a-zA-Z0-9]*'  로 시작함
src/main/java/egovframework/com/utl/fcc/service/EgovDateUtil.java:859:	AvoidReassigningParameters:	AvoidReassigningParameters: 'timeStr' 처럼 파라미터 값을 직접 변경하지 말 것
```

2. 브랜치 생성

```
feature/pmd/EgovDateUtil
```

3. 이클립스 > Source > Format

4. 개정이력 수정

```java
 *   2025.08.30  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-UselessParentheses(불필요한 괄호사용)
 *   2025.08.30  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-LocalVariableNamingConventions(final이 아닌 변수는 밑줄을 포함할 수 없음)
 *   2025.08.30  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-AvoidReassigningParameters(넘겨받는 메소드 parameter 값을 직접 변경하는 코드 탐지)
```

<hr>

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

https://youtu.be/1iruXz8jy3A
