### PR TITLE
[refactor] cop 패키지 핵심 VO에 Lombok @Getter/@Setter 적용

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -597,6 +597,13 @@
 					<artifactId>maven-compiler-plugin</artifactId>
 					<configuration>
 						<release>${java.version}</release>
+						<annotationProcessorPaths>
+							<path>
+								<groupId>org.projectlombok</groupId>
+								<artifactId>lombok</artifactId>
+								<version>${lombok.version}</version>
+							</path>
+						</annotationProcessorPaths>
 					</configuration>
 				</plugin>
 				<plugin>

--- a/src/main/java/egovframework/com/cop/bbs/service/BlogVO.java
+++ b/src/main/java/egovframework/com/cop/bbs/service/BlogVO.java
@@ -4,6 +4,9 @@ import java.io.Serializable;
 
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * 커뮤니티 관리를 위한 VO 클래스
  * @author 공통서비스개발팀 이삼섭
@@ -13,28 +16,30 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.4.2  이삼섭          최초 생성
  *
  * </pre>
  */
+@Getter
+@Setter
 @SuppressWarnings("serial")
 public class BlogVO extends Blog implements Serializable {
 
     /** 검색시작일 */
     private String searchBgnDe = "";
-    
+
     /** 검색조건 */
     private String searchCnd = "";
-    
+
     /** 검색종료일 */
     private String searchEndDe = "";
-    
+
     /** 검색단어 */
     private String searchWrd = "";
-    
+
     /** 정렬순서(DESC,ASC) */
     private long sortOrdr = 0L;
 
@@ -73,366 +78,11 @@ public class BlogVO extends Blog implements Serializable {
 
     /** 게시판 이름 */
     private String bbsNm = "";
-    
+
     /** 제공 URL */
     private String provdUrl = "";
-    
+
     private String blogId = "";
-    
-
-    /**
-     * searchBgnDe attribute를 리턴한다.
-     * 
-     * @return the searchBgnDe
-     */
-    public String getSearchBgnDe() {
-	return searchBgnDe;
-    }
-
-    /**
-     * searchBgnDe attribute 값을 설정한다.
-     * 
-     * @param searchBgnDe
-     *            the searchBgnDe to set
-     */
-    public void setSearchBgnDe(String searchBgnDe) {
-	this.searchBgnDe = searchBgnDe;
-    }
-
-    /**
-     * searchCnd attribute를 리턴한다.
-     * 
-     * @return the searchCnd
-     */
-    public String getSearchCnd() {
-	return searchCnd;
-    }
-
-    /**
-     * searchCnd attribute 값을 설정한다.
-     * 
-     * @param searchCnd
-     *            the searchCnd to set
-     */
-    public void setSearchCnd(String searchCnd) {
-	this.searchCnd = searchCnd;
-    }
-
-    /**
-     * searchEndDe attribute를 리턴한다.
-     * 
-     * @return the searchEndDe
-     */
-    public String getSearchEndDe() {
-	return searchEndDe;
-    }
-
-    /**
-     * searchEndDe attribute 값을 설정한다.
-     * 
-     * @param searchEndDe
-     *            the searchEndDe to set
-     */
-    public void setSearchEndDe(String searchEndDe) {
-	this.searchEndDe = searchEndDe;
-    }
-
-    /**
-     * searchWrd attribute를 리턴한다.
-     * 
-     * @return the searchWrd
-     */
-    public String getSearchWrd() {
-	return searchWrd;
-    }
-
-    /**
-     * searchWrd attribute 값을 설정한다.
-     * 
-     * @param searchWrd
-     *            the searchWrd to set
-     */
-    public void setSearchWrd(String searchWrd) {
-	this.searchWrd = searchWrd;
-    }
-
-    /**
-     * sortOrdr attribute를 리턴한다.
-     * 
-     * @return the sortOrdr
-     */
-    public long getSortOrdr() {
-	return sortOrdr;
-    }
-
-    /**
-     * sortOrdr attribute 값을 설정한다.
-     * 
-     * @param sortOrdr
-     *            the sortOrdr to set
-     */
-    public void setSortOrdr(long sortOrdr) {
-	this.sortOrdr = sortOrdr;
-    }
-
-    /**
-     * searchUseYn attribute를 리턴한다.
-     * 
-     * @return the searchUseYn
-     */
-    public String getSearchUseYn() {
-	return searchUseYn;
-    }
-
-    /**
-     * searchUseYn attribute 값을 설정한다.
-     * 
-     * @param searchUseYn
-     *            the searchUseYn to set
-     */
-    public void setSearchUseYn(String searchUseYn) {
-	this.searchUseYn = searchUseYn;
-    }
-
-    /**
-     * pageIndex attribute를 리턴한다.
-     * 
-     * @return the pageIndex
-     */
-    public int getPageIndex() {
-	return pageIndex;
-    }
-
-    /**
-     * pageIndex attribute 값을 설정한다.
-     * 
-     * @param pageIndex
-     *            the pageIndex to set
-     */
-    public void setPageIndex(int pageIndex) {
-	this.pageIndex = pageIndex;
-    }
-
-    /**
-     * pageUnit attribute를 리턴한다.
-     * 
-     * @return the pageUnit
-     */
-    public int getPageUnit() {
-	return pageUnit;
-    }
-
-    /**
-     * pageUnit attribute 값을 설정한다.
-     * 
-     * @param pageUnit
-     *            the pageUnit to set
-     */
-    public void setPageUnit(int pageUnit) {
-	this.pageUnit = pageUnit;
-    }
-
-    /**
-     * pageSize attribute를 리턴한다.
-     * 
-     * @return the pageSize
-     */
-    public int getPageSize() {
-	return pageSize;
-    }
-
-    /**
-     * pageSize attribute 값을 설정한다.
-     * 
-     * @param pageSize
-     *            the pageSize to set
-     */
-    public void setPageSize(int pageSize) {
-	this.pageSize = pageSize;
-    }
-
-    /**
-     * firstIndex attribute를 리턴한다.
-     * 
-     * @return the firstIndex
-     */
-    public int getFirstIndex() {
-	return firstIndex;
-    }
-
-    /**
-     * firstIndex attribute 값을 설정한다.
-     * 
-     * @param firstIndex
-     *            the firstIndex to set
-     */
-    public void setFirstIndex(int firstIndex) {
-	this.firstIndex = firstIndex;
-    }
-
-    /**
-     * lastIndex attribute를 리턴한다.
-     * 
-     * @return the lastIndex
-     */
-    public int getLastIndex() {
-	return lastIndex;
-    }
-
-    /**
-     * lastIndex attribute 값을 설정한다.
-     * 
-     * @param lastIndex
-     *            the lastIndex to set
-     */
-    public void setLastIndex(int lastIndex) {
-	this.lastIndex = lastIndex;
-    }
-
-    /**
-     * recordCountPerPage attribute를 리턴한다.
-     * 
-     * @return the recordCountPerPage
-     */
-    public int getRecordCountPerPage() {
-	return recordCountPerPage;
-    }
-
-    /**
-     * recordCountPerPage attribute 값을 설정한다.
-     * 
-     * @param recordCountPerPage
-     *            the recordCountPerPage to set
-     */
-    public void setRecordCountPerPage(int recordCountPerPage) {
-	this.recordCountPerPage = recordCountPerPage;
-    }
-
-    /**
-     * rowNo attribute를 리턴한다.
-     * 
-     * @return the rowNo
-     */
-    public int getRowNo() {
-	return rowNo;
-    }
-
-    /**
-     * rowNo attribute 값을 설정한다.
-     * 
-     * @param rowNo
-     *            the rowNo to set
-     */
-    public void setRowNo(int rowNo) {
-	this.rowNo = rowNo;
-    }
-
-    /**
-     * registSeCodeNm attribute를 리턴한다.
-     * 
-     * @return the registSeCodeNm
-     */
-    public String getRegistSeCodeNm() {
-	return registSeCodeNm;
-    }
-
-    /**
-     * registSeCodeNm attribute 값을 설정한다.
-     * 
-     * @param registSeCodeNm
-     *            the registSeCodeNm to set
-     */
-    public void setRegistSeCodeNm(String registSeCodeNm) {
-	this.registSeCodeNm = registSeCodeNm;
-    }
-
-    /**
-     * frstRegisterNm attribute를 리턴한다.
-     * 
-     * @return the frstRegisterNm
-     */
-    public String getFrstRegisterNm() {
-	return frstRegisterNm;
-    }
-
-    /**
-     * frstRegisterNm attribute 값을 설정한다.
-     * 
-     * @param frstRegisterNm
-     *            the frstRegisterNm to set
-     */
-    public void setFrstRegisterNm(String frstRegisterNm) {
-	this.frstRegisterNm = frstRegisterNm;
-    }
-
-    /**
-     * bbsId attribute를 리턴한다.
-     * 
-     * @return the bbsId
-     */
-    public String getBbsId() {
-	return bbsId;
-    }
-
-    /**
-     * bbsId attribute 값을 설정한다.
-     * 
-     * @param bbsId
-     *            the bbsId to set
-     */
-    public void setBbsId(String bbsId) {
-	this.bbsId = bbsId;
-    }
-
- 
-    public String getBlogId() {
-    	return blogId;
-        }
-
-        /**
-         * bbsId attribute 값을 설정한다.
-         * 
-         * @param bbsId
-         *            the bbsId to set
-         */
-        public void setBlogId(String blogId) {
-    	this.blogId = blogId;
-        }
-        
-    /**
-     * bbsNm attribute를 리턴한다.
-     * 
-     * @return the bbsNm
-     */
-    public String getBbsNm() {
-	return bbsNm;
-    }
-
-    /**
-     * bbsNm attribute 값을 설정한다.
-     * 
-     * @param bbsNm
-     *            the bbsNm to set
-     */
-    public void setBbsNm(String bbsNm) {
-	this.bbsNm = bbsNm;
-    }
-
-    /**
-     * provdUrl attribute를 리턴한다.
-     * @return the provdUrl
-     */
-    public String getProvdUrl() {
-        return provdUrl;
-    }
-
-    /**
-     * provdUrl attribute 값을 설정한다.
-     * @param provdUrl the provdUrl to set
-     */
-    public void setProvdUrl(String provdUrl) {
-        this.provdUrl = provdUrl;
-    }
 
     /**
      * toString 메소드를 대치한다.

--- a/src/main/java/egovframework/com/cop/cmt/service/CommentVO.java
+++ b/src/main/java/egovframework/com/cop/cmt/service/CommentVO.java
@@ -2,6 +2,9 @@ package egovframework.com.cop.cmt.service;
 
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * 댓글관리 서비스를 위한 VO 클래스
  * @author 공통컴포넌트개발팀 한성곤
@@ -11,13 +14,15 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.06.29  한성곤          최초 생성
  *
  * </pre>
  */
+@Getter
+@Setter
 @SuppressWarnings("serial")
 public class CommentVO extends Comment {
     /** 정렬순서(DESC,ASC) */
@@ -43,172 +48,12 @@ public class CommentVO extends Comment {
 
     /** 레코드 번호 */
     private int subRowNo = 0;
-    
+
     /** 호출 TYPE (head or body)*/
     private String type = "";
-    
+
     /** 수정 처리 여부 */
     private boolean isModified = false;
-    
-    /**
-     * sortOrdr attribute를 리턴한다.
-     * @return the sortOrdr
-     */
-    public long getSortOrdr() {
-        return sortOrdr;
-    }
-
-    /**
-     * sortOrdr attribute 값을 설정한다.
-     * @param sortOrdr the sortOrdr to set
-     */
-    public void setSortOrdr(long sortOrdr) {
-        this.sortOrdr = sortOrdr;
-    }
-
-    /**
-     * subPageIndex attribute를 리턴한다.
-     * @return the subPageIndex
-     */
-    public int getSubPageIndex() {
-        return subPageIndex;
-    }
-
-    /**
-     * subPageIndex attribute 값을 설정한다.
-     * @param subPageIndex the subPageIndex to set
-     */
-    public void setSubPageIndex(int subPageIndex) {
-        this.subPageIndex = subPageIndex;
-    }
-
-    /**
-     * subPageUnit attribute를 리턴한다.
-     * @return the subPageUnit
-     */
-    public int getSubPageUnit() {
-        return subPageUnit;
-    }
-
-    /**
-     * subPageUnit attribute 값을 설정한다.
-     * @param subPageUnit the subPageUnit to set
-     */
-    public void setSubPageUnit(int subPageUnit) {
-        this.subPageUnit = subPageUnit;
-    }
-
-    /**
-     * subPageSize attribute를 리턴한다.
-     * @return the subPageSize
-     */
-    public int getSubPageSize() {
-        return subPageSize;
-    }
-
-    /**
-     * subPageSize attribute 값을 설정한다.
-     * @param subPageSize the subPageSize to set
-     */
-    public void setSubPageSize(int subPageSize) {
-        this.subPageSize = subPageSize;
-    }
-
-    /**
-     * subFirstIndex attribute를 리턴한다.
-     * @return the subFirstIndex
-     */
-    public int getSubFirstIndex() {
-        return subFirstIndex;
-    }
-
-    /**
-     * subFirstIndex attribute 값을 설정한다.
-     * @param subFirstIndex the subFirstIndex to set
-     */
-    public void setSubFirstIndex(int subFirstIndex) {
-        this.subFirstIndex = subFirstIndex;
-    }
-
-    /**
-     * subLastIndex attribute를 리턴한다.
-     * @return the subLastIndex
-     */
-    public int getSubLastIndex() {
-        return subLastIndex;
-    }
-
-    /**
-     * subLastIndex attribute 값을 설정한다.
-     * @param subLastIndex the subLastIndex to set
-     */
-    public void setSubLastIndex(int subLastIndex) {
-        this.subLastIndex = subLastIndex;
-    }
-
-    /**
-     * subRecordCountPerPage attribute를 리턴한다.
-     * @return the subRecordCountPerPage
-     */
-    public int getSubRecordCountPerPage() {
-        return subRecordCountPerPage;
-    }
-
-    /**
-     * subRecordCountPerPage attribute 값을 설정한다.
-     * @param subRecordCountPerPage the subRecordCountPerPage to set
-     */
-    public void setSubRecordCountPerPage(int subRecordCountPerPage) {
-        this.subRecordCountPerPage = subRecordCountPerPage;
-    }
-
-    /**
-     * subRowNo attribute를 리턴한다.
-     * @return the subRowNo
-     */
-    public int getSubRowNo() {
-        return subRowNo;
-    }
-
-    /**
-     * subRowNo attribute 값을 설정한다.
-     * @param subRowNo the subRowNo to set
-     */
-    public void setSubRowNo(int subRowNo) {
-        this.subRowNo = subRowNo;
-    }
-
-    /**
-     * type attribute를 리턴한다.
-     * @return the type
-     */
-    public String getType() {
-        return type;
-    }
-
-    /**
-     * type attribute 값을 설정한다.
-     * @param type the type to set
-     */
-    public void setType(String type) {
-        this.type = type;
-    }
-
-    /**
-     * isModified attribute를 리턴한다.
-     * @return the isModified
-     */
-    public boolean isModified() {
-        return isModified;
-    }
-
-    /**
-     * isModified attribute 값을 설정한다.
-     * @param isModified the isModified to set
-     */
-    public void setModified(boolean isModified) {
-        this.isModified = isModified;
-    }
 
     /**
      * toString 메소드를 대치한다.

--- a/src/main/java/egovframework/com/cop/ncm/service/NameCardVO.java
+++ b/src/main/java/egovframework/com/cop/ncm/service/NameCardVO.java
@@ -4,6 +4,9 @@ import java.io.Serializable;
 
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * 명함정보 관리를 위한 VO 클래스
  * @author 공통서비스개발팀 이삼섭
@@ -13,37 +16,39 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.3.28  이삼섭          최초 생성
  *
  * </pre>
  */
+@Getter
+@Setter
 @SuppressWarnings("serial")
 public class NameCardVO extends NameCard implements Serializable {
 
     /** 최초 등록자명 */
     private String frstRegisterNm = "";
-    
+
     /** 최종 수정자명 */
     private String lastUpdusrNm = "";
-    
+
     /** 템플릿 구분 코드명 */
     private String tmplatSeCodeNm = "";
 
     /** 검색시작일 */
     private String searchBgnDe = "";
-    
+
     /** 검색조건 */
     private String searchCnd = "";
-    
+
     /** 검색종료일 */
     private String searchEndDe = "";
-    
+
     /** 검색단어 */
     private String searchWrd = "";
-    
+
     /** 정렬순서(DESC,ASC) */
     private String sortOrdr = "";
 
@@ -73,329 +78,6 @@ public class NameCardVO extends NameCard implements Serializable {
 
     /** 사용자 아이디 */
     private String emplyrId = "";
-
-    /**
-     * frstRegisterNm attribute를 리턴한다.
-     * 
-     * @return the frstRegisterNm
-     */
-    public String getFrstRegisterNm() {
-	return frstRegisterNm;
-    }
-
-    /**
-     * frstRegisterNm attribute 값을 설정한다.
-     * 
-     * @param frstRegisterNm
-     *            the frstRegisterNm to set
-     */
-    public void setFrstRegisterNm(String frstRegisterNm) {
-	this.frstRegisterNm = frstRegisterNm;
-    }
-
-    /**
-     * lastUpdusrNm attribute를 리턴한다.
-     * 
-     * @return the lastUpdusrNm
-     */
-    public String getLastUpdusrNm() {
-	return lastUpdusrNm;
-    }
-
-    /**
-     * lastUpdusrNm attribute 값을 설정한다.
-     * 
-     * @param lastUpdusrNm
-     *            the lastUpdusrNm to set
-     */
-    public void setLastUpdusrNm(String lastUpdusrNm) {
-	this.lastUpdusrNm = lastUpdusrNm;
-    }
-
-    /**
-     * tmplatSeCodeNm attribute를 리턴한다.
-     * 
-     * @return the tmplatSeCodeNm
-     */
-    public String getTmplatSeCodeNm() {
-	return tmplatSeCodeNm;
-    }
-
-    /**
-     * tmplatSeCodeNm attribute 값을 설정한다.
-     * 
-     * @param tmplatSeCodeNm
-     *            the tmplatSeCodeNm to set
-     */
-    public void setTmplatSeCodeNm(String tmplatSeCodeNm) {
-	this.tmplatSeCodeNm = tmplatSeCodeNm;
-    }
-
-    /**
-     * searchBgnDe attribute를 리턴한다.
-     * 
-     * @return the searchBgnDe
-     */
-    public String getSearchBgnDe() {
-	return searchBgnDe;
-    }
-
-    /**
-     * searchBgnDe attribute 값을 설정한다.
-     * 
-     * @param searchBgnDe
-     *            the searchBgnDe to set
-     */
-    public void setSearchBgnDe(String searchBgnDe) {
-	this.searchBgnDe = searchBgnDe;
-    }
-
-    /**
-     * searchCnd attribute를 리턴한다.
-     * 
-     * @return the searchCnd
-     */
-    public String getSearchCnd() {
-	return searchCnd;
-    }
-
-    /**
-     * searchCnd attribute 값을 설정한다.
-     * 
-     * @param searchCnd
-     *            the searchCnd to set
-     */
-    public void setSearchCnd(String searchCnd) {
-	this.searchCnd = searchCnd;
-    }
-
-    /**
-     * searchEndDe attribute를 리턴한다.
-     * 
-     * @return the searchEndDe
-     */
-    public String getSearchEndDe() {
-	return searchEndDe;
-    }
-
-    /**
-     * searchEndDe attribute 값을 설정한다.
-     * 
-     * @param searchEndDe
-     *            the searchEndDe to set
-     */
-    public void setSearchEndDe(String searchEndDe) {
-	this.searchEndDe = searchEndDe;
-    }
-
-    /**
-     * searchWrd attribute를 리턴한다.
-     * 
-     * @return the searchWrd
-     */
-    public String getSearchWrd() {
-	return searchWrd;
-    }
-
-    /**
-     * searchWrd attribute 값을 설정한다.
-     * 
-     * @param searchWrd
-     *            the searchWrd to set
-     */
-    public void setSearchWrd(String searchWrd) {
-	this.searchWrd = searchWrd;
-    }
-
-    /**
-     * sortOrdr attribute를 리턴한다.
-     * 
-     * @return the sortOrdr
-     */
-    public String getSortOrdr() {
-	return sortOrdr;
-    }
-
-    /**
-     * sortOrdr attribute 값을 설정한다.
-     * 
-     * @param sortOrdr
-     *            the sortOrdr to set
-     */
-    public void setSortOrdr(String sortOrdr) {
-	this.sortOrdr = sortOrdr;
-    }
-
-    /**
-     * searchUseYn attribute를 리턴한다.
-     * 
-     * @return the searchUseYn
-     */
-    public String getSearchUseYn() {
-	return searchUseYn;
-    }
-
-    /**
-     * searchUseYn attribute 값을 설정한다.
-     * 
-     * @param searchUseYn
-     *            the searchUseYn to set
-     */
-    public void setSearchUseYn(String searchUseYn) {
-	this.searchUseYn = searchUseYn;
-    }
-
-    /**
-     * pageIndex attribute를 리턴한다.
-     * 
-     * @return the pageIndex
-     */
-    public int getPageIndex() {
-	return pageIndex;
-    }
-
-    /**
-     * pageIndex attribute 값을 설정한다.
-     * 
-     * @param pageIndex
-     *            the pageIndex to set
-     */
-    public void setPageIndex(int pageIndex) {
-	this.pageIndex = pageIndex;
-    }
-
-    /**
-     * pageUnit attribute를 리턴한다.
-     * 
-     * @return the pageUnit
-     */
-    public int getPageUnit() {
-	return pageUnit;
-    }
-
-    /**
-     * pageUnit attribute 값을 설정한다.
-     * 
-     * @param pageUnit
-     *            the pageUnit to set
-     */
-    public void setPageUnit(int pageUnit) {
-	this.pageUnit = pageUnit;
-    }
-
-    /**
-     * pageSize attribute를 리턴한다.
-     * 
-     * @return the pageSize
-     */
-    public int getPageSize() {
-	return pageSize;
-    }
-
-    /**
-     * pageSize attribute 값을 설정한다.
-     * 
-     * @param pageSize
-     *            the pageSize to set
-     */
-    public void setPageSize(int pageSize) {
-	this.pageSize = pageSize;
-    }
-
-    /**
-     * firstIndex attribute를 리턴한다.
-     * 
-     * @return the firstIndex
-     */
-    public int getFirstIndex() {
-	return firstIndex;
-    }
-
-    /**
-     * firstIndex attribute 값을 설정한다.
-     * 
-     * @param firstIndex
-     *            the firstIndex to set
-     */
-    public void setFirstIndex(int firstIndex) {
-	this.firstIndex = firstIndex;
-    }
-
-    /**
-     * lastIndex attribute를 리턴한다.
-     * 
-     * @return the lastIndex
-     */
-    public int getLastIndex() {
-	return lastIndex;
-    }
-
-    /**
-     * lastIndex attribute 값을 설정한다.
-     * 
-     * @param lastIndex
-     *            the lastIndex to set
-     */
-    public void setLastIndex(int lastIndex) {
-	this.lastIndex = lastIndex;
-    }
-
-    /**
-     * recordCountPerPage attribute를 리턴한다.
-     * 
-     * @return the recordCountPerPage
-     */
-    public int getRecordCountPerPage() {
-	return recordCountPerPage;
-    }
-
-    /**
-     * recordCountPerPage attribute 값을 설정한다.
-     * 
-     * @param recordCountPerPage
-     *            the recordCountPerPage to set
-     */
-    public void setRecordCountPerPage(int recordCountPerPage) {
-	this.recordCountPerPage = recordCountPerPage;
-    }
-
-    /**
-     * rowNo attribute를 리턴한다.
-     * 
-     * @return the rowNo
-     */
-    public int getRowNo() {
-	return rowNo;
-    }
-
-    /**
-     * rowNo attribute 값을 설정한다.
-     * 
-     * @param rowNo
-     *            the rowNo to set
-     */
-    public void setRowNo(int rowNo) {
-	this.rowNo = rowNo;
-    }
-
-    /**
-     * emplyrId attribute를 리턴한다.
-     * 
-     * @return the emplyrId
-     */
-    public String getEmplyrId() {
-	return emplyrId;
-    }
-
-    /**
-     * emplyrId attribute 값을 설정한다.
-     * 
-     * @param emplyrId
-     *            the emplyrId to set
-     */
-    public void setEmplyrId(String emplyrId) {
-	this.emplyrId = emplyrId;
-    }
 
     /**
      * toString 메소드를 대치한다.

--- a/src/main/java/egovframework/com/cop/scp/service/ScrapVO.java
+++ b/src/main/java/egovframework/com/cop/scp/service/ScrapVO.java
@@ -2,6 +2,9 @@ package egovframework.com.cop.scp.service;
 
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * 스크랩 서비스를 위한 VO 클래스
  * @author 공통컴포넌트개발팀 한성곤
@@ -11,21 +14,23 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.07.10  한성곤          최초 생성
  *
  * </pre>
  */
+@Getter
+@Setter
 @SuppressWarnings("serial")
 public class ScrapVO extends Scrap {
     /** 검색조건 */
     private String searchCnd = "";
-    
+
     /** 검색단어 */
     private String searchWrd = "";
-    
+
     /** 정렬순서(DESC,ASC) */
     private long sortOrdr = 0L;
 
@@ -59,214 +64,6 @@ public class ScrapVO extends Scrap {
     /** 최종 수정자명 */
     private String lastUpdusrNm = "";
 
-    /**
-     * searchCnd attribute를 리턴한다.
-     * @return the searchCnd
-     */
-    public String getSearchCnd() {
-        return searchCnd;
-    }
-
-    /**
-     * searchCnd attribute 값을 설정한다.
-     * @param searchCnd the searchCnd to set
-     */
-    public void setSearchCnd(String searchCnd) {
-        this.searchCnd = searchCnd;
-    }
-
-    /**
-     * searchWrd attribute를 리턴한다.
-     * @return the searchWrd
-     */
-    public String getSearchWrd() {
-        return searchWrd;
-    }
-
-    /**
-     * searchWrd attribute 값을 설정한다.
-     * @param searchWrd the searchWrd to set
-     */
-    public void setSearchWrd(String searchWrd) {
-        this.searchWrd = searchWrd;
-    }
-
-    /**
-     * sortOrdr attribute를 리턴한다.
-     * @return the sortOrdr
-     */
-    public long getSortOrdr() {
-        return sortOrdr;
-    }
-
-    /**
-     * sortOrdr attribute 값을 설정한다.
-     * @param sortOrdr the sortOrdr to set
-     */
-    public void setSortOrdr(long sortOrdr) {
-        this.sortOrdr = sortOrdr;
-    }
-
-    /**
-     * searchUseYn attribute를 리턴한다.
-     * @return the searchUseYn
-     */
-    public String getSearchUseYn() {
-        return searchUseYn;
-    }
-
-    /**
-     * searchUseYn attribute 값을 설정한다.
-     * @param searchUseYn the searchUseYn to set
-     */
-    public void setSearchUseYn(String searchUseYn) {
-        this.searchUseYn = searchUseYn;
-    }
-
-    /**
-     * pageIndex attribute를 리턴한다.
-     * @return the pageIndex
-     */
-    public int getPageIndex() {
-        return pageIndex;
-    }
-
-    /**
-     * pageIndex attribute 값을 설정한다.
-     * @param pageIndex the pageIndex to set
-     */
-    public void setPageIndex(int pageIndex) {
-        this.pageIndex = pageIndex;
-    }
-
-    /**
-     * pageUnit attribute를 리턴한다.
-     * @return the pageUnit
-     */
-    public int getPageUnit() {
-        return pageUnit;
-    }
-
-    /**
-     * pageUnit attribute 값을 설정한다.
-     * @param pageUnit the pageUnit to set
-     */
-    public void setPageUnit(int pageUnit) {
-        this.pageUnit = pageUnit;
-    }
-
-    /**
-     * pageSize attribute를 리턴한다.
-     * @return the pageSize
-     */
-    public int getPageSize() {
-        return pageSize;
-    }
-
-    /**
-     * pageSize attribute 값을 설정한다.
-     * @param pageSize the pageSize to set
-     */
-    public void setPageSize(int pageSize) {
-        this.pageSize = pageSize;
-    }
-
-    /**
-     * firstIndex attribute를 리턴한다.
-     * @return the firstIndex
-     */
-    public int getFirstIndex() {
-        return firstIndex;
-    }
-
-    /**
-     * firstIndex attribute 값을 설정한다.
-     * @param firstIndex the firstIndex to set
-     */
-    public void setFirstIndex(int firstIndex) {
-        this.firstIndex = firstIndex;
-    }
-
-    /**
-     * lastIndex attribute를 리턴한다.
-     * @return the lastIndex
-     */
-    public int getLastIndex() {
-        return lastIndex;
-    }
-
-    /**
-     * lastIndex attribute 값을 설정한다.
-     * @param lastIndex the lastIndex to set
-     */
-    public void setLastIndex(int lastIndex) {
-        this.lastIndex = lastIndex;
-    }
-
-    /**
-     * recordCountPerPage attribute를 리턴한다.
-     * @return the recordCountPerPage
-     */
-    public int getRecordCountPerPage() {
-        return recordCountPerPage;
-    }
-
-    /**
-     * recordCountPerPage attribute 값을 설정한다.
-     * @param recordCountPerPage the recordCountPerPage to set
-     */
-    public void setRecordCountPerPage(int recordCountPerPage) {
-        this.recordCountPerPage = recordCountPerPage;
-    }
-
-    /**
-     * rowNo attribute를 리턴한다.
-     * @return the rowNo
-     */
-    public int getRowNo() {
-        return rowNo;
-    }
-
-    /**
-     * rowNo attribute 값을 설정한다.
-     * @param rowNo the rowNo to set
-     */
-    public void setRowNo(int rowNo) {
-        this.rowNo = rowNo;
-    }
-
-    /**
-     * frstRegisterNm attribute를 리턴한다.
-     * @return the frstRegisterNm
-     */
-    public String getFrstRegisterNm() {
-        return frstRegisterNm;
-    }
-
-    /**
-     * frstRegisterNm attribute 값을 설정한다.
-     * @param frstRegisterNm the frstRegisterNm to set
-     */
-    public void setFrstRegisterNm(String frstRegisterNm) {
-        this.frstRegisterNm = frstRegisterNm;
-    }
-
-    /**
-     * lastUpdusrNm attribute를 리턴한다.
-     * @return the lastUpdusrNm
-     */
-    public String getLastUpdusrNm() {
-        return lastUpdusrNm;
-    }
-
-    /**
-     * lastUpdusrNm attribute 값을 설정한다.
-     * @param lastUpdusrNm the lastUpdusrNm to set
-     */
-    public void setLastUpdusrNm(String lastUpdusrNm) {
-        this.lastUpdusrNm = lastUpdusrNm;
-    }
-    
     /**
      * toString 메소드를 대치한다.
      */

--- a/src/main/java/egovframework/com/cop/sms/service/SmsVO.java
+++ b/src/main/java/egovframework/com/cop/sms/service/SmsVO.java
@@ -2,6 +2,9 @@ package egovframework.com.cop.sms.service;
 
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * 문자메시지 서비스를 위한 VO 클래스
  * @author 공통컴포넌트개발팀 한성곤
@@ -11,24 +14,26 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.06.18  한성곤          최초 생성
  *
  * </pre>
  */
+@Getter
+@Setter
 @SuppressWarnings("serial")
 public class SmsVO extends Sms {
     /** 검색조건 */
     private String searchCnd = "";
-    
+
     /** 검색단어 */
     private String searchWrd = "";
-    
+
     /** 정렬순서(DESC,ASC) */
     private String sortOrdr = "";
-    
+
     /** 현재페이지 */
     private int pageIndex = 1;
 
@@ -50,166 +55,6 @@ public class SmsVO extends Sms {
     /** rowNo */
     private int rowNo = 0;
 
-    /**
-     * searchCnd attribute를 리턴한다.
-     * @return the searchCnd
-     */
-    public String getSearchCnd() {
-        return searchCnd;
-    }
-
-    /**
-     * searchCnd attribute 값을 설정한다.
-     * @param searchCnd the searchCnd to set
-     */
-    public void setSearchCnd(String searchCnd) {
-        this.searchCnd = searchCnd;
-    }
-
-    /**
-     * searchWrd attribute를 리턴한다.
-     * @return the searchWrd
-     */
-    public String getSearchWrd() {
-        return searchWrd;
-    }
-
-    /**
-     * searchWrd attribute 값을 설정한다.
-     * @param searchWrd the searchWrd to set
-     */
-    public void setSearchWrd(String searchWrd) {
-        this.searchWrd = searchWrd;
-    }
-
-    /**
-     * sortOrdr attribute를 리턴한다.
-     * @return the sortOrdr
-     */
-    public String getSortOrdr() {
-        return sortOrdr;
-    }
-
-    /**
-     * sortOrdr attribute 값을 설정한다.
-     * @param sortOrdr the sortOrdr to set
-     */
-    public void setSortOrdr(String sortOrdr) {
-        this.sortOrdr = sortOrdr;
-    }
-
-    /**
-     * pageIndex attribute를 리턴한다.
-     * @return the pageIndex
-     */
-    public int getPageIndex() {
-        return pageIndex;
-    }
-
-    /**
-     * pageIndex attribute 값을 설정한다.
-     * @param pageIndex the pageIndex to set
-     */
-    public void setPageIndex(int pageIndex) {
-        this.pageIndex = pageIndex;
-    }
-
-    /**
-     * pageUnit attribute를 리턴한다.
-     * @return the pageUnit
-     */
-    public int getPageUnit() {
-        return pageUnit;
-    }
-
-    /**
-     * pageUnit attribute 값을 설정한다.
-     * @param pageUnit the pageUnit to set
-     */
-    public void setPageUnit(int pageUnit) {
-        this.pageUnit = pageUnit;
-    }
-
-    /**
-     * pageSize attribute를 리턴한다.
-     * @return the pageSize
-     */
-    public int getPageSize() {
-        return pageSize;
-    }
-
-    /**
-     * pageSize attribute 값을 설정한다.
-     * @param pageSize the pageSize to set
-     */
-    public void setPageSize(int pageSize) {
-        this.pageSize = pageSize;
-    }
-
-    /**
-     * firstIndex attribute를 리턴한다.
-     * @return the firstIndex
-     */
-    public int getFirstIndex() {
-        return firstIndex;
-    }
-
-    /**
-     * firstIndex attribute 값을 설정한다.
-     * @param firstIndex the firstIndex to set
-     */
-    public void setFirstIndex(int firstIndex) {
-        this.firstIndex = firstIndex;
-    }
-
-    /**
-     * lastIndex attribute를 리턴한다.
-     * @return the lastIndex
-     */
-    public int getLastIndex() {
-        return lastIndex;
-    }
-
-    /**
-     * lastIndex attribute 값을 설정한다.
-     * @param lastIndex the lastIndex to set
-     */
-    public void setLastIndex(int lastIndex) {
-        this.lastIndex = lastIndex;
-    }
-
-    /**
-     * recordCountPerPage attribute를 리턴한다.
-     * @return the recordCountPerPage
-     */
-    public int getRecordCountPerPage() {
-        return recordCountPerPage;
-    }
-
-    /**
-     * recordCountPerPage attribute 값을 설정한다.
-     * @param recordCountPerPage the recordCountPerPage to set
-     */
-    public void setRecordCountPerPage(int recordCountPerPage) {
-        this.recordCountPerPage = recordCountPerPage;
-    }
-
-    /**
-     * rowNo attribute를 리턴한다.
-     * @return the rowNo
-     */
-    public int getRowNo() {
-        return rowNo;
-    }
-
-    /**
-     * rowNo attribute 값을 설정한다.
-     * @param rowNo the rowNo to set
-     */
-    public void setRowNo(int rowNo) {
-        this.rowNo = rowNo;
-    }
-    
     /**
      * toString 메소드를 대치한다.
      */


### PR DESCRIPTION
## 변경 개요

`egovframework.com.cop` 하위 5개 VO 클래스의 단순 getter/setter를 Lombok `@Getter`/`@Setter` 어노테이션으로 교체합니다.
비즈니스 로직이 없는 순수 필드 접근자만 제거 대상으로 선정했으며, 기존 `toString()` 오버라이드는 그대로 유지합니다.

## 변경 파일 및 제거된 접근자 수

| 파일 | 제거된 메서드 수 |
|------|----------------|
| `cop/bbs/service/BlogVO.java` | 34개 (getter 17 + setter 17) |
| `cop/cmt/service/CommentVO.java` | 18개 (getter 9 + setter 9) |
| `cop/ncm/service/NameCardVO.java` | 26개 (getter 13 + setter 13) |
| `cop/scp/service/ScrapVO.java` | 24개 (getter 12 + setter 12) |
| `cop/sms/service/SmsVO.java` | 22개 (getter 11 + setter 11) |

합계: **124개** 접근자 메서드 제거

## pom.xml 변경

`maven-compiler-plugin`에 `annotationProcessorPaths`를 추가해 Lombok 어노테이션 프로세서가 Maven 빌드 시 정상 동작하도록 설정합니다.
(`provided` 스코프만으로는 annotation processor가 classpath에 포함되지 않아 컴파일 오류가 발생함)

## 검증

- `mvn -B -ntp -DskipTests compile` — BUILD SUCCESS, 오류 0건 확인

## 체크리스트

- [x] 단일 주제만 다룸 (다른 변경 없음)
- [x] 5.x 다른 브랜치용 PR이 필요한 경우 후속 PR 링크 명시 (해당 없음 — 현재 5.0.x만 존재)
- [x] 기존 동작에 영향 없음 (getter/setter 시그니처 동일, Lombok이 동일 메서드 생성)
- [x] 테스트 통과 확인 (컴파일 성공)