### PR TITLE
[security] spring-ldap-core 2.4.4 → 3.2.13 (CVE-2024-38829)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -406,7 +406,7 @@
 		<dependency>
 			<groupId>org.springframework.ldap</groupId>
 			<artifactId>spring-ldap-core</artifactId>
-			<version>2.4.4</version>
+			<version>3.2.13</version>
 			<exclusions>
 				<exclusion>
 					<groupId>org.springframework</groupId>


### PR DESCRIPTION
## 변경 사유
`pom.xml` 주석에 [CVE-2024-38829](https://nvd.nist.gov/vuln/detail/CVE-2024-38829)가 이미 명시되어 있습니다. 2.4.x 라인은 EOL이며 백포트도 제한적인 반면, 3.x는 Spring 6 기반의 활성 지원 라인입니다. 부모 `egovframe-web-config-parent:5.0.0`이 이미 Spring 6를 사용하고 있어 정렬상 자연스러운 업그레이드입니다.

## 변경 내용
- `pom.xml` 단일 줄 수정: `<version>2.4.4</version>` → `<version>3.2.13</version>` (직접 `org.springframework.ldap:spring-ldap-core` 의존성 블록만)
- 기존 `spring-beans`/`spring-core` exclusion 유지

## 호환성 검증
`egovframework.com.ext.ldapumt` 패키지의 호출부에서 사용 중인 API는 모두 2.x → 3.x 이주 후에도 유지된 안정 API입니다.
- `LdapTemplate`, `ContextSource`, `ContextMapper`, `DirContextAdapter`
- `NameNotFoundException`, `ContainerCriteria`
- `javax.naming.*`는 JDK 표준이므로 Jakarta 이주 영향 없음

호출부 4개 파일(`OrgManageLdapDAO`, `UserManageLdapDAO`, `DeptManageLdapDAO`, `ObjectMapper`)은 별도 수정 없이 동작합니다.

## 영향 범위
- 호출부 코드 변경 없음
- spring-beans/spring-core는 여전히 부모 BOM이 관리하는 Spring 6 버전 사용
- 본 PR에서 다른 의존성은 건드리지 않음

## 체크리스트
- [x] 단일 주제(spring-ldap-core 메이저 업그레이드)
- [x] 5.0.x 브랜치 대상
- [x] 호출부 API 호환 확인 완료
- [x] exclusion 정책 유지