### PR TITLE
PMD로 소프트웨어 보안약점 진단하고 제거하기-ProxyServer

### DIFF
--- a/src/main/java/egovframework/com/utl/sys/pxy/service/ProxyServer.java
+++ b/src/main/java/egovframework/com/utl/sys/pxy/service/ProxyServer.java
@@ -27,13 +27,14 @@ import egovframework.com.utl.sys.pxy.service.impl.ProxySvcDAO;
  * @since 2010.07.15
  * @version 1.0
  * @see
- * <pre>
+ * 
+ *      <pre>
  * == 개정이력(Modification Information) ==
  *
  *  수정일                수정자             수정내용
  *  ----------   --------    ---------------------------
  *  2019.12.05   신용호              KISA 보안약점 조치 (경로조작및 자원 삽입, 부적절한 예외처리)
- * </pre>
+ *      </pre>
  */
 public class ProxyServer extends Thread {
 	/** logger */
@@ -61,7 +62,7 @@ public class ProxyServer extends Thread {
 	ProxyLog proxyLog = null;
 
 	public ProxyServer(String svcHost, String localIp, int localPort, int remotePort, String threadName,
-		ProxySvcDAO proxySvcDAO, EgovIdGnrService egovProxyLogIdGnrService) {
+			ProxySvcDAO proxySvcDAO, EgovIdGnrService egovProxyLogIdGnrService) {
 
 		try {
 			setSvcIp(svcHost);
@@ -73,7 +74,8 @@ public class ProxyServer extends Thread {
 			this.proxySvcDAO = proxySvcDAO;
 			this.egovProxyLogIdGnrService = egovProxyLogIdGnrService;
 
-			serverSocket = SSLServerSocketFactory.getDefault().createServerSocket(localPort);//2022.01. Unencrypted Socket
+			serverSocket = SSLServerSocketFactory.getDefault().createServerSocket(localPort);// 2022.01. Unencrypted
+																								// Socket
 
 		} catch (IOException e) {
 			throw new RuntimeException(e);
@@ -113,13 +115,14 @@ public class ProxyServer extends Thread {
 					OutputStream streamToClient = client.getOutputStream();
 
 					String svcIp = EgovWebUtil.filePathBlackList(getSvcIp());
-					server = SSLSocketFactory.getDefault().createSocket(svcIp, remotePort);//2022.01. Unencrypted Socket 처리
+					server = SSLSocketFactory.getDefault().createSocket(svcIp, remotePort);// 2022.01. Unencrypted
+																							// Socket 처리
 
 					InputStream streamFromServer = server.getInputStream();
 					OutputStream streamToServer = server.getOutputStream();
 
 					ProxyThread proxyThread = new ProxyThread(client, streamFromClient, streamToClient,
-						streamFromServer, streamToServer);
+							streamFromServer, streamToServer);
 					Thread thread = new Thread(proxyThread, getThreadName() + "-" + server.getLocalPort());
 					thread.start();
 
@@ -159,7 +162,7 @@ public class ProxyServer extends Thread {
 
 			proxyLog.setLogId(egovProxyLogIdGnrService.getNextStringId());
 
-			//KISA 보안약점 조치 (2018-10-29, 윤창원)
+			// KISA 보안약점 조치 (2018-10-29, 윤창원)
 			if (client.getInetAddress() != null) {
 				if (!EgovWebUtil.isIPAddress((client.getInetAddress().getHostAddress()))) {
 					throw new RuntimeException("IP is needed. (" + client.getInetAddress().getHostAddress() + ")");

--- a/src/main/java/egovframework/com/utl/sys/pxy/service/ProxyServer.java
+++ b/src/main/java/egovframework/com/utl/sys/pxy/service/ProxyServer.java
@@ -79,8 +79,8 @@ public class ProxyServer extends Thread {
 			this.proxySvcDAO = proxySvcDAO;
 			this.egovProxyLogIdGnrService = egovProxyLogIdGnrService;
 
-			serverSocket = SSLServerSocketFactory.getDefault().createServerSocket(localPort);// 2022.01. Unencrypted
-																								// Socket
+			// 2022.01. Unencrypted Socket
+			serverSocket = SSLServerSocketFactory.getDefault().createServerSocket(localPort);
 
 		} catch (IOException e) {
 			throw new RuntimeException(e);
@@ -116,12 +116,13 @@ public class ProxyServer extends Thread {
 					insertProxyLog();
 
 					LOGGER.info("client connect");
-					try (InputStream streamFromClient = client.getInputStream();
-							OutputStream streamToClient = client.getOutputStream();) {
+					try (InputStream streamFromClient = client.getInputStream();) {
+						OutputStream streamToClient = client.getOutputStream();
 
 						String svcIp = EgovWebUtil.filePathBlackList(getSvcIp());
-						server = SSLSocketFactory.getDefault().createSocket(svcIp, remotePort);// 2022.01. Unencrypted
-																								// Socket 처리
+
+						// 2022.01. Unencrypted Socket 처리
+						server = SSLSocketFactory.getDefault().createSocket(svcIp, remotePort);
 
 						try (InputStream streamFromServer = server.getInputStream();
 								OutputStream streamToServer = server.getOutputStream();) {
@@ -142,7 +143,8 @@ public class ProxyServer extends Thread {
 							} catch (IOException e) {
 								LOGGER.debug("Socket IO exception", e);
 							} finally {
-//							streamToClient.close();
+								streamToClient.close();
+
 								if (proxyThread.getIsStop()) {
 									runningThread = false;
 									break;

--- a/src/main/java/egovframework/com/utl/sys/pxy/service/ProxyServer.java
+++ b/src/main/java/egovframework/com/utl/sys/pxy/service/ProxyServer.java
@@ -22,18 +22,23 @@ import egovframework.com.utl.sys.pxy.service.impl.ProxySvcDAO;
 
 /**
  * 프록시서비스 처리 클래스
- *
+ * 
  * @author 김진만
  * @since 2010.07.15
  * @version 1.0
  * @see
- * 
- *      <pre>
- * == 개정이력(Modification Information) ==
  *
- *  수정일                수정자             수정내용
- *  ----------   --------    ---------------------------
- *  2019.12.05   신용호              KISA 보안약점 조치 (경로조작및 자원 삽입, 부적절한 예외처리)
+ *      <pre>
+ *  == 개정이력(Modification Information) ==
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2010.07.15  김진만          최초 생성
+ *   2019.12.05  신용호          KISA 보안약점 조치 (경로조작및 자원 삽입, 부적절한 예외처리)
+ *   2025.09.16  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-CloseResource(부적절한 자원 해제)
+ *   2025.09.16  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-AssignmentInOperand(피연산자내에 할당문이 사용됨. 해당 코드를 복잡하고 가독성이 떨어지게 만듬)
+ *   2025.09.16  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-UselessParentheses(불필요한 괄호사용)
+ *
  *      </pre>
  */
 public class ProxyServer extends Thread {


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

<hr>

### 2025-09-16 화 PMD로 소프트웨어 보안약점 진단하고 제거하기-ProxyServer

<hr>

1. PMD로 소프트웨어 보안약점 진단 결과

```
src/main/java/egovframework/com/utl/sys/pxy/service/ProxyServer.java:112:	CloseResource:	CloseResource: 리소스 'InputStream' 가 사용 후에 닫혔는지 확인필요
src/main/java/egovframework/com/utl/sys/pxy/service/ProxyServer.java:113:	CloseResource:	CloseResource: 리소스 'OutputStream' 가 사용 후에 닫혔는지 확인필요
src/main/java/egovframework/com/utl/sys/pxy/service/ProxyServer.java:118:	CloseResource:	CloseResource: 리소스 'InputStream' 가 사용 후에 닫혔는지 확인필요
src/main/java/egovframework/com/utl/sys/pxy/service/ProxyServer.java:119:	CloseResource:	CloseResource: 리소스 'OutputStream' 가 사용 후에 닫혔는지 확인필요
src/main/java/egovframework/com/utl/sys/pxy/service/ProxyServer.java:128:	AssignmentInOperand:	AssignmentInOperand: 피연산자내에 할당문이 사용됨. Code 를 복잡하고 가독성이 떨어지게 만듬
src/main/java/egovframework/com/utl/sys/pxy/service/ProxyServer.java:164:	UselessParentheses:	UselessParentheses: 괄호가 없어도 되는 상황에서 불필요한 괄호를 사용할 경우 마치 메소드 호출처럼 보여서 소스 코드의 가독성을 떨어뜨릴 수 있음
```

2. 브랜치 생성

```
feature/pmd/ProxyServer
```

3. 이클립스 > Source > Format

4. 수정

CloseResource(부적절한 자원 해제)
- `try-with-resources` 로 수정
AssignmentInOperand(피연산자내에 할당문이 사용됨. 해당 코드를 복잡하고 가독성이 떨어지게 만듬)
- 피연산자내에 할당문 제거
UselessParentheses(불필요한 괄호사용)
- 불필요한 괄호제거

5. 개정이력 수정

```java
 *   2025.09.16  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-CloseResource(부적절한 자원 해제)
 *   2025.09.16  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-AssignmentInOperand(피연산자내에 할당문이 사용됨. 해당 코드를 복잡하고 가독성이 떨어지게 만듬)
 *   2025.09.16  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-UselessParentheses(불필요한 괄호사용)
```

<hr>

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

https://youtu.be/qiUS5LQTaQw
