### PR TITLE
PMD로 소프트웨어 보안약점 진단하고 제거하기-EgovFormBasedUUID

### DIFF
--- a/src/main/java/egovframework/com/utl/fcc/service/EgovFormBasedUUID.java
+++ b/src/main/java/egovframework/com/utl/fcc/service/EgovFormBasedUUID.java
@@ -24,8 +24,13 @@ import java.security.SecureRandom;
  *
  *      </pre>
  */
-@SuppressWarnings("serial")
 public class EgovFormBasedUUID implements Serializable {
+
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = 1L;
+
 	/*
 	 * The most significant 64 bits of this UUID.
 	 *

--- a/src/main/java/egovframework/com/utl/fcc/service/EgovFormBasedUUID.java
+++ b/src/main/java/egovframework/com/utl/fcc/service/EgovFormBasedUUID.java
@@ -232,15 +232,15 @@ public class EgovFormBasedUUID implements Serializable {
 			components[i] = "0x" + components[i];
 		}
 
-		long mostSigBits = Long.decode(components[0]).longValue();
+		long mostSigBits = Long.decode(components[0]);
 		mostSigBits <<= 16;
-		mostSigBits |= Long.decode(components[1]).longValue();
+		mostSigBits |= Long.decode(components[1]);
 		mostSigBits <<= 16;
-		mostSigBits |= Long.decode(components[2]).longValue();
+		mostSigBits |= Long.decode(components[2]);
 
-		long leastSigBits = Long.decode(components[3]).longValue();
+		long leastSigBits = Long.decode(components[3]);
 		leastSigBits <<= 48;
-		leastSigBits |= Long.decode(components[4]).longValue();
+		leastSigBits |= Long.decode(components[4]);
 
 		return new EgovFormBasedUUID(mostSigBits, leastSigBits);
 	}
@@ -427,8 +427,8 @@ public class EgovFormBasedUUID implements Serializable {
 	 */
 	@Override
 	public String toString() {
-		return (digits(mostSigBits >> 32, 8) + "-" + digits(mostSigBits >> 16, 4) + "-" + digits(mostSigBits, 4) + "-"
-				+ digits(leastSigBits >> 48, 4) + "-" + digits(leastSigBits, 12));
+		return digits(mostSigBits >> 32, 8) + "-" + digits(mostSigBits >> 16, 4) + "-" + digits(mostSigBits, 4) + "-"
+				+ digits(leastSigBits >> 48, 4) + "-" + digits(leastSigBits, 12);
 	}
 
 	/** Returns val represented by the specified number of hex digits. */
@@ -474,7 +474,7 @@ public class EgovFormBasedUUID implements Serializable {
 			return false;
 		}
 		EgovFormBasedUUID id = (EgovFormBasedUUID) obj;
-		return (mostSigBits == id.mostSigBits && leastSigBits == id.leastSigBits);
+		return mostSigBits == id.mostSigBits && leastSigBits == id.leastSigBits;
 	}
 
 	// Comparison Operations
@@ -493,10 +493,9 @@ public class EgovFormBasedUUID implements Serializable {
 	public int compareTo(EgovFormBasedUUID val) {
 		// The ordering is intentionally set up so that the UUIDs
 		// can simply be numerically compared as two numbers
-		return (this.mostSigBits < val.mostSigBits ? -1
-				: (this.mostSigBits > val.mostSigBits ? 1
-						: (this.leastSigBits < val.leastSigBits ? -1
-								: (this.leastSigBits > val.leastSigBits ? 1 : 0))));
+		return this.mostSigBits < val.mostSigBits ? -1
+				: this.mostSigBits > val.mostSigBits ? 1
+						: this.leastSigBits < val.leastSigBits ? -1 : this.leastSigBits > val.leastSigBits ? 1 : 0;
 	}
 
 	/**

--- a/src/main/java/egovframework/com/utl/fcc/service/EgovFormBasedUUID.java
+++ b/src/main/java/egovframework/com/utl/fcc/service/EgovFormBasedUUID.java
@@ -6,56 +6,23 @@ import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 
 /**
+ * Egov 양식 기반 UUID
+ * 
+ * @author 공통컴포넌트 개발팀 홍길동
+ * @since 2009.06.01
+ * @version 1.0
+ * @see
  *
- * A class that represents an immutable universally unique identifier (UUID). A
- * UUID represents a 128-bit value.
+ *      <pre>
+ *  == 개정이력(Modification Information) ==
  *
- * <p>
- * There exist different variants of these global identifiers. The methods of
- * this class are for manipulating the Leach-Salz variant, although the
- * constructors allow the creation of any variant of UUID (described below).
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2009.03.20  홍길동          최초 생성
+ *   2025.09.01  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-UnnecessaryBoxing(불필요한 WrapperObject 생성)
+ *   2025.09.01  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-UselessParentheses(불필요한 괄호사용)
  *
- * <p>
- * The layout of a variant 2 (Leach-Salz) UUID is as follows:
- *
- * The most significant long consists of the following unsigned fields:
- *
- * <pre>
- *   0xFFFFFFFF00000000 time_low
- *   0x00000000FFFF0000 time_mid
- *   0x000000000000F000 version
- *   0x0000000000000FFF time_hi
- * </pre>
- *
- * The least significant long consists of the following unsigned fields:
- *
- * <pre>
- *   0xC000000000000000 variant
- *   0x3FFF000000000000 clock_seq
- *   0x0000FFFFFFFFFFFF node
- * </pre>
- *
- * <p>
- * The variant field contains a value which identifies the layout of the
- * <tt>UUID</tt>. The bit layout described above is valid only for a
- * <tt>UUID</tt> with a variant value of 2, which indicates the Leach-Salz
- * variant.
- *
- * <p>
- * The version field holds a value that describes the type of this
- * <tt>UUID</tt>. There are four different basic types of UUIDs: time-based, DCE
- * security, name-based, and randomly generated UUIDs. These types have a
- * version value of 1, 2, 3 and 4, respectively.
- *
- * <p>
- * For more information including algorithms used to create <tt>UUID</tt>s, see
- * the Internet-Draft <a href=
- * "http://www.ietf.org/internet-drafts/draft-mealling-uuid-urn-03.txt">UUIDs
- * and GUIDs</a> or the standards body definition at
- * <a href="http://www.iso.ch/cate/d2229.html">ISO/IEC 11578:1996</a>.
- *
- * @version 1.14, 07/12/04
- * @since 1.5
+ *      </pre>
  */
 @SuppressWarnings("serial")
 public class EgovFormBasedUUID implements Serializable {

--- a/src/main/java/egovframework/com/utl/fcc/service/EgovFormBasedUUID.java
+++ b/src/main/java/egovframework/com/utl/fcc/service/EgovFormBasedUUID.java
@@ -42,486 +42,478 @@ import java.security.SecureRandom;
  * variant.
  *
  * <p>
- * The version field holds a value that describes the type of this <tt>UUID</tt>.
- * There are four different basic types of UUIDs: time-based, DCE security,
- * name-based, and randomly generated UUIDs. These types have a version value of
- * 1, 2, 3 and 4, respectively.
+ * The version field holds a value that describes the type of this
+ * <tt>UUID</tt>. There are four different basic types of UUIDs: time-based, DCE
+ * security, name-based, and randomly generated UUIDs. These types have a
+ * version value of 1, 2, 3 and 4, respectively.
  *
  * <p>
- * For more information including algorithms used to create <tt>UUID</tt>s,
- * see the Internet-Draft <a
- * href="http://www.ietf.org/internet-drafts/draft-mealling-uuid-urn-03.txt">UUIDs
- * and GUIDs</a> or the standards body definition at <a
- * href="http://www.iso.ch/cate/d2229.html">ISO/IEC 11578:1996</a>.
+ * For more information including algorithms used to create <tt>UUID</tt>s, see
+ * the Internet-Draft <a href=
+ * "http://www.ietf.org/internet-drafts/draft-mealling-uuid-urn-03.txt">UUIDs
+ * and GUIDs</a> or the standards body definition at
+ * <a href="http://www.iso.ch/cate/d2229.html">ISO/IEC 11578:1996</a>.
  *
  * @version 1.14, 07/12/04
  * @since 1.5
  */
 @SuppressWarnings("serial")
 public class EgovFormBasedUUID implements Serializable {
-    /*
-     * The most significant 64 bits of this UUID.
-     *
-     * @serial
-     */
-    private final long mostSigBits;
+	/*
+	 * The most significant 64 bits of this UUID.
+	 *
+	 * @serial
+	 */
+	private final long mostSigBits;
 
-    /*
-     * The least significant 64 bits of this UUID.
-     *
-     * @serial
-     */
-    private final long leastSigBits;
+	/*
+	 * The least significant 64 bits of this UUID.
+	 *
+	 * @serial
+	 */
+	private final long leastSigBits;
 
-    /*
-     * The version number associated with this UUID. Computed on demand.
-     */
-    private transient int version = -1;
+	/*
+	 * The version number associated with this UUID. Computed on demand.
+	 */
+	private transient int version = -1;
 
-    /*
-     * The variant number associated with this UUID. Computed on demand.
-     */
-    private transient int variant = -1;
+	/*
+	 * The variant number associated with this UUID. Computed on demand.
+	 */
+	private transient int variant = -1;
 
-    /*
-     * The timestamp associated with this UUID. Computed on demand.
-     */
-    private transient volatile long timestamp = -1;
+	/*
+	 * The timestamp associated with this UUID. Computed on demand.
+	 */
+	private transient volatile long timestamp = -1;
 
-    /*
-     * The clock sequence associated with this UUID. Computed on demand.
-     */
-    private transient int sequence = -1;
+	/*
+	 * The clock sequence associated with this UUID. Computed on demand.
+	 */
+	private transient int sequence = -1;
 
-    /*
-     * The node number associated with this UUID. Computed on demand.
-     */
-    private transient long node = -1;
+	/*
+	 * The node number associated with this UUID. Computed on demand.
+	 */
+	private transient long node = -1;
 
-    /*
-     * The hashcode of this UUID. Computed on demand.
-     */
-    private transient int hashCode = -1;
+	/*
+	 * The hashcode of this UUID. Computed on demand.
+	 */
+	private transient int hashCode = -1;
 
-    /*
-     * The random number generator used by this class to create random based
-     * UUIDs.
-     */
-    private static volatile SecureRandom numberGenerator = null;
-    
-    // 221116	김혜준	2022 시큐어코딩 조치
-    private static SecureRandom makeSecureRandom() {
-    	SecureRandom ng = numberGenerator;
-        if (ng == null) {
-            numberGenerator = ng = new SecureRandom();
-        }
-        return ng;
-    }
+	/*
+	 * The random number generator used by this class to create random based UUIDs.
+	 */
+	private static volatile SecureRandom numberGenerator = null;
 
-    // Constructors and Factories
+	// 221116 김혜준 2022 시큐어코딩 조치
+	private static SecureRandom makeSecureRandom() {
+		SecureRandom ng = numberGenerator;
+		if (ng == null) {
+			numberGenerator = ng = new SecureRandom();
+		}
+		return ng;
+	}
 
-    /*
-     * Private constructor which uses a byte array to construct the new UUID.
-     */
-    private EgovFormBasedUUID(byte[] data) {
-        long msb = 0;
-        long lsb = 0;
-        for (int i = 0; i < 8; i++)
-            msb = (msb << 8) | (data[i] & 0xff);
-        for (int i = 8; i < 16; i++)
-            lsb = (lsb << 8) | (data[i] & 0xff);
-        this.mostSigBits = msb;
-        this.leastSigBits = lsb;
-    }
+	// Constructors and Factories
 
-    /**
-     * Constructs a new <tt>UUID</tt> using the specified data.
-     * <tt>mostSigBits</tt> is used for the most significant 64 bits of the
-     * <tt>UUID</tt> and <tt>leastSigBits</tt> becomes the least significant
-     * 64 bits of the <tt>UUID</tt>.
-     *
-     * @param mostSigBits
-     * @param leastSigBits
-     */
-    public EgovFormBasedUUID(long mostSigBits, long leastSigBits) {
-        this.mostSigBits = mostSigBits;
-        this.leastSigBits = leastSigBits;
-    }
+	/*
+	 * Private constructor which uses a byte array to construct the new UUID.
+	 */
+	private EgovFormBasedUUID(byte[] data) {
+		long msb = 0;
+		long lsb = 0;
+		for (int i = 0; i < 8; i++) {
+			msb = (msb << 8) | (data[i] & 0xff);
+		}
+		for (int i = 8; i < 16; i++) {
+			lsb = (lsb << 8) | (data[i] & 0xff);
+		}
+		this.mostSigBits = msb;
+		this.leastSigBits = lsb;
+	}
 
-    /**
-     * Static factory to retrieve a type 4 (pseudo randomly generated) UUID.
-     *
-     * The <code>UUID</code> is generated using a cryptographically strong
-     * pseudo random number generator.
-     *
-     * @return a randomly generated <tt>UUID</tt>.
-     */
-    public static EgovFormBasedUUID randomUUID() {
-        SecureRandom ng = makeSecureRandom();
+	/**
+	 * Constructs a new <tt>UUID</tt> using the specified data. <tt>mostSigBits</tt>
+	 * is used for the most significant 64 bits of the <tt>UUID</tt> and
+	 * <tt>leastSigBits</tt> becomes the least significant 64 bits of the
+	 * <tt>UUID</tt>.
+	 *
+	 * @param mostSigBits
+	 * @param leastSigBits
+	 */
+	public EgovFormBasedUUID(long mostSigBits, long leastSigBits) {
+		this.mostSigBits = mostSigBits;
+		this.leastSigBits = leastSigBits;
+	}
 
-        byte[] randomBytes = new byte[16];
-        ng.nextBytes(randomBytes);
-        randomBytes[6] &= 0x0f; /* clear version */
-        randomBytes[6] |= 0x40; /* set to version 4 */
-        randomBytes[8] &= 0x3f; /* clear variant */
-        randomBytes[8] |= 0x80; /* set to IETF variant */
+	/**
+	 * Static factory to retrieve a type 4 (pseudo randomly generated) UUID.
+	 *
+	 * The <code>UUID</code> is generated using a cryptographically strong pseudo
+	 * random number generator.
+	 *
+	 * @return a randomly generated <tt>UUID</tt>.
+	 */
+	public static EgovFormBasedUUID randomUUID() {
+		SecureRandom ng = makeSecureRandom();
 
-        return new EgovFormBasedUUID(randomBytes);
-    }
+		byte[] randomBytes = new byte[16];
+		ng.nextBytes(randomBytes);
+		randomBytes[6] &= 0x0f; /* clear version */
+		randomBytes[6] |= 0x40; /* set to version 4 */
+		randomBytes[8] &= 0x3f; /* clear variant */
+		randomBytes[8] |= 0x80; /* set to IETF variant */
 
-    /**
-     * Static factory to retrieve a type 3 (name based) <tt>UUID</tt> based on
-     * the specified byte array.
-     *
-     * @param name
-     *            a byte array to be used to construct a <tt>UUID</tt>.
-     * @return a <tt>UUID</tt> generated from the specified array.
-     */
-    public static EgovFormBasedUUID nameUUIDFromBytes(byte[] name) {
-        MessageDigest md;
-        try {
-        	// 2011.10.10 보안점검 후속조치 암호화 알고리즘 변경(MD5 -> SHA-256)
-        	//md = MessageDigest.getInstance("MD5");
-            md = MessageDigest.getInstance("SHA-256");
-        } catch (NoSuchAlgorithmException nsae) {
-        	//throw new InternalError("MD5 not supported");
-            throw new InternalError("SHA-256 not supported");
-        }
-        // 2011.10.10 보안점검 후속조치
-        if (md == null) {
-            throw new RuntimeException("MessageDigest is null!!");
-        }
-        // 2014.09.20 보안점검 후속 조치
-        // Random 방식의 salt 추가
-        SecureRandom ng = makeSecureRandom();
-        byte[] randomBytes = new byte[16];
-        ng.nextBytes(randomBytes);
+		return new EgovFormBasedUUID(randomBytes);
+	}
 
-        md.reset();
-        md.update(randomBytes);
-        byte[] sha = md.digest(name);
+	/**
+	 * Static factory to retrieve a type 3 (name based) <tt>UUID</tt> based on the
+	 * specified byte array.
+	 *
+	 * @param name a byte array to be used to construct a <tt>UUID</tt>.
+	 * @return a <tt>UUID</tt> generated from the specified array.
+	 */
+	public static EgovFormBasedUUID nameUUIDFromBytes(byte[] name) {
+		MessageDigest md;
+		try {
+			// 2011.10.10 보안점검 후속조치 암호화 알고리즘 변경(MD5 -> SHA-256)
+			// md = MessageDigest.getInstance("MD5");
+			md = MessageDigest.getInstance("SHA-256");
+		} catch (NoSuchAlgorithmException nsae) {
+			// throw new InternalError("MD5 not supported");
+			throw new InternalError("SHA-256 not supported");
+		}
+		// 2011.10.10 보안점검 후속조치
+		if (md == null) {
+			throw new RuntimeException("MessageDigest is null!!");
+		}
+		// 2014.09.20 보안점검 후속 조치
+		// Random 방식의 salt 추가
+		SecureRandom ng = makeSecureRandom();
+		byte[] randomBytes = new byte[16];
+		ng.nextBytes(randomBytes);
 
+		md.reset();
+		md.update(randomBytes);
+		byte[] sha = md.digest(name);
 
-        byte[] md5Bytes = new byte[8];
-        System.arraycopy(sha, 0, md5Bytes, 0, 8);
-        //2011.10.10 보안점검 후속조치 끝
+		byte[] md5Bytes = new byte[8];
+		System.arraycopy(sha, 0, md5Bytes, 0, 8);
+		// 2011.10.10 보안점검 후속조치 끝
 
-        md5Bytes[6] &= 0x0f; /* clear version */
-        md5Bytes[6] |= 0x30; /* set to version 3 */
-        md5Bytes[8] &= 0x3f; /* clear variant */
-        md5Bytes[8] |= 0x80; /* set to IETF variant */
+		md5Bytes[6] &= 0x0f; /* clear version */
+		md5Bytes[6] |= 0x30; /* set to version 3 */
+		md5Bytes[8] &= 0x3f; /* clear variant */
+		md5Bytes[8] |= 0x80; /* set to IETF variant */
 
-        return new EgovFormBasedUUID(md5Bytes);
-    }
+		return new EgovFormBasedUUID(md5Bytes);
+	}
 
-    /**
-     * Creates a <tt>UUID</tt> from the string standard representation as
-     * described in the {@link #toString} method.
-     *
-     * @param name
-     *            a string that specifies a <tt>UUID</tt>.
-     * @return a <tt>UUID</tt> with the specified value.
-     * @throws IllegalArgumentException
-     *             if name does not conform to the string representation as
-     *             described in {@link #toString}.
-     */
-    public static EgovFormBasedUUID fromString(String name) {
-        String[] components = name.split("-");
-        if (components.length != 5)
-            throw new IllegalArgumentException("Invalid UUID string: " + name);
-        for (int i = 0; i < 5; i++)
-            components[i] = "0x" + components[i];
+	/**
+	 * Creates a <tt>UUID</tt> from the string standard representation as described
+	 * in the {@link #toString} method.
+	 *
+	 * @param name a string that specifies a <tt>UUID</tt>.
+	 * @return a <tt>UUID</tt> with the specified value.
+	 * @throws IllegalArgumentException if name does not conform to the string
+	 *                                  representation as described in
+	 *                                  {@link #toString}.
+	 */
+	public static EgovFormBasedUUID fromString(String name) {
+		String[] components = name.split("-");
+		if (components.length != 5) {
+			throw new IllegalArgumentException("Invalid UUID string: " + name);
+		}
+		for (int i = 0; i < 5; i++) {
+			components[i] = "0x" + components[i];
+		}
 
-        long mostSigBits = Long.decode(components[0]).longValue();
-        mostSigBits <<= 16;
-        mostSigBits |= Long.decode(components[1]).longValue();
-        mostSigBits <<= 16;
-        mostSigBits |= Long.decode(components[2]).longValue();
+		long mostSigBits = Long.decode(components[0]).longValue();
+		mostSigBits <<= 16;
+		mostSigBits |= Long.decode(components[1]).longValue();
+		mostSigBits <<= 16;
+		mostSigBits |= Long.decode(components[2]).longValue();
 
-        long leastSigBits = Long.decode(components[3]).longValue();
-        leastSigBits <<= 48;
-        leastSigBits |= Long.decode(components[4]).longValue();
+		long leastSigBits = Long.decode(components[3]).longValue();
+		leastSigBits <<= 48;
+		leastSigBits |= Long.decode(components[4]).longValue();
 
-        return new EgovFormBasedUUID(mostSigBits, leastSigBits);
-    }
+		return new EgovFormBasedUUID(mostSigBits, leastSigBits);
+	}
 
-    // Field Accessor Methods
+	// Field Accessor Methods
 
-    /**
-     * Returns the least significant 64 bits of this UUID's 128 bit value.
-     *
-     * @return the least significant 64 bits of this UUID's 128 bit value.
-     */
-    public long getLeastSignificantBits() {
-        return leastSigBits;
-    }
+	/**
+	 * Returns the least significant 64 bits of this UUID's 128 bit value.
+	 *
+	 * @return the least significant 64 bits of this UUID's 128 bit value.
+	 */
+	public long getLeastSignificantBits() {
+		return leastSigBits;
+	}
 
-    /**
-     * Returns the most significant 64 bits of this UUID's 128 bit value.
-     *
-     * @return the most significant 64 bits of this UUID's 128 bit value.
-     */
-    public long getMostSignificantBits() {
-        return mostSigBits;
-    }
+	/**
+	 * Returns the most significant 64 bits of this UUID's 128 bit value.
+	 *
+	 * @return the most significant 64 bits of this UUID's 128 bit value.
+	 */
+	public long getMostSignificantBits() {
+		return mostSigBits;
+	}
 
-    /**
-     * The version number associated with this <tt>UUID</tt>. The version
-     * number describes how this <tt>UUID</tt> was generated.
-     *
-     * The version number has the following meaning:
-     * <p>
-     * <ul>
-     * <li>1 Time-based UUID
-     * <li>2 DCE security UUID
-     * <li>3 Name-based UUID
-     * <li>4 Randomly generated UUID
-     * </ul>
-     *
-     * @return the version number of this <tt>UUID</tt>.
-     */
-    public int version() {
-        if (version < 0) {
-            // Version is bits masked by 0x000000000000F000 in MS long
-            version = (int) ((mostSigBits >> 12) & 0x0f);
-        }
-        return version;
-    }
+	/**
+	 * The version number associated with this <tt>UUID</tt>. The version number
+	 * describes how this <tt>UUID</tt> was generated.
+	 *
+	 * The version number has the following meaning:
+	 * <p>
+	 * <ul>
+	 * <li>1 Time-based UUID
+	 * <li>2 DCE security UUID
+	 * <li>3 Name-based UUID
+	 * <li>4 Randomly generated UUID
+	 * </ul>
+	 *
+	 * @return the version number of this <tt>UUID</tt>.
+	 */
+	public int version() {
+		if (version < 0) {
+			// Version is bits masked by 0x000000000000F000 in MS long
+			version = (int) ((mostSigBits >> 12) & 0x0f);
+		}
+		return version;
+	}
 
-    /**
-     * The variant number associated with this <tt>UUID</tt>. The variant
-     * number describes the layout of the <tt>UUID</tt>.
-     *
-     * The variant number has the following meaning:
-     * <p>
-     * <ul>
-     * <li>0 Reserved for NCS backward compatibility
-     * <li>2 The Leach-Salz variant (used by this class)
-     * <li>6 Reserved, Microsoft Corporation backward compatibility
-     * <li>7 Reserved for future definition
-     * </ul>
-     *
-     * @return the variant number of this <tt>UUID</tt>.
-     */
-    public int variant() {
-        if (variant < 0) {
-            // This field is composed of a varying number of bits
-            if ((leastSigBits >>> 63) == 0) {
-                variant = 0;
-            } else if ((leastSigBits >>> 62) == 2) {
-                variant = 2;
-            } else {
-                variant = (int) (leastSigBits >>> 61);
-            }
-        }
-        return variant;
-    }
+	/**
+	 * The variant number associated with this <tt>UUID</tt>. The variant number
+	 * describes the layout of the <tt>UUID</tt>.
+	 *
+	 * The variant number has the following meaning:
+	 * <p>
+	 * <ul>
+	 * <li>0 Reserved for NCS backward compatibility
+	 * <li>2 The Leach-Salz variant (used by this class)
+	 * <li>6 Reserved, Microsoft Corporation backward compatibility
+	 * <li>7 Reserved for future definition
+	 * </ul>
+	 *
+	 * @return the variant number of this <tt>UUID</tt>.
+	 */
+	public int variant() {
+		if (variant < 0) {
+			// This field is composed of a varying number of bits
+			if ((leastSigBits >>> 63) == 0) {
+				variant = 0;
+			} else if ((leastSigBits >>> 62) == 2) {
+				variant = 2;
+			} else {
+				variant = (int) (leastSigBits >>> 61);
+			}
+		}
+		return variant;
+	}
 
-    /**
-     * The timestamp value associated with this UUID.
-     *
-     * <p>
-     * The 60 bit timestamp value is constructed from the time_low, time_mid,
-     * and time_hi fields of this <tt>UUID</tt>. The resulting timestamp is
-     * measured in 100-nanosecond units since midnight, October 15, 1582 UTC.
-     * <p>
-     *
-     * The timestamp value is only meaningful in a time-based UUID, which has
-     * version type 1. If this <tt>UUID</tt> is not a time-based UUID then
-     * this method throws UnsupportedOperationException.
-     *
-     * @throws UnsupportedOperationException
-     *             if this UUID is not a version 1 UUID.
-     */
-    public long timestamp() {
-        if (version() != 1) {
-            throw new UnsupportedOperationException("Not a time-based UUID");
-        }
-        long result = timestamp;
-        if (result < 0) {
-            result = (mostSigBits & 0x0000000000000FFFL) << 48;
-            result |= ((mostSigBits >> 16) & 0xFFFFL) << 32;
-            result |= mostSigBits >>> 32;
-            timestamp = result;
-        }
-        return result;
-    }
+	/**
+	 * The timestamp value associated with this UUID.
+	 *
+	 * <p>
+	 * The 60 bit timestamp value is constructed from the time_low, time_mid, and
+	 * time_hi fields of this <tt>UUID</tt>. The resulting timestamp is measured in
+	 * 100-nanosecond units since midnight, October 15, 1582 UTC.
+	 * <p>
+	 *
+	 * The timestamp value is only meaningful in a time-based UUID, which has
+	 * version type 1. If this <tt>UUID</tt> is not a time-based UUID then this
+	 * method throws UnsupportedOperationException.
+	 *
+	 * @throws UnsupportedOperationException if this UUID is not a version 1 UUID.
+	 */
+	public long timestamp() {
+		if (version() != 1) {
+			throw new UnsupportedOperationException("Not a time-based UUID");
+		}
+		long result = timestamp;
+		if (result < 0) {
+			result = (mostSigBits & 0x0000000000000FFFL) << 48;
+			result |= ((mostSigBits >> 16) & 0xFFFFL) << 32;
+			result |= mostSigBits >>> 32;
+			timestamp = result;
+		}
+		return result;
+	}
 
-    /**
-     * The clock sequence value associated with this UUID.
-     *
-     * <p>
-     * The 14 bit clock sequence value is constructed from the clock sequence
-     * field of this UUID. The clock sequence field is used to guarantee
-     * temporal uniqueness in a time-based UUID.
-     * <p>
-     *
-     * The clockSequence value is only meaningful in a time-based UUID, which
-     * has version type 1. If this UUID is not a time-based UUID then this
-     * method throws UnsupportedOperationException.
-     *
-     * @return the clock sequence of this <tt>UUID</tt>.
-     * @throws UnsupportedOperationException
-     *             if this UUID is not a version 1 UUID.
-     */
-    public int clockSequence() {
-        if (version() != 1) {
-            throw new UnsupportedOperationException("Not a time-based UUID");
-        }
-        if (sequence < 0) {
-            sequence = (int) ((leastSigBits & 0x3FFF000000000000L) >>> 48);
-        }
-        return sequence;
-    }
+	/**
+	 * The clock sequence value associated with this UUID.
+	 *
+	 * <p>
+	 * The 14 bit clock sequence value is constructed from the clock sequence field
+	 * of this UUID. The clock sequence field is used to guarantee temporal
+	 * uniqueness in a time-based UUID.
+	 * <p>
+	 *
+	 * The clockSequence value is only meaningful in a time-based UUID, which has
+	 * version type 1. If this UUID is not a time-based UUID then this method throws
+	 * UnsupportedOperationException.
+	 *
+	 * @return the clock sequence of this <tt>UUID</tt>.
+	 * @throws UnsupportedOperationException if this UUID is not a version 1 UUID.
+	 */
+	public int clockSequence() {
+		if (version() != 1) {
+			throw new UnsupportedOperationException("Not a time-based UUID");
+		}
+		if (sequence < 0) {
+			sequence = (int) ((leastSigBits & 0x3FFF000000000000L) >>> 48);
+		}
+		return sequence;
+	}
 
-    /**
-     * The node value associated with this UUID.
-     *
-     * <p>
-     * The 48 bit node value is constructed from the node field of this UUID.
-     * This field is intended to hold the IEEE 802 address of the machine that
-     * generated this UUID to guarantee spatial uniqueness.
-     * <p>
-     *
-     * The node value is only meaningful in a time-based UUID, which has version
-     * type 1. If this UUID is not a time-based UUID then this method throws
-     * UnsupportedOperationException.
-     *
-     * @return the node value of this <tt>UUID</tt>.
-     * @throws UnsupportedOperationException
-     *             if this UUID is not a version 1 UUID.
-     */
-    public long node() {
-        if (version() != 1) {
-            throw new UnsupportedOperationException("Not a time-based UUID");
-        }
-        if (node < 0) {
-            node = leastSigBits & 0x0000FFFFFFFFFFFFL;
-        }
-        return node;
-    }
+	/**
+	 * The node value associated with this UUID.
+	 *
+	 * <p>
+	 * The 48 bit node value is constructed from the node field of this UUID. This
+	 * field is intended to hold the IEEE 802 address of the machine that generated
+	 * this UUID to guarantee spatial uniqueness.
+	 * <p>
+	 *
+	 * The node value is only meaningful in a time-based UUID, which has version
+	 * type 1. If this UUID is not a time-based UUID then this method throws
+	 * UnsupportedOperationException.
+	 *
+	 * @return the node value of this <tt>UUID</tt>.
+	 * @throws UnsupportedOperationException if this UUID is not a version 1 UUID.
+	 */
+	public long node() {
+		if (version() != 1) {
+			throw new UnsupportedOperationException("Not a time-based UUID");
+		}
+		if (node < 0) {
+			node = leastSigBits & 0x0000FFFFFFFFFFFFL;
+		}
+		return node;
+	}
 
-    // Object Inherited Methods
+	// Object Inherited Methods
 
-    /**
-     * Returns a <code>String</code> object representing this
-     * <code>UUID</code>.
-     *
-     * <p>
-     * The UUID string representation is as described by this BNF :
-     *
-     * <pre>
-     *    UUID                   = &lt;time_low&gt; &quot;-&quot; &lt;time_mid&gt; &quot;-&quot;
-     *                             &lt;time_high_and_version&gt; &quot;-&quot;
-     *                             &lt;variant_and_sequence&gt; &quot;-&quot;
-     *                             &lt;node&gt;
-     *    time_low               = 4*&lt;hexOctet&gt;
-     *    time_mid               = 2*&lt;hexOctet&gt;
-     *    time_high_and_version  = 2*&lt;hexOctet&gt;
-     *    variant_and_sequence   = 2*&lt;hexOctet&gt;
-     *    node                   = 6*&lt;hexOctet&gt;
-     *    hexOctet               = &lt;hexDigit&gt;&lt;hexDigit&gt;
-     *    hexDigit               =
-     *          &quot;0&quot; | &quot;1&quot; | &quot;2&quot; | &quot;3&quot; | &quot;4&quot; | &quot;5&quot; | &quot;6&quot; | &quot;7&quot; | &quot;8&quot; | &quot;9&quot;
-     *          | &quot;a&quot; | &quot;b&quot; | &quot;c&quot; | &quot;d&quot; | &quot;e&quot; | &quot;f&quot;
-     *          | &quot;A&quot; | &quot;B&quot; | &quot;C&quot; | &quot;D&quot; | &quot;E&quot; | &quot;F&quot;
-     * </pre>
-     *
-     * @return a string representation of this <tt>UUID</tt>.
-     */
-    @Override
+	/**
+	 * Returns a <code>String</code> object representing this <code>UUID</code>.
+	 *
+	 * <p>
+	 * The UUID string representation is as described by this BNF :
+	 *
+	 * <pre>
+	 *    UUID                   = &lt;time_low&gt; &quot;-&quot; &lt;time_mid&gt; &quot;-&quot;
+	 *                             &lt;time_high_and_version&gt; &quot;-&quot;
+	 *                             &lt;variant_and_sequence&gt; &quot;-&quot;
+	 *                             &lt;node&gt;
+	 *    time_low               = 4*&lt;hexOctet&gt;
+	 *    time_mid               = 2*&lt;hexOctet&gt;
+	 *    time_high_and_version  = 2*&lt;hexOctet&gt;
+	 *    variant_and_sequence   = 2*&lt;hexOctet&gt;
+	 *    node                   = 6*&lt;hexOctet&gt;
+	 *    hexOctet               = &lt;hexDigit&gt;&lt;hexDigit&gt;
+	 *    hexDigit               =
+	 *          &quot;0&quot; | &quot;1&quot; | &quot;2&quot; | &quot;3&quot; | &quot;4&quot; | &quot;5&quot; | &quot;6&quot; | &quot;7&quot; | &quot;8&quot; | &quot;9&quot;
+	 *          | &quot;a&quot; | &quot;b&quot; | &quot;c&quot; | &quot;d&quot; | &quot;e&quot; | &quot;f&quot;
+	 *          | &quot;A&quot; | &quot;B&quot; | &quot;C&quot; | &quot;D&quot; | &quot;E&quot; | &quot;F&quot;
+	 * </pre>
+	 *
+	 * @return a string representation of this <tt>UUID</tt>.
+	 */
+	@Override
 	public String toString() {
-        return (digits(mostSigBits >> 32, 8) + "-"
-                + digits(mostSigBits >> 16, 4) + "-" + digits(mostSigBits, 4)
-                + "-" + digits(leastSigBits >> 48, 4) + "-" + digits(
-                leastSigBits, 12));
-    }
+		return (digits(mostSigBits >> 32, 8) + "-" + digits(mostSigBits >> 16, 4) + "-" + digits(mostSigBits, 4) + "-"
+				+ digits(leastSigBits >> 48, 4) + "-" + digits(leastSigBits, 12));
+	}
 
-    /** Returns val represented by the specified number of hex digits. */
-    private static String digits(long val, int digits) {
-        long hi = 1L << (digits * 4);
-        return Long.toHexString(hi | (val & (hi - 1))).substring(1);
-    }
+	/** Returns val represented by the specified number of hex digits. */
+	private static String digits(long val, int digits) {
+		long hi = 1L << (digits * 4);
+		return Long.toHexString(hi | (val & (hi - 1))).substring(1);
+	}
 
-    /**
-     * Returns a hash code for this <code>UUID</code>.
-     *
-     * @return a hash code value for this <tt>UUID</tt>.
-     */
-    @Override
+	/**
+	 * Returns a hash code for this <code>UUID</code>.
+	 *
+	 * @return a hash code value for this <tt>UUID</tt>.
+	 */
+	@Override
 	public int hashCode() {
-        if (hashCode == -1) {
-            hashCode = (int) ((mostSigBits >> 32) ^ mostSigBits
-                    ^ (leastSigBits >> 32) ^ leastSigBits);
-        }
-        return hashCode;
-    }
+		if (hashCode == -1) {
+			hashCode = (int) ((mostSigBits >> 32) ^ mostSigBits ^ (leastSigBits >> 32) ^ leastSigBits);
+		}
+		return hashCode;
+	}
 
-    /**
-     * Compares this object to the specified object. The result is <tt>true</tt>
-     * if and only if the argument is not <tt>null</tt>, is a <tt>UUID</tt>
-     * object, has the same variant, and contains the same value, bit for bit,
-     * as this <tt>UUID</tt>.
-     *
-     * @param obj
-     *            the object to compare with.
-     * @return <code>true</code> if the objects are the same;
-     *         <code>false</code> otherwise.
-     */
-    @Override
+	/**
+	 * Compares this object to the specified object. The result is <tt>true</tt> if
+	 * and only if the argument is not <tt>null</tt>, is a <tt>UUID</tt> object, has
+	 * the same variant, and contains the same value, bit for bit, as this
+	 * <tt>UUID</tt>.
+	 *
+	 * @param obj the object to compare with.
+	 * @return <code>true</code> if the objects are the same; <code>false</code>
+	 *         otherwise.
+	 */
+	@Override
 	public boolean equals(Object obj) {
-        // 보안 취약점 점검 지적사항 반영 시작
-    	if (obj == null)
-        	return false;
-    	// 보안 취약점 점검 지적사항 반영 시작 끝
-    	if (!(obj instanceof EgovFormBasedUUID))
-            return false;
-        if (((EgovFormBasedUUID) obj).variant() != this.variant())
-            return false;
-        EgovFormBasedUUID id = (EgovFormBasedUUID) obj;
-        return (mostSigBits == id.mostSigBits && leastSigBits == id.leastSigBits);
-    }
+		// 보안 취약점 점검 지적사항 반영 시작
+		if (obj == null) {
+			return false;
+		}
+		// 보안 취약점 점검 지적사항 반영 시작 끝
+		if (!(obj instanceof EgovFormBasedUUID)) {
+			return false;
+		}
+		if (((EgovFormBasedUUID) obj).variant() != this.variant()) {
+			return false;
+		}
+		EgovFormBasedUUID id = (EgovFormBasedUUID) obj;
+		return (mostSigBits == id.mostSigBits && leastSigBits == id.leastSigBits);
+	}
 
-    // Comparison Operations
+	// Comparison Operations
 
-    /**
-     * Compares this UUID with the specified UUID.
-     *
-     * <p>
-     * The first of two UUIDs follows the second if the most significant field
-     * in which the UUIDs differ is greater for the first UUID.
-     *
-     * @param val
-     *            <tt>UUID</tt> to which this <tt>UUID</tt> is to be
-     *            compared.
-     * @return -1, 0 or 1 as this <tt>UUID</tt> is less than, equal to, or
-     *         greater than <tt>val</tt>.
-     */
-    public int compareTo(EgovFormBasedUUID val) {
-        // The ordering is intentionally set up so that the UUIDs
-        // can simply be numerically compared as two numbers
-        return (this.mostSigBits < val.mostSigBits ? -1
-                : (this.mostSigBits > val.mostSigBits ? 1
-                        : (this.leastSigBits < val.leastSigBits ? -1
-                                : (this.leastSigBits > val.leastSigBits ? 1 : 0))));
-    }
+	/**
+	 * Compares this UUID with the specified UUID.
+	 *
+	 * <p>
+	 * The first of two UUIDs follows the second if the most significant field in
+	 * which the UUIDs differ is greater for the first UUID.
+	 *
+	 * @param val <tt>UUID</tt> to which this <tt>UUID</tt> is to be compared.
+	 * @return -1, 0 or 1 as this <tt>UUID</tt> is less than, equal to, or greater
+	 *         than <tt>val</tt>.
+	 */
+	public int compareTo(EgovFormBasedUUID val) {
+		// The ordering is intentionally set up so that the UUIDs
+		// can simply be numerically compared as two numbers
+		return (this.mostSigBits < val.mostSigBits ? -1
+				: (this.mostSigBits > val.mostSigBits ? 1
+						: (this.leastSigBits < val.leastSigBits ? -1
+								: (this.leastSigBits > val.leastSigBits ? 1 : 0))));
+	}
 
-    /**
-     * Reconstitute the <tt>UUID</tt> instance from a stream (that is,
-     * deserialize it). This is necessary to set the transient fields to their
-     * correct uninitialized value so they will be recomputed on demand.
-     */
-    private void readObject(java.io.ObjectInputStream in)
-            throws java.io.IOException, ClassNotFoundException {
+	/**
+	 * Reconstitute the <tt>UUID</tt> instance from a stream (that is, deserialize
+	 * it). This is necessary to set the transient fields to their correct
+	 * uninitialized value so they will be recomputed on demand.
+	 */
+	private void readObject(java.io.ObjectInputStream in) throws java.io.IOException, ClassNotFoundException {
 
-        in.defaultReadObject();
+		in.defaultReadObject();
 
-        // Set "cached computation" fields to their initial values
-        version = -1;
-        variant = -1;
-        timestamp = -1;
-        sequence = -1;
-        node = -1;
-        hashCode = -1;
-    }
+		// Set "cached computation" fields to their initial values
+		version = -1;
+		variant = -1;
+		timestamp = -1;
+		sequence = -1;
+		node = -1;
+		hashCode = -1;
+	}
 }


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

<hr>

### 2025-09-01 토 PMD로 소프트웨어 보안약점 진단하고 제거하기-EgovFormBasedUUID

불필요한 WrapperObject `.longValue()` 제거
```java
//        long mostSigBits = Long.decode(components[0]).longValue();
        long mostSigBits = Long.decode(components[0]);
        mostSigBits <<= 16;
//        mostSigBits |= Long.decode(components[1]).longValue();
        mostSigBits |= Long.decode(components[1]);
        mostSigBits <<= 16;
//        mostSigBits |= Long.decode(components[2]).longValue();
        mostSigBits |= Long.decode(components[2]);

//        long leastSigBits = Long.decode(components[3]).longValue();
        long leastSigBits = Long.decode(components[3]);
        leastSigBits <<= 48;
//        leastSigBits |= Long.decode(components[4]).longValue();
        leastSigBits |= Long.decode(components[4]);
```

불필요한 괄호제거
```java
//        return (digits(mostSigBits >> 32, 8) + "-"
//                + digits(mostSigBits >> 16, 4) + "-" + digits(mostSigBits, 4)
//                + "-" + digits(leastSigBits >> 48, 4) + "-" + digits(
//                leastSigBits, 12));
        return digits(mostSigBits >> 32, 8) + "-"
                + digits(mostSigBits >> 16, 4) + "-" + digits(mostSigBits, 4)
                + "-" + digits(leastSigBits >> 48, 4) + "-" + digits(
                leastSigBits, 12);

//        return (mostSigBits == id.mostSigBits && leastSigBits == id.leastSigBits);
        return mostSigBits == id.mostSigBits && leastSigBits == id.leastSigBits;

//        return (this.mostSigBits < val.mostSigBits ? -1
//                : (this.mostSigBits > val.mostSigBits ? 1
//                        : (this.leastSigBits < val.leastSigBits ? -1
//                                : (this.leastSigBits > val.leastSigBits ? 1 : 0))));
        return this.mostSigBits < val.mostSigBits ? -1
                : this.mostSigBits > val.mostSigBits ? 1
                        : this.leastSigBits < val.leastSigBits ? -1
                                : this.leastSigBits > val.leastSigBits ? 1 : 0;
```

`@SuppressWarnings("serial")` 제거하고 `private static final long serialVersionUID = 1L;` 추가

<hr>

1. PMD로 소프트웨어 보안약점 진단 결과

```
src/main/java/egovframework/com/utl/fcc/service/EgovFormBasedUUID.java:235:	UnnecessaryBoxing:	UnnecessaryBoxing: 불필요한 explicit unboxing
src/main/java/egovframework/com/utl/fcc/service/EgovFormBasedUUID.java:237:	UnnecessaryBoxing:	UnnecessaryBoxing: 불필요한 explicit unboxing
src/main/java/egovframework/com/utl/fcc/service/EgovFormBasedUUID.java:239:	UnnecessaryBoxing:	UnnecessaryBoxing: 불필요한 explicit unboxing
src/main/java/egovframework/com/utl/fcc/service/EgovFormBasedUUID.java:241:	UnnecessaryBoxing:	UnnecessaryBoxing: 불필요한 explicit unboxing
src/main/java/egovframework/com/utl/fcc/service/EgovFormBasedUUID.java:243:	UnnecessaryBoxing:	UnnecessaryBoxing: 불필요한 explicit unboxing
src/main/java/egovframework/com/utl/fcc/service/EgovFormBasedUUID.java:434:	UselessParentheses:	UselessParentheses: 괄호가 없어도 되는 상황에서 불필요한 괄호를 사용할 경우 마치 메소드 호출처럼 보여서 소스 코드의 가독성을 떨어뜨릴 수 있음
src/main/java/egovframework/com/utl/fcc/service/EgovFormBasedUUID.java:482:	UselessParentheses:	UselessParentheses: 괄호가 없어도 되는 상황에서 불필요한 괄호를 사용할 경우 마치 메소드 호출처럼 보여서 소스 코드의 가독성을 떨어뜨릴 수 있음
src/main/java/egovframework/com/utl/fcc/service/EgovFormBasedUUID.java:503:	UselessParentheses:	UselessParentheses: 괄호가 없어도 되는 상황에서 불필요한 괄호를 사용할 경우 마치 메소드 호출처럼 보여서 소스 코드의 가독성을 떨어뜨릴 수 있음
src/main/java/egovframework/com/utl/fcc/service/EgovFormBasedUUID.java:504:	UselessParentheses:	UselessParentheses: 괄호가 없어도 되는 상황에서 불필요한 괄호를 사용할 경우 마치 메소드 호출처럼 보여서 소스 코드의 가독성을 떨어뜨릴 수 있음
src/main/java/egovframework/com/utl/fcc/service/EgovFormBasedUUID.java:505:	UselessParentheses:	UselessParentheses: 괄호가 없어도 되는 상황에서 불필요한 괄호를 사용할 경우 마치 메소드 호출처럼 보여서 소스 코드의 가독성을 떨어뜨릴 수 있음
src/main/java/egovframework/com/utl/fcc/service/EgovFormBasedUUID.java:506:	UselessParentheses:	UselessParentheses: 괄호가 없어도 되는 상황에서 불필요한 괄호를 사용할 경우 마치 메소드 호출처럼 보여서 소스 코드의 가독성을 떨어뜨릴 수 있음
```

2. 브랜치 생성

```
feature/pmd/EgovFormBasedUUID
```

3. 이클립스 > Source > Format

4. 개정이력 수정

```java
 *   2025.09.01  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-UnnecessaryBoxing(불필요한 WrapperObject 생성)
 *   2025.09.01  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-UselessParentheses(불필요한 괄호사용)
```

<hr>

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

https://youtu.be/8OPO_0e-8Go
