### PR TITLE
PMD로 소프트웨어 보안약점 진단하고 제거하기-EgovPdfCnvr

### DIFF
--- a/src/main/java/egovframework/com/utl/sim/service/EgovPdfCnvr.java
+++ b/src/main/java/egovframework/com/utl/sim/service/EgovPdfCnvr.java
@@ -1,21 +1,3 @@
-/**
- *  Class Name : EgovPdfCnvr.java
- *  Description : xls,doc,ppt를 Pdf로 변환하는 화면 Business Interface class
- *  Modification Information
- *
- *     수정일         수정자                   수정내용
- *   -------    --------    ---------------------------
- *   2009.02.02    이 용          최초 생성
- *   2017.03.03          조성원 	    시큐어코딩(ES)-부적절한 예외 처리[CWE-253, CWE-440, CWE-754]
- *
- *  @author 공통 서비스 개발팀 이 용
- *  @since 2009. 02. 02
- *  @version 1.0
- *  @see
- * The type com.sun.star.lang.XeventListener cannot be resolved. It is indirectly referenced from required .class files
- *  Copyright (C) 2009 by EGOV  All rights reserved.
- */
-
 package egovframework.com.utl.sim.service;
 
 import java.io.File;
@@ -43,6 +25,27 @@ import egovframework.com.cmm.util.EgovBasicLogger;
 import egovframework.com.utl.fcc.service.EgovStringUtil;
 import lombok.extern.slf4j.Slf4j;
 
+/**
+ * xls,doc,ppt를 Pdf로 변환하는 화면 Business Interface class
+ * 
+ * @author 공통 서비스 개발팀 이용
+ * @since 2009.02.02
+ * @version 1.0
+ * @see
+ *
+ *      <pre>
+ *  == 개정이력(Modification Information) ==
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2009.02.02  이용           최초 생성
+ *   2017.03.03  조성원          시큐어코딩(ES)-부적절한 예외 처리[CWE-253, CWE-440, CWE-754]
+ *   2025.09.11  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-LocalVariableNamingConventions(final이 아닌 변수는 밑줄을 포함할 수 없음)
+ *   2025.09.11  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-CloseResource(부적절한 자원 해제)
+ *   2025.09.11  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-AssignmentInOperand(피연산자내에 할당문이 사용됨. 해당 코드를 복잡하고 가독성이 떨어지게 만듬)
+ *
+ *      </pre>
+ */
 @Slf4j
 public class EgovPdfCnvr {
 	public static String addrIP = "";

--- a/src/main/java/egovframework/com/utl/sim/service/EgovPdfCnvr.java
+++ b/src/main/java/egovframework/com/utl/sim/service/EgovPdfCnvr.java
@@ -58,20 +58,24 @@ public class EgovPdfCnvr {
 	 * <pre>
 	 * Comment : doc, xls 파일등을 PDF변환 변환한다.
 	 * </pre>
-	 * @param String pdfFileSrc        doc, xls 파일 전체경로
-	 * @param String targetPdf         변환파일명(확장자 제외)
-	 * @return boolean  status         true/false 를 리턴한다.
+	 * 
+	 * @param String pdfFileSrc doc, xls 파일 전체경로
+	 * @param String targetPdf 변환파일명(확장자 제외)
+	 * @return boolean status true/false 를 리턴한다.
 	 * @version 1.0 (2009.02.10)
 	 * @see
 	 */
-	public static boolean getPDF(String targetPdf, HttpServletRequest request, HttpServletResponse response) throws Exception {
+	public static boolean getPDF(String targetPdf, HttpServletRequest request, HttpServletResponse response)
+			throws Exception {
 		boolean status = false;
 
 		try {
-			MultipartHttpServletRequest mptRequest = WebUtils.getNativeRequest(request,MultipartHttpServletRequest.class);
+			MultipartHttpServletRequest mptRequest = WebUtils.getNativeRequest(request,
+					MultipartHttpServletRequest.class);
 
-			// 2022.01 Possible null pointer dereference due to return value of called method 조치
-			if(mptRequest!= null) {
+			// 2022.01 Possible null pointer dereference due to return value of called
+			// method 조치
+			if (mptRequest != null) {
 				Iterator<String> file_iter = mptRequest.getFileNames();
 
 				while (file_iter.hasNext()) {
@@ -84,36 +88,38 @@ public class EgovPdfCnvr {
 					}
 
 					String newName = "";
-	
-					//newName 은 Naming Convention에 의해서 생성
+
+					// newName 은 Naming Convention에 의해서 생성
 					newName = EgovStringUtil.getTimeStamp();
 					writeFile(mFile, newName);
-	
-					File inputFile = new File(EgovWebUtil.filePathBlackList(STORE_FILE_PATH + FilenameUtils.getName(newName)));
-	
+
+					File inputFile = new File(
+							EgovWebUtil.filePathBlackList(STORE_FILE_PATH + FilenameUtils.getName(newName)));
+
 					if (inputFile.exists()) {
-	
+
 						// connect to an OpenOffice.org instance running on port 8100
 						SocketOpenOfficeConnection connection = new SocketOpenOfficeConnection(8100);
 						connection.connect();
-						//원본 디렉토리에 targetPdf 명칭지정
+						// 원본 디렉토리에 targetPdf 명칭지정
 						String valueFile = null;
-						//KISA 보안약점 조치 (2018-10-29, 윤창원)
-						valueFile = EgovStringUtil.isNullToString(inputFile.getParent()).replace('\\', FILE_SEPARATOR).replace('/', FILE_SEPARATOR);
+						// KISA 보안약점 조치 (2018-10-29, 윤창원)
+						valueFile = EgovStringUtil.isNullToString(inputFile.getParent()).replace('\\', FILE_SEPARATOR)
+								.replace('/', FILE_SEPARATOR);
 						File outputFile = new File(valueFile + "/" + targetPdf + ".pdf");
 						// convert
 						DocumentConverter converter = new OpenOfficeDocumentConverter(connection);
 						converter.convert(inputFile, outputFile);
 						// close the connection
 						connection.disconnect();
-	
+
 						if (inputFile.exists()) {
-							//3. 삭제해줍니다.
+							// 3. 삭제해줍니다.
 							status = inputFile.delete();
 						}
-	
+
 						status = true;
-	
+
 					} else {
 						status = false;
 					}
@@ -132,6 +138,7 @@ public class EgovPdfCnvr {
 
 	/**
 	 * 파일을 실제 물리적인 경로에 생성한다.
+	 * 
 	 * @param file
 	 * @param newName
 	 * @param stordFilePath
@@ -155,7 +162,8 @@ public class EgovPdfCnvr {
 				}
 			}
 
-			bos = new FileOutputStream(EgovWebUtil.filePathBlackList(STORE_FILE_PATH + File.separator + FilenameUtils.getName(newName)));
+			bos = new FileOutputStream(
+					EgovWebUtil.filePathBlackList(STORE_FILE_PATH + File.separator + FilenameUtils.getName(newName)));
 
 			int bytesRead = 0;
 			byte[] buffer = new byte[BUFF_SIZE];


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

<hr>

### 2025-09-11 목 PMD로 소프트웨어 보안약점 진단하고 제거하기-EgovPdfCnvr

`file_iter` 를 `fileIter` 로 이름 바꾸기

`FileCopyUtils.copy` 로 수정

피연산자내에 할당문 제거

`LOGGER` 제거하고 `@Slf4j` 추가

`throws Exception` 제거하고 `throw new UncheckedIOException(e);` 추가

<hr>

1. PMD로 소프트웨어 보안약점 진단 결과

```
src/main/java/egovframework/com/utl/sim/service/EgovPdfCnvr.java:75:	LocalVariableNamingConventions:	LocalVariableNamingConventions: 'local variable' 의 변수 'file_iter' 이  '[a-z][a-zA-Z0-9]*'  로 시작함
src/main/java/egovframework/com/utl/sim/service/EgovPdfCnvr.java:141:	CloseResource:	CloseResource: 리소스 'InputStream' 가 사용 후에 닫혔는지 확인필요
src/main/java/egovframework/com/utl/sim/service/EgovPdfCnvr.java:142:	CloseResource:	CloseResource: 리소스 'OutputStream' 가 사용 후에 닫혔는지 확인필요
src/main/java/egovframework/com/utl/sim/service/EgovPdfCnvr.java:162:	AssignmentInOperand:	AssignmentInOperand: 피연산자내에 할당문이 사용됨. Code 를 복잡하고 가독성이 떨어지게 만듬
```

2. 브랜치 생성

```
feature/pmd/EgovPdfCnvr
```

3. 이클립스 > Source > Format

4. 개정이력 수정

```java
 *   2025.09.11  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-LocalVariableNamingConventions(final이 아닌 변수는 밑줄을 포함할 수 없음)
 *   2025.09.11  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-CloseResource(부적절한 자원 해제)
 *   2025.09.11  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-AssignmentInOperand(피연산자내에 할당문이 사용됨. 해당 코드를 복잡하고 가독성이 떨어지게 만듬)
```

<hr>

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

https://youtu.be/VtYZRSobSns
