### PR TITLE
PMD로 소프트웨어 보안약점 진단하고 제거하기-ProxyThread

### DIFF
--- a/src/main/java/egovframework/com/utl/sys/pxy/service/ProxyThread.java
+++ b/src/main/java/egovframework/com/utl/sys/pxy/service/ProxyThread.java
@@ -20,7 +20,7 @@ public class ProxyThread implements Runnable {
 
 	/** 클라이언트 소켓 */
 	@SuppressWarnings("unused")
-	private Socket client = null;
+	private final Socket client;
 
 	/** 클라이언트로부터의 입력 스트림 */
 	private InputStream streamFromClient = null;
@@ -92,12 +92,12 @@ public class ProxyThread implements Runnable {
 	@Override
 	public void run() {
 
-		int bytesRead;
 		String strReceive = "";
 
 		try {
 			if (streamFromClient != null) {
-				while ((bytesRead = streamFromClient.read(request)) != -1) {
+				int bytesRead = streamFromClient.read(request);
+				while (bytesRead != -1) {
 
 					strReceive = new String(request, 0, bytesRead);
 
@@ -110,6 +110,8 @@ public class ProxyThread implements Runnable {
 					// 클라이언트로부터 받은 데이터를 서버로 전송합니다.
 					streamToServer.write(request, 0, bytesRead);
 					streamToServer.flush();
+
+					bytesRead = streamFromClient.read(request);
 				}
 			}
 		} catch (IOException e) {

--- a/src/main/java/egovframework/com/utl/sys/pxy/service/ProxyThread.java
+++ b/src/main/java/egovframework/com/utl/sys/pxy/service/ProxyThread.java
@@ -12,6 +12,21 @@ import egovframework.com.cmm.util.EgovResourceCloseHelper;
 
 /**
  * 프록시 스레드 클래스는 클라이언트와 서버 간의 통신을 중계합니다.
+ * 
+ * @author 공통컴포넌트 개발팀
+ * @since
+ * @version 1.0
+ * @see
+ *
+ *      <pre>
+ *  == 개정이력(Modification Information) ==
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2025.09.16  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-ImmutableField(생성자를 통해 할당된 변수를 Final로 선언하지 않았음)
+ *   2025.09.16  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-AssignmentInOperand(피연산자내에 할당문이 사용됨. 해당 코드를 복잡하고 가독성이 떨어지게 만듬)
+ *
+ *      </pre>
  */
 public class ProxyThread implements Runnable {
 

--- a/src/main/java/egovframework/com/utl/sys/pxy/service/ProxyThread.java
+++ b/src/main/java/egovframework/com/utl/sys/pxy/service/ProxyThread.java
@@ -9,6 +9,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import egovframework.com.cmm.util.EgovResourceCloseHelper;
+
 /**
  * 프록시 스레드 클래스는 클라이언트와 서버 간의 통신을 중계합니다.
  */
@@ -52,13 +53,14 @@ public class ProxyThread implements Runnable {
 	/**
 	 * 스트림 및 클라이언트 소켓을 사용하여 ProxyThread 객체를 생성합니다.
 	 *
-	 * @param client 클라이언트 소켓
+	 * @param client           클라이언트 소켓
 	 * @param streamFromClient 클라이언트로부터의 입력 스트림
-	 * @param streamToClient 클라이언트로의 출력 스트림
+	 * @param streamToClient   클라이언트로의 출력 스트림
 	 * @param streamFromServer 서버로부터의 입력 스트림
-	 * @param streamToServer 서버로의 출력 스트림
+	 * @param streamToServer   서버로의 출력 스트림
 	 */
-	public ProxyThread(Socket client, InputStream streamFromClient, OutputStream streamToClient, InputStream streamFromServer, OutputStream streamToServer) throws IOException {
+	public ProxyThread(Socket client, InputStream streamFromClient, OutputStream streamToClient,
+			InputStream streamFromServer, OutputStream streamToServer) throws IOException {
 		this.client = client;
 		this.streamFromClient = streamFromClient;
 		this.streamToClient = streamToClient;
@@ -85,8 +87,7 @@ public class ProxyThread implements Runnable {
 	}
 
 	/**
-	 * 프록시 스레드의 주 실행 메서드입니다.
-	 * 클라이언트에서 서버로의 데이터 전달을 처리합니다.
+	 * 프록시 스레드의 주 실행 메서드입니다. 클라이언트에서 서버로의 데이터 전달을 처리합니다.
 	 */
 	@Override
 	public void run() {


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

<hr>

### 2025-09-16 화 PMD로 소프트웨어 보안약점 진단하고 제거하기-ProxyThread

<hr>

1. PMD로 소프트웨어 보안약점 진단 결과

```
src/main/java/egovframework/com/utl/sys/pxy/service/ProxyThread.java:22:	ImmutableField:	ImmutableField: 생성자에서 Assign된 변수 'client' 를 Final로 선언하지 않았음
src/main/java/egovframework/com/utl/sys/pxy/service/ProxyThread.java:99:	AssignmentInOperand:	AssignmentInOperand: 피연산자내에 할당문이 사용됨. Code 를 복잡하고 가독성이 떨어지게 만듬
```

2. 브랜치 생성

```
feature/pmd/ProxyThread
```

3. 이클립스 > Source > Format

4. 수정

ImmutableField(생성자를 통해 할당된 변수를 Final로 선언하지 않았음)
- 생성자를 통해 할당된 변수를 Final로 선언

AssignmentInOperand(피연산자내에 할당문이 사용됨. 해당 코드를 복잡하고 가독성이 떨어지게 만듬)
- 피연산자내에 할당문 제거


5. 개정이력 수정

```java
 *   2025.09.16  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-ImmutableField(생성자를 통해 할당된 변수를 Final로 선언하지 않았음)
 *   2025.09.16  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-AssignmentInOperand(피연산자내에 할당문이 사용됨. 해당 코드를 복잡하고 가독성이 떨어지게 만듬)
```

<hr>

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

https://youtu.be/fkBnRk0ecCA
