### PR TITLE
PMD로 소프트웨어 보안약점 진단하고 제거하기-EgovUnitCalcUtil

### DIFF
--- a/src/main/java/egovframework/com/utl/fda/ucc/service/EgovUnitCalcUtil.java
+++ b/src/main/java/egovframework/com/utl/fda/ucc/service/EgovUnitCalcUtil.java
@@ -9,13 +9,15 @@ import java.util.HashMap;
  * @since 2010.06.16
  * @version 1.0
  * @see
- * 
+ *
  *      <pre>
- * 개정이력(Modification Information)
+ *  == 개정이력(Modification Information) ==
  *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2010.06.16  장동한          최초 생성
+ *   2025.09.03  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-FieldNamingConventions(변수명에 밑줄 사용)
+ *   2025.09.03  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-UselessParentheses(불필요한 괄호사용)
  *
  *      </pre>
  */

--- a/src/main/java/egovframework/com/utl/fda/ucc/service/EgovUnitCalcUtil.java
+++ b/src/main/java/egovframework/com/utl/fda/ucc/service/EgovUnitCalcUtil.java
@@ -136,8 +136,8 @@ public class EgovUnitCalcUtil {
 	 */
 	public double convertWeightCalcUnit(double nWeight, String sWeightUnit, String sWeightUnitAs) {
 
-		double nSelWt = hmAr.get(sWeightUnit);
-		double nSelWtAs = hmAr.get(sWeightUnitAs);
+		double nSelWt = hmWt.get(sWeightUnit);
+		double nSelWtAs = hmWt.get(sWeightUnitAs);
 
 		return nSelWt / nSelWtAs * nWeight;
 	}

--- a/src/main/java/egovframework/com/utl/fda/ucc/service/EgovUnitCalcUtil.java
+++ b/src/main/java/egovframework/com/utl/fda/ucc/service/EgovUnitCalcUtil.java
@@ -22,73 +22,73 @@ import java.util.HashMap;
 public class EgovUnitCalcUtil {
 
 	// 길이
-	HashMap<String, Double> g_hmVt = new HashMap<String, Double>();
+	HashMap<String, Double> hmVt = new HashMap<String, Double>();
 
 	// 부피
-	HashMap<String, Double> g_hmVl = new HashMap<String, Double>();
+	HashMap<String, Double> hmVl = new HashMap<String, Double>();
 
 	// 넓이
-	HashMap<String, Double> g_hmAr = new HashMap<String, Double>();
+	HashMap<String, Double> hmAr = new HashMap<String, Double>();
 
 	// 무게
-	HashMap<String, Double> g_hmWt = new HashMap<String, Double>();
+	HashMap<String, Double> hmWt = new HashMap<String, Double>();
 
 	/**
 	 * 생성자를 통하여 길이, 부피, 넓이, 무게 환산 데이터를 생성한다.
 	 */
 	public EgovUnitCalcUtil() {
 		// 길이
-		g_hmVt.put("vt0", (double) 0);
-		g_hmVt.put("vt1", (double) 1);
-		g_hmVt.put("vt2", 0.01);
-		g_hmVt.put("vt3", (1 / 2.54));
-		g_hmVt.put("vt4", (1 / 30.48));
-		g_hmVt.put("vt5", (1 / 91.44));
-		g_hmVt.put("vt6", (1 / 160934.4));
-		g_hmVt.put("vt7", 0.033);
-		g_hmVt.put("vt8", (0.033 / 6));
-		g_hmVt.put("vt9", (0.033 / 360));
-		g_hmVt.put("vt10", (0.033 / 1296));
+		hmVt.put("vt0", (double) 0);
+		hmVt.put("vt1", (double) 1);
+		hmVt.put("vt2", 0.01);
+		hmVt.put("vt3", 1 / 2.54);
+		hmVt.put("vt4", 1 / 30.48);
+		hmVt.put("vt5", 1 / 91.44);
+		hmVt.put("vt6", 1 / 160934.4);
+		hmVt.put("vt7", 0.033);
+		hmVt.put("vt8", 0.033 / 6);
+		hmVt.put("vt9", 0.033 / 360);
+		hmVt.put("vt10", 0.033 / 1296);
 
 		// 부피
-		g_hmVl.put("vl0", (double) 0);
-		g_hmVl.put("vl1", (1 / 0.18039));
-		g_hmVl.put("vl2", (1 / 1.8039));
-		g_hmVl.put("vl3", (1 / 18.039));
-		g_hmVl.put("vl4", 10000.0);
-		g_hmVl.put("vl5", 0.001);
-		g_hmVl.put("vl6", (double) 1);
-		g_hmVl.put("vl7", (1000 / 16.387064));
-		g_hmVl.put("vl8", (1000 / Math.pow(2.54 * 12, 3)));
-		g_hmVl.put("vl9", (1000 / Math.pow(2.54 * 36, 3)));
-		g_hmVl.put("vl10", (1000 / (Math.pow(2.54, 3) * 231)));
+		hmVl.put("vl0", (double) 0);
+		hmVl.put("vl1", 1 / 0.18039);
+		hmVl.put("vl2", 1 / 1.8039);
+		hmVl.put("vl3", 1 / 18.039);
+		hmVl.put("vl4", 10000.0);
+		hmVl.put("vl5", 0.001);
+		hmVl.put("vl6", (double) 1);
+		hmVl.put("vl7", 1000 / 16.387064);
+		hmVl.put("vl8", 1000 / Math.pow(2.54 * 12, 3));
+		hmVl.put("vl9", 1000 / Math.pow(2.54 * 36, 3));
+		hmVl.put("vl10", 1000 / (Math.pow(2.54, 3) * 231));
 
 		// 넓이
-		g_hmAr.put("ar0", (double) 0);
-		g_hmAr.put("ar1", 1089d / 100d);
-		g_hmAr.put("ar2", 1089d / 3600d);
-		g_hmAr.put("ar3", 1089d / 1080000d);
-		g_hmAr.put("ar4", 1089d / 10800000d);
-		g_hmAr.put("ar5", (double) 1);
-		g_hmAr.put("ar6", 0.01);
-		g_hmAr.put("ar7", (1 / Math.pow(2.54 * 12 / 100, 2)));
-		g_hmAr.put("ar8", (1 / Math.pow(2.54 * 36 / 100, 2)));
-		g_hmAr.put("ar9", (1 / (Math.pow(2.54 * 36 / 100, 2) * 4840)));
-		g_hmAr.put("ar10", 0.0001);
+		hmAr.put("ar0", (double) 0);
+		hmAr.put("ar1", 1089d / 100d);
+		hmAr.put("ar2", 1089d / 3600d);
+		hmAr.put("ar3", 1089d / 1080000d);
+		hmAr.put("ar4", 1089d / 10800000d);
+		hmAr.put("ar5", (double) 1);
+		hmAr.put("ar6", 0.01);
+		hmAr.put("ar7", 1 / Math.pow(2.54 * 12 / 100, 2));
+		hmAr.put("ar8", 1 / Math.pow(2.54 * 36 / 100, 2));
+		hmAr.put("ar9", 1 / (Math.pow(2.54 * 36 / 100, 2) * 4840));
+		hmAr.put("ar10", 0.0001);
 
 		// 무게
-		g_hmWt.put("wt0", (double) 0);
-		g_hmWt.put("wt1", (double) 1);
-		g_hmWt.put("wt2", (double) 1000);
-		g_hmWt.put("wt3", 0.001);
-		g_hmWt.put("wt4", 0.000001);
-		g_hmWt.put("wt5", (1 / 0.06479891));
-		g_hmWt.put("wt6", (16 / 453.59237));
-		g_hmWt.put("wt7", (1 / 453.59237));
-		g_hmWt.put("wt8", (1 / 3.75));
-		g_hmWt.put("wt9", (1 / 37.5));
-		g_hmWt.put("wt10", 1 / 600d);
-		g_hmWt.put("wt11", 1 / 3750d);
+		hmWt.put("wt0", (double) 0);
+		hmWt.put("wt1", (double) 1);
+		hmWt.put("wt2", (double) 1000);
+		hmWt.put("wt3", 0.001);
+		hmWt.put("wt4", 0.000001);
+		hmWt.put("wt5", 1 / 0.06479891);
+		hmWt.put("wt6", 16 / 453.59237);
+		hmWt.put("wt7", 1 / 453.59237);
+		hmWt.put("wt8", 1 / 3.75);
+		hmWt.put("wt9", 1 / 37.5);
+		hmWt.put("wt10", 1 / 600d);
+		hmWt.put("wt11", 1 / 3750d);
 	}
 
 	/**
@@ -101,10 +101,10 @@ public class EgovUnitCalcUtil {
 	 */
 	public double convertLengthCalcUnit(double nLength, String sLengthUnit, String sLengthUnitAs) {
 
-		double nSelAr = g_hmVt.get(sLengthUnit);
-		double nSelArAs = g_hmVt.get(sLengthUnitAs);
+		double nSelAr = hmVt.get(sLengthUnit);
+		double nSelArAs = hmVt.get(sLengthUnitAs);
 
-		return (nSelArAs / nSelAr) * nLength;
+		return nSelArAs / nSelAr * nLength;
 	}
 
 	/**
@@ -117,10 +117,10 @@ public class EgovUnitCalcUtil {
 	 */
 	public double convertVolumeCalcUnit(double nVolume, String sVolumeUnit, String sVolumeUnitAs) {
 
-		double nSelVl = g_hmVl.get(sVolumeUnit);
-		double nSelVlAs = g_hmVl.get(sVolumeUnitAs);
+		double nSelVl = hmVl.get(sVolumeUnit);
+		double nSelVlAs = hmVl.get(sVolumeUnitAs);
 
-		return (nSelVl / nSelVlAs) * nVolume;
+		return nSelVl / nSelVlAs * nVolume;
 	}
 
 	/**
@@ -133,10 +133,10 @@ public class EgovUnitCalcUtil {
 	 */
 	public double convertWeightCalcUnit(double nWeight, String sWeightUnit, String sWeightUnitAs) {
 
-		double nSelWt = g_hmAr.get(sWeightUnit);
-		double nSelWtAs = g_hmAr.get(sWeightUnitAs);
+		double nSelWt = hmAr.get(sWeightUnit);
+		double nSelWtAs = hmAr.get(sWeightUnitAs);
 
-		return (nSelWt / nSelWtAs) * nWeight;
+		return nSelWt / nSelWtAs * nWeight;
 	}
 
 	/**
@@ -149,9 +149,9 @@ public class EgovUnitCalcUtil {
 	 */
 	public double convertWidthCalcUnit(double nWidth, String sWidthUnit, String sWidthUnitAs) {
 
-		double nSelAr = g_hmWt.get(sWidthUnit);
-		double nSelArAs = g_hmWt.get(sWidthUnitAs);
+		double nSelAr = hmWt.get(sWidthUnit);
+		double nSelArAs = hmWt.get(sWidthUnitAs);
 
-		return (nSelAr / nSelArAs) * nWidth;
+		return nSelAr / nSelArAs * nWidth;
 	}
 }

--- a/src/main/java/egovframework/com/utl/fda/ucc/service/EgovUnitCalcUtil.java
+++ b/src/main/java/egovframework/com/utl/fda/ucc/service/EgovUnitCalcUtil.java
@@ -1,6 +1,7 @@
 package egovframework.com.utl.fda.ucc.service;
 
 import java.util.HashMap;
+import java.util.Map;
 
 /**
  * 길이, 부피, 넓이, 무게 환산 데이터를 생성하는 Service Class 구현
@@ -24,16 +25,16 @@ import java.util.HashMap;
 public class EgovUnitCalcUtil {
 
 	// 길이
-	HashMap<String, Double> hmVt = new HashMap<String, Double>();
+	private final Map<String, Double> hmVt = new HashMap<>();
 
 	// 부피
-	HashMap<String, Double> hmVl = new HashMap<String, Double>();
+	private final Map<String, Double> hmVl = new HashMap<>();
 
 	// 넓이
-	HashMap<String, Double> hmAr = new HashMap<String, Double>();
+	private final Map<String, Double> hmAr = new HashMap<>();
 
 	// 무게
-	HashMap<String, Double> hmWt = new HashMap<String, Double>();
+	private final Map<String, Double> hmWt = new HashMap<>();
 
 	/**
 	 * 생성자를 통하여 길이, 부피, 넓이, 무게 환산 데이터를 생성한다.

--- a/src/main/java/egovframework/com/utl/fda/ucc/service/EgovUnitCalcUtil.java
+++ b/src/main/java/egovframework/com/utl/fda/ucc/service/EgovUnitCalcUtil.java
@@ -4,99 +4,102 @@ import java.util.HashMap;
 
 /**
  * 길이, 부피, 넓이, 무게 환산 데이터를 생성하는 Service Class 구현
+ * 
  * @author 공통서비스 장동한
  * @since 2010.06.16
  * @version 1.0
- * @see <pre>
+ * @see
+ * 
+ *      <pre>
  * 개정이력(Modification Information)
  *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2010.06.16  장동한          최초 생성
  *
- * </pre>
+ *      </pre>
  */
 public class EgovUnitCalcUtil {
 
-	//길이
+	// 길이
 	HashMap<String, Double> g_hmVt = new HashMap<String, Double>();
 
-	//부피
+	// 부피
 	HashMap<String, Double> g_hmVl = new HashMap<String, Double>();
 
-	//넓이
+	// 넓이
 	HashMap<String, Double> g_hmAr = new HashMap<String, Double>();
 
-	//무게
+	// 무게
 	HashMap<String, Double> g_hmWt = new HashMap<String, Double>();
 
 	/**
 	 * 생성자를 통하여 길이, 부피, 넓이, 무게 환산 데이터를 생성한다.
 	 */
-	public EgovUnitCalcUtil(){
-		//길이
-		g_hmVt.put("vt0", (double)0);
-		g_hmVt.put("vt1", (double)1);
+	public EgovUnitCalcUtil() {
+		// 길이
+		g_hmVt.put("vt0", (double) 0);
+		g_hmVt.put("vt1", (double) 1);
 		g_hmVt.put("vt2", 0.01);
-		g_hmVt.put("vt3", (1/2.54));
-		g_hmVt.put("vt4", (1/30.48));
-		g_hmVt.put("vt5", (1/91.44));
-		g_hmVt.put("vt6", (1/160934.4));
+		g_hmVt.put("vt3", (1 / 2.54));
+		g_hmVt.put("vt4", (1 / 30.48));
+		g_hmVt.put("vt5", (1 / 91.44));
+		g_hmVt.put("vt6", (1 / 160934.4));
 		g_hmVt.put("vt7", 0.033);
-		g_hmVt.put("vt8", (0.033/6));
-		g_hmVt.put("vt9", (0.033/360));
-		g_hmVt.put("vt10", (0.033/1296));
+		g_hmVt.put("vt8", (0.033 / 6));
+		g_hmVt.put("vt9", (0.033 / 360));
+		g_hmVt.put("vt10", (0.033 / 1296));
 
-
-		//부피
-		g_hmVl.put("vl0", (double)0);
-		g_hmVl.put("vl1", (1/0.18039));
-		g_hmVl.put("vl2", (1/1.8039));
-		g_hmVl.put("vl3", (1/18.039));
+		// 부피
+		g_hmVl.put("vl0", (double) 0);
+		g_hmVl.put("vl1", (1 / 0.18039));
+		g_hmVl.put("vl2", (1 / 1.8039));
+		g_hmVl.put("vl3", (1 / 18.039));
 		g_hmVl.put("vl4", 10000.0);
 		g_hmVl.put("vl5", 0.001);
-		g_hmVl.put("vl6", (double)1);
-		g_hmVl.put("vl7", (1000/16.387064));
-		g_hmVl.put("vl8", (1000/Math.pow(2.54*12,3)));
-		g_hmVl.put("vl9", (1000/Math.pow(2.54*36,3)));
-		g_hmVl.put("vl10", (1000/(Math.pow(2.54,3)*231)));
+		g_hmVl.put("vl6", (double) 1);
+		g_hmVl.put("vl7", (1000 / 16.387064));
+		g_hmVl.put("vl8", (1000 / Math.pow(2.54 * 12, 3)));
+		g_hmVl.put("vl9", (1000 / Math.pow(2.54 * 36, 3)));
+		g_hmVl.put("vl10", (1000 / (Math.pow(2.54, 3) * 231)));
 
-		//넓이
-		g_hmAr.put("ar0", (double)0);
-		g_hmAr.put("ar1", (double)(1089d/100d));
-		g_hmAr.put("ar2", (double)(1089d/3600d));
-		g_hmAr.put("ar3", (double)(1089d/1080000d));
-		g_hmAr.put("ar4", (double)(1089d/10800000d));
-		g_hmAr.put("ar5", (double)1);
+		// 넓이
+		g_hmAr.put("ar0", (double) 0);
+		g_hmAr.put("ar1", 1089d / 100d);
+		g_hmAr.put("ar2", 1089d / 3600d);
+		g_hmAr.put("ar3", 1089d / 1080000d);
+		g_hmAr.put("ar4", 1089d / 10800000d);
+		g_hmAr.put("ar5", (double) 1);
 		g_hmAr.put("ar6", 0.01);
-		g_hmAr.put("ar7", (1/Math.pow(2.54*12/100,2)));
-		g_hmAr.put("ar8", (1/Math.pow(2.54*36/100,2)));
-		g_hmAr.put("ar9", (1/(Math.pow(2.54*36/100,2)*4840)));
+		g_hmAr.put("ar7", (1 / Math.pow(2.54 * 12 / 100, 2)));
+		g_hmAr.put("ar8", (1 / Math.pow(2.54 * 36 / 100, 2)));
+		g_hmAr.put("ar9", (1 / (Math.pow(2.54 * 36 / 100, 2) * 4840)));
 		g_hmAr.put("ar10", 0.0001);
 
-		//무게
-		g_hmWt.put("wt0", (double)0);
-		g_hmWt.put("wt1", (double)1);
-		g_hmWt.put("wt2", (double)1000);
+		// 무게
+		g_hmWt.put("wt0", (double) 0);
+		g_hmWt.put("wt1", (double) 1);
+		g_hmWt.put("wt2", (double) 1000);
 		g_hmWt.put("wt3", 0.001);
 		g_hmWt.put("wt4", 0.000001);
-		g_hmWt.put("wt5", (1/0.06479891));
-		g_hmWt.put("wt6", (16/453.59237));
-		g_hmWt.put("wt7", (1/453.59237));
-		g_hmWt.put("wt8", (1/3.75));
-		g_hmWt.put("wt9", (1/37.5));
-		g_hmWt.put("wt10", (double)(1/600d));
-		g_hmWt.put("wt11", (double)(1/3750d));
+		g_hmWt.put("wt5", (1 / 0.06479891));
+		g_hmWt.put("wt6", (16 / 453.59237));
+		g_hmWt.put("wt7", (1 / 453.59237));
+		g_hmWt.put("wt8", (1 / 3.75));
+		g_hmWt.put("wt9", (1 / 37.5));
+		g_hmWt.put("wt10", 1 / 600d);
+		g_hmWt.put("wt11", 1 / 3750d);
 	}
 
 	/**
 	 * 길이단위를 환산하여 리턴한다.
-	 * @param nLength -길이
-	 * @param sLengthUnit-길이 단위
+	 * 
+	 * @param nLength          -길이
+	 * @param sLengthUnit-길이   단위
 	 * @param sLengthUnitAs-길이 환산 단위
 	 * @return double -환산된 길이
 	 */
-	public double convertLengthCalcUnit(double nLength, String sLengthUnit, String sLengthUnitAs){
+	public double convertLengthCalcUnit(double nLength, String sLengthUnit, String sLengthUnitAs) {
 
 		double nSelAr = g_hmVt.get(sLengthUnit);
 		double nSelArAs = g_hmVt.get(sLengthUnitAs);
@@ -106,12 +109,13 @@ public class EgovUnitCalcUtil {
 
 	/**
 	 * 부피단위를 환산하여 리턴한다.
-	 * @param nVolume -부피
-	 * @param sVolumeUnit-부피 단위
+	 * 
+	 * @param nVolume          -부피
+	 * @param sVolumeUnit-부피   단위
 	 * @param sVolumeUnitAs-부피 환산 단위
 	 * @return double -환산된 부피
 	 */
-	public double convertVolumeCalcUnit(double nVolume, String sVolumeUnit, String sVolumeUnitAs){
+	public double convertVolumeCalcUnit(double nVolume, String sVolumeUnit, String sVolumeUnitAs) {
 
 		double nSelVl = g_hmVl.get(sVolumeUnit);
 		double nSelVlAs = g_hmVl.get(sVolumeUnitAs);
@@ -121,12 +125,13 @@ public class EgovUnitCalcUtil {
 
 	/**
 	 * 무게단위를 환산하여 리턴한다.
-	 * @param nWeight -무게
-	 * @param sWeightUnit -무게 단위
+	 * 
+	 * @param nWeight       -무게
+	 * @param sWeightUnit   -무게 단위
 	 * @param sWeightUnitAs -무게 환산 단위
 	 * @return double -환산된 무게
 	 */
-	public double convertWeightCalcUnit(double nWeight, String sWeightUnit, String sWeightUnitAs){
+	public double convertWeightCalcUnit(double nWeight, String sWeightUnit, String sWeightUnitAs) {
 
 		double nSelWt = g_hmAr.get(sWeightUnit);
 		double nSelWtAs = g_hmAr.get(sWeightUnitAs);
@@ -136,12 +141,13 @@ public class EgovUnitCalcUtil {
 
 	/**
 	 * 넓이단위를 환산하여 리턴한다.
-	 * @param nWidth -넓이
-	 * @param sWidthUnit-넓이 단위
+	 * 
+	 * @param nWidth          -넓이
+	 * @param sWidthUnit-넓이   단위
 	 * @param sWidthUnitAs-넓이 환산 단위
 	 * @return double -환산된 넓이
 	 */
-	public double convertWidthCalcUnit(double nWidth, String sWidthUnit, String sWidthUnitAs){
+	public double convertWidthCalcUnit(double nWidth, String sWidthUnit, String sWidthUnitAs) {
 
 		double nSelAr = g_hmWt.get(sWidthUnit);
 		double nSelArAs = g_hmWt.get(sWidthUnitAs);

--- a/src/main/java/egovframework/com/utl/fda/ucc/service/EgovUnitCalcUtil.java
+++ b/src/main/java/egovframework/com/utl/fda/ucc/service/EgovUnitCalcUtil.java
@@ -152,8 +152,8 @@ public class EgovUnitCalcUtil {
 	 */
 	public double convertWidthCalcUnit(double nWidth, String sWidthUnit, String sWidthUnitAs) {
 
-		double nSelAr = hmWt.get(sWidthUnit);
-		double nSelArAs = hmWt.get(sWidthUnitAs);
+		double nSelAr = hmAr.get(sWidthUnit);
+		double nSelArAs = hmAr.get(sWidthUnitAs);
 
 		return nSelAr / nSelArAs * nWidth;
 	}


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

<hr>

### 2025-09-03 수 PMD로 소프트웨어 보안약점 진단하고 제거하기-EgovUnitCalcUtil

`g_hmVt` 를 `hmVt` 로 이름 바꾸기

`g_hmVl` 를 `hmVl` 로 이름 바꾸기

`g_hmAr` 를 `hmAr` 로 이름 바꾸기

`g_hmWt` 를 `hmWt` 로 이름 바꾸기

불필요한 괄호제거

`private final` 추가
```java
	// 길이
//	HashMap<String, Double> hmVt = new HashMap<String, Double>();
	private Map<String, Double> hmVt = new HashMap<>();
```

<hr>

1. PMD로 소프트웨어 보안약점 진단 결과

```
src/main/java/egovframework/com/utl/fda/ucc/service/EgovUnitCalcUtil.java:22:	FieldNamingConventions:	FieldNamingConventions: 'field' 의 변수 'g_hmVt' 이  '[a-z][a-zA-Z0-9]*'  로 시작함
src/main/java/egovframework/com/utl/fda/ucc/service/EgovUnitCalcUtil.java:25:	FieldNamingConventions:	FieldNamingConventions: 'field' 의 변수 'g_hmVl' 이  '[a-z][a-zA-Z0-9]*'  로 시작함
src/main/java/egovframework/com/utl/fda/ucc/service/EgovUnitCalcUtil.java:28:	FieldNamingConventions:	FieldNamingConventions: 'field' 의 변수 'g_hmAr' 이  '[a-z][a-zA-Z0-9]*'  로 시작함
src/main/java/egovframework/com/utl/fda/ucc/service/EgovUnitCalcUtil.java:31:	FieldNamingConventions:	FieldNamingConventions: 'field' 의 변수 'g_hmWt' 이  '[a-z][a-zA-Z0-9]*'  로 시작함
src/main/java/egovframework/com/utl/fda/ucc/service/EgovUnitCalcUtil.java:41:	UselessParentheses:	UselessParentheses: 괄호가 없어도 되는 상황에서 불필요한 괄호를 사용할 경우 마치 메소드 호출처럼 보여서 소스 코드의 가독성을 떨어뜨릴 수 있음
src/main/java/egovframework/com/utl/fda/ucc/service/EgovUnitCalcUtil.java:42:	UselessParentheses:	UselessParentheses: 괄호가 없어도 되는 상황에서 불필요한 괄호를 사용할 경우 마치 메소드 호출처럼 보여서 소스 코드의 가독성을 떨어뜨릴 수 있음
src/main/java/egovframework/com/utl/fda/ucc/service/EgovUnitCalcUtil.java:43:	UselessParentheses:	UselessParentheses: 괄호가 없어도 되는 상황에서 불필요한 괄호를 사용할 경우 마치 메소드 호출처럼 보여서 소스 코드의 가독성을 떨어뜨릴 수 있음
src/main/java/egovframework/com/utl/fda/ucc/service/EgovUnitCalcUtil.java:44:	UselessParentheses:	UselessParentheses: 괄호가 없어도 되는 상황에서 불필요한 괄호를 사용할 경우 마치 메소드 호출처럼 보여서 소스 코드의 가독성을 떨어뜨릴 수 있음
src/main/java/egovframework/com/utl/fda/ucc/service/EgovUnitCalcUtil.java:46:	UselessParentheses:	UselessParentheses: 괄호가 없어도 되는 상황에서 불필요한 괄호를 사용할 경우 마치 메소드 호출처럼 보여서 소스 코드의 가독성을 떨어뜨릴 수 있음
src/main/java/egovframework/com/utl/fda/ucc/service/EgovUnitCalcUtil.java:47:	UselessParentheses:	UselessParentheses: 괄호가 없어도 되는 상황에서 불필요한 괄호를 사용할 경우 마치 메소드 호출처럼 보여서 소스 코드의 가독성을 떨어뜨릴 수 있음
src/main/java/egovframework/com/utl/fda/ucc/service/EgovUnitCalcUtil.java:48:	UselessParentheses:	UselessParentheses: 괄호가 없어도 되는 상황에서 불필요한 괄호를 사용할 경우 마치 메소드 호출처럼 보여서 소스 코드의 가독성을 떨어뜨릴 수 있음
src/main/java/egovframework/com/utl/fda/ucc/service/EgovUnitCalcUtil.java:53:	UselessParentheses:	UselessParentheses: 괄호가 없어도 되는 상황에서 불필요한 괄호를 사용할 경우 마치 메소드 호출처럼 보여서 소스 코드의 가독성을 떨어뜨릴 수 있음
src/main/java/egovframework/com/utl/fda/ucc/service/EgovUnitCalcUtil.java:54:	UselessParentheses:	UselessParentheses: 괄호가 없어도 되는 상황에서 불필요한 괄호를 사용할 경우 마치 메소드 호출처럼 보여서 소스 코드의 가독성을 떨어뜨릴 수 있음
src/main/java/egovframework/com/utl/fda/ucc/service/EgovUnitCalcUtil.java:55:	UselessParentheses:	UselessParentheses: 괄호가 없어도 되는 상황에서 불필요한 괄호를 사용할 경우 마치 메소드 호출처럼 보여서 소스 코드의 가독성을 떨어뜨릴 수 있음
src/main/java/egovframework/com/utl/fda/ucc/service/EgovUnitCalcUtil.java:59:	UselessParentheses:	UselessParentheses: 괄호가 없어도 되는 상황에서 불필요한 괄호를 사용할 경우 마치 메소드 호출처럼 보여서 소스 코드의 가독성을 떨어뜨릴 수 있음
src/main/java/egovframework/com/utl/fda/ucc/service/EgovUnitCalcUtil.java:60:	UselessParentheses:	UselessParentheses: 괄호가 없어도 되는 상황에서 불필요한 괄호를 사용할 경우 마치 메소드 호출처럼 보여서 소스 코드의 가독성을 떨어뜨릴 수 있음
src/main/java/egovframework/com/utl/fda/ucc/service/EgovUnitCalcUtil.java:61:	UselessParentheses:	UselessParentheses: 괄호가 없어도 되는 상황에서 불필요한 괄호를 사용할 경우 마치 메소드 호출처럼 보여서 소스 코드의 가독성을 떨어뜨릴 수 있음
src/main/java/egovframework/com/utl/fda/ucc/service/EgovUnitCalcUtil.java:62:	UselessParentheses:	UselessParentheses: 괄호가 없어도 되는 상황에서 불필요한 괄호를 사용할 경우 마치 메소드 호출처럼 보여서 소스 코드의 가독성을 떨어뜨릴 수 있음
src/main/java/egovframework/com/utl/fda/ucc/service/EgovUnitCalcUtil.java:72:	UselessParentheses:	UselessParentheses: 괄호가 없어도 되는 상황에서 불필요한 괄호를 사용할 경우 마치 메소드 호출처럼 보여서 소스 코드의 가독성을 떨어뜨릴 수 있음
src/main/java/egovframework/com/utl/fda/ucc/service/EgovUnitCalcUtil.java:73:	UselessParentheses:	UselessParentheses: 괄호가 없어도 되는 상황에서 불필요한 괄호를 사용할 경우 마치 메소드 호출처럼 보여서 소스 코드의 가독성을 떨어뜨릴 수 있음
src/main/java/egovframework/com/utl/fda/ucc/service/EgovUnitCalcUtil.java:74:	UselessParentheses:	UselessParentheses: 괄호가 없어도 되는 상황에서 불필요한 괄호를 사용할 경우 마치 메소드 호출처럼 보여서 소스 코드의 가독성을 떨어뜨릴 수 있음
src/main/java/egovframework/com/utl/fda/ucc/service/EgovUnitCalcUtil.java:83:	UselessParentheses:	UselessParentheses: 괄호가 없어도 되는 상황에서 불필요한 괄호를 사용할 경우 마치 메소드 호출처럼 보여서 소스 코드의 가독성을 떨어뜨릴 수 있음
src/main/java/egovframework/com/utl/fda/ucc/service/EgovUnitCalcUtil.java:84:	UselessParentheses:	UselessParentheses: 괄호가 없어도 되는 상황에서 불필요한 괄호를 사용할 경우 마치 메소드 호출처럼 보여서 소스 코드의 가독성을 떨어뜨릴 수 있음
src/main/java/egovframework/com/utl/fda/ucc/service/EgovUnitCalcUtil.java:85:	UselessParentheses:	UselessParentheses: 괄호가 없어도 되는 상황에서 불필요한 괄호를 사용할 경우 마치 메소드 호출처럼 보여서 소스 코드의 가독성을 떨어뜨릴 수 있음
src/main/java/egovframework/com/utl/fda/ucc/service/EgovUnitCalcUtil.java:86:	UselessParentheses:	UselessParentheses: 괄호가 없어도 되는 상황에서 불필요한 괄호를 사용할 경우 마치 메소드 호출처럼 보여서 소스 코드의 가독성을 떨어뜨릴 수 있음
src/main/java/egovframework/com/utl/fda/ucc/service/EgovUnitCalcUtil.java:87:	UselessParentheses:	UselessParentheses: 괄호가 없어도 되는 상황에서 불필요한 괄호를 사용할 경우 마치 메소드 호출처럼 보여서 소스 코드의 가독성을 떨어뜨릴 수 있음
src/main/java/egovframework/com/utl/fda/ucc/service/EgovUnitCalcUtil.java:104:	UselessParentheses:	UselessParentheses: 괄호가 없어도 되는 상황에서 불필요한 괄호를 사용할 경우 마치 메소드 호출처럼 보여서 소스 코드의 가독성을 떨어뜨릴 수 있음
src/main/java/egovframework/com/utl/fda/ucc/service/EgovUnitCalcUtil.java:119:	UselessParentheses:	UselessParentheses: 괄호가 없어도 되는 상황에서 불필요한 괄호를 사용할 경우 마치 메소드 호출처럼 보여서 소스 코드의 가독성을 떨어뜨릴 수 있음
src/main/java/egovframework/com/utl/fda/ucc/service/EgovUnitCalcUtil.java:134:	UselessParentheses:	UselessParentheses: 괄호가 없어도 되는 상황에서 불필요한 괄호를 사용할 경우 마치 메소드 호출처럼 보여서 소스 코드의 가독성을 떨어뜨릴 수 있음
src/main/java/egovframework/com/utl/fda/ucc/service/EgovUnitCalcUtil.java:149:	UselessParentheses:	UselessParentheses: 괄호가 없어도 되는 상황에서 불필요한 괄호를 사용할 경우 마치 메소드 호출처럼 보여서 소스 코드의 가독성을 떨어뜨릴 수 있음
```

2. 브랜치 생성

```
feature/pmd/EgovUnitCalcUtil
```

3. 이클립스 > Source > Format

4. 개정이력 수정

```java
 *   2025.09.03  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-FieldNamingConventions(변수명에 밑줄 사용)
 *   2025.09.03  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-UselessParentheses(불필요한 괄호사용)
```

<hr>

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

https://youtu.be/jxGYCBEZB6E
