### PR TITLE
PMD로 소프트웨어 보안약점 진단하고 제거하기-ProcessMonChecker

### DIFF
--- a/src/main/java/egovframework/com/utl/sys/prm/service/ProcessMonChecker.java
+++ b/src/main/java/egovframework/com/utl/sys/prm/service/ProcessMonChecker.java
@@ -10,16 +10,19 @@ import egovframework.com.cmm.service.Globals;
 import egovframework.com.cmm.util.EgovResourceCloseHelper;
 
 /**
+ * <pre>
  * 개요
  * - 프로세스 모니터링을 위한 Check 클래스
  *
  * 상세내용
  * - 프로세스의 상태 결과를 제공한다.
+ * </pre>
+ * 
  * @author 박종선
  * @version 1.0
  * @created 7-9-2010
  * 
- * <pre>
+ *          <pre>
  * << 개정이력(Modification Information) >>
  *
  *  수정일               수정자            수정내용
@@ -27,19 +30,21 @@ import egovframework.com.cmm.util.EgovResourceCloseHelper;
  *  2019.12.06   신용호             KISA 보안약점 조치 (부적절한 예외처리)
  *  2022.11.11   김혜준             시큐어코딩 처리
  *
- * </pre>
+ *          </pre>
  * 
  */
 
 public class ProcessMonChecker {
 
 	// Log
-	//private static final Logger LOGGER = LoggerFactory.getLogger(ProcessMonChecker.class);
+	// private static final Logger LOGGER =
+	// LoggerFactory.getLogger(ProcessMonChecker.class);
 
 	/**
 	 * <pre>
 	 * Comment : 프로세스 정보를 확인한다. (
 	 * </pre>
+	 * 
 	 * @param String processName
 	 * @return List<String[]> 프로세스 정보를 리턴한다.
 	 * @version 1.0 (2009.01.12.)
@@ -59,14 +64,14 @@ public class ProcessMonChecker {
 			// 2011.10.10 보안점검 후속조치 끝
 
 			if ("WINDOWS".equals(Globals.OS_TYPE)) {
-				cnt = -1; //윈도우의 경우 정상 프로세스 일때 두번째 줄에 결과를 리턴한다.
+				cnt = -1; // 윈도우의 경우 정상 프로세스 일때 두번째 줄에 결과를 리턴한다.
 				String execStr = "tasklist /fo table /nh /fi \"imagename eq " + processNm + "\"";
 				// 2022.11.11 시큐어코딩 처리
 				FileSystemUtils util = new FileSystemUtils();
 				p = util.processOperate("EgovNetworkState", execStr);
 
 			} else if ("UNIX".equals(Globals.OS_TYPE)) {
-				String cmd = "/bin/csh" + "-c" + "ps -A | grep " + EgovWebUtil.removeOSCmdRisk(processNm); 
+				String cmd = "/bin/csh" + "-c" + "ps -A | grep " + EgovWebUtil.removeOSCmdRisk(processNm);
 				// 2022.11.11 시큐어코딩 처리
 				FileSystemUtils util = new FileSystemUtils();
 				p = util.processOperate("EgovNetworkState", cmd);

--- a/src/main/java/egovframework/com/utl/sys/prm/service/ProcessMonChecker.java
+++ b/src/main/java/egovframework/com/utl/sys/prm/service/ProcessMonChecker.java
@@ -7,7 +7,6 @@ import java.io.InputStreamReader;
 import egovframework.com.cmm.EgovWebUtil;
 import egovframework.com.cmm.service.FileSystemUtils;
 import egovframework.com.cmm.service.Globals;
-import egovframework.com.cmm.util.EgovResourceCloseHelper;
 
 /**
  * <pre>
@@ -54,7 +53,6 @@ public class ProcessMonChecker {
 
 		Process p = null;
 		String procsSttus = null;
-		BufferedReader buf = null;
 		int cnt = 0;
 
 		try {
@@ -80,9 +78,10 @@ public class ProcessMonChecker {
 			if (p == null) {
 				return "02";
 			}
-			buf = new BufferedReader(new InputStreamReader(p.getInputStream()));
-			while ((buf.readLine()) != null) {
-				cnt++;
+			try (BufferedReader buf = new BufferedReader(new InputStreamReader(p.getInputStream()));) {
+				while (buf.readLine() != null) {
+					cnt++;
+				}
 			}
 			if (cnt > 0) {
 				procsSttus = "01";
@@ -92,8 +91,6 @@ public class ProcessMonChecker {
 
 		} catch (IOException e) {
 			procsSttus = "02";
-		} finally {
-			EgovResourceCloseHelper.close(buf);
 		}
 
 		return procsSttus;

--- a/src/main/java/egovframework/com/utl/sys/prm/service/ProcessMonChecker.java
+++ b/src/main/java/egovframework/com/utl/sys/prm/service/ProcessMonChecker.java
@@ -18,21 +18,23 @@ import egovframework.com.cmm.service.Globals;
  * </pre>
  * 
  * @author 박종선
+ * @since 2010.09.07
  * @version 1.0
- * @created 7-9-2010
- * 
- *          <pre>
- * << 개정이력(Modification Information) >>
+ * @see
  *
- *  수정일               수정자            수정내용
- *  ----------   --------   ---------------------------
- *  2019.12.06   신용호             KISA 보안약점 조치 (부적절한 예외처리)
- *  2022.11.11   김혜준             시큐어코딩 처리
+ *      <pre>
+ *  == 개정이력(Modification Information) ==
  *
- *          </pre>
- * 
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2010.09.07  박종선          최초 생성
+ *   2019.12.06  신용호          KISA 보안약점 조치 (부적절한 예외처리)
+ *   2022.11.11  김혜준          시큐어코딩 처리
+ *   2025.09.15  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-CloseResource(부적절한 자원 해제)
+ *   2025.09.15  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-UselessParentheses(불필요한 괄호사용)
+ *
+ *      </pre>
  */
-
 public class ProcessMonChecker {
 
 	// Log


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

<hr>

### 2025-09-15 월 PMD로 소프트웨어 보안약점 진단하고 제거하기-ProcessMonChecker


CloseResource(부적절한 자원 해제)
- `BufferedReader buf = null;`
- `try-with-resources` 로 수정

UselessParentheses(불필요한 괄호사용)
- `while ((buf.readLine()) != null) {` 을 `while (buf.readLine() != null) {` 로 수정
- 불필요한 괄호제거

<hr>

1. PMD로 소프트웨어 보안약점 진단 결과

```
src/main/java/egovframework/com/utl/sys/prm/service/ProcessMonChecker.java:52:	CloseResource:	CloseResource: 리소스 'BufferedReader' 가 사용 후에 닫혔는지 확인필요
src/main/java/egovframework/com/utl/sys/prm/service/ProcessMonChecker.java:79:	UselessParentheses:	UselessParentheses: 괄호가 없어도 되는 상황에서 불필요한 괄호를 사용할 경우 마치 메소드 호출처럼 보여서 소스 코드의 가독성을 떨어뜨릴 수 있음
```

2. 브랜치 생성

```
feature/pmd/ProcessMonChecker
```

3. 이클립스 > Source > Format

4. 개정이력 수정

```java
 *   2025.09.15  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-CloseResource(부적절한 자원 해제)
 *   2025.09.15  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-UselessParentheses(불필요한 괄호사용)
```

<hr>

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

https://youtu.be/aFFEJ5E4_As
