### PR TITLE
PMD로 소프트웨어 보안약점 진단하고 제거하기-EgovStringUtil

### DIFF
--- a/src/main/java/egovframework/com/utl/fcc/service/EgovStringUtil.java
+++ b/src/main/java/egovframework/com/utl/fcc/service/EgovStringUtil.java
@@ -45,32 +45,38 @@ public class EgovStringUtil {
 	 * 빈 문자열 <code>""</code>.
 	 */
 	public static final String EMPTY = "";
-	
-	// 221116	김혜준	2022 시큐어코딩 조치
+
+	// 221116 김혜준 2022 시큐어코딩 조치
 	private static SecureRandom rnd = new SecureRandom();
 
 	/**
-	 * <p>Padding을 할 수 있는 최대 수치</p>
+	 * <p>
+	 * Padding을 할 수 있는 최대 수치
+	 * </p>
 	 */
 	// private static final int PAD_LIMIT = 8192;
 
 	/**
-	 * <p>An array of <code>String</code>s used for padding.</p>
-	 * <p>Used for efficient space padding. The length of each String expands as needed.</p>
+	 * <p>
+	 * An array of <code>String</code>s used for padding.
+	 * </p>
+	 * <p>
+	 * Used for efficient space padding. The length of each String expands as
+	 * needed.
+	 * </p>
 	 */
 	/*
-	private static final String[] PADDING = new String[Character.MAX_VALUE];
-
-	static {
-		// space padding is most common, start with 64 chars
-		PADDING[32] = "                                                                ";
-	}
+	 * private static final String[] PADDING = new String[Character.MAX_VALUE];
+	 * 
+	 * static { // space padding is most common, start with 64 chars PADDING[32] =
+	 * "                                                                "; }
 	 */
 
 	/**
 	 * 문자열이 지정한 길이를 초과했을때 지정한길이에다가 해당 문자열을 붙여주는 메서드.
-	 * @param source 원본 문자열 배열
-	 * @param output 더할문자열
+	 * 
+	 * @param source  원본 문자열 배열
+	 * @param output  더할문자열
 	 * @param slength 지정길이
 	 * @return 지정길이로 잘라서 더할분자열 합친 문자열
 	 */
@@ -88,7 +94,8 @@ public class EgovStringUtil {
 
 	/**
 	 * 문자열이 지정한 길이를 초과했을때 해당 문자열을 삭제하는 메서드
-	 * @param source 원본 문자열 배열
+	 * 
+	 * @param source  원본 문자열 배열
 	 * @param slength 지정길이
 	 * @return 지정길이로 잘라서 더할분자열 합친 문자열
 	 */
@@ -125,7 +132,9 @@ public class EgovStringUtil {
 	}
 
 	/**
-	 * <p>기준 문자열에 포함된 모든 대상 문자(char)를 제거한다.</p>
+	 * <p>
+	 * 기준 문자열에 포함된 모든 대상 문자(char)를 제거한다.
+	 * </p>
 	 *
 	 * <pre>
 	 * StringUtil.remove(null, *)       = null
@@ -134,8 +143,8 @@ public class EgovStringUtil {
 	 * StringUtil.remove("queued", 'z') = "queued"
 	 * </pre>
 	 *
-	 * @param str  입력받는 기준 문자열
-	 * @param remove  입력받는 문자열에서 제거할 대상 문자열
+	 * @param str    입력받는 기준 문자열
+	 * @param remove 입력받는 문자열에서 제거할 대상 문자열
 	 * @return 제거대상 문자열이 제거된 입력문자열. 입력문자열이 null인 경우 출력문자열은 null
 	 */
 	public static String remove(String str, char remove) {
@@ -153,7 +162,9 @@ public class EgovStringUtil {
 	}
 
 	/**
-	 * <p>문자열 내부의 콤마 character(,)를 모두 제거한다.</p>
+	 * <p>
+	 * 문자열 내부의 콤마 character(,)를 모두 제거한다.
+	 * </p>
 	 *
 	 * <pre>
 	 * StringUtil.removeCommaChar(null)       = null
@@ -162,15 +173,16 @@ public class EgovStringUtil {
 	 * </pre>
 	 *
 	 * @param str 입력받는 기준 문자열
-	 * @return " , "가 제거된 입력문자열
-	 *  입력문자열이 null인 경우 출력문자열은 null
+	 * @return " , "가 제거된 입력문자열 입력문자열이 null인 경우 출력문자열은 null
 	 */
 	public static String removeCommaChar(String str) {
 		return remove(str, ',');
 	}
 
 	/**
-	 * <p>문자열 내부의 마이너스 character(-)를 모두 제거한다.</p>
+	 * <p>
+	 * 문자열 내부의 마이너스 character(-)를 모두 제거한다.
+	 * </p>
 	 *
 	 * <pre>
 	 * StringUtil.removeMinusChar(null)       = null
@@ -178,9 +190,8 @@ public class EgovStringUtil {
 	 * StringUtil.removeMinusChar("a-sdfg-qweqe") = "asdfgqweqe"
 	 * </pre>
 	 *
-	 * @param str  입력받는 기준 문자열
-	 * @return " - "가 제거된 입력문자열
-	 *  입력문자열이 null인 경우 출력문자열은 null
+	 * @param str 입력받는 기준 문자열
+	 * @return " - "가 제거된 입력문자열 입력문자열이 null인 경우 출력문자열은 null
 	 */
 	public static String removeMinusChar(String str) {
 		return remove(str, '-');
@@ -188,9 +199,10 @@ public class EgovStringUtil {
 
 	/**
 	 * 원본 문자열의 포함된 특정 문자열을 새로운 문자열로 변환하는 메서드
-	 * @param source 원본 문자열
+	 * 
+	 * @param source  원본 문자열
 	 * @param subject 원본 문자열에 포함된 특정 문자열
-	 * @param object 변환할 문자열
+	 * @param object  변환할 문자열
 	 * @return sb.toString() 새로운 문자열로 변환된 문자열
 	 */
 	public static String replace(String source, String subject, String object) {
@@ -212,9 +224,10 @@ public class EgovStringUtil {
 
 	/**
 	 * 원본 문자열의 포함된 특정 문자열 첫번째 한개만 새로운 문자열로 변환하는 메서드
-	 * @param source 원본 문자열
+	 * 
+	 * @param source  원본 문자열
 	 * @param subject 원본 문자열에 포함된 특정 문자열
-	 * @param object 변환할 문자열
+	 * @param object  변환할 문자열
 	 * @return sb.toString() 새로운 문자열로 변환된 문자열 / source 특정문자열이 없는 경우 원본 문자열
 	 */
 	public static String replaceOnce(String source, String subject, String object) {
@@ -235,9 +248,9 @@ public class EgovStringUtil {
 	/**
 	 * <code>subject</code>에 포함된 각각의 문자를 object로 변환한다.
 	 *
-	 * @param source 원본 문자열
+	 * @param source  원본 문자열
 	 * @param subject 원본 문자열에 포함된 특정 문자열
-	 * @param object 변환할 문자열
+	 * @param object  변환할 문자열
 	 * @return sb.toString() 새로운 문자열로 변환된 문자열
 	 */
 	public static String replaceChar(String source, String subject, String object) {
@@ -262,9 +275,13 @@ public class EgovStringUtil {
 	}
 
 	/**
-	 * <p><code>str</code> 중 <code>searchStr</code>의 시작(index) 위치를 반환.</p>
+	 * <p>
+	 * <code>str</code> 중 <code>searchStr</code>의 시작(index) 위치를 반환.
+	 * </p>
 	 *
-	 * <p>입력값 중 <code>null</code>이 있을 경우 <code>-1</code>을 반환.</p>
+	 * <p>
+	 * 입력값 중 <code>null</code>이 있을 경우 <code>-1</code>을 반환.
+	 * </p>
 	 *
 	 * <pre>
 	 * StringUtil.indexOf(null, *)          = -1
@@ -276,8 +293,8 @@ public class EgovStringUtil {
 	 * StringUtil.indexOf("aabaabaa", "")   = 0
 	 * </pre>
 	 *
-	 * @param str  검색 문자열
-	 * @param searchStr  검색 대상문자열
+	 * @param str       검색 문자열
+	 * @param searchStr 검색 대상문자열
 	 * @return 검색 문자열 중 검색 대상문자열이 있는 시작 위치 검색대상 문자열이 없거나 null인 경우 -1
 	 */
 	public static int indexOf(String str, String searchStr) {
@@ -289,9 +306,10 @@ public class EgovStringUtil {
 	}
 
 	/**
-	 * <p>오라클의 decode 함수와 동일한 기능을 가진 메서드이다.
-	 * <code>sourStr</code>과 <code>compareStr</code>의 값이 같으면
-	 * <code>returStr</code>을 반환하며, 다르면  <code>defaultStr</code>을 반환한다.
+	 * <p>
+	 * 오라클의 decode 함수와 동일한 기능을 가진 메서드이다. <code>sourStr</code>과
+	 * <code>compareStr</code>의 값이 같으면 <code>returStr</code>을 반환하며, 다르면
+	 * <code>defaultStr</code>을 반환한다.
 	 * </p>
 	 *
 	 * <pre>
@@ -304,27 +322,27 @@ public class EgovStringUtil {
 	 * StringUtil.decode("하이", "하이  ", "foo", "bar") = "bar"
 	 * </pre>
 	 *
-	 * @param sourceStr 비교할 문자열
+	 * @param sourceStr  비교할 문자열
 	 * @param compareStr 비교 대상 문자열
-	 * @param returnStr sourceStr와 compareStr의 값이 같을 때 반환할 문자열
+	 * @param returnStr  sourceStr와 compareStr의 값이 같을 때 반환할 문자열
 	 * @param defaultStr sourceStr와 compareStr의 값이 다를 때 반환할 문자열
-	 * @return sourceStr과 compareStr의 값이 동일(equal)할 때 returnStr을 반환하며,
-	 *         <br/>다르면 defaultStr을 반환한다.
+	 * @return sourceStr과 compareStr의 값이 동일(equal)할 때 returnStr을 반환하며, <br/>
+	 *         다르면 defaultStr을 반환한다.
 	 */
 	public static String decode(String sourceStr, String compareStr, String returnStr, String defaultStr) {
-		//		if (sourceStr == null && compareStr == null) {
-		//			return returnStr;
-		//		}
+		// if (sourceStr == null && compareStr == null) {
+		// return returnStr;
+		// }
 		//
-		//		if (sourceStr == null && compareStr != null) {
-		//			return defaultStr;
-		//		}
+		// if (sourceStr == null && compareStr != null) {
+		// return defaultStr;
+		// }
 		//
-		//		if (sourceStr.trim().equals(compareStr)) {
-		//			return returnStr;
-		//		}
+		// if (sourceStr.trim().equals(compareStr)) {
+		// return returnStr;
+		// }
 
-		if (sourceStr == null) { //2022.01. Possible null pointer dereference
+		if (sourceStr == null) { // 2022.01. Possible null pointer dereference
 			if (compareStr == null) {
 				return returnStr;
 			} else {
@@ -340,9 +358,10 @@ public class EgovStringUtil {
 	}
 
 	/**
-	 * <p>오라클의 decode 함수와 동일한 기능을 가진 메서드이다.
-	 * <code>sourStr</code>과 <code>compareStr</code>의 값이 같으면
-	 * <code>returStr</code>을 반환하며, 다르면  <code>sourceStr</code>을 반환한다.
+	 * <p>
+	 * 오라클의 decode 함수와 동일한 기능을 가진 메서드이다. <code>sourStr</code>과
+	 * <code>compareStr</code>의 값이 같으면 <code>returStr</code>을 반환하며, 다르면
+	 * <code>sourceStr</code>을 반환한다.
 	 * </p>
 	 *
 	 * <pre>
@@ -354,11 +373,11 @@ public class EgovStringUtil {
 	 * StringUtil.decode("하이", "바이", "foo") = "하이"
 	 * </pre>
 	 *
-	 * @param sourceStr 비교할 문자열
+	 * @param sourceStr  비교할 문자열
 	 * @param compareStr 비교 대상 문자열
-	 * @param returnStr sourceStr와 compareStr의 값이 같을 때 반환할 문자열
-	 * @return sourceStr과 compareStr의 값이 동일(equal)할 때 returnStr을 반환하며,
-	 *         <br/>다르면 sourceStr을 반환한다.
+	 * @param returnStr  sourceStr와 compareStr의 값이 같을 때 반환할 문자열
+	 * @return sourceStr과 compareStr의 값이 동일(equal)할 때 returnStr을 반환하며, <br/>
+	 *         다르면 sourceStr을 반환한다.
 	 */
 	public static String decode(String sourceStr, String compareStr, String returnStr) {
 		return decode(sourceStr, compareStr, returnStr, sourceStr);
@@ -366,6 +385,7 @@ public class EgovStringUtil {
 
 	/**
 	 * 객체가 null인지 확인하고 null인 경우 "" 로 바꾸는 메서드
+	 * 
 	 * @param object 원본 객체
 	 * @return resultVal 문자열
 	 */
@@ -380,51 +400,51 @@ public class EgovStringUtil {
 	}
 
 	/**
-	 *<pre>
+	 * <pre>
 	 * 인자로 받은 String이 null일 경우 &quot;&quot;로 리턴한다.
 	 * &#064;param src null값일 가능성이 있는 String 값.
 	 * &#064;return 만약 String이 null 값일 경우 &quot;&quot;로 바꾼 String 값.
-	 *</pre>
+	 * </pre>
 	 */
 	public static String nullConvert(Object src) {
-		//if (src != null && src.getClass().getName().equals("java.math.BigDecimal")) {
+		// if (src != null && src.getClass().getName().equals("java.math.BigDecimal")) {
 		if (src != null && src instanceof java.math.BigDecimal) {
-			return ((BigDecimal)src).toString();
+			return ((BigDecimal) src).toString();
 		}
 
 		if (src == null || src.equals("null")) {
 			return "";
 		} else {
-			return ((String)src).trim();
+			return ((String) src).trim();
 		}
 	}
 
 	/**
-	 *<pre>
+	 * <pre>
 	 * 인자로 받은 String이 null일 경우 &quot;&quot;로 리턴한다.
 	 * &#064;param src null값일 가능성이 있는 String 값.
 	 * &#064;return 만약 String이 null 값일 경우 &quot;&quot;로 바꾼 String 값.
-	 *</pre>
+	 * </pre>
 	 */
 	public static String nullConvertInt(Object src) {
-		//if (src != null && src.getClass().getName().equals("java.math.BigDecimal")) {
+		// if (src != null && src.getClass().getName().equals("java.math.BigDecimal")) {
 		if (src != null && src instanceof java.math.BigDecimal) {
-			return ((BigDecimal)src).toString();
+			return ((BigDecimal) src).toString();
 		}
 
 		if (src == null || src.equals("null")) {
 			return "0";
 		} else {
-			return ((String)src).trim();
+			return ((String) src).trim();
 		}
 	}
 
 	/**
-	 *<pre>
+	 * <pre>
 	 * 인자로 받은 String이 null일 경우 &quot;&quot;로 리턴한다.
 	 * &#064;param src null값일 가능성이 있는 String 값.
 	 * &#064;return 만약 String이 null 값일 경우 &quot;&quot;로 바꾼 String 값.
-	 *</pre>
+	 * </pre>
 	 */
 	public static String nullConvert(String src) {
 
@@ -436,27 +456,27 @@ public class EgovStringUtil {
 	}
 
 	/**
-	 *<pre>
+	 * <pre>
 	 * 인자로 받은 String이 null일 경우 &quot;0&quot;로 리턴한다.
 	 * &#064;param src null값일 가능성이 있는 String 값.
 	 * &#064;return 만약 String이 null 값일 경우 &quot;0&quot;로 바꾼 String 값.
-	 *</pre>
+	 * </pre>
 	 */
 	public static int zeroConvert(Object src) {
 
 		if (src == null || src.equals("null")) {
 			return 0;
 		} else {
-			return Integer.parseInt(((String)src).trim());
+			return Integer.parseInt(((String) src).trim());
 		}
 	}
 
 	/**
-	 *<pre>
+	 * <pre>
 	 * 인자로 받은 String이 null일 경우 &quot;&quot;로 리턴한다.
 	 * &#064;param src null값일 가능성이 있는 String 값.
 	 * &#064;return 만약 String이 null 값일 경우 &quot;&quot;로 바꾼 String 값.
-	 *</pre>
+	 * </pre>
 	 */
 	public static int zeroConvert(String src) {
 
@@ -468,8 +488,9 @@ public class EgovStringUtil {
 	}
 
 	/**
-	 * <p>문자열에서 {@link Character#isWhitespace(char)}에 정의된
-	 * 모든 공백문자를 제거한다.</p>
+	 * <p>
+	 * 문자열에서 {@link Character#isWhitespace(char)}에 정의된 모든 공백문자를 제거한다.
+	 * </p>
 	 *
 	 * <pre>
 	 * StringUtil.removeWhitespace(null)         = null
@@ -478,7 +499,7 @@ public class EgovStringUtil {
 	 * StringUtil.removeWhitespace("   ab  c  ") = "abc"
 	 * </pre>
 	 *
-	 * @param str  공백문자가 제거도어야 할 문자열
+	 * @param str 공백문자가 제거도어야 할 문자열
 	 * @return the 공백문자가 제거된 문자열, null이 입력되면 <code>null</code>이 리턴
 	 */
 	public static String removeWhitespace(String str) {
@@ -518,26 +539,26 @@ public class EgovStringUtil {
 			chrBuff = strString.charAt(i);
 
 			switch (chrBuff) {
-				case '<':
-					strTxt.append("&lt;");
-					break;
-				case '>':
-					strTxt.append("&gt;");
-					break;
-				case '"':
-					strTxt.append("&quot;");
-					break;
-				case 10:
-					strTxt.append("<br>");
-					break;
-				case ' ':
-					strTxt.append("&nbsp;");
-					break;
-				//case '&' :
-				//strTxt.append("&amp;");
-				//break;
-				default:
-					strTxt.append(chrBuff);
+			case '<':
+				strTxt.append("&lt;");
+				break;
+			case '>':
+				strTxt.append("&gt;");
+				break;
+			case '"':
+				strTxt.append("&quot;");
+				break;
+			case 10:
+				strTxt.append("<br>");
+				break;
+			case ' ':
+				strTxt.append("&nbsp;");
+				break;
+			// case '&' :
+			// strTxt.append("&amp;");
+			// break;
+			default:
+				strTxt.append(chrBuff);
 			}
 		}
 
@@ -548,7 +569,8 @@ public class EgovStringUtil {
 
 	/**
 	 * 문자열을 지정한 분리자에 의해 배열로 리턴하는 메서드.
-	 * @param source 원본 문자열
+	 * 
+	 * @param source    원본 문자열
 	 * @param separator 분리자
 	 * @return result 분리자로 나뉘어진 문자열 배열
 	 */
@@ -577,7 +599,9 @@ public class EgovStringUtil {
 	}
 
 	/**
-	 * <p>{@link String#toLowerCase()}를 이용하여 소문자로 변환한다.</p>
+	 * <p>
+	 * {@link String#toLowerCase()}를 이용하여 소문자로 변환한다.
+	 * </p>
 	 *
 	 * <pre>
 	 * StringUtil.lowerCase(null)  = null
@@ -597,7 +621,9 @@ public class EgovStringUtil {
 	}
 
 	/**
-	 * <p>{@link String#toUpperCase()}를 이용하여 대문자로 변환한다.</p>
+	 * <p>
+	 * {@link String#toUpperCase()}를 이용하여 대문자로 변환한다.
+	 * </p>
 	 *
 	 * <pre>
 	 * StringUtil.upperCase(null)  = null
@@ -617,7 +643,9 @@ public class EgovStringUtil {
 	}
 
 	/**
-	 * <p>입력된 String의 앞쪽에서 두번째 인자로 전달된 문자(stripChars)를 모두 제거한다.</p>
+	 * <p>
+	 * 입력된 String의 앞쪽에서 두번째 인자로 전달된 문자(stripChars)를 모두 제거한다.
+	 * </p>
 	 *
 	 * <pre>
 	 * StringUtil.stripStart(null, *)          = null
@@ -630,7 +658,7 @@ public class EgovStringUtil {
 	 * StringUtil.stripStart("yxabc  ", "xyz") = "abc  "
 	 * </pre>
 	 *
-	 * @param str 지정된 문자가 제거되어야 할 문자열
+	 * @param str        지정된 문자가 제거되어야 할 문자열
 	 * @param stripChars 제거대상 문자열
 	 * @return 지정된 문자가 제거된 문자열, null이 입력되면 <code>null</code> 리턴
 	 */
@@ -656,7 +684,9 @@ public class EgovStringUtil {
 	}
 
 	/**
-	 * <p>입력된 String의 뒤쪽에서 두번째 인자로 전달된 문자(stripChars)를 모두 제거한다.</p>
+	 * <p>
+	 * 입력된 String의 뒤쪽에서 두번째 인자로 전달된 문자(stripChars)를 모두 제거한다.
+	 * </p>
 	 *
 	 * <pre>
 	 * StringUtil.stripEnd(null, *)          = null
@@ -669,7 +699,7 @@ public class EgovStringUtil {
 	 * StringUtil.stripEnd("  abcyx", "xyz") = "  abc"
 	 * </pre>
 	 *
-	 * @param str 지정된 문자가 제거되어야 할 문자열
+	 * @param str        지정된 문자가 제거되어야 할 문자열
 	 * @param stripChars 제거대상 문자열
 	 * @return 지정된 문자가 제거된 문자열, null이 입력되면 <code>null</code> 리턴
 	 */
@@ -695,7 +725,9 @@ public class EgovStringUtil {
 	}
 
 	/**
-	 * <p>입력된 String의 앞, 뒤에서 두번째 인자로 전달된 문자(stripChars)를 모두 제거한다.</p>
+	 * <p>
+	 * 입력된 String의 앞, 뒤에서 두번째 인자로 전달된 문자(stripChars)를 모두 제거한다.
+	 * </p>
 	 *
 	 * <pre>
 	 * StringUtil.strip(null, *)          = null
@@ -707,7 +739,7 @@ public class EgovStringUtil {
 	 * StringUtil.strip("  abcyx", "xyz") = "  abc"
 	 * </pre>
 	 *
-	 * @param str 지정된 문자가 제거되어야 할 문자열
+	 * @param str        지정된 문자가 제거되어야 할 문자열
 	 * @param stripChars 제거대상 문자열
 	 * @return 지정된 문자가 제거된 문자열, null이 입력되면 <code>null</code> 리턴
 	 */
@@ -724,8 +756,9 @@ public class EgovStringUtil {
 
 	/**
 	 * 문자열을 지정한 분리자에 의해 지정된 길이의 배열로 리턴하는 메서드.
-	 * @param source 원본 문자열
-	 * @param separator 분리자
+	 * 
+	 * @param source      원본 문자열
+	 * @param separator   분리자
 	 * @param arraylength 배열 길이
 	 * @return 분리자로 나뉘어진 문자열 배열
 	 */
@@ -754,7 +787,7 @@ public class EgovStringUtil {
 	 * 문자열 A에서 Z사이의 랜덤 문자열을 구하는 기능을 제공 시작문자열과 종료문자열 사이의 랜덤 문자열을 구하는 기능
 	 *
 	 * @param startChr - 첫 문자
-	 * @param endChr - 마지막문자
+	 * @param endChr   - 마지막문자
 	 * @return 랜덤문자
 	 * @exception MyException
 	 * @see
@@ -779,21 +812,20 @@ public class EgovStringUtil {
 		} while (randomInt < startInt); // 입력받은 문자 'A'(65)보다 작으면 다시 랜덤 숫자 발생.
 
 		// 랜덤 숫자를 문자로 변환 후 스트링으로 다시 변환
-		randomStr = (char)randomInt + "";
+		randomStr = (char) randomInt + "";
 
 		// 랜덤문자열를 리턴
 		return randomStr;
 	}
 
 	/**
-	 * 문자열을 다양한 문자셋(EUC-KR[KSC5601],UTF-8..)을 사용하여 인코딩하는 기능 역으로 디코딩하여 원래의 문자열을
-	 * 복원하는 기능을 제공함 String temp = new String(문자열.getBytes("바꾸기전 인코딩"),"바꿀 인코딩");
-	 * String temp = new String(문자열.getBytes("8859_1"),"KSC5601"); => UTF-8 에서
-	 * EUC-KR
+	 * 문자열을 다양한 문자셋(EUC-KR[KSC5601],UTF-8..)을 사용하여 인코딩하는 기능 역으로 디코딩하여 원래의 문자열을 복원하는
+	 * 기능을 제공함 String temp = new String(문자열.getBytes("바꾸기전 인코딩"),"바꿀 인코딩"); String
+	 * temp = new String(문자열.getBytes("8859_1"),"KSC5601"); => UTF-8 에서 EUC-KR
 	 *
-	 * @param srcString - 문자열
+	 * @param srcString    - 문자열
 	 * @param srcCharsetNm - 원래 CharsetNm
-	 * @param charsetNm - CharsetNm
+	 * @param charsetNm    - CharsetNm
 	 * @return 인(디)코딩 문자열
 	 * @exception MyException
 	 * @see
@@ -816,12 +848,13 @@ public class EgovStringUtil {
 	}
 
 	/**
-	     * 특수문자를 웹 브라우저에서 정상적으로 보이기 위해 특수문자를 처리('<' -> & lT)하는 기능이다
-	     * @param 	srcString 		- '<'
-	     * @return 	변환문자열('<' -> "&lt"
-	     * @exception MyException
-	     * @see
-	     */
+	 * 특수문자를 웹 브라우저에서 정상적으로 보이기 위해 특수문자를 처리('<' -> & lT)하는 기능이다
+	 * 
+	 * @param srcString - '<'
+	 * @return 변환문자열('<' -> "&lt"
+	 * @exception MyException
+	 * @see
+	 */
 	public static String getSpclStrCnvr(String srcString) {
 
 		String rtnStr = null;
@@ -835,17 +868,17 @@ public class EgovStringUtil {
 			chrBuff = srcString.charAt(i);
 
 			switch (chrBuff) {
-				case '<':
-					strTxt.append("&lt;");
-					break;
-				case '>':
-					strTxt.append("&gt;");
-					break;
-				case '&':
-					strTxt.append("&amp;");
-					break;
-				default:
-					strTxt.append(chrBuff);
+			case '<':
+				strTxt.append("&lt;");
+				break;
+			case '>':
+				strTxt.append("&gt;");
+				break;
+			case '&':
+				strTxt.append("&amp;");
+				break;
+			default:
+				strTxt.append(chrBuff);
 			}
 		}
 
@@ -901,52 +934,48 @@ public class EgovStringUtil {
 	}
 
 	/**
-	 * <p>날짜 형식의 문자열 내부에 마이너스 character(-)를 추가한다.</p>
+	 * <p>
+	 * 날짜 형식의 문자열 내부에 마이너스 character(-)를 추가한다.
+	 * </p>
 	 *
 	 * <pre>
-	 *   StringUtil.addMinusChar("20100901") = "2010-09-01"
+	 * StringUtil.addMinusChar("20100901") = "2010-09-01"
 	 * </pre>
 	 *
-	 * @param date  입력받는 문자열
+	 * @param date 입력받는 문자열
 	 * @return " - "가 추가된 입력문자열
 	 */
 	public static String addMinusChar(String date) {
 		if (date.length() == 8) {
 			return date.substring(0, 4).concat("-").concat(date.substring(4, 6)).concat("-")
-				.concat(date.substring(6, 8));
+					.concat(date.substring(6, 8));
 		} else {
 			return "";
 		}
 	}
 
 	/**
-	 * 주어진 명사에 맞는 보조사를 반환한다.
-	 * 예: "이름" -> "이름은", "나이" -> "나이는"
+	 * 주어진 명사에 맞는 보조사를 반환한다. 예: "이름" -> "이름은", "나이" -> "나이는"
 	 *
 	 * @param noun 명사
 	 * @return 보조사 조사 ("은" 또는 "는")
 	 */
-	public static String getAuxiliaryParticle(String noun){
-		return noun+( hasFinalConsonant(noun) ? "은" : "는") ;
+	public static String getAuxiliaryParticle(String noun) {
+		return noun + (hasFinalConsonant(noun) ? "은" : "는");
 	}
 
-
 	/**
-	 * 주어진 명사에 맞는 주격 조사를 반환한다.
-	 * 예: "책상" -> "책상이", "청소기" -> "청소기"
+	 * 주어진 명사에 맞는 주격 조사를 반환한다. 예: "책상" -> "책상이", "청소기" -> "청소기"
 	 *
 	 * @param noun 명사
 	 * @return 주격 조사 ("이" 또는 "")
 	 */
 	public static String getSubjectParticle(String noun) {
-		return hasFinalConsonant(noun) ? noun+"이" : noun;
+		return hasFinalConsonant(noun) ? noun + "이" : noun;
 	}
 
-
-
 	/**
-	 * 주어진 명사에 맞는 목적격 조사를 반환한다.
-	 * 예: "책상" -> "책상을", "청소기" -> "청소기를"
+	 * 주어진 명사에 맞는 목적격 조사를 반환한다. 예: "책상" -> "책상을", "청소기" -> "청소기를"
 	 *
 	 * @param noun 명사
 	 * @return 목적격 조사 ("을" 또는 "를")
@@ -954,7 +983,6 @@ public class EgovStringUtil {
 	public static String getObjectParticle(String noun) {
 		return noun + (hasFinalConsonant(noun) ? "을" : "를");
 	}
-
 
 	/**
 	 * 주어진 명사가 종성을 가지는지 여부를 확인한다.

--- a/src/main/java/egovframework/com/utl/fcc/service/EgovStringUtil.java
+++ b/src/main/java/egovframework/com/utl/fcc/service/EgovStringUtil.java
@@ -1,21 +1,3 @@
-/**
- * @Class Name  : EgovStringUtil.java
- * @Description : 문자열 데이터 처리 관련 유틸리티
- * @Modification Information
- *
- *     수정일         수정자                   수정내용
- *     -------          --------        ---------------------------
- *   2009.01.13     박정규          최초 생성
- *   2009.02.13     이삼섭          내용 추가
- *   2024.10.29		Chung10Kr		명사에 맞는 조사 반환 기능 개발
- *
- * @author 공통 서비스 개발팀 박정규
- * @since 2009. 01. 13
- * @version 1.0
- * @see
- *
- */
-
 package egovframework.com.utl.fcc.service;
 
 /*
@@ -40,6 +22,27 @@ import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
 import java.util.Locale;
 
+/**
+ * 문자열 데이터 처리 관련 유틸리티
+ * 
+ * @author 공통 서비스 개발팀 박정규
+ * @since 2009.01.13
+ * @version 1.0
+ * @see
+ *
+ *      <pre>
+ *  == 개정이력(Modification Information) ==
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2009.01.13  박정규          최초 생성
+ *   2009.02.13  이삼섭          내용 추가
+ *   2024.10.29  Chung10Kr     명사에 맞는 조사 반환 기능 개발
+ *   2025.09.02  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-AssignmentInOperand(피연산자내에 할당문이 사용됨. 해당 코드를 복잡하고 가독성이 떨어지게 만듬)
+ *   2025.09.02  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-UnnecessaryBoxing(불필요한 WrapperObject 생성)
+ *
+ *      </pre>
+ */
 public class EgovStringUtil {
 	/**
 	 * 빈 문자열 <code>""</code>.

--- a/src/main/java/egovframework/com/utl/fcc/service/EgovStringUtil.java
+++ b/src/main/java/egovframework/com/utl/fcc/service/EgovStringUtil.java
@@ -663,8 +663,8 @@ public class EgovStringUtil {
 	 * @return 지정된 문자가 제거된 문자열, null이 입력되면 <code>null</code> 리턴
 	 */
 	public static String stripStart(String str, String stripChars) {
-		int strLen;
-		if (str == null || (strLen = str.length()) == 0) {
+		int strLen = str.length();
+		if (str == null || strLen == 0) {
 			return str;
 		}
 		int start = 0;
@@ -704,8 +704,8 @@ public class EgovStringUtil {
 	 * @return 지정된 문자가 제거된 문자열, null이 입력되면 <code>null</code> 리턴
 	 */
 	public static String stripEnd(String str, String stripChars) {
-		int end;
-		if (str == null || (end = str.length()) == 0) {
+		int end = str.length();
+		if (str == null || end == 0) {
 			return str;
 		}
 
@@ -798,8 +798,8 @@ public class EgovStringUtil {
 		String randomStr = null;
 
 		// 시작문자 및 종료문자를 아스키숫자로 변환한다.
-		int startInt = Integer.valueOf(startChr);
-		int endInt = Integer.valueOf(endChr);
+		int startInt = startChr;
+		int endInt = endChr;
 
 		// 시작문자열이 종료문자열보가 클경우
 		if (startInt > endInt) {


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

<hr>

### 2025-09-02 화 PMD로 소프트웨어 보안약점 진단하고 제거하기-EgovStringUtil

피연산자내에 할당문이 사용된 것 제거
```java
//		int strLen;
		int strLen = str.length();
//		if (str == null || (strLen = str.length()) == 0) {
		if (str == null || strLen == 0) {

//		int end;
		int end = str.length();
//		if (str == null || (end = str.length()) == 0) {
		if (str == null || end == 0) {
```

불필요한 WrapperObject 제거
- 자동 형변환 (A의 유니코드 65)
- 즉, char는 내부적으로 2바이트 유니코드 정수라서 int로 변환하면 문자 코드값이 나옵니다.
```java
		// 시작문자 및 종료문자를 아스키숫자로 변환한다.
//		int startInt = Integer.valueOf(startChr);
		int startInt = startChr;
//		int endInt = Integer.valueOf(endChr);
		int endInt = endChr;
```

<hr>

1. PMD로 소프트웨어 보안약점 진단 결과

```
src/main/java/egovframework/com/utl/fcc/service/EgovStringUtil.java:639:	AssignmentInOperand:	AssignmentInOperand: 피연산자내에 할당문이 사용됨. Code 를 복잡하고 가독성이 떨어지게 만듬
src/main/java/egovframework/com/utl/fcc/service/EgovStringUtil.java:678:	AssignmentInOperand:	AssignmentInOperand: 피연산자내에 할당문이 사용됨. Code 를 복잡하고 가독성이 떨어지게 만듬
src/main/java/egovframework/com/utl/fcc/service/EgovStringUtil.java:768:	UnnecessaryBoxing:	UnnecessaryBoxing: 불필요한 explicit conversion from char to int through Integer
src/main/java/egovframework/com/utl/fcc/service/EgovStringUtil.java:769:	UnnecessaryBoxing:	UnnecessaryBoxing: 불필요한 explicit conversion from char to int through Integer
```

2. 브랜치 생성

```
feature/pmd/EgovStringUtil
```

3. 이클립스 > Source > Format

4. 개정이력 수정

```java
 *   2025.09.02  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-AssignmentInOperand(피연산자내에 할당문이 사용됨. 해당 코드를 복잡하고 가독성이 떨어지게 만듬)
 *   2025.09.02  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-UnnecessaryBoxing(불필요한 WrapperObject 생성)
```

<hr>

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

https://youtu.be/l3MANuAhoj8
