### PR TITLE
PMD로 소프트웨어 보안약점 진단하고 제거하기-EgovFileTool

### DIFF
--- a/src/main/java/egovframework/com/utl/sim/service/EgovFileTool.java
+++ b/src/main/java/egovframework/com/utl/sim/service/EgovFileTool.java
@@ -43,7 +43,8 @@ import egovframework.com.utl.fcc.service.EgovStringUtil;
  *
  * @author 김진만
  * @see
- * <pre>
+ * 
+ *      <pre>
  * == 개정이력(Modification Information) ==
  *
  *  수정일                수정자           수정내용
@@ -53,7 +54,7 @@ import egovframework.com.utl.fcc.service.EgovStringUtil;
  *  2024.10.29   win777	    디렉토리 생성 성공 시 생성된 절대경로를 리턴하도록 변경
  *  2025.02.06   신용호       deleteFile() KISA 시큐어코딩 처리
  *
- * </pre>
+ *      </pre>
  */
 
 public class EgovFileTool {
@@ -66,9 +67,8 @@ public class EgovFileTool {
 
 	// LOGGER
 	private static final Logger LOGGER = LoggerFactory.getLogger(EgovFileTool.class);
-	
-	private static final String FILE_STORE_PATH = EgovProperties.getProperty("Globals.fileStorePath");
 
+	private static final String FILE_STORE_PATH = EgovProperties.getProperty("Globals.fileStorePath");
 
 	/**
 	 * <pre>
@@ -81,7 +81,7 @@ public class EgovFileTool {
 	public static String deletePath(String filePath) {
 		return deletePath(FILE_STORE_PATH, filePath);
 	}
-	
+
 	/**
 	 * <pre>
 	 * Comment : 디렉토리(파일)를 삭제한다. (파일,디렉토리 구분없이 존재하는 경우 무조건 삭제한다)
@@ -92,12 +92,12 @@ public class EgovFileTool {
 	 * @return 성공하면 삭제된 절대경로, 아니면블랭크
 	 */
 	public static String deletePath(String basePath, String filePath) {
-		
+
 		// 인자 값이 없는 경우 "Globals.fileStorePath" 기본 경로를 지정한다.
 		if (basePath == null || basePath.equals("")) {
 			basePath = FILE_STORE_PATH;
 		}
-		
+
 		String result = "";
 
 		File file = new File(EgovWebUtil.filePathBlackList(basePath + filePath));
@@ -117,25 +117,25 @@ public class EgovFileTool {
 	 * </pre>
 	 *
 	 * @param basePath 기본 경로
-	 * @param dirPath 생성하고자 하는 절대경로
+	 * @param dirPath  생성하고자 하는 절대경로
 	 * @return 성공하면 생성된 절대경로, 아니면 블랭크
 	 */
 	public static String createDirectories(String dirPath) {
 		return createDirectories(FILE_STORE_PATH, dirPath);
 	}
-	
+
 	/**
 	 * <pre>
 	 * Comment : 디렉토리를 생성한다. (여러 레벨의 경로를 동시에 생성)
 	 * </pre>
 	 *
 	 * @param basePath 기본 경로
-	 * @param dirPath 생성하고자 하는 절대경로
+	 * @param dirPath  생성하고자 하는 절대경로
 	 * @return 성공하면 생성된 절대경로, 아니면 블랭크
 	 */
 	public static String createDirectories(String basePath, String dirPath) {
 		String result = "";
-		
+
 		// 인자 값이 없는 경우 "Globals.fileStorePath" 기본 경로를 지정한다.
 		if (basePath == null || basePath.equals("")) {
 			basePath = FILE_STORE_PATH;
@@ -189,14 +189,14 @@ public class EgovFileTool {
 
 		return createNewDirectory(FILE_STORE_PATH, dirPath);
 	}
-	
+
 	/**
 	 * <pre>
 	 * Comment : 디렉토리를 생성한다.
 	 * </pre>
 	 *
 	 * @param basePath 기본 경로
-	 * @param dirPath 생성하고자 하는 절대경로
+	 * @param dirPath  생성하고자 하는 절대경로
 	 * @return 성공하면 새성된 절대경로, 아니면 블랭크
 	 */
 	public static String createNewDirectory(String basePath, String dirPath) {
@@ -205,7 +205,7 @@ public class EgovFileTool {
 		if (basePath == null || basePath.equals("")) {
 			basePath = FILE_STORE_PATH;
 		}
-		
+
 		// 인자값 유효하지 않은 경우 블랭크 리턴
 		if (dirPath == null || dirPath.equals("")) {
 			return "";
@@ -217,7 +217,7 @@ public class EgovFileTool {
 		if (file.exists()) {
 			// 혹시 존재해도 파일이면 생성 - 생성되지 않는다.(아래는 실질적으로는 진행되지 않음)
 			if (file.isFile()) {
-				//new File(file.getParent()).mkdirs();
+				// new File(file.getParent()).mkdirs();
 				if (file.mkdirs()) {
 					result = file.getAbsolutePath();
 				}
@@ -233,7 +233,7 @@ public class EgovFileTool {
 
 		return result;
 	}
-	
+
 	/**
 	 * <pre>
 	 * Comment : 파일을 생성한다.
@@ -245,7 +245,7 @@ public class EgovFileTool {
 	public static String createNewFile(String filePath) {
 		return createNewFile(FILE_STORE_PATH, filePath);
 	}
-	
+
 	/**
 	 * <pre>
 	 * Comment : 파일을 생성한다.
@@ -256,7 +256,7 @@ public class EgovFileTool {
 	 * @return 성공하면 생성된 파일의 절대경로, 아니면블랭크
 	 */
 	public static String createNewFile(String basePath, String filePath) {
-		
+
 		// 인자 값이 없는 경우 "Globals.fileStorePath" 기본 경로를 지정한다.
 		if (basePath == null || basePath.equals("")) {
 			basePath = FILE_STORE_PATH;
@@ -303,18 +303,18 @@ public class EgovFileTool {
 	public static String deleteFile(String fileDeletePath) {
 		return deleteFile(FILE_STORE_PATH, fileDeletePath);
 	}
-	
+
 	/**
 	 * <pre>
 	 * Comment : 파일을 삭제한다.
 	 * </pre>
 	 *
-	 * @param basePath 기본 경로
+	 * @param basePath       기본 경로
 	 * @param fileDeletePath 삭제하고자 하는파일의 절대경로
 	 * @return 성공하면 삭제된 파일의 절대경로, 아니면블랭크
 	 */
 	public static String deleteFile(String basePath, String fileDeletePath) {
-		
+
 		// 인자 값이 없는 경우 "Globals.fileStorePath" 기본 경로를 지정한다.
 		if (basePath == null || basePath.equals("")) {
 			basePath = FILE_STORE_PATH;
@@ -338,23 +338,24 @@ public class EgovFileTool {
 	/**
 	 * 파일을 특정 구분자(',', '|', 'TAB')로 파싱하는 기능
 	 *
-	 * @param parFile 파일
-	 * @param parChar 구분자(',', '|', 'TAB')
+	 * @param parFile  파일
+	 * @param parChar  구분자(',', '|', 'TAB')
 	 * @param parField 필드수
 	 * @return Vector parResult 파싱결과 구조체
 	 * @exception Exception
 	 */
-	public static Vector<List<String>> parsFileByChar(String basePath, String parFile, String parChar, int parField) throws Exception {
+	public static Vector<List<String>> parsFileByChar(String basePath, String parFile, String parChar, int parField)
+			throws Exception {
 
 		// 인자 값이 없는 경우 "Globals.fileStorePath" 기본 경로를 지정한다.
 		if (basePath == null || basePath.equals("")) {
 			basePath = FILE_STORE_PATH;
 		}
-		
+
 		if (!EgovFileBasePathSecurityValidator.validate(basePath)) {
 			throw new SecurityException("Unacceptable base path : " + basePath);
 		}
-		
+
 		// 파싱결과 구조체
 		Vector<List<String>> parResult = new Vector<List<String>>();
 

--- a/src/main/java/egovframework/com/utl/sim/service/EgovFileTool.java
+++ b/src/main/java/egovframework/com/utl/sim/service/EgovFileTool.java
@@ -1,23 +1,3 @@
-/**
- *  Class Name : EgovFileTool.java
- *  Description : 시스템 디렉토리 정보를 확인하여 제공하는  Business class
- *  Modification Information
- *
- *     수정일         수정자                   수정내용
- *   -------    --------    ---------------------------
- *   2009.01.13    조재영          최초 생성
- *   2017.03.03    조성원 	     시큐어코딩(ES)-부적절한 예외 처리[CWE-253, CWE-440, CWE-754]
- *   2017.03.03    조성원          시큐어코딩(ES)-Null Pointer 역참조[CWE-476]
- *   2018.03.19    신용호          createDirectories() 추가 : 여러 레벨의 디렉토리를 한번에 생성
- *
- *
- *  @author 공통 서비스 개발팀 조재영,박지욱
- *  @since 2009. 01. 13
- *  @version 1.0
- *  @see
- *
- *  Copyright (C) 2009 by MOPAS  All rights reserved.
- */
 package egovframework.com.utl.sim.service;
 
 import java.io.BufferedReader;
@@ -39,24 +19,36 @@ import egovframework.com.cmm.service.EgovProperties;
 import egovframework.com.utl.fcc.service.EgovStringUtil;
 
 /**
+ * 시스템 디렉토리 정보를 확인하여 제공하는 Business class
+ * <p>
  * EgovFileTool 클래스를 정의한다.
- *
- * @author 김진만
- * @see
  * 
- *      <pre>
- * == 개정이력(Modification Information) ==
+ * @author 공통 서비스 개발팀 조재영,박지욱
+ * @author 김진만
+ * @since 2009.01.13
+ * @since 2009.06.01
+ * @version 1.0
+ * @see
  *
- *  수정일                수정자           수정내용
- *  ----------   --------   ---------------------------
- *  2020.12.07   신용호       KISA 보안약점 조치
- *  2022.11.11   김혜준       시큐어코딩 처리
- *  2024.10.29   win777	    디렉토리 생성 성공 시 생성된 절대경로를 리턴하도록 변경
- *  2025.02.06   신용호       deleteFile() KISA 시큐어코딩 처리
+ *      <pre>
+ *  == 개정이력(Modification Information) ==
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2009.01.13  조재영          최초 생성
+ *   2017.03.03  조성원 	       시큐어코딩(ES)-부적절한 예외 처리[CWE-253, CWE-440, CWE-754]
+ *   2017.03.03  조성원          시큐어코딩(ES)-Null Pointer 역참조[CWE-476]
+ *   2018.03.19  신용호          createDirectories() 추가 : 여러 레벨의 디렉토리를 한번에 생성
+ *   2020.12.07  신용호          KISA 보안약점 조치
+ *   2022.11.11  김혜준          시큐어코딩 처리
+ *   2024.10.29  win777        디렉토리 생성 성공 시 생성된 절대경로를 리턴하도록 변경
+ *   2025.02.06  신용호          deleteFile() KISA 시큐어코딩 처리
+ *   2025.09.09  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-AvoidReassigningParameters(넘겨받는 메소드 parameter 값을 직접 변경하는 코드 탐지)
+ *   2025.09.09  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-CloseResource(부적절한 자원 해제)
+ *   2025.09.09  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-AssignmentInOperand(피연산자내에 할당문이 사용됨. 해당 코드를 복잡하고 가독성이 떨어지게 만듬)
  *
  *      </pre>
  */
-
 public class EgovFileTool {
 
 	// 파일구분자

--- a/src/main/java/egovframework/com/utl/sim/service/EgovFileTool.java
+++ b/src/main/java/egovframework/com/utl/sim/service/EgovFileTool.java
@@ -25,6 +25,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Vector;
@@ -35,7 +36,6 @@ import org.slf4j.LoggerFactory;
 import egovframework.com.cmm.EgovWebUtil;
 import egovframework.com.cmm.aop.EgovFileBasePathSecurityValidator;
 import egovframework.com.cmm.service.EgovProperties;
-import egovframework.com.cmm.util.EgovResourceCloseHelper;
 import egovframework.com.utl.fcc.service.EgovStringUtil;
 
 /**
@@ -92,15 +92,16 @@ public class EgovFileTool {
 	 * @return 성공하면 삭제된 절대경로, 아니면블랭크
 	 */
 	public static String deletePath(String basePath, String filePath) {
+		String basePath2 = null;
 
 		// 인자 값이 없는 경우 "Globals.fileStorePath" 기본 경로를 지정한다.
 		if (basePath == null || basePath.equals("")) {
-			basePath = FILE_STORE_PATH;
+			basePath2 = FILE_STORE_PATH;
 		}
 
 		String result = "";
 
-		File file = new File(EgovWebUtil.filePathBlackList(basePath + filePath));
+		File file = new File(EgovWebUtil.filePathBlackList(basePath2 + filePath));
 		if (file.exists()) {
 			result = file.getAbsolutePath();
 			if (!file.delete()) {
@@ -136,12 +137,14 @@ public class EgovFileTool {
 	public static String createDirectories(String basePath, String dirPath) {
 		String result = "";
 
+		String basePath2 = null;
+
 		// 인자 값이 없는 경우 "Globals.fileStorePath" 기본 경로를 지정한다.
 		if (basePath == null || basePath.equals("")) {
-			basePath = FILE_STORE_PATH;
+			basePath2 = FILE_STORE_PATH;
 		}
 
-		File file = new File(EgovWebUtil.filePathBlackList(basePath + dirPath));
+		File file = new File(EgovWebUtil.filePathBlackList(basePath2 + dirPath));
 		if (!file.exists()) {
 			if (file.mkdirs()) {
 				LOGGER.debug("[file.mkdirs] file : Path Creation Success");
@@ -200,10 +203,11 @@ public class EgovFileTool {
 	 * @return 성공하면 새성된 절대경로, 아니면 블랭크
 	 */
 	public static String createNewDirectory(String basePath, String dirPath) {
+		String basePath2 = null;
 
 		// 인자 값이 없는 경우 "Globals.fileStorePath" 기본 경로를 지정한다.
 		if (basePath == null || basePath.equals("")) {
-			basePath = FILE_STORE_PATH;
+			basePath2 = FILE_STORE_PATH;
 		}
 
 		// 인자값 유효하지 않은 경우 블랭크 리턴
@@ -211,7 +215,7 @@ public class EgovFileTool {
 			return "";
 		}
 
-		File file = new File(EgovWebUtil.filePathBlackList(basePath + dirPath));
+		File file = new File(EgovWebUtil.filePathBlackList(basePath2 + dirPath));
 		String result = "";
 		// 없으면 생성
 		if (file.exists()) {
@@ -256,10 +260,11 @@ public class EgovFileTool {
 	 * @return 성공하면 생성된 파일의 절대경로, 아니면블랭크
 	 */
 	public static String createNewFile(String basePath, String filePath) {
+		String basePath2 = null;
 
 		// 인자 값이 없는 경우 "Globals.fileStorePath" 기본 경로를 지정한다.
 		if (basePath == null || basePath.equals("")) {
-			basePath = FILE_STORE_PATH;
+			basePath2 = FILE_STORE_PATH;
 		}
 
 		// 인자값 유효하지 않은 경우 블랭크 리턴
@@ -267,7 +272,7 @@ public class EgovFileTool {
 			return "";
 		}
 
-		File file = new File(EgovWebUtil.filePathBlackList(basePath + filePath));
+		File file = new File(EgovWebUtil.filePathBlackList(basePath2 + filePath));
 		String result = "";
 		try {
 			if (file.exists()) {
@@ -286,7 +291,7 @@ public class EgovFileTool {
 				}
 			}
 		} catch (IOException e) {
-			throw new RuntimeException(e);
+			throw new UncheckedIOException(e);
 		}
 
 		return result;
@@ -314,10 +319,11 @@ public class EgovFileTool {
 	 * @return 성공하면 삭제된 파일의 절대경로, 아니면블랭크
 	 */
 	public static String deleteFile(String basePath, String fileDeletePath) {
+		String basePath2 = null;
 
 		// 인자 값이 없는 경우 "Globals.fileStorePath" 기본 경로를 지정한다.
 		if (basePath == null || basePath.equals("")) {
-			basePath = FILE_STORE_PATH;
+			basePath2 = FILE_STORE_PATH;
 		}
 
 		// 인자값 유효하지 않은 경우 블랭크 리턴
@@ -327,7 +333,7 @@ public class EgovFileTool {
 		String result = "";
 		File file = new File(EgovWebUtil.filePathBlackList(fileDeletePath));
 		if (file.isFile()) {
-			result = deletePath(basePath, fileDeletePath);
+			result = deletePath(basePath2, fileDeletePath);
 		} else {
 			result = "";
 		}
@@ -346,14 +352,15 @@ public class EgovFileTool {
 	 */
 	public static Vector<List<String>> parsFileByChar(String basePath, String parFile, String parChar, int parField)
 			throws Exception {
+		String basePath2 = null;
 
 		// 인자 값이 없는 경우 "Globals.fileStorePath" 기본 경로를 지정한다.
 		if (basePath == null || basePath.equals("")) {
-			basePath = FILE_STORE_PATH;
+			basePath2 = FILE_STORE_PATH;
 		}
 
-		if (!EgovFileBasePathSecurityValidator.validate(basePath)) {
-			throw new SecurityException("Unacceptable base path : " + basePath);
+		if (!EgovFileBasePathSecurityValidator.validate(basePath2)) {
+			throw new SecurityException("Unacceptable base path : " + basePath2);
 		}
 
 		// 파싱결과 구조체
@@ -361,20 +368,20 @@ public class EgovFileTool {
 
 		// 파일 오픈
 		String parFile1 = parFile.replace('\\', FILE_SEPARATOR).replace('/', FILE_SEPARATOR);
-		File file = new File(EgovWebUtil.filePathBlackList(basePath + parFile1));
-		BufferedReader br = null;
-		try {
-			// 파일이며, 존재하면 파싱 시작
-			if (file.exists() && file.isFile()) {
+		File file = new File(EgovWebUtil.filePathBlackList(basePath2 + parFile1));
+		// 파일이며, 존재하면 파싱 시작
+		if (file.exists() && file.isFile()) {
+			// 1. 파일 텍스트 내용을 읽어서 StringBuffer에 쌓는다.
+			try (BufferedReader br = new BufferedReader(new InputStreamReader(new FileInputStream(file)));) {
 
-				// 1. 파일 텍스트 내용을 읽어서 StringBuffer에 쌓는다.
-				br = new BufferedReader(new InputStreamReader(new FileInputStream(file)));
 				StringBuffer strBuff = new StringBuffer();
-				String line = "";
-				while ((line = br.readLine()) != null) {
+				String line = br.readLine();
+				while (line != null) {
 					if (line.length() < MAX_STR_LEN) {
 						strBuff.append(line);
 					}
+
+					line = br.readLine();
 				}
 
 				// 2. 쌓은 내용을 특정 구분자로 파싱하여 String 배열로 얻는다.
@@ -417,8 +424,6 @@ public class EgovFileTool {
 					filedCnt++;
 				}
 			}
-		} finally {
-			EgovResourceCloseHelper.close(br);
 		}
 
 		return parResult;


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

<hr>

### 2025-09-09 화 PMD로 소프트웨어 보안약점 진단하고 제거하기-EgovFileTool

`basePath2` 추가

`try-with-resources` 로 수정

피연산자내에 할당문 제거

`RuntimeException` 을 `UncheckedIOException` 으로 수정

<hr>

1. PMD로 소프트웨어 보안약점 진단 결과

```
src/main/java/egovframework/com/utl/sim/service/EgovFileTool.java:98:	AvoidReassigningParameters:	AvoidReassigningParameters: 'basePath' 처럼 파라미터 값을 직접 변경하지 말 것
src/main/java/egovframework/com/utl/sim/service/EgovFileTool.java:141:	AvoidReassigningParameters:	AvoidReassigningParameters: 'basePath' 처럼 파라미터 값을 직접 변경하지 말 것
src/main/java/egovframework/com/utl/sim/service/EgovFileTool.java:206:	AvoidReassigningParameters:	AvoidReassigningParameters: 'basePath' 처럼 파라미터 값을 직접 변경하지 말 것
src/main/java/egovframework/com/utl/sim/service/EgovFileTool.java:262:	AvoidReassigningParameters:	AvoidReassigningParameters: 'basePath' 처럼 파라미터 값을 직접 변경하지 말 것
src/main/java/egovframework/com/utl/sim/service/EgovFileTool.java:320:	AvoidReassigningParameters:	AvoidReassigningParameters: 'basePath' 처럼 파라미터 값을 직접 변경하지 말 것
src/main/java/egovframework/com/utl/sim/service/EgovFileTool.java:351:	AvoidReassigningParameters:	AvoidReassigningParameters: 'basePath' 처럼 파라미터 값을 직접 변경하지 말 것
src/main/java/egovframework/com/utl/sim/service/EgovFileTool.java:364:	CloseResource:	CloseResource: 리소스 'BufferedReader' 가 사용 후에 닫혔는지 확인필요
src/main/java/egovframework/com/utl/sim/service/EgovFileTool.java:373:	AssignmentInOperand:	AssignmentInOperand: 피연산자내에 할당문이 사용됨. Code 를 복잡하고 가독성이 떨어지게 만듬
```

2. 브랜치 생성

```
feature/pmd/EgovFileTool
```

3. 이클립스 > Source > Format

4. 개정이력 수정

```java
 *   2025.09.09  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-AvoidReassigningParameters(넘겨받는 메소드 parameter 값을 직접 변경하는 코드 탐지)
 *   2025.09.09  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-CloseResource(부적절한 자원 해제)
 *   2025.09.09  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-AssignmentInOperand(피연산자내에 할당문이 사용됨. 해당 코드를 복잡하고 가독성이 떨어지게 만듬)
```

<hr>

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

https://youtu.be/UpehCQPqbcc
