### PR TITLE
2025 멘토링-PMD로 소프트웨어 보안약점 진단하고 제거하기-EgovSynchrnServerServiceImpl

### DIFF
--- a/src/main/java/egovframework/com/utl/sys/ssy/service/impl/EgovSynchrnServerServiceImpl.java
+++ b/src/main/java/egovframework/com/utl/sys/ssy/service/impl/EgovSynchrnServerServiceImpl.java
@@ -33,26 +33,30 @@ import egovframework.com.utl.sys.ssy.service.SynchrnServer;
 import egovframework.com.utl.sys.ssy.service.SynchrnServerVO;
 
 /**
+ * <pre>
  * 개요
  * - 동기화대상 서버에 대한 ServiceImpl 클래스를 정의한다.
  *
  * 상세내용
  * - 동기화대상 서버에 대한 등록, 수정, 삭제, 조회 기능을 제공한다.
  * - 동기화대상 서버의 조회기능은 목록조회, 상세조회로 구분된다.
- * - 2015.03.31	 업로드 파일의 목록을 조회시 업로드 디렉토리가 없을 경우 생성하도록 수정 
+ * - 2015.03.31	 업로드 파일의 목록을 조회시 업로드 디렉토리가 없을 경우 생성하도록 수정
+ * </pre>
+ * 
  * @author lee.m.j
  * @version 1.0
  * @created 28-6-2010 오전 10:44:34
  * 
+ *          <pre>
  *      수정일         수정자                   수정내용
  *   -------    --------    ---------------------------
  *   2017-02-08    이정은        시큐어코딩(ES) - 시큐어코딩 부적절한 예외 처리[CWE-253, CWE-440, CWE-754]
  *   2018-11-12    이정은        processFtp() FILE_TYPE 설정 수정
- * 
+ *          </pre>
  */
 @Service("egovSynchrnServerService")
 public class EgovSynchrnServerServiceImpl extends EgovAbstractServiceImpl implements EgovSynchrnServerService {
-	
+
 	// LOGGER
 	private static final Logger LOGGER = LoggerFactory.getLogger(EgovSynchrnServerServiceImpl.class);
 	private static final String SYNCH_SERVER_PATH = EgovProperties.getProperty("Globals.SynchrnServerPath");
@@ -62,36 +66,44 @@ public class EgovSynchrnServerServiceImpl extends EgovAbstractServiceImpl implem
 
 	/**
 	 * 동기화대상 서버를 관리하기 위해 등록된 동기화대상 서버목록을 조회한다.
+	 * 
 	 * @param synchrnServerVO - 동기화대상 서버 Vo
 	 * @return List - 동기화대상 서버 목록
 	 */
+	@Override
 	public List<SynchrnServerVO> selectSynchrnServerList(SynchrnServerVO synchrnServerVO) throws Exception {
 		return synchrnServerDAO.selectSynchrnServerList(synchrnServerVO);
 	}
 
 	/**
 	 * 동기화대상 서버목록 총 개수를 조회한다.
+	 * 
 	 * @param synchrnServerVO - 동기화대상 서버 Vo
 	 * @return int - 동기화대상 서버 카운트 수
 	 */
+	@Override
 	public int selectSynchrnServerListTotCnt(SynchrnServerVO synchrnServerVO) throws Exception {
 		return synchrnServerDAO.selectSynchrnServerListTotCnt(synchrnServerVO);
 	}
 
 	/**
 	 * 등록된 동기화대상 서버의 상세정보를 조회한다.
+	 * 
 	 * @param synchrnServerVO - 동기화대상 서버 Vo
 	 * @return synchrnServerVO - 동기화대상 서버 Vo
 	 */
+	@Override
 	public SynchrnServerVO selectSynchrnServer(SynchrnServerVO synchrnServerVO) throws Exception {
 		return synchrnServerDAO.selectSynchrnServer(synchrnServerVO);
 	}
 
 	/**
 	 * 등록된 동기화대상 서버의 파일 목록을 조회한다.
+	 * 
 	 * @param synchrnServerVO - 동기화대상 서버 Vo
 	 * @return List<String> - String Type List
 	 */
+	@Override
 	public List<String> selectSynchrnServerFiles(SynchrnServerVO synchrnServerVO) throws Exception {
 
 		List<String> list = new ArrayList<String>();
@@ -108,8 +120,9 @@ public class EgovSynchrnServerServiceImpl extends EgovAbstractServiceImpl implem
 
 			ftpClient.connect(host, Integer.parseInt(synchrnServerVO.getServerPort()));
 			boolean isLogin = ftpClient.login(synchrnServerVO.getFtpId(), synchrnServerVO.getFtpPassword());
-			if (!isLogin)
+			if (!isLogin) {
 				throw new Exception("FTP Client Login Error : \n");
+			}
 
 			FTPFile[] fTPFile = null;
 
@@ -118,8 +131,9 @@ public class EgovSynchrnServerServiceImpl extends EgovAbstractServiceImpl implem
 				fTPFile = ftpClient.listFiles(synchrnServerVO.getSynchrnLc());
 
 				for (int i = 0; i < fTPFile.length; i++) {
-					if (fTPFile[i].isFile())
+					if (fTPFile[i].isFile()) {
 						list.add(fTPFile[i].getName());
+					}
 				}
 			} finally {
 				ftpClient.logout();
@@ -134,8 +148,10 @@ public class EgovSynchrnServerServiceImpl extends EgovAbstractServiceImpl implem
 
 	/**
 	 * 등록된 동기화대상 서버의 파일을 삭제한다.
+	 * 
 	 * @param synchrnServerVO - 동기화대상 서버 Vo
 	 */
+	@Override
 	public void deleteSynchrnServerFile(SynchrnServerVO synchrnServerVO) throws Exception {
 
 		FTPClient ftpClient = new FTPClient();
@@ -157,9 +173,10 @@ public class EgovSynchrnServerServiceImpl extends EgovAbstractServiceImpl implem
 			fTPFile = ftpClient.listFiles(synchrnServerVO.getSynchrnLc());
 
 			for (int i = 0; i < fTPFile.length; i++) {
-				//KISA 보안약점 조치 (2018-10-29, 윤창원)
-				if (EgovStringUtil.isNullToString(synchrnServerVO.getDeleteFileNm()).equals(fTPFile[i].getName()))
+				// KISA 보안약점 조치 (2018-10-29, 윤창원)
+				if (EgovStringUtil.isNullToString(synchrnServerVO.getDeleteFileNm()).equals(fTPFile[i].getName())) {
 					ftpClient.deleteFile(fTPFile[i].getName());
+				}
 			}
 
 			SynchrnServer synchrnServer = new SynchrnServer();
@@ -174,9 +191,11 @@ public class EgovSynchrnServerServiceImpl extends EgovAbstractServiceImpl implem
 
 	/**
 	 * 등록된 동기화대상 서버의 파일을 다운로드 한다.
+	 * 
 	 * @param synchrnServerVO - 동기화대상 서버 Vo
-	 * @param fileNm - 다운로드 대상 파일
+	 * @param fileNm          - 다운로드 대상 파일
 	 */
+	@Override
 	public void downloadFtpFile(SynchrnServerVO synchrnServerVO, String fileNm) throws Exception {
 
 		FTPClient ftpClient = new FTPClient();
@@ -199,8 +218,9 @@ public class EgovSynchrnServerServiceImpl extends EgovAbstractServiceImpl implem
 			outputStream = new FileOutputStream(downFile);
 			ftpClient.retrieveFile(fileNm, outputStream);
 		} finally {
-			if (outputStream != null)
+			if (outputStream != null) {
 				outputStream.close();
+			}
 		}
 
 		ftpClient.logout();
@@ -208,10 +228,13 @@ public class EgovSynchrnServerServiceImpl extends EgovAbstractServiceImpl implem
 
 	/**
 	 * 동기화대상 서버정보를 신규로 등록한다.
-	 * @param synchrnServer - 동기화대상 서버 model
-	 * @param synchrnServerVO    - 동기화대상 서버 VO
+	 * 
+	 * @param synchrnServer   - 동기화대상 서버 model
+	 * @param synchrnServerVO - 동기화대상 서버 VO
 	 */
-	public SynchrnServerVO insertSynchrnServer(SynchrnServer synchrnServer, SynchrnServerVO synchrnServerVO) throws Exception {
+	@Override
+	public SynchrnServerVO insertSynchrnServer(SynchrnServer synchrnServer, SynchrnServerVO synchrnServerVO)
+			throws Exception {
 		synchrnServerDAO.insertSynchrnServer(synchrnServer);
 		synchrnServerVO.setServerId(synchrnServer.getServerId());
 		return synchrnServerDAO.selectSynchrnServer(synchrnServerVO);
@@ -219,25 +242,31 @@ public class EgovSynchrnServerServiceImpl extends EgovAbstractServiceImpl implem
 
 	/**
 	 * 기 등록된 동기화대상 서버정보를 수정한다.
+	 * 
 	 * @param synchrnServer - 동기화대상 서버 model
 	 */
+	@Override
 	public void updateSynchrnServer(SynchrnServer synchrnServer) throws Exception {
 		synchrnServerDAO.updateSynchrnServer(synchrnServer);
 	}
 
 	/**
 	 * 기 등록된 동기화대상 서버정보를 삭제한다.
+	 * 
 	 * @param synchrnServer - 동기화대상 서버 model
 	 */
+	@Override
 	public void deleteSynchrnServer(SynchrnServer synchrnServer) throws Exception {
 		synchrnServerDAO.deleteSynchrnServer(synchrnServer);
 	}
 
 	/**
 	 * 업로드 파일을 동기화대상 서버들을 대상으로 동기화 처리를 한다.
+	 * 
 	 * @param synchrnServerVO - 동기화대상 서버 Vo
 	 * @return boolean - 성공여부
 	 */
+	@Override
 	public boolean processSynchrn(SynchrnServerVO synchrnServerVO, File[] uploadFile) throws Exception {
 
 		List<SynchrnServerVO> synchrnServerList = synchrnServerDAO.processSynchrnServerList(synchrnServerVO);
@@ -248,8 +277,9 @@ public class EgovSynchrnServerServiceImpl extends EgovAbstractServiceImpl implem
 		while (iterator.hasNext()) {
 			SynchrnServerVO SynchrnServerVo = iterator.next();
 
-			reflctAt = processFtp(SynchrnServerVo.getServerIp(), Integer.parseInt(SynchrnServerVo.getServerPort()), SynchrnServerVo.getFtpId(), SynchrnServerVo.getFtpPassword(),
-					SynchrnServerVo.getSynchrnLc(), synchrnServerVO.getFilePath(), uploadFile);
+			reflctAt = processFtp(SynchrnServerVo.getServerIp(), Integer.parseInt(SynchrnServerVo.getServerPort()),
+					SynchrnServerVo.getFtpId(), SynchrnServerVo.getFtpPassword(), SynchrnServerVo.getSynchrnLc(),
+					synchrnServerVO.getFilePath(), uploadFile);
 
 			synchrnServer.setServerId(SynchrnServerVo.getServerId());
 			if (reflctAt) {
@@ -266,14 +296,16 @@ public class EgovSynchrnServerServiceImpl extends EgovAbstractServiceImpl implem
 
 	/**
 	 * FTP 서버에 있는 화일 목록을 조회한다.
-	 * @param serverIp - String
-	 * @param port - int
-	 * @param user - String
-	 * @param password - String
+	 * 
+	 * @param serverIp    - String
+	 * @param port        - int
+	 * @param user        - String
+	 * @param password    - String
 	 * @param synchrnPath - String
 	 * @return List - 화일 목록
 	 */
-	public List<String> getFtpFileList(String serverIp, int port, String user, String password, String synchrnPath) throws Exception {
+	public List<String> getFtpFileList(String serverIp, int port, String user, String password, String synchrnPath)
+			throws Exception {
 
 		List<String> list = new ArrayList<String>();
 		FTPClient ftpClient = new FTPClient();
@@ -298,10 +330,12 @@ public class EgovSynchrnServerServiceImpl extends EgovAbstractServiceImpl implem
 
 	/**
 	 * 동기화 서버들을 대상으로 FTP Upload 처리를 한다.
+	 * 
 	 * @param synchrnServerVO - 동기화대상 서버 Vo
 	 * @return boolean - 성공여부
 	 */
-	public boolean processFtp(String serverIp, int port, String user, String password, String synchrnPath, String filePath, File[] uploadFile) throws Exception {
+	public boolean processFtp(String serverIp, int port, String user, String password, String synchrnPath,
+			String filePath, File[] uploadFile) throws Exception {
 
 		boolean upload = false;
 
@@ -316,11 +350,13 @@ public class EgovSynchrnServerServiceImpl extends EgovAbstractServiceImpl implem
 			InetAddress host = InetAddress.getByName(serverIp);
 
 			ftpClient.connect(host, port);
-			if (!ftpClient.login(user, password))
+			if (!ftpClient.login(user, password)) {
 				throw new Exception("FTP Client Login Error : \n");
+			}
 
-			if (synchrnPath.length() != 0)
+			if (synchrnPath.length() != 0) {
 				ftpClient.changeWorkingDirectory(synchrnPath);
+			}
 
 			FTPFile[] fTPFile = ftpClient.listFiles(synchrnPath);
 
@@ -330,7 +366,7 @@ public class EgovSynchrnServerServiceImpl extends EgovAbstractServiceImpl implem
 					if (uploadFile[i].isFile()) {
 						if (!isExist(fTPFile, uploadFile[i])) {
 							fis = new FileInputStream(uploadFile[i]);
-							//ftpClient.setFileType(FTP.ASCII_FILE_TYPE); // TEXT FILE 전송
+							// ftpClient.setFileType(FTP.ASCII_FILE_TYPE); // TEXT FILE 전송
 							ftpClient.setFileType(FTP.BINARY_FILE_TYPE); // 바이너리 파일 전송
 							ftpClient.storeFile(synchrnPath + uploadFile[i].getName(), fis);
 						}
@@ -340,7 +376,7 @@ public class EgovSynchrnServerServiceImpl extends EgovAbstractServiceImpl implem
 					}
 				}
 
-				// 업로드 파일 목록에 없는  FTP 서버에 있는 파일을 삭제한다.
+				// 업로드 파일 목록에 없는 FTP 서버에 있는 파일을 삭제한다.
 				fTPFile = ftpClient.listFiles(synchrnPath);
 				deleteFtpFile(ftpClient, fTPFile, uploadFile);
 
@@ -353,7 +389,7 @@ public class EgovSynchrnServerServiceImpl extends EgovAbstractServiceImpl implem
 			}
 			ftpClient.logout();
 
-		} catch (IOException e) {//KISA 보안약점 조치 (2018-10-29, 윤창원)
+		} catch (IOException e) {// KISA 보안약점 조치 (2018-10-29, 윤창원)
 			EgovBasicLogger.debug("processFtp error (IOException)", e);
 			upload = false;
 		} catch (Exception e) {
@@ -366,7 +402,8 @@ public class EgovSynchrnServerServiceImpl extends EgovAbstractServiceImpl implem
 
 	/**
 	 * 동기화 서버에 upload 할 파일이 존재하는지 확인한다.
-	 * @param fTPFiles - 동기화대상 서버의 파일 목록
+	 * 
+	 * @param fTPFiles   - 동기화대상 서버의 파일 목록
 	 * @param targetFile - 동기화대상 파일
 	 * @return boolean - 존재여부
 	 */
@@ -376,8 +413,9 @@ public class EgovSynchrnServerServiceImpl extends EgovAbstractServiceImpl implem
 
 		for (int i = 0; i < fTPFiles.length; i++) {
 			if (fTPFiles[i].isFile()) {
-				if (fTPFiles[i].getName().equals(targetFile.getName()))
+				if (fTPFiles[i].getName().equals(targetFile.getName())) {
 					isExist = true;
+				}
 			}
 		}
 
@@ -386,7 +424,8 @@ public class EgovSynchrnServerServiceImpl extends EgovAbstractServiceImpl implem
 
 	/**
 	 * 동기화 서버의 파일 목록 중 upload 파일 목록에 없는 파일은 삭제한다.
-	 * @param fTPFiles - 동기화대상 서버의 파일 목록
+	 * 
+	 * @param fTPFiles   - 동기화대상 서버의 파일 목록
 	 * @param uploadFile - 업로드 파일 목록
 	 * @return boolean - 존재여부
 	 */
@@ -414,26 +453,28 @@ public class EgovSynchrnServerServiceImpl extends EgovAbstractServiceImpl implem
 
 	/**
 	 * 업로드 파일의 목록을 조회한다.
+	 * 
 	 * @param filePath - 업로드 경로
 	 * @return List - 업로드 파일 리스트
 	 */
+	@Override
 	public List<String> getFileName() throws Exception {
 
 		File uploadFile = new File(EgovWebUtil.filePathBlackList(SYNCH_SERVER_PATH));
-		
-		if(!uploadFile.exists()){
-			//2017.02.08 	이정은 	시큐어코딩(ES)-부적절한 예외 처리[CWE-253, CWE-440, CWE-754]
-			if(uploadFile.mkdirs()){
+
+		if (!uploadFile.exists()) {
+			// 2017.02.08 이정은 시큐어코딩(ES)-부적절한 예외 처리[CWE-253, CWE-440, CWE-754]
+			if (uploadFile.mkdirs()) {
 				LOGGER.debug("[file.mkdirs] uploadFile : Directory Creation Success");
-			}else{
+			} else {
 				LOGGER.error("[file.mkdirs] uploadFile : Directory Creation Fail");
 			}
 		}
-				
+
 		File[] fileList = uploadFile.listFiles();
 		List<String> fileArray = new ArrayList<String>();
 
-		//KISA 보안약점 조치 (2018-10-29, 윤창원)
+		// KISA 보안약점 조치 (2018-10-29, 윤창원)
 		if (fileList != null) {
 			for (int i = 0; i < fileList.length; i++) {
 				if (fileList[i].isFile()) {
@@ -441,17 +482,20 @@ public class EgovSynchrnServerServiceImpl extends EgovAbstractServiceImpl implem
 				}
 			}
 		}
-		
+
 		return fileArray;
 	}
 
 	/**
 	 * 동기화 대상 파일을 업로드 한다.
-	 * @param file - 업로드 대상 파일
-	 * @param newName - 업로드 대상 파일명
+	 * 
+	 * @param file          - 업로드 대상 파일
+	 * @param newName       - 업로드 대상 파일명
 	 * @param stordFilePath - 업로드 경로
 	 */
-	public void writeFile(MultipartFile multipartFile, String newName, SynchrnServerVO synchrnServerVO) throws Exception {
+	@Override
+	public void writeFile(MultipartFile multipartFile, String newName, SynchrnServerVO synchrnServerVO)
+			throws Exception {
 
 		List<SynchrnServerVO> synchrnServerList = synchrnServerDAO.processSynchrnServerList(synchrnServerVO);
 		Iterator<SynchrnServerVO> iterator = synchrnServerList.iterator();
@@ -464,15 +508,17 @@ public class EgovSynchrnServerServiceImpl extends EgovAbstractServiceImpl implem
 			stream = multipartFile.getInputStream();
 			File cFile = new File(EgovWebUtil.filePathBlackList(SYNCH_SERVER_PATH));
 
-			if (!cFile.isDirectory())
-				//2017.02.08 	이정은 	시큐어코딩(ES)-부적절한 예외 처리[CWE-253, CWE-440, CWE-754]
-				if(cFile.mkdir()){
+			if (!cFile.isDirectory()) {
+				// 2017.02.08 이정은 시큐어코딩(ES)-부적절한 예외 처리[CWE-253, CWE-440, CWE-754]
+				if (cFile.mkdir()) {
 					LOGGER.debug("[file.mkdirs] cFile : Directory Creation Success");
-				}else{
+				} else {
 					LOGGER.error("[file.mkdirs] cFile : Directory Creation Fail");
 				}
+			}
 
-			bos = new FileOutputStream(EgovWebUtil.filePathBlackList(SYNCH_SERVER_PATH + File.separator + FilenameUtils.getName(newName)));
+			bos = new FileOutputStream(
+					EgovWebUtil.filePathBlackList(SYNCH_SERVER_PATH + File.separator + FilenameUtils.getName(newName)));
 
 			int bytesRead = 0;
 			byte[] buffer = new byte[2048];
@@ -495,8 +541,10 @@ public class EgovSynchrnServerServiceImpl extends EgovAbstractServiceImpl implem
 
 	/**
 	 * 업로드 파일을 삭제한다.
+	 * 
 	 * @param synchrnServerVO - 동기화대상 서버 Vo
 	 */
+	@Override
 	public void deleteFile(String deleteFiles, SynchrnServerVO synchrnServerVO) throws Exception {
 
 		List<SynchrnServerVO> synchrnServerList = synchrnServerDAO.processSynchrnServerList(synchrnServerVO);
@@ -506,13 +554,14 @@ public class EgovSynchrnServerServiceImpl extends EgovAbstractServiceImpl implem
 		String[] strDeleteFiles = deleteFiles.split(";");
 
 		for (int i = 0; i < strDeleteFiles.length; i++) {
-			File uploadFile = new File(EgovWebUtil.filePathBlackList(SYNCH_SERVER_PATH + FilenameUtils.getName(strDeleteFiles[i])));
-			//2017.02.08 	이정은 	시큐어코딩(ES)-부적절한 예외 처리[CWE-253, CWE-440, CWE-754]
-			if(uploadFile.delete()){
+			File uploadFile = new File(
+					EgovWebUtil.filePathBlackList(SYNCH_SERVER_PATH + FilenameUtils.getName(strDeleteFiles[i])));
+			// 2017.02.08 이정은 시큐어코딩(ES)-부적절한 예외 처리[CWE-253, CWE-440, CWE-754]
+			if (uploadFile.delete()) {
 				LOGGER.debug("[file.delete] uploadFile : File Deletion Success");
-			}else{
+			} else {
 				LOGGER.error("[file.delete] uploadFile : File Deletion Fail");
-			}			
+			}
 		}
 
 		while (iterator.hasNext()) {

--- a/src/main/java/egovframework/com/utl/sys/ssy/service/impl/EgovSynchrnServerServiceImpl.java
+++ b/src/main/java/egovframework/com/utl/sys/ssy/service/impl/EgovSynchrnServerServiceImpl.java
@@ -42,16 +42,24 @@ import egovframework.com.utl.sys.ssy.service.SynchrnServerVO;
  * - 2015.03.31	 업로드 파일의 목록을 조회시 업로드 디렉토리가 없을 경우 생성하도록 수정
  * </pre>
  * 
- * @author lee.m.j
+ * @author 이문준
+ * @since 2010.06.28
  * @version 1.0
- * @created 28-6-2010 오전 10:44:34
- * 
- *          <pre>
- *      수정일         수정자                   수정내용
- *   -------    --------    ---------------------------
- *   2017-02-08    이정은        시큐어코딩(ES) - 시큐어코딩 부적절한 예외 처리[CWE-253, CWE-440, CWE-754]
- *   2018-11-12    이정은        processFtp() FILE_TYPE 설정 수정
- *          </pre>
+ * @see
+ *
+ *      <pre>
+ *  == 개정이력(Modification Information) ==
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2010.06.28  이문준          최초 생성
+ *   2017-02-08  이정은          시큐어코딩(ES) - 시큐어코딩 부적절한 예외 처리[CWE-253, CWE-440, CWE-754]
+ *   2018-11-12  이정은          processFtp() FILE_TYPE 설정 수정
+ *   2025.09.06  이선규          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-LocalVariableNamingConventions(final이 아닌 변수는 밑줄을 포함할 수 없음)
+ *   2025.09.06  이선규          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-CloseResource(부적절한 자원 해제)
+ *   2025.09.06  이선규          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-AssignmentInOperand(피연산자내에 할당문이 사용됨. 해당 코드를 복잡하고 가독성이 떨어지게 만듬)
+ *
+ *      </pre>
  */
 @Service("egovSynchrnServerService")
 public class EgovSynchrnServerServiceImpl extends EgovAbstractServiceImpl implements EgovSynchrnServerService {

--- a/src/main/java/egovframework/com/utl/sys/trm/service/impl/TrsmrcvMntrngCheckerTestImpl.java
+++ b/src/main/java/egovframework/com/utl/sys/trm/service/impl/TrsmrcvMntrngCheckerTestImpl.java
@@ -1,6 +1,5 @@
 package egovframework.com.utl.sys.trm.service.impl;
 
-
 import java.security.SecureRandom;
 
 import org.slf4j.Logger;
@@ -13,12 +12,14 @@ import egovframework.com.utl.sys.trm.service.TrsmrcvMntrngResult;
  * @Class Name : EgovTrsmrcvMntrngCheckerImpl.java
  * @Description : 송수신모니터링을 위한 Check interface 예제 구현클래스
  * @Modification Information
- *
+ * 
+ *               <pre>
  *    수정일       수정자         수정내용
  *    -------        -------     -------------------
  *    2010.08.16     김진만   최초생성
- *
- * @author  김진만
+ *               </pre>
+ * 
+ * @author 김진만
  * @version
  * @see
  *
@@ -27,23 +28,24 @@ import egovframework.com.utl.sys.trm.service.TrsmrcvMntrngResult;
 public class TrsmrcvMntrngCheckerTestImpl implements TrsmrcvMntrngChecker {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(TrsmrcvMntrngCheckerTestImpl.class);
-	private static SecureRandom oRandom = new SecureRandom();		// 221115	김혜준	2022 시큐어코딩 조치
+	private static SecureRandom oRandom = new SecureRandom(); // 221115 김혜준 2022 시큐어코딩 조치
 
 	/**
 	 * 송수신모니터링을 수행한다.
 	 *
-	 * 연계ID를 이용하여 연계기관과 통신에 필요한 정보를 얻은 다음 연계기관과 통신을 수행한다.
-	 * 통신결과를 TrsmrcvMntrngResult 클래스 객체에 담아서 리턴한다.
+	 * 연계ID를 이용하여 연계기관과 통신에 필요한 정보를 얻은 다음 연계기관과 통신을 수행한다. 통신결과를 TrsmrcvMntrngResult
+	 * 클래스 객체에 담아서 리턴한다.
 	 *
-	 * 통신결과가 true일때 : TrsmrcvMntrngResult의 nrmltAt에 true, cause에 null을 저장.
-	 * 통신결과가 false일때: TrsmrcvMntrngResult의 nrmltAt에 false, cause에 에러원인 Exception을 저장한다.
+	 * 통신결과가 true일때 : TrsmrcvMntrngResult의 nrmltAt에 true, cause에 null을 저장. 통신결과가
+	 * false일때: TrsmrcvMntrngResult의 nrmltAt에 false, cause에 에러원인 Exception을 저장한다.
 	 *
 	 *
 	 * @return 모니터링결과
 	 *
-	 * @param cntcId   모니터링 대상 연계ID
+	 * @param cntcId 모니터링 대상 연계ID
 	 *
 	 */
+	@Override
 	public TrsmrcvMntrngResult check(String cntcId) {
 		Boolean b = oRandom.nextBoolean();
 		TrsmrcvMntrngResult result = null;
@@ -51,9 +53,10 @@ public class TrsmrcvMntrngCheckerTestImpl implements TrsmrcvMntrngChecker {
 		if (b.booleanValue()) {
 			result = new TrsmrcvMntrngResult(b.booleanValue(), null);
 		} else {
-			result = new TrsmrcvMntrngResult(b.booleanValue(), new UnsupportedOperationException("송수신샘플Check클래스에서 발생한 Exception입니다."));
+			result = new TrsmrcvMntrngResult(b.booleanValue(),
+					new UnsupportedOperationException("송수신샘플Check클래스에서 발생한 Exception입니다."));
 		}
 		LOGGER.debug("result cause : {}", result.getCause());
-		return result ;
+		return result;
 	}
 }

--- a/src/main/java/egovframework/com/utl/sys/trm/service/impl/TrsmrcvMntrngCheckerTestImpl.java
+++ b/src/main/java/egovframework/com/utl/sys/trm/service/impl/TrsmrcvMntrngCheckerTestImpl.java
@@ -50,11 +50,10 @@ public class TrsmrcvMntrngCheckerTestImpl implements TrsmrcvMntrngChecker {
 		Boolean b = oRandom.nextBoolean();
 		TrsmrcvMntrngResult result = null;
 
-		if (b.booleanValue()) {
-			result = new TrsmrcvMntrngResult(b.booleanValue(), null);
+		if (b) {
+			result = new TrsmrcvMntrngResult(b, null);
 		} else {
-			result = new TrsmrcvMntrngResult(b.booleanValue(),
-					new UnsupportedOperationException("송수신샘플Check클래스에서 발생한 Exception입니다."));
+			result = new TrsmrcvMntrngResult(b, new UnsupportedOperationException("송수신샘플Check클래스에서 발생한 Exception입니다."));
 		}
 		LOGGER.debug("result cause : {}", result.getCause());
 		return result;

--- a/src/main/java/egovframework/com/utl/sys/trm/service/impl/TrsmrcvMntrngCheckerTestImpl.java
+++ b/src/main/java/egovframework/com/utl/sys/trm/service/impl/TrsmrcvMntrngCheckerTestImpl.java
@@ -9,22 +9,22 @@ import egovframework.com.utl.sys.trm.service.TrsmrcvMntrngChecker;
 import egovframework.com.utl.sys.trm.service.TrsmrcvMntrngResult;
 
 /**
- * @Class Name : EgovTrsmrcvMntrngCheckerImpl.java
- * @Description : 송수신모니터링을 위한 Check interface 예제 구현클래스
- * @Modification Information
- * 
- *               <pre>
- *    수정일       수정자         수정내용
- *    -------        -------     -------------------
- *    2010.08.16     김진만   최초생성
- *               </pre>
+ * 송수신모니터링을 위한 Check interface 예제 구현클래스
  * 
  * @author 김진만
- * @version
+ * @since 2010.08.16
+ * @version 1.0
  * @see
  *
+ *      <pre>
+ *  == 개정이력(Modification Information) ==
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2010.08.16  김진만          최초 생성
+ *	 2025.09.06  이선규          2025년 컨트리뷰션 멘토링 PMD로 소프트웨어 보안약점 진단하고 제거하기-UnnecessaryBoxing(불필요한 WrapperObject 생성)
+ *      </pre>
  */
-
 public class TrsmrcvMntrngCheckerTestImpl implements TrsmrcvMntrngChecker {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(TrsmrcvMntrngCheckerTestImpl.class);


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.


<hr>

### 2025-09-06 토 PMD로 소프트웨어 보안약점 진단하고 제거하기-EgovSynchrnServerServiceImpl

`SynchrnServerVo` 를 `synchrnServerVO2` 로 이름 바꾸기
- LocalVariableNamingConventions
```java
//			SynchrnServerVO SynchrnServerVo = iterator.next();
			SynchrnServerVO synchrnServerVO2 = iterator.next();
```

processFtp 메서드에서 try-with-resources 로 수정
- CloseResource
```java
//			FileInputStream fis = null;
			try {
				for (int i = 0; i < uploadFile.length; i++) {
					if (uploadFile[i].isFile()) {
						if (!isExist(fTPFile, uploadFile[i])) {
							try (FileInputStream fis = new FileInputStream(uploadFile[i]);) {
								//ftpClient.setFileType(FTP.ASCII_FILE_TYPE); // TEXT FILE 전송
								ftpClient.setFileType(FTP.BINARY_FILE_TYPE); // 바이너리 파일 전송
								ftpClient.storeFile(synchrnPath + uploadFile[i].getName(), fis);
							}
						}
//						if (fis != null) {
//							fis.close();
//						}
					}
				}

				// 업로드 파일 목록에 없는  FTP 서버에 있는 파일을 삭제한다.
				fTPFile = ftpClient.listFiles(synchrnPath);
				deleteFtpFile(ftpClient, fTPFile, uploadFile);

				upload = true;

			} catch (IOException ex) {
				EgovBasicLogger.debug("FTP IO error", ex);
//			} finally {
//				EgovResourceCloseHelper.close(fis);
			}
			ftpClient.logout();
```

writeFile 메서드에서 `stream.read` 를 `FileCopyUtils.copy` 로 수정
- CloseResource, AssignmentInOperand
```java
//		InputStream stream = null;
//		OutputStream bos = null;

//		try {
//			stream = multipartFile.getInputStream();
			File cFile = new File(EgovWebUtil.filePathBlackList(SYNCH_SERVER_PATH));

			if (!cFile.isDirectory())
				//2017.02.08 	이정은 	시큐어코딩(ES)-부적절한 예외 처리[CWE-253, CWE-440, CWE-754]
				if(cFile.mkdir()){
					LOGGER.debug("[file.mkdirs] cFile : Directory Creation Success");
				}else{
					LOGGER.error("[file.mkdirs] cFile : Directory Creation Fail");
				}

//			bos = new FileOutputStream(EgovWebUtil.filePathBlackList(SYNCH_SERVER_PATH + File.separator + FilenameUtils.getName(newName)));
//
//			int bytesRead = 0;
//			byte[] buffer = new byte[2048];
//
//			while ((bytesRead = stream.read(buffer, 0, 2048)) != -1) {
//				bos.write(buffer, 0, bytesRead);
//			}

			FileCopyUtils.copy(multipartFile.getInputStream(), new FileOutputStream(EgovWebUtil
					.filePathBlackList(SYNCH_SERVER_PATH + File.separator + FilenameUtils.getName(newName))));

			while (iterator.hasNext()) {
				SynchrnServerVO SynchrnServerVo = iterator.next();
				synchrnServer.setServerId(SynchrnServerVo.getServerId());
				synchrnServer.setReflctAt("N");
				synchrnServerDAO.processSynchrn(synchrnServer);
			}

//		} finally {
//			EgovResourceCloseHelper.close(bos, stream);
//		}
```

<hr>

1. PMD로 소프트웨어 보안약점 진단 결과

```
src/main/java/egovframework/com/utl/sys/ssy/service/impl/EgovSynchrnServerServiceImpl.java:249:	LocalVariableNamingConventions:	LocalVariableNamingConventions: 'local variable' 의 변수 'SynchrnServerVo' 이  '[a-z][a-zA-Z0-9]*'  로 시작함
src/main/java/egovframework/com/utl/sys/ssy/service/impl/EgovSynchrnServerServiceImpl.java:327:	CloseResource:	CloseResource: 리소스 'FileInputStream' 가 사용 후에 닫혔는지 확인필요
src/main/java/egovframework/com/utl/sys/ssy/service/impl/EgovSynchrnServerServiceImpl.java:460:	CloseResource:	CloseResource: 리소스 'InputStream' 가 사용 후에 닫혔는지 확인필요
src/main/java/egovframework/com/utl/sys/ssy/service/impl/EgovSynchrnServerServiceImpl.java:461:	CloseResource:	CloseResource: 리소스 'OutputStream' 가 사용 후에 닫혔는지 확인필요
src/main/java/egovframework/com/utl/sys/ssy/service/impl/EgovSynchrnServerServiceImpl.java:480:	AssignmentInOperand:	AssignmentInOperand: 피연산자내에 할당문이 사용됨. Code 를 복잡하고 가독성이 떨어지게 만듬
src/main/java/egovframework/com/utl/sys/ssy/service/impl/EgovSynchrnServerServiceImpl.java:485:	LocalVariableNamingConventions:	LocalVariableNamingConventions: 'local variable' 의 변수 'SynchrnServerVo' 이  '[a-z][a-zA-Z0-9]*'  로 시작함
src/main/java/egovframework/com/utl/sys/ssy/service/impl/EgovSynchrnServerServiceImpl.java:519:	LocalVariableNamingConventions:	LocalVariableNamingConventions: 'local variable' 의 변수 'SynchrnServerVo' 이  '[a-z][a-zA-Z0-9]*'  로 시작함
```

2. 브랜치 생성

```
feature/pmd/EgovSynchrnServerServiceImpl
```

3. 이클립스 > Source > Format

4. 개정이력 수정

```java
 *   2025.09.06  이선규          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-LocalVariableNamingConventions(final이 아닌 변수는 밑줄을 포함할 수 없음)
 *   2025.09.06  이선규          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-CloseResource(부적절한 자원 해제)
 *   2025.09.06  이선규          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-AssignmentInOperand(피연산자내에 할당문이 사용됨. 해당 코드를 복잡하고 가독성이 떨어지게 만듬)
```

<hr>


## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.
