### PR TITLE
PMD로 소프트웨어 보안약점 진단하고 제거하기-EgovNetworkState

### DIFF
--- a/src/main/java/egovframework/com/utl/sim/service/EgovNetworkState.java
+++ b/src/main/java/egovframework/com/utl/sim/service/EgovNetworkState.java
@@ -37,7 +37,8 @@ import egovframework.com.cmm.util.EgovResourceCloseHelper;
  *
  * @author 김진만
  * @see
- * <pre>
+ * 
+ *      <pre>
  * == 개정이력(Modification Information) ==
  *
  *  수정일		수정자		수정내용
@@ -45,8 +46,8 @@ import egovframework.com.cmm.util.EgovResourceCloseHelper;
  *  2020.12.07	신용호		KISA 보안약점 조치
  *  2022.11.11	김혜준		시큐어코딩 처리
  *  2023.06.09	김신해		NSR 보안조치 (SCAN 기능 구현 추가)
- *  
- * </pre>
+ * 
+ *      </pre>
  */
 
 public class EgovNetworkState {
@@ -63,19 +64,21 @@ public class EgovNetworkState {
 	 * <pre>
 	 * Comment : Local MAC Address를 확인한다.
 	 * </pre>
-	 * @param String localIP  로컬 IP주소
-	 * @return String mac        MAC Address를 리턴한다.
+	 * 
+	 * @param String localIP 로컬 IP주소
+	 * @return String mac MAC Address를 리턴한다.
 	 * @version 1.0 (2009.02.03.)
 	 * @see
 	 */
 	public static String getMyMACAddress(String localIP) {
-		//log.debug("getMyMACAddress Start!! : ");
+		// log.debug("getMyMACAddress Start!! : ");
 		String mac = null;
 		try {
 			if ("WINDOWS".equals(Globals.OS_TYPE)) {
 				// 2020-12-07 KISA 보안코드 검증 조치
-				if (!EgovWebUtil.isIPAddress(localIP))
+				if (!EgovWebUtil.isIPAddress(localIP)) {
 					throw new SecurityException("IP Address is Not Valid~~~!");
+				}
 
 				String execStr = "nbtstat -A " + localIP;
 				// 2022.11.11 시큐어코딩 처리
@@ -94,7 +97,7 @@ public class EgovNetworkState {
 				mac = out.substring(out.indexOf("MAC Address = ") + 14, out.indexOf("MAC Address = ") + 31);
 
 			} else if ("UNIX".equals(Globals.OS_TYPE)) {
-				//log.debug("getMyMACAddress IP : " + localIP);
+				// log.debug("getMyMACAddress IP : " + localIP);
 				mac = getNetWorkInfo("MAC");
 			}
 		} catch (IOException e) {
@@ -107,8 +110,8 @@ public class EgovNetworkState {
 	 * <pre>
 	 * Comment : Local Port를 확인한다.
 	 * </pre>
-
-	 * @return String port       port를 리턴한다.
+	 * 
+	 * @return String port port를 리턴한다.
 	 * @version 1.0 (2009.02.03.)
 	 * @see
 	 */
@@ -116,7 +119,7 @@ public class EgovNetworkState {
 
 		List<String> processes = new ArrayList<String>();
 		BufferedReader input = null;
-		
+
 		try {
 
 			if ("WINDOWS".equals(Globals.OS_TYPE)) {
@@ -128,8 +131,9 @@ public class EgovNetworkState {
 
 				while (true) {
 					String str = input.readLine();
-					if (str == null)
+					if (str == null) {
 						break;
+					}
 					if (str.length() >= MAX_STR_LEN) {
 						throw new RuntimeException("input too long");
 					}
@@ -138,7 +142,8 @@ public class EgovNetworkState {
 					}
 				}
 			} else if ("UNIX".equals(Globals.OS_TYPE)) {
-				String cmdStr = EgovProperties.getPathProperty(Globals.SERVER_CONF_PATH, "SHELL." + Globals.OS_TYPE + ".getNetWorkInfo");
+				String cmdStr = EgovProperties.getPathProperty(Globals.SERVER_CONF_PATH,
+						"SHELL." + Globals.OS_TYPE + ".getNetWorkInfo");
 				String command = cmdStr.replace('\\', FILE_SEPARATOR).replace('/', FILE_SEPARATOR) + "SCAN";
 				// 2022.11.11 시큐어코딩 처리
 				FileSystemUtils util = new FileSystemUtils();
@@ -146,8 +151,9 @@ public class EgovNetworkState {
 				input = new BufferedReader(new InputStreamReader(p.getInputStream()));
 				while (true) {
 					String str = input.readLine();
-					if (str == null)
+					if (str == null) {
 						break;
+					}
 					if (str.length() >= MAX_STR_LEN) {
 						throw new RuntimeException("input too long");
 					}
@@ -161,7 +167,7 @@ public class EgovNetworkState {
 		} finally {
 			EgovResourceCloseHelper.close(input);
 		}
-		
+
 		return processes;
 	}
 
@@ -169,7 +175,8 @@ public class EgovNetworkState {
 	 * <pre>
 	 * Comment : Local IPAddress를 확인한다.
 	 * </pre>
-	 * @return String mac        Local IPAddress를 리턴한다.
+	 * 
+	 * @return String mac Local IPAddress를 리턴한다.
 	 * @version 1.0 (2009.02.03.)
 	 * @see
 	 */
@@ -186,7 +193,7 @@ public class EgovNetworkState {
 		} catch (IOException ex) {
 			throw new RuntimeException(ex);
 		}
-		
+
 		return addrIP;
 	}
 
@@ -194,8 +201,9 @@ public class EgovNetworkState {
 	 * <pre>
 	 * Comment : 네트워크 상태체크를 확인한다.
 	 * </pre>
-	 * @param String localIP           localhost, gateway, host 주소
-	 * @return boolean  status         true/false 를 리턴한다.
+	 * 
+	 * @param String localIP localhost, gateway, host 주소
+	 * @return boolean status true/false 를 리턴한다.
 	 * @version 1.0 (2009.02.03.)
 	 * @see
 	 */
@@ -216,7 +224,8 @@ public class EgovNetworkState {
 	 * <pre>
 	 * Comment : 네트워크(MAC,IP,S/M,G/W,DNS) 정보를 확인한다.
 	 * </pre>
-	 * @param String stringOne         확인할 네트웍 정보 표기 ( ex:"MAC","IP","S/M","G/W","DNS")
+	 * 
+	 * @param String stringOne 확인할 네트웍 정보 표기 ( ex:"MAC","IP","S/M","G/W","DNS")
 	 * @return String (MAC,IP,S/M,G/W,DNS) 정보를 리턴한다.
 	 * @version 1.0 (2009.02.07.)
 	 * @see
@@ -224,13 +233,14 @@ public class EgovNetworkState {
 	public static String getNetWorkInfo(String stringOne) throws IOException {
 		// 실행할 명령을 프로퍼티 파일에서 확인한다.
 		Process p = null;
-		
+
 		BufferedReader b_out = null;
 
 		String tmp = "";
 		String outValue = "";
 		try {
-			String cmdStr = EgovProperties.getPathProperty(Globals.SERVER_CONF_PATH, "SHELL." + Globals.OS_TYPE + ".getNetWorkInfo");
+			String cmdStr = EgovProperties.getPathProperty(Globals.SERVER_CONF_PATH,
+					"SHELL." + Globals.OS_TYPE + ".getNetWorkInfo");
 			String command = cmdStr.replace('\\', FILE_SEPARATOR).replace('/', FILE_SEPARATOR) + stringOne;
 			// 2022.11.11 시큐어코딩 처리
 			FileSystemUtils util = new FileSystemUtils();
@@ -238,15 +248,16 @@ public class EgovNetworkState {
 			b_out = new BufferedReader(new InputStreamReader(p.getInputStream()));
 			while (true) {
 				tmp = b_out.readLine();
-				if (tmp == null)
+				if (tmp == null) {
 					break;
+				}
 				if (tmp.length() >= MAX_STR_LEN) {
 					throw new IllegalArgumentException("input too long");
 				}
-				// netstat -v ent0 | grep "하드웨어 주소"   -MAC
-				// prtconf | grep "IP 주소"                 -IP
-				// prtconf | grep "서브넷 마스크"           -SM
-				// prtconf | grep "게이트웨이"              -GW
+				// netstat -v ent0 | grep "하드웨어 주소" -MAC
+				// prtconf | grep "IP 주소" -IP
+				// prtconf | grep "서브넷 마스크" -SM
+				// prtconf | grep "게이트웨이" -GW
 				if ("MAC".equals(stringOne)) {
 					outValue = getCharFilter(tmp);
 				} else if ("IP".equals(stringOne)) {
@@ -256,7 +267,7 @@ public class EgovNetworkState {
 				} else if ("GW".equals(stringOne)) {
 					outValue = getCharFilter(tmp);
 				} else if ("DNS".equals(stringOne)) {
-					//tmp = "was은(는) 192.168.200.21입니다";
+					// tmp = "was은(는) 192.168.200.21입니다";
 					outValue = getCharFilter(tmp);
 				} else if ("SCAN".equals(stringOne)) {
 					outValue = getCharFilter(tmp);
@@ -266,7 +277,7 @@ public class EgovNetworkState {
 			}
 		} finally {
 			EgovResourceCloseHelper.close(b_out);
-			
+
 			if (p != null) {
 				p.destroy();
 			}
@@ -278,8 +289,9 @@ public class EgovNetworkState {
 	 * <pre>
 	 * Comment : String 타입의 str값 중 숫자 정보만 필터링, 담아서 리턴.
 	 * </pre>
-	 * @param String str         필터링 대상 정보
-	 * @return String outValue   숫자 정보를 필터링 리턴한다.
+	 * 
+	 * @param String str 필터링 대상 정보
+	 * @return String outValue 숫자 정보를 필터링 리턴한다.
 	 * @version 1.0 (2009.02.07.)
 	 * @see
 	 */

--- a/src/main/java/egovframework/com/utl/sim/service/EgovNetworkState.java
+++ b/src/main/java/egovframework/com/utl/sim/service/EgovNetworkState.java
@@ -1,20 +1,3 @@
-/**
- *  Class Name : EgovNetworkState.java
- *  Description : 네트워크(Network)상태 체크 Business Interface class
- *  Modification Information
- *
- *     수정일         수정자                   수정내용
- *   -------    --------    ---------------------------
- *   2009.02.02    이 용          최초 생성
- *
- *  @author 공통 서비스 개발팀 이 용
- *  @since 2009. 02. 02
- *  @version 1.0
- *  @see
- * The type com.sun.star.lang.XeventListener cannot be resolved. It is indirectly referenced from required .class files
- *  Copyright (C) 2009 by EGOV  All rights reserved.
- */
-
 package egovframework.com.utl.sim.service;
 
 import java.io.BufferedReader;
@@ -35,23 +18,33 @@ import egovframework.com.cmm.service.FileSystemUtils;
 import egovframework.com.cmm.service.Globals;
 
 /**
+ * 네트워크(Network)상태 체크 Business Interface class
+ * <p>
  * EgovNetworkState 클래스를 정의한다.
- *
+ * 
+ * @author 공통 서비스 개발팀 이용
  * @author 김진만
+ * @since 2009.02.02
+ * @version 1.0
  * @see
- * 
- *      <pre>
- * == 개정이력(Modification Information) ==
  *
- *  수정일		수정자		수정내용
- *  ----------	--------	---------------------------
- *  2020.12.07	신용호		KISA 보안약점 조치
- *  2022.11.11	김혜준		시큐어코딩 처리
- *  2023.06.09	김신해		NSR 보안조치 (SCAN 기능 구현 추가)
- * 
+ *      <pre>
+ *  == 개정이력(Modification Information) ==
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2009.02.02  이용           최초 생성
+ *   2020.12.07  신용호          KISA 보안약점 조치
+ *   2022.11.11  김혜준          시큐어코딩 처리
+ *   2023.06.09  김신해          NSR 보안조치 (SCAN 기능 구현 추가)
+ *   2025.09.10  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-CloseResource(부적절한 자원 해제)
+ *   2025.09.10  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-AssignmentInOperand(피연산자내에 할당문이 사용됨. 해당 코드를 복잡하고 가독성이 떨어지게 만듬)
+ *   2025.09.10  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-StringInstantiation(불필요한 String Instance를 생성하는 코드를 탐지. 간단한 형태의 코드로 변경 필요)
+ *   2025.09.10  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-LocalVariableNamingConventions(final이 아닌 변수는 밑줄을 포함할 수 없음)
+ *   2025.09.10  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-UnnecessaryBoxing(불필요한 WrapperObject 생성)
+ *
  *      </pre>
  */
-
 public class EgovNetworkState {
 	public static String addrIP = "";
 	static final char FILE_SEPARATOR = File.separatorChar;


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

<hr>

### 2025-09-10 수 PMD로 소프트웨어 보안약점 진단하고 제거하기-EgovNetworkState

`try-with-resources` 로 수정

피연산자내에 할당문 제거

`out = out + new String(new Character((char) c).toString());` 을 `out = out + new Character((char) c).toString();` 로 수정
- `new String(` 제거

`InetA` 를 `inetA` 로 이름 바꾸기

`b_out` 를 `bOut` 로 이름 바꾸기

`new Character(c);` 를 `c;` 로 수정
- `new Character(` 제거

`RuntimeException` 을 `UncheckedIOException` 으로 수정

`RuntimeException` 을 `BaseRuntimeException` 으로 수정

`ex` 를 `e` 로 이름 바꾸기

<hr>

1. PMD로 소프트웨어 보안약점 진단 결과

```
src/main/java/egovframework/com/utl/sim/service/EgovNetworkState.java:84:	CloseResource:	CloseResource: 리소스 'InputStream' 가 사용 후에 닫혔는지 확인필요
src/main/java/egovframework/com/utl/sim/service/EgovNetworkState.java:87:	AssignmentInOperand:	AssignmentInOperand: 피연산자내에 할당문이 사용됨. Code 를 복잡하고 가독성이 떨어지게 만듬
src/main/java/egovframework/com/utl/sim/service/EgovNetworkState.java:88:	StringInstantiation:	StringInstantiation: 필요없는 Instance가 생성되어 있음
src/main/java/egovframework/com/utl/sim/service/EgovNetworkState.java:118:	CloseResource:	CloseResource: 리소스 'BufferedReader' 가 사용 후에 닫혔는지 확인필요
src/main/java/egovframework/com/utl/sim/service/EgovNetworkState.java:183:	LocalVariableNamingConventions:	LocalVariableNamingConventions: 'local variable' 의 변수 'InetA' 이  '[a-z][a-zA-Z0-9]*'  로 시작함
src/main/java/egovframework/com/utl/sim/service/EgovNetworkState.java:228:	CloseResource:	CloseResource: 리소스 'BufferedReader' 가 사용 후에 닫혔는지 확인필요
src/main/java/egovframework/com/utl/sim/service/EgovNetworkState.java:228:	LocalVariableNamingConventions:	LocalVariableNamingConventions: 'local variable' 의 변수 'b_out' 이  '[a-z][a-zA-Z0-9]*'  로 시작함
src/main/java/egovframework/com/utl/sim/service/EgovNetworkState.java:293:	UnnecessaryBoxing:	UnnecessaryBoxing: 불필요한 explicit boxing
```

2. 브랜치 생성

```
feature/pmd/EgovNetworkState
```

3. 이클립스 > Source > Format

4. 개정이력 수정

```java
 *   2025.09.10  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-CloseResource(부적절한 자원 해제)
 *   2025.09.10  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-AssignmentInOperand(피연산자내에 할당문이 사용됨. 해당 코드를 복잡하고 가독성이 떨어지게 만듬)
 *   2025.09.10  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-StringInstantiation(불필요한 String Instance를 생성하는 코드를 탐지. 간단한 형태의 코드로 변경 필요)
 *   2025.09.10  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-LocalVariableNamingConventions(final이 아닌 변수는 밑줄을 포함할 수 없음)
 *   2025.09.10  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-UnnecessaryBoxing(불필요한 WrapperObject 생성)
```

<hr>

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

https://youtu.be/DrlWJa1rdMA
