### PR TITLE
PMD로 소프트웨어 보안약점 진단하고 제거하기-FileSystemChecker

### DIFF
--- a/src/main/java/egovframework/com/utl/sys/fsm/service/FileSystemChecker.java
+++ b/src/main/java/egovframework/com/utl/sys/fsm/service/FileSystemChecker.java
@@ -18,22 +18,27 @@ import egovframework.com.cmm.service.Globals;
 import egovframework.com.cmm.util.EgovResourceCloseHelper;
 
 /**
+ * <pre>
  * 개요
  * - 파일시스템 모니터링을 위한 Check 클래스
  *
  * 상세내용
  * - 파일시스템의 총크기와 여유크기의 결과를 제공한다.
  * - Open Souce인 Apache Commons IO 를 이용한다.
+ * </pre>
+ * 
  * @author 장철호
  * @version 1.0
  * @created 28-6-2010 오전 11:33:43
  * 
+ *          <pre>
  *     수정일         수정자                   수정내용
  *   -------    --------    ---------------------------
  *   2017-02-08    이정은        시큐어코딩(ES) - 시큐어코딩 부적절한 예외 처리[CWE-253, CWE-440, CWE-754]
+ *          </pre>
  */
 public class FileSystemChecker {
-	
+
 	// LOGGER
 	private static final Logger LOGGER = LoggerFactory.getLogger(FileSystemChecker.class);
 
@@ -41,8 +46,9 @@ public class FileSystemChecker {
 
 	/**
 	 * 파일시스템의 여유크기를 계산한다. (GB 단위)
+	 * 
 	 * @param String - 파일시스템명
-	 * @return  int - 파일시스템 여유크기
+	 * @return int - 파일시스템 여유크기
 	 *
 	 * @param path
 	 */
@@ -52,8 +58,9 @@ public class FileSystemChecker {
 
 	/**
 	 * 파일시스템의 크기를 계산한다. (GB 단위)
+	 * 
 	 * @param String - 파일시스템명
-	 * @return  int - 파일시스템 크기
+	 * @return int - 파일시스템 크기
 	 *
 	 * @param path
 	 */
@@ -63,9 +70,10 @@ public class FileSystemChecker {
 
 	/**
 	 * 파일시스템의 크기를 계산한다.
+	 * 
 	 * @param String - 파일시스템명
 	 * @param String - OS종류
-	 * @return  long - 파일시스템 크기
+	 * @return long - 파일시스템 크기
 	 *
 	 * @param path
 	 * @param os
@@ -86,8 +94,9 @@ public class FileSystemChecker {
 
 	/**
 	 * 윈도우즈 OS에서의 파일시스템의 크기를 계산한다.
+	 * 
 	 * @param String - 파일시스템명
-	 * @return  long - 파일시스템 크기
+	 * @return long - 파일시스템 크기
 	 *
 	 * @param path
 	 */
@@ -99,10 +108,10 @@ public class FileSystemChecker {
 
 		File folder = new File("C:\\temp\\");
 		if (!folder.isDirectory()) {
-			//2017.02.08 	이정은 	시큐어코딩(ES)-부적절한 예외 처리[CWE-253, CWE-440, CWE-754]
-			if(folder.mkdirs()){
+			// 2017.02.08 이정은 시큐어코딩(ES)-부적절한 예외 처리[CWE-253, CWE-440, CWE-754]
+			if (folder.mkdirs()) {
 				LOGGER.debug("[file.mkdirs] folder : Directory Creation Success");
-			}else{				
+			} else {
 				LOGGER.error("[file.mkdirs] folder : Directory Creation Fail");
 			}
 		}
@@ -122,12 +131,10 @@ public class FileSystemChecker {
 		List<String> lines = performCommand(cmdAttribs, Integer.MAX_VALUE);
 		String line = "";
 		/*
-		for (int i = lines.size() - 1; i >= 0; i--) {
-			line = (String) lines.get(i);
-			break;
-		}
-		*/
-		line = (String) lines.get(lines.size() - 1);
+		 * for (int i = lines.size() - 1; i >= 0; i--) { line = (String) lines.get(i);
+		 * break; }
+		 */
+		line = lines.get(lines.size() - 1);
 
 		long totalSpace = 0;
 		String size = "";
@@ -141,21 +148,21 @@ public class FileSystemChecker {
 			size = size.replace(",", "");
 			totalSpace = Long.valueOf(size) * 1024;
 		}
-		
+
 		// 불필요
 		/*
-		if (line == null) {
-			throw new IllegalStateException("Exception caught when using diskpart command");
-		}
-		*/
+		 * if (line == null) { throw new
+		 * IllegalStateException("Exception caught when using diskpart command"); }
+		 */
 
 		return totalSpace;
 	}
 
 	/**
 	 * UNIX OS에서의 파일시스템의 크기를 계산한다.
+	 * 
 	 * @param String - 파일시스템명
-	 * @return  long - 파일시스템 크기
+	 * @return long - 파일시스템 크기
 	 *
 	 * @param path
 	 */
@@ -182,25 +189,28 @@ public class FileSystemChecker {
 			dfCommand = "bdf";
 		}
 
-		String[] cmdAttribs = (flags.length() > 1 ? new String[] { dfCommand, flags, path } : new String[] { dfCommand, path });
+		String[] cmdAttribs = (flags.length() > 1 ? new String[] { dfCommand, flags, path }
+				: new String[] { dfCommand, path });
 
 		// perform the command, asking for up to 3 lines (header, interesting, overflow)
 		List<String> lines = performCommand(cmdAttribs, 3);
 		if (lines.size() < 2) {
 			// unknown problem, throw exception
-			throw new IOException("Command line 'df' did not return info as expected " + "for path '" + path + "'- response was " + lines);
+			throw new IOException("Command line 'df' did not return info as expected " + "for path '" + path
+					+ "'- response was " + lines);
 		}
-		String line2 = (String) lines.get(1); // the line we're interested in
+		String line2 = lines.get(1); // the line we're interested in
 
 		// Now, we tokenize the string. The fourth element is what we want.
 		StringTokenizer tok = new StringTokenizer(line2, " ");
 		if (tok.countTokens() < 4) {
 			// could be long Filesystem, thus data on third line
 			if (tok.countTokens() == 1 && lines.size() >= 3) {
-				String line3 = (String) lines.get(2); // the line may be interested in
+				String line3 = lines.get(2); // the line may be interested in
 				tok = new StringTokenizer(line3, " ");
 			} else {
-				throw new IOException("Command line 'df' did not return data as expected " + "for path '" + path + "'- check path is valid");
+				throw new IOException("Command line 'df' did not return data as expected " + "for path '" + path
+						+ "'- check path is valid");
 			}
 		} else {
 			tok.nextToken(); // Ignore Filesystem
@@ -210,19 +220,22 @@ public class FileSystemChecker {
 		try {
 			freeSpace = Long.valueOf(totalSpace);
 			if (freeSpace < 0) {
-				throw new IOException("Command line 'df' did not find free space in response " + "for path '" + path + "'- check path is valid");
+				throw new IOException("Command line 'df' did not find free space in response " + "for path '" + path
+						+ "'- check path is valid");
 			}
 		} catch (NumberFormatException ex) {
-			throw new IOException("Command line 'df' did not return numeric data as expected " + "for path '" + path + "'- check path is valid");
+			throw new IOException("Command line 'df' did not return numeric data as expected " + "for path '" + path
+					+ "'- check path is valid");
 		}
 		return freeSpace;
 	}
 
 	/**
 	 * OS커맨드를 수행한 뒤 그 결과값을 라인별로 반환해준다.
+	 * 
 	 * @param String - OS 커맨드
-	 * @param int - 최대라인 수
-	 * @return  List<String> - 결과라인 리스트
+	 * @param int    - 최대라인 수
+	 * @return List<String> - 결과라인 리스트
 	 *
 	 * @param cmdAttribs
 	 * @param max
@@ -245,19 +258,22 @@ public class FileSystemChecker {
 			p.waitFor();
 			if (p.exitValue() != 0) {
 				// os command problem, throw exception
-				throw new IOException("Command line returned OS error code '" + p.exitValue() + "' for command " + Arrays.asList(cmdAttribs));
+				throw new IOException("Command line returned OS error code '" + p.exitValue() + "' for command "
+						+ Arrays.asList(cmdAttribs));
 			}
 			if (lines.size() == 0) {
 				// unknown problem, throw exception
-				throw new IOException("Command line did not return any info " + "for command " + Arrays.asList(cmdAttribs));
+				throw new IOException(
+						"Command line did not return any info " + "for command " + Arrays.asList(cmdAttribs));
 			}
 			return lines;
 
 		} catch (InterruptedException ex) {
-			throw new IOException("Command line threw an InterruptedException '" + ex.getMessage() + "' for command " + Arrays.asList(cmdAttribs));
+			throw new IOException("Command line threw an InterruptedException '" + ex.getMessage() + "' for command "
+					+ Arrays.asList(cmdAttribs));
 		} finally {
 			EgovResourceCloseHelper.close(b_out);
-			
+
 			if (p != null) {
 				p.destroy();
 			}

--- a/src/main/java/egovframework/com/utl/sys/fsm/service/FileSystemChecker.java
+++ b/src/main/java/egovframework/com/utl/sys/fsm/service/FileSystemChecker.java
@@ -29,14 +29,23 @@ import egovframework.com.cmm.service.Globals;
  * </pre>
  * 
  * @author 장철호
+ * @since 2010.06.28
  * @version 1.0
- * @created 28-6-2010 오전 11:33:43
- * 
- *          <pre>
- *     수정일         수정자                   수정내용
- *   -------    --------    ---------------------------
- *   2017-02-08    이정은        시큐어코딩(ES) - 시큐어코딩 부적절한 예외 처리[CWE-253, CWE-440, CWE-754]
- *          </pre>
+ * @see
+ *
+ *      <pre>
+ *  == 개정이력(Modification Information) ==
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2010.03.20  장철호          최초 생성
+ *   2017.02.08  이정은          시큐어코딩(ES) - 시큐어코딩 부적절한 예외 처리[CWE-253, CWE-440, CWE-754]
+ *   2025.09.12  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-CloseResource(부적절한 자원 해제)
+ *   2025.09.12  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-UnnecessaryBoxing(불필요한 WrapperObject 생성)
+ *   2025.09.12  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-UselessParentheses(불필요한 괄호사용)
+ *   2025.09.12  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-LocalVariableNamingConventions(final이 아닌 변수는 밑줄을 포함할 수 없음)
+ *
+ *      </pre>
  */
 public class FileSystemChecker {
 


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

<hr>

### 2025-09-12 금 PMD로 소프트웨어 보안약점 진단하고 제거하기-FileSystemChecker

CloseResource(부적절한 자원 해제)
- `try-with-resources` 로 수정

UnnecessaryBoxing(불필요한 WrapperObject 생성)
- `Long.valueOf` 대신 Long.parseLong(...)을 사용
- 불필요한 implicit unboxing. Use Long.parseLong(...) instead
  - 암시적 언박싱을 수행합니다. 대신 Long.parseLong(...)을 사용하세요

UselessParentheses(불필요한 괄호사용)
- 불필요한 괄호제거

LocalVariableNamingConventions(final이 아닌 변수는 밑줄을 포함할 수 없음)
- `b_out` 을 `bOut` 으로 이름 바꾸기

`throws IOException` 제거하고 `throw new UncheckedIOException(e);` 을 추가

`throw new IOException("Command line threw an InterruptedException` 을 `BaseRuntimeException` 로 수정

<hr>

1. PMD로 소프트웨어 보안약점 진단 결과

```
src/main/java/egovframework/com/utl/sys/fsm/service/FileSystemChecker.java:110:	CloseResource:	CloseResource: 리소스 'FileWriter' 가 사용 후에 닫혔는지 확인필요
src/main/java/egovframework/com/utl/sys/fsm/service/FileSystemChecker.java:138:	UnnecessaryBoxing:	UnnecessaryBoxing: 불필요한 implicit unboxing. Use Long.parseLong(...) instead
src/main/java/egovframework/com/utl/sys/fsm/service/FileSystemChecker.java:142:	UnnecessaryBoxing:	UnnecessaryBoxing: 불필요한 implicit unboxing. Use Long.parseLong(...) instead
src/main/java/egovframework/com/utl/sys/fsm/service/FileSystemChecker.java:185:	UselessParentheses:	UselessParentheses: 괄호가 없어도 되는 상황에서 불필요한 괄호를 사용할 경우 마치 메소드 호출처럼 보여서 소스 코드의 가독성을 떨어뜨릴 수 있음
src/main/java/egovframework/com/utl/sys/fsm/service/FileSystemChecker.java:211:	UnnecessaryBoxing:	UnnecessaryBoxing: 불필요한 implicit unboxing. Use Long.parseLong(...) instead
src/main/java/egovframework/com/utl/sys/fsm/service/FileSystemChecker.java:233:	CloseResource:	CloseResource: 리소스 'BufferedReader' 가 사용 후에 닫혔는지 확인필요
src/main/java/egovframework/com/utl/sys/fsm/service/FileSystemChecker.java:233:	LocalVariableNamingConventions:	LocalVariableNamingConventions: 'local variable' 의 변수 'b_out' 이  '[a-z][a-zA-Z0-9]*'  로 시작함
```

2. 브랜치 생성

```
feature/pmd/FileSystemChecker
```

3. 이클립스 > Source > Format

4. 개정이력 수정

```java
 *   2025.09.12  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-CloseResource(부적절한 자원 해제)
 *   2025.09.12  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-UnnecessaryBoxing(불필요한 WrapperObject 생성)
 *   2025.09.12  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-UselessParentheses(불필요한 괄호사용)
 *   2025.09.12  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-LocalVariableNamingConventions(final이 아닌 변수는 밑줄을 포함할 수 없음)
```

<hr>

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

https://youtu.be/jKOxaAHXABQ
