### PR TITLE
PMD로 소프트웨어 보안약점 진단하고 제거하기-EgovFormBasedFileUtil

### DIFF
--- a/src/main/java/egovframework/com/utl/fcc/service/EgovFormBasedFileUtil.java
+++ b/src/main/java/egovframework/com/utl/fcc/service/EgovFormBasedFileUtil.java
@@ -1,14 +1,11 @@
 package egovframework.com.utl.fcc.service;
 
-import java.io.BufferedInputStream;
-import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.HashMap;
@@ -19,9 +16,9 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.util.FileCopyUtils;
 
 import egovframework.com.cmm.EgovWebUtil;
-import egovframework.com.cmm.util.EgovResourceCloseHelper;
 
 /**
  * @Class Name : EgovFormBasedFileUtil.java
@@ -106,24 +103,7 @@ public class EgovFormBasedFileUtil {
 			}
 		}
 
-		OutputStream os = null;
-		long size = 0L;
-
-		try {
-			os = new FileOutputStream(file);
-
-			int bytesRead = 0;
-			byte[] buffer = new byte[BUFFER_SIZE];
-
-			while ((bytesRead = is.read(buffer, 0, BUFFER_SIZE)) != -1) {
-				size += bytesRead;
-				os.write(buffer, 0, bytesRead);
-			}
-		} finally {
-			EgovResourceCloseHelper.close(os);
-		}
-
-		return size;
+		return FileCopyUtils.copy(is, new FileOutputStream(file));
 	}
 
 	/**
@@ -208,30 +188,14 @@ public class EgovFormBasedFileUtil {
 			throw new FileNotFoundException(downFileName);
 		}
 
-		byte[] b = new byte[BUFFER_SIZE];
-
-		original = original.replaceAll("\r", "").replaceAll("\n", "");
+		String original2 = original.replaceAll("\r", "").replaceAll("\n", "");
 		response.setContentType("application/octet-stream");
-		response.setHeader("Content-Disposition", "attachment; filename=\"" + convert(original) + "\";");
+		response.setHeader("Content-Disposition", "attachment; filename=\"" + convert(original2) + "\";");
 		response.setHeader("Content-Transfer-Encoding", "binary");
 		response.setHeader("Pragma", "no-cache");
 		response.setHeader("Expires", "0");
 
-		BufferedInputStream fin = null;
-		BufferedOutputStream outs = null;
-
-		try {
-			fin = new BufferedInputStream(new FileInputStream(file));
-			outs = new BufferedOutputStream(response.getOutputStream());
-
-			int read = 0;
-
-			while ((read = fin.read(b)) != -1) {
-				outs.write(b, 0, read);
-			}
-		} finally {
-			EgovResourceCloseHelper.close(outs, fin);
-		}
+		FileCopyUtils.copy(new FileInputStream(file), response.getOutputStream());
 	}
 
 	/**
@@ -262,8 +226,6 @@ public class EgovFormBasedFileUtil {
 			throw new FileNotFoundException(downFileName);
 		}
 
-		byte[] b = new byte[BUFFER_SIZE];
-
 		if (mimeType == null) {
 			mimeType = "application/octet-stream;";
 		}
@@ -290,21 +252,7 @@ public class EgovFormBasedFileUtil {
 
 		response.setHeader("Content-Disposition", "filename=image;");
 
-		BufferedInputStream fin = null;
-		BufferedOutputStream outs = null;
-
-		try {
-			fin = new BufferedInputStream(new FileInputStream(file));
-			outs = new BufferedOutputStream(response.getOutputStream());
-
-			int read = 0;
-
-			while ((read = fin.read(b)) != -1) {
-				outs.write(b, 0, read);
-			}
-		} finally {
-			EgovResourceCloseHelper.close(outs, fin);
-		}
+		FileCopyUtils.copy(new FileInputStream(file), response.getOutputStream());
 	}
 
 	public static Map<String, String> getContentTypeWL() {

--- a/src/main/java/egovframework/com/utl/fcc/service/EgovFormBasedFileUtil.java
+++ b/src/main/java/egovframework/com/utl/fcc/service/EgovFormBasedFileUtil.java
@@ -21,23 +21,27 @@ import org.springframework.util.FileCopyUtils;
 import egovframework.com.cmm.EgovWebUtil;
 
 /**
- * @Class Name : EgovFormBasedFileUtil.java
- * @Description : Form-based File Upload 유틸리티
- * @Modification Information
- * 
- *               <pre>
- *   수정일			수정자		수정내용
- *   ----------		--------	---------------------------
- *   2009.08.26		한성곤		최초 생성
- *   2017.03.03		조성원		시큐어코딩(ES)-부적절한 예외 처리[CWE-253, CWE-440, CWE-754]
- *   2019.12.09		신용호		KISA 보안약점 조치 (위험한 형식 파일 업로드) : uploadFiles 삭제  => EgovFileUploadUtil.uploadFilesExt(확장자 기록) 대체
- *   2023.06.27		김혜준		NSR 보안조치 (CKEditor 이미지 보기 기능의 스크립트 실행 취약점)
- *               </pre>
+ * Form-based File Upload 유틸리티
  * 
  * @author 공통컴포넌트 개발팀 한성곤
  * @since 2009.08.26
  * @version 1.0
  * @see
+ *
+ *      <pre>
+ *  == 개정이력(Modification Information) ==
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2009.08.26  한성곤          최초 생성
+ *   2017.03.03  조성원          시큐어코딩(ES)-부적절한 예외 처리[CWE-253, CWE-440, CWE-754]
+ *   2019.12.09  신용호          KISA 보안약점 조치 (위험한 형식 파일 업로드) : uploadFiles 삭제  => EgovFileUploadUtil.uploadFilesExt(확장자 기록) 대체
+ *   2023.06.27  김혜준          NSR 보안조치 (CKEditor 이미지 보기 기능의 스크립트 실행 취약점)
+ *   2025.09.01  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-CloseResource(부적절한 자원 해제)
+ *   2025.09.01  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-AssignmentInOperand(피연산자내에 할당문이 사용됨. 해당 코드를 복잡하고 가독성이 떨어지게 만듬)
+ *   2025.09.01  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-AvoidReassigningParameters(넘겨받는 메소드 parameter 값을 직접 변경하는 코드 탐지)
+ *
+ *      </pre>
  */
 public class EgovFormBasedFileUtil {
 	/** Buffer size */


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

<hr>

### 2025-09-01 토 PMD로 소프트웨어 보안약점 진단하고 제거하기-EgovFormBasedFileUtil

부적절한 자원 해제, 피연산자내에 할당문이 사용된 것 제거
```java
FileCopyUtils.copy(is, os);
```

넘겨받는 메소드 parameter 값을 직접 변경하는 코드 수정
```java
//		original = original.replaceAll("\r", "").replaceAll("\n", "");
		String original2 = original.replaceAll("\r", "").replaceAll("\n", "");
		response.setContentType("application/octet-stream");
//		response.setHeader("Content-Disposition", "attachment; filename=\"" + convert(original) + "\";");
		response.setHeader("Content-Disposition", "attachment; filename=\"" + convert(original2) + "\";");
```

<hr>

1. PMD로 소프트웨어 보안약점 진단 결과

```
src/main/java/egovframework/com/utl/fcc/service/EgovFormBasedFileUtil.java:104:	CloseResource:	CloseResource: 리소스 'OutputStream' 가 사용 후에 닫혔는지 확인필요
src/main/java/egovframework/com/utl/fcc/service/EgovFormBasedFileUtil.java:113:	AssignmentInOperand:	AssignmentInOperand: 피연산자내에 할당문이 사용됨. Code 를 복잡하고 가독성이 떨어지게 만듬
src/main/java/egovframework/com/utl/fcc/service/EgovFormBasedFileUtil.java:218:	AvoidReassigningParameters:	AvoidReassigningParameters: 'original' 처럼 파라미터 값을 직접 변경하지 말 것
src/main/java/egovframework/com/utl/fcc/service/EgovFormBasedFileUtil.java:225:	CloseResource:	CloseResource: 리소스 'BufferedInputStream' 가 사용 후에 닫혔는지 확인필요
src/main/java/egovframework/com/utl/fcc/service/EgovFormBasedFileUtil.java:226:	CloseResource:	CloseResource: 리소스 'BufferedOutputStream' 가 사용 후에 닫혔는지 확인필요
src/main/java/egovframework/com/utl/fcc/service/EgovFormBasedFileUtil.java:234:	AssignmentInOperand:	AssignmentInOperand: 피연산자내에 할당문이 사용됨. Code 를 복잡하고 가독성이 떨어지게 만듬
src/main/java/egovframework/com/utl/fcc/service/EgovFormBasedFileUtil.java:297:	CloseResource:	CloseResource: 리소스 'BufferedInputStream' 가 사용 후에 닫혔는지 확인필요
src/main/java/egovframework/com/utl/fcc/service/EgovFormBasedFileUtil.java:298:	CloseResource:	CloseResource: 리소스 'BufferedOutputStream' 가 사용 후에 닫혔는지 확인필요
src/main/java/egovframework/com/utl/fcc/service/EgovFormBasedFileUtil.java:306:	AssignmentInOperand:	AssignmentInOperand: 피연산자내에 할당문이 사용됨. Code 를 복잡하고 가독성이 떨어지게 만듬
```

2. 브랜치 생성

```
feature/pmd/EgovFormBasedFileUtil
```

3. 이클립스 > Source > Format

4. 개정이력 수정

```java
 *   2025.09.01  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-CloseResource(부적절한 자원 해제)
 *   2025.09.01  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-AssignmentInOperand(피연산자내에 할당문이 사용됨. 해당 코드를 복잡하고 가독성이 떨어지게 만듬)
 *   2025.09.01  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-AvoidReassigningParameters(넘겨받는 메소드 parameter 값을 직접 변경하는 코드 탐지)
```

<hr>

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

https://youtu.be/MsWGEK-wxV8
