### PR TITLE
[refactor] cmm 패키지 핵심 VO에 Lombok @Getter/@Setter 적용

### DIFF
--- a/src/main/java/egovframework/com/cmm/ComDefaultCodeVO.java
+++ b/src/main/java/egovframework/com/cmm/ComDefaultCodeVO.java
@@ -4,6 +4,9 @@ import java.io.Serializable;
 
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  *  클래스
  * @author 공통서비스개발팀 이삼섭
@@ -13,168 +16,37 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------       --------    ---------------------------
  *   2009.3.11   이삼섭          최초 생성
  *
  * </pre>
  */
+@Getter
+@Setter
 @SuppressWarnings("serial")
 public class ComDefaultCodeVO implements Serializable {
     /** 코드 ID */
     private String codeId = "";
-    
+
     /** 상세코드 */
     private String code = "";
-    
+
     /** 코드명 */
     private String codeNm = "";
-    
+
     /** 코드설명 */
     private String codeDc = "";
-    
+
     /** 특정테이블명 */
     private String tableNm = "";	//특정테이블에서 코드정보를추출시 사용
-    
+
     /** 상세 조건 여부 */
     private String haveDetailCondition = "N";
-    
+
     /** 상세 조건 */
     private String detailCondition = "";
-    
-    /**
-     * codeId attribute를 리턴한다.
-     * 
-     * @return the codeId
-     */
-    public String getCodeId() {
-    	return codeId;
-    }
-
-    /**
-     * codeId attribute 값을 설정한다.
-     * 
-     * @param codeId
-     *            the codeId to set
-     */
-    public void setCodeId(String codeId) {
-    	this.codeId = codeId;
-    }
-
-    /**
-     * code attribute를 리턴한다.
-     * 
-     * @return the code
-     */
-    public String getCode() {
-    	return code;
-    }
-
-    /**
-     * code attribute 값을 설정한다.
-     * 
-     * @param code
-     *            the code to set
-     */
-    public void setCode(String code) {
-    	this.code = code;
-    }
-
-    /**
-     * codeNm attribute를 리턴한다.
-     * 
-     * @return the codeNm
-     */
-    public String getCodeNm() {
-    	return codeNm;
-    }
-
-    /**
-     * codeNm attribute 값을 설정한다.
-     * 
-     * @param codeNm
-     *            the codeNm to set
-     */
-    public void setCodeNm(String codeNm) {
-    	this.codeNm = codeNm;
-    }
-
-    /**
-     * codeDc attribute를 리턴한다.
-     * 
-     * @return the codeDc
-     */
-    public String getCodeDc() {
-    	return codeDc;
-    }
-
-    /**
-     * codeDc attribute 값을 설정한다.
-     * 
-     * @param codeDc
-     *            the codeDc to set
-     */
-    public void setCodeDc(String codeDc) {
-    	this.codeDc = codeDc;
-    }
-
-    /**
-     * tableNm attribute를 리턴한다.
-     * 
-     * @return the tableNm
-     */
-    public String getTableNm() {
-    	return tableNm;
-    }
-
-    /**
-     * tableNm attribute 값을 설정한다.
-     * 
-     * @param tableNm
-     *            the tableNm to set
-     */
-    public void setTableNm(String tableNm) {
-    	this.tableNm = tableNm;
-    }
-
-    /**
-     * haveDetailCondition attribute를 리턴한다.
-     * 
-     * @return the haveDetailCondition
-     */
-    public String getHaveDetailCondition() {
-    	return haveDetailCondition;
-    }
-
-    /**
-     * haveDetailCondition attribute 값을 설정한다.
-     * 
-     * @param haveDetailCondition
-     *            the haveDetailCondition to set
-     */
-    public void setHaveDetailCondition(String haveDetailCondition) {
-    	this.haveDetailCondition = haveDetailCondition;
-    }
-
-    /**
-     * detailCondition attribute를 리턴한다.
-     * 
-     * @return the detailCondition
-     */
-    public String getDetailCondition() {
-    	return detailCondition;
-    }
-
-    /**
-     * detailCondition attribute 값을 설정한다.
-     * 
-     * @param detailCondition
-     *            the detailCondition to set
-     */
-    public void setDetailCondition(String detailCondition) {
-    	this.detailCondition = detailCondition;
-    }
 
     /**
      * toString 메소드를 대치한다.

--- a/src/main/java/egovframework/com/cmm/IncludedCompInfoVO.java
+++ b/src/main/java/egovframework/com/cmm/IncludedCompInfoVO.java
@@ -1,12 +1,15 @@
 package egovframework.com.cmm;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * IncludedCompInfoVO 클래스
- * 
+ *
  * <p>
  *  Description : IncludedInfo annotation을 바탕으로 화면에 표시할 정보를 구성하기 위한 VO 클래스
  * </p>
- * 
+ *
  * @author 공통컴포넌트 정진오
  * @since 2011.08.26
  * @version 2.0.0
@@ -14,42 +17,20 @@ package egovframework.com.cmm;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *  수정일		수정자		수정내용
  *  -------    	--------    ---------------------------
  *  2011.08.26	정진오 		최초 생성
  * </pre>
- * 
+ *
  */
+@Getter
+@Setter
 public class IncludedCompInfoVO {
-	
+
 	private String name;
 	private String listUrl;
 	private int order;
 	private int gid;
-	
-	public String getName() {
-		return name;
-	}
-	public void setName(String name) {
-		this.name = name;
-	}
-	public String getListUrl() {
-		return listUrl;
-	}
-	public void setListUrl(String listUrl) {
-		this.listUrl = listUrl;
-	}
-	public int getOrder() {
-		return order;
-	}
-	public void setOrder(int order) {
-		this.order = order;
-	}
-	public int getGid() {
-		return gid;
-	}
-	public void setGid(int gid) {
-		this.gid = gid;
-	}
+
 }

--- a/src/main/java/egovframework/com/cmm/LoginVO.java
+++ b/src/main/java/egovframework/com/cmm/LoginVO.java
@@ -5,6 +5,9 @@ import java.io.Serializable;
 import org.egovframe.rte.ptl.reactive.validation.EgovNullCheck;
 import org.egovframe.rte.ptl.reactive.validation.EgovEmailCheck;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * @Class Name : LoginVO.java
  * @Description : Login VO class
@@ -23,15 +26,17 @@ import org.egovframe.rte.ptl.reactive.validation.EgovEmailCheck;
  *  @since 2009.03.03
  *  @version 1.0
  *  @see
- *  
+ *
  */
+@Getter
+@Setter
 public class LoginVO implements Serializable{
-	
+
 	/**
-	 * 
+	 *
 	 */
 	private static final long serialVersionUID = -8274004534207618049L;
-	
+
 	/** 아이디 */
 	@EgovNullCheck
 	private String id;
@@ -70,229 +75,5 @@ public class LoginVO implements Serializable{
 	private String onepassUserkey;
 	/** 디지털원패스 사용자세션값 */
 	private String onepassIntfToken;
-
-	/**
-	 * id attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getId() {
-		return id;
-	}
-	/**
-	 * id attribute 값을 설정한다.
-	 * @param id String
-	 */
-	public void setId(String id) {
-		this.id = id;
-	}
-	/**
-	 * name attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getName() {
-		return name;
-	}
-	/**
-	 * name attribute 값을 설정한다.
-	 * @param name String
-	 */
-	public void setName(String name) {
-		this.name = name;
-	}
-	/**
-	 * ihidNum attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getIhidNum() {
-		return ihidNum;
-	}
-	/**
-	 * ihidNum attribute 값을 설정한다.
-	 * @param ihidNum String
-	 */
-	public void setIhidNum(String ihidNum) {
-		this.ihidNum = ihidNum;
-	}
-	/**
-	 * email attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getEmail() {
-		return email;
-	}
-	/**
-	 * email attribute 값을 설정한다.
-	 * @param email String
-	 */
-	public void setEmail(String email) {
-		this.email = email;
-	}
-	/**
-	 * password attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getPassword() {
-		return password;
-	}
-	/**
-	 * password attribute 값을 설정한다.
-	 * @param password String
-	 */
-	public void setPassword(String password) {
-		this.password = password;
-	}
-	/**
-	 * passwordHint attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getPasswordHint() {
-		return passwordHint;
-	}
-	/**
-	 * passwordHint attribute 값을 설정한다.
-	 * @param passwordHint String
-	 */
-	public void setPasswordHint(String passwordHint) {
-		this.passwordHint = passwordHint;
-	}
-	/**
-	 * passwordCnsr attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getPasswordCnsr() {
-		return passwordCnsr;
-	}
-	/**
-	 * passwordCnsr attribute 값을 설정한다.
-	 * @param passwordCnsr String
-	 */
-	public void setPasswordCnsr(String passwordCnsr) {
-		this.passwordCnsr = passwordCnsr;
-	}
-	/**
-	 * userSe attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getUserSe() {
-		return userSe;
-	}
-	/**
-	 * userSe attribute 값을 설정한다.
-	 * @param userSe String
-	 */
-	public void setUserSe(String userSe) {
-		this.userSe = userSe;
-	}
-	/**
-	 * orgnztId attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getOrgnztId() {
-		return orgnztId;
-	}
-	/**
-	 * orgnztId attribute 값을 설정한다.
-	 * @param orgnztId String
-	 */
-	public void setOrgnztId(String orgnztId) {
-		this.orgnztId = orgnztId;
-	}
-	/**
-	 * uniqId attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getUniqId() {
-		return uniqId;
-	}
-	/**
-	 * uniqId attribute 값을 설정한다.
-	 * @param uniqId String
-	 */
-	public void setUniqId(String uniqId) {
-		this.uniqId = uniqId;
-	}
-	/**
-	 * url attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getUrl() {
-		return url;
-	}
-	/**
-	 * url attribute 값을 설정한다.
-	 * @param url String
-	 */
-	public void setUrl(String url) {
-		this.url = url;
-	}
-	/**
-	 * ip attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getIp() {
-		return ip;
-	}
-	/**
-	 * ip attribute 값을 설정한다.
-	 * @param ip String
-	 */
-	public void setIp(String ip) {
-		this.ip = ip;
-	}
-	/**
-	 * dn attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getDn() {
-		return dn;
-	}
-	/**
-	 * dn attribute 값을 설정한다.
-	 * @param dn String
-	 */
-	public void setDn(String dn) {
-		this.dn = dn;
-	}
-	/**
-	 * @return the orgnztNm
-	 */
-	public String getOrgnztNm() {
-		return orgnztNm;
-	}
-	/**
-	 * @param orgnztNm the orgnztNm to set
-	 */
-	public void setOrgnztNm(String orgnztNm) {
-		this.orgnztNm = orgnztNm;
-	}
-	
-	/**
-	 * 디지털원패스 사용자키를 리턴한다.
-	 * @return onepassUserkey
-	 */
-	public String getOnepassUserkey() {
-		return onepassUserkey;
-	}
-	/**
-	 * 디지털원패스 사용자키를 설정한다.
-	 * @param onepassUserkey
-	 */
-	public void setOnepassUserkey(String onepassUserkey) {
-		this.onepassUserkey = onepassUserkey;
-	}
-	/**
-	 * 디지털원패스 사용자세션값을 리턴한다.
-	 * @return
-	 */
-	public String getOnepassIntfToken() {
-		return onepassIntfToken;
-	}
-	/**
-	 * 디지털원패스 사용자세션값을 설정한다.
-	 * @param onepassIntfToken
-	 */
-	public void setOnepassIntfToken(String onepassIntfToken) {
-		this.onepassIntfToken = onepassIntfToken;
-	}
 
 }


### PR DESCRIPTION
## 변경 사유

`egovframework.com.cmm` 패키지의 핵심 VO 클래스들이 단순 필드 접근만 수행하는 수작업 getter/setter로 구성되어 있어, 코드 가독성 및 유지보수 일관성을 높이기 위해 Lombok을 도입합니다. pom.xml에는 이미 `lombok` 의존성이 `provided` 스코프로 선언되어 있어 별도 의존성 추가는 불필요합니다.

## 변경 내용

| 파일 | 제거된 접근자 수 |
|------|----------------|
| `LoginVO.java` | getter 13 + setter 13 = 26개 |
| `ComDefaultCodeVO.java` | getter 7 + setter 7 = 14개 |
| `IncludedCompInfoVO.java` | getter 4 + setter 4 = 8개 |

총 48개의 수작업 접근자 메서드를 클래스 레벨 `@Getter` / `@Setter` 어노테이션으로 대체하였습니다.

## 제외 항목 및 사유

- **ComDefaultVO**: `getPageIndex()`, `getFirstIndex()` 등 accessor에 null 방어 로직(`pageIndex == null ? 1 : pageIndex`) 포함 — 비즈니스 로직이 있어 보존
- **SessionVO**: setter 파라미터명이 필드명과 불일치(`setSUserId(String userId)` 등) — Lombok 자동 생성 시 파라미터명이 달라지므로 제외

## 영향 범위

- 호출부(Service, Controller), JSP EL, MyBatis 매퍼: 메서드 시그니처 동일하여 영향 없음
- validation 어노테이션(`@EgovNullCheck`, `@EgovEmailCheck`): 필드에 유지되어 영향 없음
- `serialVersionUID`: 유지
- `toString()` 오버라이드: `ComDefaultCodeVO`의 기존 `ToStringBuilder` 기반 구현 보존

## 적용 범위 안내

본 PR은 `cmm` 패키지 핵심 VO 5개 중 안전하게 적용 가능한 3개만 대상입니다. 나머지 패키지(cop, sec, uss, utl 등)의 VO Lombok 적용은 별도 PR로 분리 예정입니다.

## 체크리스트

- [x] 단일 주제만 다룸 (Lombok 적용 외 변경 없음)
- [x] cop/sec/uss/utl 등 다른 패키지 변경 없음
- [x] 의존성 추가 불필요 (pom.xml에 lombok provided 스코프 기존 선언)
- [x] 기존 동작에 영향 없음 (메서드 시그니처 동일)
- [x] 비즈니스 로직 포함 accessor는 보존 처리