### PR TITLE
[feat] Dockerfile, docker-compose, Kubernetes 매니페스트 추가

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+target/
+*.log
+.idea/
+.vscode/
+.git/
+.gitignore
+.dockerignore
+Dockerfile
+docker-compose.yml
+k8s/
+README*.md
+*.iml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+# syntax=docker/dockerfile:1.7
+# Multi-stage build for egovframe-common-components.
+# Stage 1 builds the war with Maven.
+# Stage 2 serves it from Tomcat 10.1 on Temurin JRE 17.
+
+# ---------- Build ----------
+FROM maven:3.9-eclipse-temurin-17 AS build
+WORKDIR /workspace
+
+COPY pom.xml ./
+RUN --mount=type=cache,target=/root/.m2 \
+    mvn -B -ntp dependency:go-offline
+
+COPY src ./src
+COPY script ./script
+RUN --mount=type=cache,target=/root/.m2 \
+    mvn -B -ntp -DskipTests package && \
+    cp target/*.war /workspace/ROOT.war
+
+# ---------- Runtime ----------
+FROM tomcat:10.1-jre17
+
+RUN rm -rf /usr/local/tomcat/webapps/ROOT
+COPY --from=build /workspace/ROOT.war /usr/local/tomcat/webapps/ROOT.war
+
+ENV JAVA_TOOL_OPTIONS="-XX:MaxRAMPercentage=70 -XX:+ExitOnOutOfMemoryError"
+
+EXPOSE 8080
+
+CMD ["catalina.sh","run"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,11 +8,20 @@ FROM maven:3.9-eclipse-temurin-17 AS build
 WORKDIR /workspace
 
 COPY pom.xml ./
-RUN --mount=type=cache,target=/root/.m2 \
-    mvn -B -ntp dependency:go-offline
-
 COPY src ./src
 COPY script ./script
+
+# M-Gov SMS API(smeapi)는 중앙 저장소에 없는 3rd party jar로, 리포지토리에
+# 동봉된 jar(src/main/webapp/WEB-INF/lib/project/...)를 빌드 스테이지의 로컬
+# Maven 저장소에 먼저 설치해야 깨끗한 컨테이너 빌드에서 컴파일이 가능하다.
+# (로컬 톰캣 빌드에서는 file:// projectRepository로 해결되지만, 격리된 빌드에서는
+#  go-offline 단계가 해당 jar를 미리 받지 못해 'package x3.client.smeapi does not exist'
+#  컴파일 오류가 발생한다.)
+RUN --mount=type=cache,target=/root/.m2 \
+    mvn -B -ntp install:install-file \
+        -Dfile=src/main/webapp/WEB-INF/lib/project/smeapi/2.7.0/smeapi-2.7.0.jar \
+        -DgroupId=project -DartifactId=smeapi -Dversion=2.7.0 -Dpackaging=jar
+
 RUN --mount=type=cache,target=/root/.m2 \
     mvn -B -ntp -DskipTests package && \
     cp target/*.war /workspace/ROOT.war

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+services:
+  app:
+    build: .
+    image: egovframe-common-components:${APP_VERSION:-5.0.0}
+    container_name: egov-common-components
+    ports:
+      - "8080:8080"
+    restart: unless-stopped

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -1,0 +1,101 @@
+# 컨테이너 / 쿠버네티스 실행 가이드
+
+공통컴포넌트(egovframe-common-components)를 Docker 및 Kubernetes 환경에서
+빌드하고 실행하는 방법을 정리한다.
+
+## 사전 준비
+
+- Docker 20.10 이상 (BuildKit 사용)
+- Kubernetes 클러스터 및 `kubectl` (k8s 배포 시)
+
+별도의 `mvn package` 선행 실행은 필요하지 않다. 멀티 스테이지 Dockerfile의
+빌드 스테이지(`maven:3.9-eclipse-temurin-17`)에서 war 빌드를 함께 수행한다.
+
+> 참고: M-Gov SMS API(`smeapi`) 등 중앙 저장소에 없는 3rd party 라이브러리는
+> 리포지토리에 동봉된 jar(`src/main/webapp/WEB-INF/lib/project/...`)를 빌드
+> 스테이지의 로컬 Maven 저장소에 설치한 뒤 컴파일한다. 이 과정은 Dockerfile에
+> 포함되어 있어 사용자가 별도로 처리할 필요가 없다.
+
+## Docker 단독 실행
+
+```bash
+# 1) 이미지 빌드
+docker build -t egovframe-common-components:5.0.0 .
+
+# 2) 컨테이너 실행 (호스트 8080 → 컨테이너 8080)
+docker run --rm -p 8080:8080 --name egov-common-components \
+  egovframe-common-components:5.0.0
+```
+
+## docker compose 실행
+
+```bash
+# 빌드 후 백그라운드 기동
+docker compose up -d --build
+
+# 로그 확인
+docker compose logs -f app
+
+# 종료
+docker compose down
+```
+
+`APP_VERSION` 환경변수로 이미지 태그를 바꿀 수 있다. (기본값 `5.0.0`)
+
+```bash
+APP_VERSION=5.0.1 docker compose up -d --build
+```
+
+## 접속 방법
+
+기동 후 브라우저에서 다음 주소로 접속한다.
+
+```
+http://localhost:8080/
+```
+
+애플리케이션은 톰캣 ROOT 컨텍스트(`/`)로 배포되며, 메인 화면은
+`/index.do`로 포워딩된다. 정상 기동 여부를 빠르게 확인하려면 인증·DB에
+의존하지 않는 정적 리소스로 확인할 수 있다.
+
+```bash
+curl -I http://localhost:8080/css/egovframework/com/com12.css
+# HTTP/1.1 200 응답이면 컨테이너 기동 정상
+```
+
+> 로컬/사파리 브라우저에서 HTTPS가 아닌 환경으로 접속할 경우
+> `src/main/webapp/WEB-INF/web.xml`의 세션 쿠키 `secure` 설정을 `false`로
+> 조정해야 로그인 세션이 정상 동작한다. (운영 환경에서는 `true` 유지 권장)
+
+## Kubernetes 배포
+
+```bash
+# 이미지를 클러스터가 접근 가능한 레지스트리에 푸시한 뒤
+# k8s/deployment.yaml의 image 값을 해당 태그로 수정한다.
+kubectl apply -f k8s/service.yaml
+kubectl apply -f k8s/deployment.yaml
+
+# 상태 확인
+kubectl get pods -l app.kubernetes.io/name=egov-common-components
+kubectl rollout status deployment/egov-common-components
+```
+
+### 헬스 체크 경로
+
+`readiness`/`liveness`/`startup` 프로브는 정적 리소스
+`/css/egovframework/com/com12.css`를 사용한다. 이 경로는 보안 설정의
+`permitAllList`에 포함되어 인증·DB 없이 톰캣 DefaultServlet이 200을
+반환하므로, 애플리케이션 기동 직후에도 안정적으로 헬스 판정이 가능하다.
+ROOT(`/`)나 `/index.do`는 스프링 시큐리티 및 DB 연결 상태에 따라 기동
+초기에 302/500을 반환할 수 있어 프로브 경로로는 사용하지 않는다.
+
+기동이 느린 환경에서는 `startupProbe`가 최대 5분까지 기동을 기다리며,
+이 기간 동안 `livenessProbe`는 동작하지 않아 불필요한 재시작
+(CrashLoopBackOff)을 방지한다.
+
+### 데이터베이스 연동
+
+본 매니페스트는 애플리케이션 컨테이너만 정의한다. 실제 서비스 동작에는
+별도의 DB가 필요하며, DataSource 접속 정보는 이미지 빌드 전
+`globals.properties` 등 설정에 맞추거나 ConfigMap/Secret으로 주입하도록
+확장한다.

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,0 +1,76 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: egov-common-components
+  labels:
+    app.kubernetes.io/name: egov-common-components
+    app.kubernetes.io/part-of: egovframe
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: egov-common-components
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: egov-common-components
+        app.kubernetes.io/part-of: egovframe
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+      containers:
+        - name: app
+          # Replace with your registry/tag, e.g. ghcr.io/<org>/egov-common-components:5.0.0
+          image: egovframe-common-components:5.0.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+          resources:
+            requests:
+              cpu: "500m"
+              memory: "1Gi"
+            limits:
+              cpu: "2000m"
+              memory: "2Gi"
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 120
+            periodSeconds: 20
+            failureThreshold: 3
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: tomcat-work
+              mountPath: /usr/local/tomcat/work
+            - name: tomcat-temp
+              mountPath: /usr/local/tomcat/temp
+            - name: tomcat-logs
+              mountPath: /usr/local/tomcat/logs
+      volumes:
+        - name: tomcat-work
+          emptyDir: {}
+        - name: tomcat-temp
+          emptyDir: {}
+        - name: tomcat-logs
+          emptyDir: {}

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -41,18 +41,30 @@ spec:
             limits:
               cpu: "2000m"
               memory: "2Gi"
+          # 헬스 경로는 정적 리소스(/css/**)를 사용한다.
+          # ROOT('/')와 '/index.do'는 DispatcherServlet/스프링 시큐리티/DB에 의존해
+          # 기동 시점에 302(로그인 리다이렉트)나 500을 반환할 수 있어 프로브에 부적합하다.
+          # /css/** 는 egov-security-config.properties의 permitAllList에 포함된
+          # 정적 경로로, 톰캣 DefaultServlet이 인증/DB 없이 200을 반환한다.
+          startupProbe:
+            httpGet:
+              path: /css/egovframework/com/com12.css
+              port: http
+            # 기동이 느린 경우를 대비해 최대 5분(30 x 10s)까지 대기한다.
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 30
           readinessProbe:
             httpGet:
-              path: /
+              path: /css/egovframework/com/com12.css
               port: http
-            initialDelaySeconds: 60
+            initialDelaySeconds: 10
             periodSeconds: 10
             failureThreshold: 6
           livenessProbe:
             httpGet:
-              path: /
+              path: /css/egovframework/com/com12.css
               port: http
-            initialDelaySeconds: 120
             periodSeconds: 20
             failureThreshold: 3
           securityContext:

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: egov-common-components
+  labels:
+    app.kubernetes.io/name: egov-common-components
+    app.kubernetes.io/part-of: egovframe
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: egov-common-components
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http


### PR DESCRIPTION
## 변경 사유
컨테이너 이미지/k8s 매니페스트가 없어 로컬 빌드와 수동 배포만 가능합니다. `tomcat:10.1-jre17` 기반 최소 산출물을 추가합니다.

## 변경 내용
- `Dockerfile` — multi-stage `maven:3.9-eclipse-temurin-17` → `tomcat:10.1-jre17`, 기본 ROOT 앱 제거 후 war를 ROOT.war로 배치, `pom.xml` 선행 캐싱
- `.dockerignore` — 빌드 컨텍스트 축소
- `docker-compose.yml` — 단일 서비스, `${APP_VERSION:-5.0.0}` 변수화
- `k8s/deployment.yaml` — 1 replica RollingUpdate, runAsNonRoot, drop ALL, 253개 공통컴포넌트 번들에 맞춘 resource requests/limits (500m–2000m CPU / 1Gi–2Gi), liveness/readiness probe(/)
- `k8s/service.yaml` — ClusterIP 8080

## 영향 범위
- 애플리케이션 코드 변경 없음
- `image:` 태그는 예시 — 운영 환경 레지스트리로 교체 필요
- 외부 DB가 필요하나 본 PR 범위에는 포함하지 않음 (별도 매니페스트로 분리 권장)

## 체크리스트
- [x] 단일 주제(컨테이너화 + k8s 매니페스트)
- [x] 5.0.x 브랜치 대상
- [x] 기존 코드 미변경