### PR TITLE
[security][5.0.x] parsson 1.1.7 → 1.1.8 패치 업그레이드

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -383,7 +383,7 @@
 		<dependency>
 			<groupId>org.eclipse.parsson</groupId>
 			<artifactId>parsson</artifactId>
-			<version>1.1.7</version>
+			<version>1.1.8</version>
 		</dependency>
 
 		<!-- ajax json -->


### PR DESCRIPTION
## 변경 사유
`pom.xml`이 명시적으로 pin 하고 있는 `org.eclipse.parsson:parsson:1.1.7`을 동일 1.1.x 라인의 최신 패치인 `1.1.8`로 올립니다. 기존 pom 주석에 이미 `CVE-2023-7272`, `CVE-2023-4043`이 인용되어 있으며, 1.1.8은 같은 라인에서 추가된 파서 강화 패치입니다.

## 변경 내용
- `pom.xml` 단일 줄 수정: `<version>1.1.7</version>` → `<version>1.1.8</version>`

## 영향 범위
- API 표면 변화 없음 (1.1.x 라인의 패치 릴리스)
- 다른 의존성/빌드 설정 변경 없음

## 체크리스트
- [x] 단일 주제 (parsson 패치)
- [x] 5.0.x 브랜치 대상
- [x] breaking change 없음