### PR TITLE
PMD로 소프트웨어 보안약점 진단하고 제거하기-EgovEhgtCalcUtil

### DIFF
--- a/src/main/java/egovframework/com/utl/fcc/service/EgovEhgtCalcUtil.java
+++ b/src/main/java/egovframework/com/utl/fcc/service/EgovEhgtCalcUtil.java
@@ -31,7 +31,6 @@ import javax.swing.text.html.HTMLEditorKit;
 import javax.swing.text.html.parser.ParserDelegator;
 
 import egovframework.com.cmm.service.EgovProperties;
-import egovframework.com.cmm.util.EgovResourceCloseHelper;
 import twitter4j.JSONArray;
 import twitter4j.JSONObject;
 
@@ -79,20 +78,19 @@ public class EgovEhgtCalcUtil {
 	 */
 	public void readHtmlParsing(String str) {
 		HttpURLConnection con = null;
-		InputStream is = null;
-		InputStreamReader reader = null;
 		try {
 			// 입력받은 URL에 연결하여 InputStream을 통해 읽은 후 파싱 한다.
 			URL url = new URL(EHGT_URL + str);
 
 			con = (HttpURLConnection) url.openConnection();
 
-			is = con.getInputStream();
-			reader = new InputStreamReader(is, "euc-kr");
-			// InputStreamReader reader = new InputStreamReader(con.getInputStream(),
-			// "utf-8");
+			try (InputStream is = con.getInputStream();
+					InputStreamReader reader = new InputStreamReader(is, "euc-kr");) {
+				// InputStreamReader reader = new InputStreamReader(con.getInputStream(),
+				// "utf-8");
 
-			new ParserDelegator().parse(reader, new CallbackHandler(), true);
+				new ParserDelegator().parse(reader, new CallbackHandler(), true);
+			}
 
 			con.disconnect();
 
@@ -101,8 +99,6 @@ public class EgovEhgtCalcUtil {
 		} catch (IOException e) {
 			throw new RuntimeException(e);
 		} finally {
-			EgovResourceCloseHelper.close(reader, is);
-
 			if (con != null) {
 				con.disconnect();
 			}
@@ -262,7 +258,7 @@ public class EgovEhgtCalcUtil {
 				sCnvrAmount = bSrcAmount.toString();
 			} else if (cnvrChr == 'J') {
 				// 변환금액 = (변환대상금액 / 변환매매비율) * 100;
-				sCnvrAmount = (bSrcAmount.divide(bCnvrStdrRt, 4, 4)).multiply(bStdr).setScale(2, 4).toString();
+				sCnvrAmount = bSrcAmount.divide(bCnvrStdrRt, 4, 4).multiply(bStdr).setScale(2, 4).toString();
 			} else {
 				// 변환금액 = (변환대상금액 / 변환매매비율);
 				sCnvrAmount = bSrcAmount.divide(bCnvrStdrRt, 2, 4).toString();
@@ -278,11 +274,11 @@ public class EgovEhgtCalcUtil {
 				sCnvrAmount = bSrcAmount.multiply(bSrcStdrRt).setScale(2, 4).toString();
 			} else if (cnvrChr == 'J') {
 				// cnvrAmount = ((변환대상금액 * 원래 매매 비율) / 변환 매매 비율) * 100;
-				sCnvrAmount = ((bSrcAmount.multiply(bSrcStdrRt).setScale(4, 4)).divide(bCnvrStdrRt, 2, 4))
-						.multiply(bStdr).setScale(2, 4).toString();
+				sCnvrAmount = bSrcAmount.multiply(bSrcStdrRt).setScale(4, 4).divide(bCnvrStdrRt, 2, 4).multiply(bStdr)
+						.setScale(2, 4).toString();
 			} else {
 				// cnvrAmount = (변환대상금액 * 원래 매매 비율) / 변환 매매 비율;
-				sCnvrAmount = (bSrcAmount.multiply(bSrcStdrRt).setScale(4, 4)).divide(bCnvrStdrRt, 2, 4).toString();
+				sCnvrAmount = bSrcAmount.multiply(bSrcStdrRt).setScale(4, 4).divide(bCnvrStdrRt, 2, 4).toString();
 			}
 			break;
 
@@ -295,11 +291,11 @@ public class EgovEhgtCalcUtil {
 				sCnvrAmount = bSrcAmount.multiply(bSrcStdrRt).setScale(2, 4).toString();
 			} else if (cnvrChr == 'J') {
 				// cnvrAmount = ((변환대상금액 * 원래 매매 비율) / 변환 매매 비율) * 100;
-				sCnvrAmount = ((bSrcAmount.multiply(bSrcStdrRt).setScale(4, 4)).divide(bCnvrStdrRt, 2, 4))
-						.multiply(bStdr).setScale(2, 4).toString();
+				sCnvrAmount = bSrcAmount.multiply(bSrcStdrRt).setScale(4, 4).divide(bCnvrStdrRt, 2, 4).multiply(bStdr)
+						.setScale(2, 4).toString();
 			} else {
 				// cnvrAmount = (변환대상금액 * 원래 매매 비율) / 변환 매매 비율;
-				sCnvrAmount = (bSrcAmount.multiply(bSrcStdrRt).setScale(4, 4)).divide(bCnvrStdrRt, 2, 4).toString();
+				sCnvrAmount = bSrcAmount.multiply(bSrcStdrRt).setScale(4, 4).divide(bCnvrStdrRt, 2, 4).toString();
 			}
 			break;
 
@@ -309,10 +305,10 @@ public class EgovEhgtCalcUtil {
 				sCnvrAmount = bSrcAmount.toString();
 			} else if (cnvrChr == 'K') {
 				// cnvrAmount = (변환대상금액 * 원래 매매 비율) / 100;
-				sCnvrAmount = (bSrcAmount.multiply(bSrcStdrRt).setScale(4, 4)).divide(bStdr, 2, 4).toString();
+				sCnvrAmount = bSrcAmount.multiply(bSrcStdrRt).setScale(4, 4).divide(bStdr, 2, 4).toString();
 			} else {
 				// cnvrAmount = ((변환대상금액 * 원래 매매 비율) / 100) / 변환 매매 비율;
-				sCnvrAmount = ((bSrcAmount.multiply(bSrcStdrRt).setScale(4, 4)).divide(bStdr, 2, 4))
+				sCnvrAmount = bSrcAmount.multiply(bSrcStdrRt).setScale(4, 4).divide(bStdr, 2, 4)
 						.divide(bCnvrStdrRt, 2, 4).toString();
 			}
 			break;
@@ -326,11 +322,11 @@ public class EgovEhgtCalcUtil {
 				sCnvrAmount = bSrcAmount.multiply(bSrcStdrRt).setScale(2, 4).toString();
 			} else if (cnvrChr == 'J') {
 				// cnvrAmount = ((변환대상금액 * 원래 매매 비율) / 변환 매매 비율) * 100;
-				sCnvrAmount = ((bSrcAmount.multiply(bSrcStdrRt).setScale(4, 4)).divide(bCnvrStdrRt, 2, 4))
-						.multiply(bStdr).setScale(2, 4).toString();
+				sCnvrAmount = bSrcAmount.multiply(bSrcStdrRt).setScale(4, 4).divide(bCnvrStdrRt, 2, 4).multiply(bStdr)
+						.setScale(2, 4).toString();
 			} else {
 				// cnvrAmount = (변환대상금액 * 원래 매매 비율) / 변환 매매 비율;
-				sCnvrAmount = (bSrcAmount.multiply(bSrcStdrRt).setScale(4, 4)).divide(bCnvrStdrRt, 2, 4).toString();
+				sCnvrAmount = bSrcAmount.multiply(bSrcStdrRt).setScale(4, 4).divide(bCnvrStdrRt, 2, 4).toString();
 			}
 			break;
 

--- a/src/main/java/egovframework/com/utl/fcc/service/EgovEhgtCalcUtil.java
+++ b/src/main/java/egovframework/com/utl/fcc/service/EgovEhgtCalcUtil.java
@@ -1,20 +1,3 @@
-/**
- * @Class Name : EgovEhgtCalcUtil.java
- * @Description : 대한민국, 미국,유럽연합, 일본, 중국연합 사이의 환율계산기능을
- * 제공하는  Business Interface class
- * @Modification Information
- * @
- * @  수정일         수정자                   수정내용
- * @ -------    --------    ---------------------------
- * @ 2009.01.13    박정규          최초 생성
- *
- *  @author 공통 서비스 개발팀 박정규
- *  @since 2009. 01. 13
- *  @version 1.0
- *  @see
- *
- */
-
 package egovframework.com.utl.fcc.service;
 
 import java.io.IOException;
@@ -35,17 +18,27 @@ import twitter4j.JSONArray;
 import twitter4j.JSONObject;
 
 /**
+ * 대한민국, 미국,유럽연합, 일본, 중국연합 사이의 환율계산기능을 제공하는 Business Interface class
+ * <p>
+ * 요소기술 - 환율계산
  * 
- * @Class name : EgovEhgtCalcUtl.java
- * @Description : 요소기술 - 환율계산
- * 
- *              <pre>
- * 수정일			수정자		수정내용
- * ----------	----------	------------------------------
- * 2023.08.25	김혜준		외환은행 제공 환율 api에서 한국수출입은행 제공 환율 api로 변경
- *              </pre>
+ * @author 공통 서비스 개발팀 박정규
+ * @since 2009.01.13
+ * @version 1.0
+ * @see
+ *
+ *      <pre>
+ *  == 개정이력(Modification Information) ==
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2009.01.13  박정규          최초 생성
+ *   2023.08.25  김혜준          외환은행 제공 환율 api에서 한국수출입은행 제공 환율 api로 변경
+ *   2025.08.30  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-CloseResource(부적절한 자원 해제)
+ *   2025.08.30  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-UselessParentheses(불필요한 괄호사용)
+ *
+ *      </pre>
  */
-
 public class EgovEhgtCalcUtil {
 
 	static private final String EHGT_URL = "https://www.koreaexim.go.kr/site/program/financial/exchangeJSON";

--- a/src/main/java/egovframework/com/utl/fcc/service/EgovEhgtCalcUtil.java
+++ b/src/main/java/egovframework/com/utl/fcc/service/EgovEhgtCalcUtil.java
@@ -37,13 +37,14 @@ import twitter4j.JSONObject;
 
 /**
  * 
- * @Class name	: EgovEhgtCalcUtl.java
- * @Description	: 요소기술 - 환율계산
+ * @Class name : EgovEhgtCalcUtl.java
+ * @Description : 요소기술 - 환율계산
  * 
+ *              <pre>
  * 수정일			수정자		수정내용
  * ----------	----------	------------------------------
  * 2023.08.25	김혜준		외환은행 제공 환율 api에서 한국수출입은행 제공 환율 api로 변경
- *
+ *              </pre>
  */
 
 public class EgovEhgtCalcUtil {
@@ -111,6 +112,7 @@ public class EgovEhgtCalcUtil {
 	// 파서는 콜백 형식으로 되어 있다. 각 태그가 들어 올때 적절한 메소드가 호출됨
 	private class CallbackHandler extends HTMLEditorKit.ParserCallback {
 
+		@Override
 		public void handleText(char[] data, int pos) {
 
 			String srcStr = new String(data);
@@ -124,15 +126,15 @@ public class EgovEhgtCalcUtil {
 	/**
 	 * 주어진 소스 화폐 유형 및 금액에 따라 대상 화폐 유형으로의 환율을 계산하는 메서드.
 	 *
-	 * @param srcType    원래 화폐 유형
-	 * @param srcAmount  변환하려는 금액
-	 * @param cnvrType   대상 화폐 유형
+	 * @param srcType   원래 화폐 유형
+	 * @param srcAmount 변환하려는 금액
+	 * @param cnvrType  대상 화폐 유형
 	 * @return 변환된 금액과 대상 화폐 유형을 포함하는 문자열
 	 * @throws Exception 예외 발생 시
 	 */
 	public static String getEhgtCalc(String srcType, long srcAmount, String cnvrType) throws Exception {
 
-		sb.setLength(0);	// 일자 변경 후 재호출 시 오류 방지를 위한 초기화
+		sb.setLength(0); // 일자 변경 후 재호출 시 오류 방지를 위한 초기화
 		String rtnStr = null;
 
 		JSONArray eghtStdrRt = null; // Html에서 파싱한 환율매매기준율을 저장하기 위한 문자열배열
@@ -140,7 +142,7 @@ public class EgovEhgtCalcUtil {
 		double srcStdrRt = 0.00; // 원래 매매기준율
 		double cnvrStdrRt = 0.00; // 변환 매매기준율
 
-		//double  cnvrAmount = 0.00;				// 변환금액
+		// double cnvrAmount = 0.00; // 변환금액
 		String sCnvrAmount = null; // 변환금액
 
 		String srcStr = null;
@@ -154,16 +156,16 @@ public class EgovEhgtCalcUtil {
 		LocalDate currentDate = LocalDate.now();
 		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd");
 		String searchDate = "";
-		
-		for(int i = 0 ; i < 10 ; i++) {					// 비영업일/비영업시간 조회 시 전날 데이터 조회하도록 일자 변경 후 요청 반복
+
+		for (int i = 0; i < 10; i++) { // 비영업일/비영업시간 조회 시 전날 데이터 조회하도록 일자 변경 후 요청 반복
 			searchDate = currentDate.format(formatter);
-			parser.readHtmlParsing("?authkey="+AUTH_KEY+"&data=AP01&searchdate="+searchDate);
+			parser.readHtmlParsing("?authkey=" + AUTH_KEY + "&data=AP01&searchdate=" + searchDate);
 			eghtStdrRt = new JSONArray(sb.toString());
-			
-			if(eghtStdrRt.length() != 0) {
+
+			if (eghtStdrRt.length() != 0) {
 				break;
 			}
-			
+
 			sb.setLength(0);
 			currentDate = currentDate.minusDays(1);
 		}
@@ -171,9 +173,10 @@ public class EgovEhgtCalcUtil {
 		if (sb == null) {
 			throw new RuntimeException("StringBuffer is null!!");
 		}
-		
-		if (eghtStdrRt == null || (eghtStdrRt.length() == 0))
+
+		if (eghtStdrRt == null || (eghtStdrRt.length() == 0)) {
 			throw new RuntimeException("String Split Error!");
+		}
 
 		char srcChr = srcTypeCnvr.charAt(0);
 		char cnvrChr = cnvrTypeCnvr.charAt(0);
@@ -181,68 +184,68 @@ public class EgovEhgtCalcUtil {
 		// 원래 환율기준 정의
 		switch (srcChr) {
 
-			case EGHT_USD: // 미국
-				srcStr = "USD";
-				break;
+		case EGHT_USD: // 미국
+			srcStr = "USD";
+			break;
 
-			case EGHT_JPY: // 일본
-				srcStr = "JPY(100)";
-				break;
+		case EGHT_JPY: // 일본
+			srcStr = "JPY(100)";
+			break;
 
-			case EGHT_EUR: // 유럽연합
-				srcStr = "EUR";
-				break;
+		case EGHT_EUR: // 유럽연합
+			srcStr = "EUR";
+			break;
 
-			case EGHT_CNY: // 중국연합
-				srcStr = "CNH";
-				break;
+		case EGHT_CNY: // 중국연합
+			srcStr = "CNH";
+			break;
 
-			default:
-				srcStr = "USD";
-				break;
+		default:
+			srcStr = "USD";
+			break;
 		}
 
 		// 변환하고자 하는 환율기준 정의
 		switch (cnvrChr) {
 
-			case EGHT_USD: // 미국
-				cnvrStr = "USD";
-				break;
+		case EGHT_USD: // 미국
+			cnvrStr = "USD";
+			break;
 
-			case EGHT_JPY: // 일본
-				cnvrStr = "JPY(100)";
-				break;
+		case EGHT_JPY: // 일본
+			cnvrStr = "JPY(100)";
+			break;
 
-			case EGHT_EUR: // 유럽연합
-				cnvrStr = "EUR";
-				break;
+		case EGHT_EUR: // 유럽연합
+			cnvrStr = "EUR";
+			break;
 
-			case EGHT_CNY: // 중국연합
-				cnvrStr = "CNH";
-				break;
+		case EGHT_CNY: // 중국연합
+			cnvrStr = "CNH";
+			break;
 
-			default:
-				cnvrStr = "KRW";
-				break;
+		default:
+			cnvrStr = "KRW";
+			break;
 		}
 
 		// 변환하고자 하는 국가의 환율매매기준율 추출...
-		// 원래  매매기준율 추출
+		// 원래 매매기준율 추출
 		for (int i = 0; i < eghtStdrRt.length(); i++) {
-            JSONObject jsonObject = eghtStdrRt.getJSONObject(i);
-            if (srcStr.equals(jsonObject.getString("cur_unit"))) {
-                srcStdrRt = Double.parseDouble(jsonObject.getString("deal_bas_r").replace(",", ""));
-                break;
-            }
-        }
+			JSONObject jsonObject = eghtStdrRt.getJSONObject(i);
+			if (srcStr.equals(jsonObject.getString("cur_unit"))) {
+				srcStdrRt = Double.parseDouble(jsonObject.getString("deal_bas_r").replace(",", ""));
+				break;
+			}
+		}
 		// 변환 매매기준율 추출
 		for (int i = 0; i < eghtStdrRt.length(); i++) {
-            JSONObject jsonObject = eghtStdrRt.getJSONObject(i);
-            if (cnvrStr.equals(jsonObject.getString("cur_unit"))) {
-                cnvrStdrRt = Double.parseDouble(jsonObject.getString("deal_bas_r").replace(",", ""));
-                break;
-            }
-        }
+			JSONObject jsonObject = eghtStdrRt.getJSONObject(i);
+			if (cnvrStr.equals(jsonObject.getString("cur_unit"))) {
+				cnvrStdrRt = Double.parseDouble(jsonObject.getString("deal_bas_r").replace(",", ""));
+				break;
+			}
+		}
 
 		// 정확한 계산을 위한 BigDecimal 형태로 구현.
 		BigDecimal bSrcAmount = new BigDecimal(String.valueOf(srcAmount)); // 변환하고자 하는 금액
@@ -253,79 +256,88 @@ public class EgovEhgtCalcUtil {
 		// 원래 매매기준율 및 변환매매기준율 기준으로 환율금액 계산
 		switch (srcChr) {
 
-			case EGHT_KWR: // 대한민국
-				if (cnvrChr == 'K')
-					//변환금액 = 변환대상금액;
-					sCnvrAmount = bSrcAmount.toString();
-				else if (cnvrChr == 'J')
-					//변환금액 = (변환대상금액 / 변환매매비율) * 100;
-					sCnvrAmount = (bSrcAmount.divide(bCnvrStdrRt, 4, 4)).multiply(bStdr).setScale(2, 4).toString();
-				else
-					//변환금액 = (변환대상금액 / 변환매매비율);
-					sCnvrAmount = bSrcAmount.divide(bCnvrStdrRt, 2, 4).toString();
-				break;
-
-			case EGHT_USD: // 미국
-				if (cnvrChr == 'U')
-					//변환금액 = 변환대상금액;
-					sCnvrAmount = bSrcAmount.toString();
-				else if (cnvrChr == 'K')
-					//변환금액 = 변환대상금액 * 원래 매매 비율;
-					sCnvrAmount = bSrcAmount.multiply(bSrcStdrRt).setScale(2, 4).toString();
-				else if (cnvrChr == 'J')
-					//cnvrAmount = ((변환대상금액 * 원래 매매 비율) / 변환 매매 비율) * 100;
-					sCnvrAmount = ((bSrcAmount.multiply(bSrcStdrRt).setScale(4, 4)).divide(bCnvrStdrRt, 2, 4)).multiply(bStdr).setScale(2, 4).toString();
-				else
-					//cnvrAmount = (변환대상금액 * 원래 매매 비율) / 변환 매매 비율;
-					sCnvrAmount = (bSrcAmount.multiply(bSrcStdrRt).setScale(4, 4)).divide(bCnvrStdrRt, 2, 4).toString();
-				break;
-
-			case EGHT_EUR: // 유럽연합
-				if (cnvrChr == 'E')
-					//변환금액 = 변환대상금액;
-					sCnvrAmount = bSrcAmount.toString();
-				else if (cnvrChr == 'K')
-					//cnvrAmount = 변환대상금액 * 원래 매매 비율;
-					sCnvrAmount = bSrcAmount.multiply(bSrcStdrRt).setScale(2, 4).toString();
-				else if (cnvrChr == 'J')
-					//cnvrAmount = ((변환대상금액 * 원래 매매 비율) / 변환 매매 비율) * 100;
-					sCnvrAmount = ((bSrcAmount.multiply(bSrcStdrRt).setScale(4, 4)).divide(bCnvrStdrRt, 2, 4)).multiply(bStdr).setScale(2, 4).toString();
-				else
-					//cnvrAmount = (변환대상금액 * 원래 매매 비율) / 변환 매매 비율;
-					sCnvrAmount = (bSrcAmount.multiply(bSrcStdrRt).setScale(4, 4)).divide(bCnvrStdrRt, 2, 4).toString();
-				break;
-
-			case EGHT_JPY: // 일본
-				if (cnvrChr == 'J')
-					//변환금액 = 변환대상금액;
-					sCnvrAmount = bSrcAmount.toString();
-				else if (cnvrChr == 'K')
-					//cnvrAmount = (변환대상금액 * 원래 매매 비율) / 100;
-					sCnvrAmount = (bSrcAmount.multiply(bSrcStdrRt).setScale(4, 4)).divide(bStdr, 2, 4).toString();
-				else
-					//cnvrAmount = ((변환대상금액 * 원래 매매 비율) / 100) / 변환 매매 비율;
-					sCnvrAmount = ((bSrcAmount.multiply(bSrcStdrRt).setScale(4, 4)).divide(bStdr, 2, 4)).divide(bCnvrStdrRt, 2, 4).toString();
-				break;
-
-			case EGHT_CNY: // 중국연합
-				if (cnvrChr == 'C')
-					//변환금액 = 변환대상금액;
-					sCnvrAmount = bSrcAmount.toString();
-				else if (cnvrChr == 'K')
-					//cnvrAmount = 변환대상금액 * 원래 매매 비율;
-					sCnvrAmount = bSrcAmount.multiply(bSrcStdrRt).setScale(2, 4).toString();
-				else if (cnvrChr == 'J')
-					//cnvrAmount = ((변환대상금액 * 원래 매매 비율) / 변환 매매 비율) * 100;
-					sCnvrAmount = ((bSrcAmount.multiply(bSrcStdrRt).setScale(4, 4)).divide(bCnvrStdrRt, 2, 4)).multiply(bStdr).setScale(2, 4).toString();
-				else
-					//cnvrAmount = (변환대상금액 * 원래 매매 비율) / 변환 매매 비율;
-					sCnvrAmount = (bSrcAmount.multiply(bSrcStdrRt).setScale(4, 4)).divide(bCnvrStdrRt, 2, 4).toString();
-				break;
-
-			default:
-				//변환금액 = (변환대상금액 / 변환매매비율);
+		case EGHT_KWR: // 대한민국
+			if (cnvrChr == 'K') {
+				// 변환금액 = 변환대상금액;
+				sCnvrAmount = bSrcAmount.toString();
+			} else if (cnvrChr == 'J') {
+				// 변환금액 = (변환대상금액 / 변환매매비율) * 100;
+				sCnvrAmount = (bSrcAmount.divide(bCnvrStdrRt, 4, 4)).multiply(bStdr).setScale(2, 4).toString();
+			} else {
+				// 변환금액 = (변환대상금액 / 변환매매비율);
 				sCnvrAmount = bSrcAmount.divide(bCnvrStdrRt, 2, 4).toString();
-				break;
+			}
+			break;
+
+		case EGHT_USD: // 미국
+			if (cnvrChr == 'U') {
+				// 변환금액 = 변환대상금액;
+				sCnvrAmount = bSrcAmount.toString();
+			} else if (cnvrChr == 'K') {
+				// 변환금액 = 변환대상금액 * 원래 매매 비율;
+				sCnvrAmount = bSrcAmount.multiply(bSrcStdrRt).setScale(2, 4).toString();
+			} else if (cnvrChr == 'J') {
+				// cnvrAmount = ((변환대상금액 * 원래 매매 비율) / 변환 매매 비율) * 100;
+				sCnvrAmount = ((bSrcAmount.multiply(bSrcStdrRt).setScale(4, 4)).divide(bCnvrStdrRt, 2, 4))
+						.multiply(bStdr).setScale(2, 4).toString();
+			} else {
+				// cnvrAmount = (변환대상금액 * 원래 매매 비율) / 변환 매매 비율;
+				sCnvrAmount = (bSrcAmount.multiply(bSrcStdrRt).setScale(4, 4)).divide(bCnvrStdrRt, 2, 4).toString();
+			}
+			break;
+
+		case EGHT_EUR: // 유럽연합
+			if (cnvrChr == 'E') {
+				// 변환금액 = 변환대상금액;
+				sCnvrAmount = bSrcAmount.toString();
+			} else if (cnvrChr == 'K') {
+				// cnvrAmount = 변환대상금액 * 원래 매매 비율;
+				sCnvrAmount = bSrcAmount.multiply(bSrcStdrRt).setScale(2, 4).toString();
+			} else if (cnvrChr == 'J') {
+				// cnvrAmount = ((변환대상금액 * 원래 매매 비율) / 변환 매매 비율) * 100;
+				sCnvrAmount = ((bSrcAmount.multiply(bSrcStdrRt).setScale(4, 4)).divide(bCnvrStdrRt, 2, 4))
+						.multiply(bStdr).setScale(2, 4).toString();
+			} else {
+				// cnvrAmount = (변환대상금액 * 원래 매매 비율) / 변환 매매 비율;
+				sCnvrAmount = (bSrcAmount.multiply(bSrcStdrRt).setScale(4, 4)).divide(bCnvrStdrRt, 2, 4).toString();
+			}
+			break;
+
+		case EGHT_JPY: // 일본
+			if (cnvrChr == 'J') {
+				// 변환금액 = 변환대상금액;
+				sCnvrAmount = bSrcAmount.toString();
+			} else if (cnvrChr == 'K') {
+				// cnvrAmount = (변환대상금액 * 원래 매매 비율) / 100;
+				sCnvrAmount = (bSrcAmount.multiply(bSrcStdrRt).setScale(4, 4)).divide(bStdr, 2, 4).toString();
+			} else {
+				// cnvrAmount = ((변환대상금액 * 원래 매매 비율) / 100) / 변환 매매 비율;
+				sCnvrAmount = ((bSrcAmount.multiply(bSrcStdrRt).setScale(4, 4)).divide(bStdr, 2, 4))
+						.divide(bCnvrStdrRt, 2, 4).toString();
+			}
+			break;
+
+		case EGHT_CNY: // 중국연합
+			if (cnvrChr == 'C') {
+				// 변환금액 = 변환대상금액;
+				sCnvrAmount = bSrcAmount.toString();
+			} else if (cnvrChr == 'K') {
+				// cnvrAmount = 변환대상금액 * 원래 매매 비율;
+				sCnvrAmount = bSrcAmount.multiply(bSrcStdrRt).setScale(2, 4).toString();
+			} else if (cnvrChr == 'J') {
+				// cnvrAmount = ((변환대상금액 * 원래 매매 비율) / 변환 매매 비율) * 100;
+				sCnvrAmount = ((bSrcAmount.multiply(bSrcStdrRt).setScale(4, 4)).divide(bCnvrStdrRt, 2, 4))
+						.multiply(bStdr).setScale(2, 4).toString();
+			} else {
+				// cnvrAmount = (변환대상금액 * 원래 매매 비율) / 변환 매매 비율;
+				sCnvrAmount = (bSrcAmount.multiply(bSrcStdrRt).setScale(4, 4)).divide(bCnvrStdrRt, 2, 4).toString();
+			}
+			break;
+
+		default:
+			// 변환금액 = (변환대상금액 / 변환매매비율);
+			sCnvrAmount = bSrcAmount.divide(bCnvrStdrRt, 2, 4).toString();
+			break;
 		}
 
 		rtnStr = sCnvrAmount + "  " + cnvrStr;


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

<hr>

### 2025-08-30 토 PMD로 소프트웨어 보안약점 진단하고 제거하기-EgovEhgtCalcUtil

try-with-resources 로 수정
```java
	public void readHtmlParsing(String str) {
		HttpURLConnection con = null;
//		InputStream is = null;
//		InputStreamReader reader = null;
		try {
			// 입력받은 URL에 연결하여 InputStream을 통해 읽은 후 파싱 한다.
			URL url = new URL(EHGT_URL + str);

			con = (HttpURLConnection) url.openConnection();

			try (InputStream is = con.getInputStream();
					InputStreamReader reader = new InputStreamReader(is, "euc-kr");) {
			// InputStreamReader reader = new InputStreamReader(con.getInputStream(),
			// "utf-8");

			new ParserDelegator().parse(reader, new CallbackHandler(), true);
			}

			con.disconnect();

		} catch (MalformedURLException e) {
			throw new RuntimeException(e);
		} catch (IOException e) {
			throw new RuntimeException(e);
		} finally {
//			EgovResourceCloseHelper.close(reader, is);

			if (con != null) {
				con.disconnect();
			}
		}
	}
```

불필요한 괄호제거
```java
//sCnvrAmount = (bSrcAmount.divide(bCnvrStdrRt, 4, 4)).multiply(bStdr).setScale(2, 4).toString();
sCnvrAmount = bSrcAmount.divide(bCnvrStdrRt, 4, 4).multiply(bStdr).setScale(2, 4).toString();

//sCnvrAmount = ((bSrcAmount.multiply(bSrcStdrRt).setScale(4, 4)).divide(bCnvrStdrRt, 2, 4)).multiply(bStdr).setScale(2, 4).toString();
sCnvrAmount = bSrcAmount.multiply(bSrcStdrRt).setScale(4, 4).divide(bCnvrStdrRt, 2, 4).multiply(bStdr).setScale(2, 4).toString();

//sCnvrAmount = (bSrcAmount.multiply(bSrcStdrRt).setScale(4, 4)).divide(bCnvrStdrRt, 2, 4).toString();
sCnvrAmount = bSrcAmount.multiply(bSrcStdrRt).setScale(4, 4).divide(bCnvrStdrRt, 2, 4).toString();

//sCnvrAmount = (bSrcAmount.multiply(bSrcStdrRt).setScale(4, 4)).divide(bStdr, 2, 4).toString();
sCnvrAmount = bSrcAmount.multiply(bSrcStdrRt).setScale(4, 4).divide(bStdr, 2, 4).toString();

//sCnvrAmount = ((bSrcAmount.multiply(bSrcStdrRt).setScale(4, 4)).divide(bStdr, 2, 4)).divide(bCnvrStdrRt, 2, 4).toString();
sCnvrAmount = bSrcAmount.multiply(bSrcStdrRt).setScale(4, 4).divide(bStdr, 2, 4).divide(bCnvrStdrRt, 2, 4).toString();
```

<hr>

1. PMD로 소프트웨어 보안약점 진단 결과

```
src/main/java/egovframework/com/utl/fcc/service/EgovEhgtCalcUtil.java:81:	CloseResource:	CloseResource: 리소스 'InputStream' 가 사용 후에 닫혔는지 확인필요
src/main/java/egovframework/com/utl/fcc/service/EgovEhgtCalcUtil.java:82:	CloseResource:	CloseResource: 리소스 'InputStreamReader' 가 사용 후에 닫혔는지 확인필요
src/main/java/egovframework/com/utl/fcc/service/EgovEhgtCalcUtil.java:262:	UselessParentheses:	UselessParentheses: 괄호가 없어도 되는 상황에서 불필요한 괄호를 사용할 경우 마치 메소드 호출처럼 보여서 소스 코드의 가독성을 떨어뜨릴 수 있음
src/main/java/egovframework/com/utl/fcc/service/EgovEhgtCalcUtil.java:277:	UselessParentheses:	UselessParentheses: 괄호가 없어도 되는 상황에서 불필요한 괄호를 사용할 경우 마치 메소드 호출처럼 보여서 소스 코드의 가독성을 떨어뜨릴 수 있음
src/main/java/egovframework/com/utl/fcc/service/EgovEhgtCalcUtil.java:277:	UselessParentheses:	UselessParentheses: 괄호가 없어도 되는 상황에서 불필요한 괄호를 사용할 경우 마치 메소드 호출처럼 보여서 소스 코드의 가독성을 떨어뜨릴 수 있음
src/main/java/egovframework/com/utl/fcc/service/EgovEhgtCalcUtil.java:280:	UselessParentheses:	UselessParentheses: 괄호가 없어도 되는 상황에서 불필요한 괄호를 사용할 경우 마치 메소드 호출처럼 보여서 소스 코드의 가독성을 떨어뜨릴 수 있음
src/main/java/egovframework/com/utl/fcc/service/EgovEhgtCalcUtil.java:292:	UselessParentheses:	UselessParentheses: 괄호가 없어도 되는 상황에서 불필요한 괄호를 사용할 경우 마치 메소드 호출처럼 보여서 소스 코드의 가독성을 떨어뜨릴 수 있음
src/main/java/egovframework/com/utl/fcc/service/EgovEhgtCalcUtil.java:292:	UselessParentheses:	UselessParentheses: 괄호가 없어도 되는 상황에서 불필요한 괄호를 사용할 경우 마치 메소드 호출처럼 보여서 소스 코드의 가독성을 떨어뜨릴 수 있음
src/main/java/egovframework/com/utl/fcc/service/EgovEhgtCalcUtil.java:295:	UselessParentheses:	UselessParentheses: 괄호가 없어도 되는 상황에서 불필요한 괄호를 사용할 경우 마치 메소드 호출처럼 보여서 소스 코드의 가독성을 떨어뜨릴 수 있음
src/main/java/egovframework/com/utl/fcc/service/EgovEhgtCalcUtil.java:304:	UselessParentheses:	UselessParentheses: 괄호가 없어도 되는 상황에서 불필요한 괄호를 사용할 경우 마치 메소드 호출처럼 보여서 소스 코드의 가독성을 떨어뜨릴 수 있음
src/main/java/egovframework/com/utl/fcc/service/EgovEhgtCalcUtil.java:307:	UselessParentheses:	UselessParentheses: 괄호가 없어도 되는 상황에서 불필요한 괄호를 사용할 경우 마치 메소드 호출처럼 보여서 소스 코드의 가독성을 떨어뜨릴 수 있음
src/main/java/egovframework/com/utl/fcc/service/EgovEhgtCalcUtil.java:307:	UselessParentheses:	UselessParentheses: 괄호가 없어도 되는 상황에서 불필요한 괄호를 사용할 경우 마치 메소드 호출처럼 보여서 소스 코드의 가독성을 떨어뜨릴 수 있음
src/main/java/egovframework/com/utl/fcc/service/EgovEhgtCalcUtil.java:319:	UselessParentheses:	UselessParentheses: 괄호가 없어도 되는 상황에서 불필요한 괄호를 사용할 경우 마치 메소드 호출처럼 보여서 소스 코드의 가독성을 떨어뜨릴 수 있음
src/main/java/egovframework/com/utl/fcc/service/EgovEhgtCalcUtil.java:319:	UselessParentheses:	UselessParentheses: 괄호가 없어도 되는 상황에서 불필요한 괄호를 사용할 경우 마치 메소드 호출처럼 보여서 소스 코드의 가독성을 떨어뜨릴 수 있음
src/main/java/egovframework/com/utl/fcc/service/EgovEhgtCalcUtil.java:322:	UselessParentheses:	UselessParentheses: 괄호가 없어도 되는 상황에서 불필요한 괄호를 사용할 경우 마치 메소드 호출처럼 보여서 소스 코드의 가독성을 떨어뜨릴 수 있음
```

2. 브랜치 생성

```
feature/pmd/EgovEhgtCalcUtil
```

3. 이클립스 > Source > Format

4. 개정이력 수정

```java
 *   2025.08.30  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-CloseResource(부적절한 자원 해제)
 *   2025.08.30  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-UselessParentheses(불필요한 괄호사용)
```

<hr>

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

https://youtu.be/R1kD8Ptoqy4
