### PR TITLE
PMD로 소프트웨어 보안약점 진단하고 제거하기-EgovFileCmprs

### DIFF
--- a/src/main/java/egovframework/com/utl/sim/service/EgovFileCmprs.java
+++ b/src/main/java/egovframework/com/utl/sim/service/EgovFileCmprs.java
@@ -1,98 +1,92 @@
-/**
- *  Class Name : EgovFileCmprs.java
- *  Description : 파일(디렉토리)의 압축 및 압축해제 하는 Business Interface class
- *  Modification Information
- *
- *   수정일               수정자              수정내용
- *   ----------   --------    ---------------------------
- *   2009.02.04   박지욱              최초 생성
- *   2017.03.03   조성원              시큐어코딩(ES)-부적절한 예외 처리[CWE-253, CWE-440, CWE-754]
- *   2017.03.03   조성원              시큐어코딩(ES)-Null Pointer 역참조[CWE-476]
- *   2018.03.19   신용호              createDirectories() 호출및 예외처리 수정
- *   2020.08.28   신용호              시큐어코딩(ES)-부적절한 예외 처리[CWE-253, CWE-440, CWE-754]
- *   2020.10.29   신용호              KISA 보안약점 조치 (경로 조작 및 자원 삽입)
- *   2022.11.11   김혜준			  시큐어코딩 처리
- *
- *  @author 공통 서비스 개발팀 박지욱
- *  @since 2009. 02. 04
- *  @version 1.0
- *  @see
- *
- *  Copyright (C) 2009 by MOPAS  All rights reserved.
- */
 package egovframework.com.utl.sim.service;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
+import java.io.IOException;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
+import org.apache.commons.io.IOUtils;
+import org.egovframe.rte.fdl.cmmn.exception.BaseRuntimeException;
+
 import egovframework.com.cmm.EgovWebUtil;
-import egovframework.com.cmm.util.EgovResourceCloseHelper;
 
+/**
+ * 파일(디렉토리)의 압축 및 압축해제 하는 Business Interface class
+ * 
+ * @author 공통 서비스 개발팀 박지욱
+ * @since 2009.02.04
+ * @version 1.0
+ * @see
+ *
+ *      <pre>
+ *  == 개정이력(Modification Information) ==
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2009.02.04  박지욱          최초 생성
+ *   2017.03.03  조성원          시큐어코딩(ES)-부적절한 예외 처리[CWE-253, CWE-440, CWE-754]
+ *   2017.03.03  조성원          시큐어코딩(ES)-Null Pointer 역참조[CWE-476]
+ *   2018.03.19  신용호          createDirectories() 호출및 예외처리 수정
+ *   2020.08.28  신용호          시큐어코딩(ES)-부적절한 예외 처리[CWE-253, CWE-440, CWE-754]
+ *   2020.10.29  신용호          KISA 보안약점 조치 (경로 조작 및 자원 삽입)
+ *   2022.11.11  김혜준          시큐어코딩 처리
+ *   2025.09.07  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-CloseResource(부적절한 자원 해제)
+ *   2025.09.07  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-AssignmentInOperand(피연산자내에 할당문이 사용됨. 해당 코드를 복잡하고 가독성이 떨어지게 만듬)
+ *
+ *      </pre>
+ */
 public class EgovFileCmprs {
-
-	final static int BUFFER_SIZE = 64 * 1024;
-	final static char FILE_SEPARATOR = File.separatorChar;
 
 	/**
 	 * 파일(디렉토리)을 압축해제하는 기능
+	 * 
 	 * @param source 압축파일명
 	 * @param target 압출이 풀릴 디렉토리
 	 * @return boolean result 압축해제성공여부 True / False
 	 */
-	public static boolean decmprsFile(String source, String target) throws Exception {
-
+	public static boolean decmprsFile(String source, String target) {
 		// 압축해제성공여부
 		boolean result = false;
-		int cnt = 0;
-		// 읽어들일 byte 버퍼
-		byte[] buffer = new byte[BUFFER_SIZE];
 
-		FileInputStream finput = null;
-		FileOutputStream foutput = null;
-		ZipInputStream zinput = null;
-
-		String source1 = source.replace('\\', FILE_SEPARATOR).replace('/', FILE_SEPARATOR);
-		String target1 = target.replace('\\', FILE_SEPARATOR).replace('/', FILE_SEPARATOR);
+		String source1 = source.replace('\\', File.separatorChar).replace('/', File.separatorChar);
+		String target1 = target.replace('\\', File.separatorChar).replace('/', File.separatorChar);
 		File srcFile = new File(source1);
 
 		if (srcFile.exists() && srcFile.isFile()) {
-
 			String target2 = EgovFileTool.createNewDirectory(target1);
 			File tarFile = new File(target2);
-			finput = new FileInputStream(srcFile);
-			zinput = new ZipInputStream(finput);
 
-			ZipEntry entry;
-
-			try {
+			try (FileInputStream finput = new FileInputStream(srcFile);
+					ZipInputStream zinput = new ZipInputStream(finput);) {
+				ZipEntry entry = zinput.getNextEntry();
 
 				File efile;
-				while ((entry = zinput.getNextEntry()) != null) {
+				while (entry != null) {
 
 					String filename = entry.getName();
-					String entryFilePath = tarFile.getAbsolutePath() + FILE_SEPARATOR + filename;
+					String entryFilePath = tarFile.getAbsolutePath() + File.separatorChar + filename;
 					entryFilePath = EgovWebUtil.filePathBlackList(entryFilePath);
 					efile = new File(entryFilePath);
 					if (entry.isDirectory()) {
 						EgovFileTool.createDirectories(efile.getAbsolutePath());
 					} else {
-						foutput = new FileOutputStream(efile);
-						// 2022.11.11 시큐어코딩 처리
-						while ((cnt = zinput.read(buffer)) != -1) {
-							foutput.write(buffer, 0, cnt);
-						}
+						IOUtils.copy(zinput, new FileOutputStream(efile));
 					}
+
+					entry = zinput.getNextEntry();
 				}
 
 				result = true;
-
-			} finally {
-				EgovResourceCloseHelper.close(finput, zinput, foutput);
+			} catch (FileNotFoundException e) {
+				throw new BaseRuntimeException(e);
+			} catch (IOException e) {
+				throw new BaseRuntimeException(e);
 			}
 		}
+
 		return result;
 	}
 

--- a/src/test/java/egovframework/com/file/TestDecompress.java
+++ b/src/test/java/egovframework/com/file/TestDecompress.java
@@ -1,52 +1,104 @@
 package egovframework.com.file;
 
+import java.io.BufferedOutputStream;
 import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
+import java.time.LocalDateTime;
+import java.util.Collection;
+
+import org.apache.commons.compress.archivers.ArchiveOutputStream;
+import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
+import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.egovframe.rte.fdl.cmmn.exception.BaseRuntimeException;
 
 import egovframework.com.utl.sim.service.EgovFileCmprs;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public class TestDecompress {
 
 	public static void main(String[] args) {
-		
 		// 프로젝트 ROOT
-		//String strDirPath = "C:\\eGovFrameDev-4.0.0-64bit\\workspace\\test.simple_homepage";
-	    String strDirPath = "";
+		// String strDirPath =
+		// "C:\\eGovFrameDev-4.0.0-64bit\\workspace\\test.simple_homepage";
+		String strDirPath = "";
 		strDirPath = System.getProperty("user.dir");
-	    System.out.println("Working Directory = " + strDirPath);
-
-	    //Path relativePath = Paths.get("");
-	    //strDirPath = relativePath.toAbsolutePath().toString();
-	    //System.out.println("Working Directory = " + strDirPath);
-
-	    String source = strDirPath + File.separator + "target" + File.separator + "sample.zip";
-	    String target = strDirPath + File.separator + "target" + File.separator + "result";
-	    String moved = target + File.separator + "sample.zip.bak";
-	    System.out.println("source = " + source);
-	    System.out.println("target = " + target);
-	    boolean result = false;
-	    try {
-	    	result = EgovFileCmprs.decmprsFile(source, target);
-		} catch (Exception e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
+		if (log.isDebugEnabled()) {
+			log.debug("Working Directory = {}", strDirPath);
 		}
-	    
-	    System.out.println("result = " + result);
 
-	    // source => target 파일 이동
-	    // sample.zip => sample.zip.bak
-	    try {
-	        Path filePath = Paths.get(source);
-	        Path filePathToMove = Paths.get(moved);
-	        Files.move(filePath, filePathToMove);
-	    } catch (IOException e) {
-	        e.printStackTrace();
-	    }
-		
+		// Path relativePath = Paths.get("");
+		// strDirPath = relativePath.toAbsolutePath().toString();
+//		if (log.isDebugEnabled()) {
+//			log.debug("Working Directory = {}", strDirPath);
+//		}
+
+		String source = strDirPath + File.separator + "target" + File.separator + "sample.zip";
+		String target = "test/result/result_" + LocalDateTime.now().toString().replaceAll(":", "-");
+//		String moved = target + File.separator + "sample.zip.bak";
+		if (log.isDebugEnabled()) {
+			log.debug("source = {}", source);
+			log.debug("target = {}", target);
+		}
+
+		zipCommonArchivalLogic(strDirPath, source);
+
+		boolean result = EgovFileCmprs.decmprsFile(source, target);
+
+		if (log.isDebugEnabled()) {
+			log.debug("result = {}", result);
+		}
+
+//		// source => target 파일 이동
+//		// sample.zip => sample.zip.bak
+//		try {
+//			Path filePath = Paths.get(source);
+//			Path filePathToMove = Paths.get(moved);
+//			Files.move(filePath, filePathToMove);
+//		} catch (IOException e) {
+//			throw new BaseRuntimeException(e);
+//		}
+	}
+
+	private static void zipCommonArchivalLogic(String strDirPath, String source) {
+		Collection<File> filesToArchive = FileUtils
+				.listFiles(new File(strDirPath, "/src/test/resources/egovframework/data"), null, false);
+		if (log.isDebugEnabled()) {
+			log.debug("filesToArchive={}", filesToArchive);
+		}
+		for (File f : filesToArchive) {
+			if (log.isDebugEnabled()) {
+				log.debug("f={}", f);
+				log.debug("getName={}", f.getName());
+			}
+		}
+
+		try (ArchiveOutputStream<ZipArchiveEntry> o = new ZipArchiveOutputStream(
+				new BufferedOutputStream(new FileOutputStream(source)))) {
+			for (File f : filesToArchive) {
+				// maybe skip directories for formats like AR that don't store directories
+				ZipArchiveEntry entry = o.createArchiveEntry(f, f.getName());
+				// potentially add more flags to entry
+				o.putArchiveEntry(entry);
+				if (f.isFile()) {
+					try (InputStream i = Files.newInputStream(f.toPath())) {
+						IOUtils.copy(i, o);
+					}
+				}
+				o.closeArchiveEntry();
+			}
+			o.finish();
+		} catch (FileNotFoundException e) {
+			throw new BaseRuntimeException(e);
+		} catch (IOException e) {
+			throw new BaseRuntimeException(e);
+		}
 	}
 
 }


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

<hr>

### 2025-09-07 일 PMD로 소프트웨어 보안약점 진단하고 제거하기-EgovFileCmprs

`TestDecompress` 테스트 실행 에러 수정

`CloseResource(부적절한 자원 해제)` 제거

`AssignmentInOperand(피연산자내에 할당문이 사용됨. 해당 코드를 복잡하고 가독성이 떨어지게 만듬)` 제거

`throws Exception` 제거

<hr>

TestDecompress 테스트 실행
- NoSuchFileException
- 해당 파일 없음 예외
- `java.nio.file.NoSuchFileException: C:\eGovFrameDev-4.3.0-64bit\workspace-egov\git\egovframe-common-components-25a\target\sample.zip` 예외 확인
```
Working Directory = C:\eGovFrameDev-4.3.0-64bit\workspace-egov\git\egovframe-common-components-25a
source = C:\eGovFrameDev-4.3.0-64bit\workspace-egov\git\egovframe-common-components-25a\target\sample.zip
target = C:\eGovFrameDev-4.3.0-64bit\workspace-egov\git\egovframe-common-components-25a\target\result
[log4j]2025-09-07 12:35:55,022 DEBUG [egovframework.com.cmm.service.EgovProperties] ===>>> getProperty/C:/eGovFrameDev-4.3.0-64bit/workspace-egov/git/egovframe-common-components-25a/target/classes/
[log4j]2025-09-07 12:35:55,091 DEBUG [egovframework.com.cmm.service.EgovProperties] getProperty : /C:/eGovFrameDev-4.3.0-64bit/workspace-egov/git/egovframe-common-components-25a/target/test-classes/egovframework/egovProps\globals.properties = Globals.fileStorePath
result = true
java.nio.file.NoSuchFileException: C:\eGovFrameDev-4.3.0-64bit\workspace-egov\git\egovframe-common-components-25a\target\sample.zip -> C:\eGovFrameDev-4.3.0-64bit\workspace-egov\git\egovframe-common-components-25a\target\result\sample.zip.bak
	at sun.nio.fs.WindowsException.translateToIOException(WindowsException.java:79)
	at sun.nio.fs.WindowsException.rethrowAsIOException(WindowsException.java:97)
	at sun.nio.fs.WindowsFileCopy.move(WindowsFileCopy.java:387)
	at sun.nio.fs.WindowsFileSystemProvider.move(WindowsFileSystemProvider.java:287)
	at java.nio.file.Files.move(Files.java:1395)
	at egovframework.com.file.TestDecompress.main(TestDecompress.java:45)
```

<hr>

`/egovframe-common-components-25a/src/test/resources/egovframework/data` 를 `/egovframe-common-components-25a/target/sample.zip` 으로 압축하기
- https://commons.apache.org/proper/commons-compress/examples.html
- Common Archival Logic

<hr>

파일/폴더 위치
```
C:\eGovFrameDev-4.3.0-64bit\workspace-egov\git\egovframe-common-components-25a\target
sample.zip

C:\egovframework\upload\test\result
result_2025-09-07T13-40-43.606
result_2025-09-07T13-43-04.297
result_2025-09-07T13-44-32.030
```

<hr>

// TODO recursive 재귀적 압축 하기/풀기

<hr>

1. PMD로 소프트웨어 보안약점 진단 결과

```
src/main/java/egovframework/com/utl/sim/service/EgovFileCmprs.java:53:	CloseResource:	CloseResource: 리소스 'FileInputStream' 가 사용 후에 닫혔는지 확인필요
src/main/java/egovframework/com/utl/sim/service/EgovFileCmprs.java:54:	CloseResource:	CloseResource: 리소스 'FileOutputStream' 가 사용 후에 닫혔는지 확인필요
src/main/java/egovframework/com/utl/sim/service/EgovFileCmprs.java:55:	CloseResource:	CloseResource: 리소스 'ZipInputStream' 가 사용 후에 닫혔는지 확인필요
src/main/java/egovframework/com/utl/sim/service/EgovFileCmprs.java:73:	AssignmentInOperand:	AssignmentInOperand: 피연산자내에 할당문이 사용됨. Code 를 복잡하고 가독성이 떨어지게 만듬
src/main/java/egovframework/com/utl/sim/service/EgovFileCmprs.java:84:	AssignmentInOperand:	AssignmentInOperand: 피연산자내에 할당문이 사용됨. Code 를 복잡하고 가독성이 떨어지게 만듬
```

2. 브랜치 생성

```
feature/pmd/EgovFileCmprs
```

3. 이클립스 > Source > Format

4. 개정이력 수정

```java
 *   2025.09.07  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-CloseResource(부적절한 자원 해제)
 *   2025.09.07  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-AssignmentInOperand(피연산자내에 할당문이 사용됨. 해당 코드를 복잡하고 가독성이 떨어지게 만듬)
```

<hr>

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [x] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

https://youtu.be/xOCWcHprIoI
