### PR TITLE
[refactor] sec 패키지 핵심 VO에 Lombok @Getter/@Setter 적용

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -597,6 +597,13 @@
 					<artifactId>maven-compiler-plugin</artifactId>
 					<configuration>
 						<release>${java.version}</release>
+						<annotationProcessorPaths>
+							<path>
+								<groupId>org.projectlombok</groupId>
+								<artifactId>lombok</artifactId>
+								<version>${lombok.version}</version>
+							</path>
+						</annotationProcessorPaths>
 					</configuration>
 				</plugin>
 				<plugin>

--- a/src/main/java/egovframework/com/sec/drm/service/DeptAuthorVO.java
+++ b/src/main/java/egovframework/com/sec/drm/service/DeptAuthorVO.java
@@ -2,7 +2,6 @@ package egovframework.com.sec.drm.service;
 
 import java.util.List;
 
-
 import lombok.Getter;
 import lombok.Setter;
 
@@ -15,7 +14,7 @@ import lombok.Setter;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.03.20  이문준          최초 생성
@@ -32,11 +31,11 @@ public class DeptAuthorVO extends DeptAuthor {
 	/**
 	 * 부서권한목록
 	 */
-	List <DeptAuthorVO> deptAuthorList;
+	List<DeptAuthorVO> deptAuthorList;
 	/**
 	 * 부서목록
 	 */
-	List <DeptAuthorVO> deptList;	
+	List<DeptAuthorVO> deptList;
 	/**
 	 * 부서코드
 	 */
@@ -45,7 +44,5 @@ public class DeptAuthorVO extends DeptAuthor {
 	 * 부서 명
 	 */
 	private String deptNm;
-	
 
-	
 }

--- a/src/main/java/egovframework/com/sec/drm/service/DeptAuthorVO.java
+++ b/src/main/java/egovframework/com/sec/drm/service/DeptAuthorVO.java
@@ -3,6 +3,9 @@ package egovframework.com.sec.drm.service;
 import java.util.List;
 
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * 부서권한에 대한 Vo 클래스를 정의한다.
  * @author 공통서비스 개발팀 이문준
@@ -19,7 +22,8 @@ import java.util.List;
  *
  * </pre>
  */
-
+@Getter
+@Setter
 public class DeptAuthorVO extends DeptAuthor {
 	/**
 	 * serialVersionUID
@@ -42,61 +46,6 @@ public class DeptAuthorVO extends DeptAuthor {
 	 */
 	private String deptNm;
 	
-	/**
-	 * deptAuthorList attribute 를 리턴한다.
-	 * @return List<DeptAuthorVO>
-	 */
-	public List<DeptAuthorVO> getDeptAuthorList() {
-		return deptAuthorList;
-	}
-	/**
-	 * deptAuthorList attribute 값을 설정한다.
-	 * @param deptAuthorList List<DeptAuthorVO> 
-	 */
-	public void setDeptAuthorList(List<DeptAuthorVO> deptAuthorList) {
-		this.deptAuthorList = deptAuthorList;
-	}
-	/**
-	 * deptList attribute 를 리턴한다.
-	 * @return List<DeptAuthorVO>
-	 */
-	public List<DeptAuthorVO> getDeptList() {
-		return deptList;
-	}
-	/**
-	 * deptList attribute 값을 설정한다.
-	 * @param deptList List<DeptAuthorVO> 
-	 */
-	public void setDeptList(List<DeptAuthorVO> deptList) {
-		this.deptList = deptList;
-	}
-	/**
-	 * deptCode attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getDeptCode() {
-		return deptCode;
-	}
-	/**
-	 * deptCode attribute 값을 설정한다.
-	 * @param deptCode String 
-	 */
-	public void setDeptCode(String deptCode) {
-		this.deptCode = deptCode;
-	}
-	/**
-	 * deptNm attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getDeptNm() {
-		return deptNm;
-	}
-	/**
-	 * deptNm attribute 값을 설정한다.
-	 * @param deptNm String 
-	 */
-	public void setDeptNm(String deptNm) {
-		this.deptNm = deptNm;
-	}
+
 	
 }

--- a/src/main/java/egovframework/com/sec/gmt/service/GroupManageVO.java
+++ b/src/main/java/egovframework/com/sec/gmt/service/GroupManageVO.java
@@ -23,6 +23,8 @@ import lombok.Setter;
  *
  *      </pre>
  */
+@Getter
+@Setter
 public class GroupManageVO extends GroupManage {
 
 	/**
@@ -36,26 +38,8 @@ public class GroupManageVO extends GroupManage {
 	/**
 	 * 삭제대상 목록
 	 */
-	@Getter
-	@Setter
 	String[] delYn;
 
-	/**
-	 * groupManageList attribute 를 리턴한다.
-	 * 
-	 * @return List<GroupManageVO>
-	 */
-	public List<GroupManageVO> getGroupManageList() {
-		return groupManageList;
-	}
 
-	/**
-	 * groupManageList attribute 값을 설정한다.
-	 * 
-	 * @param groupManageList List<GroupManageVO>
-	 */
-	public void setGroupManageList(List<GroupManageVO> groupManageList) {
-		this.groupManageList = groupManageList;
-	}
 
 }

--- a/src/main/java/egovframework/com/sec/ram/service/AuthorManageVO.java
+++ b/src/main/java/egovframework/com/sec/ram/service/AuthorManageVO.java
@@ -14,7 +14,7 @@ import lombok.Setter;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.03.20  이문준          최초 생성
@@ -27,11 +27,6 @@ public class AuthorManageVO extends AuthorManage {
 
 	private static final long serialVersionUID = 1L;
 
-	List <AuthorManageVO> authorManageList;
-
-
-
-
-
+	List<AuthorManageVO> authorManageList;
 
 }

--- a/src/main/java/egovframework/com/sec/ram/service/AuthorManageVO.java
+++ b/src/main/java/egovframework/com/sec/ram/service/AuthorManageVO.java
@@ -2,6 +2,9 @@ package egovframework.com.sec.ram.service;
 
 import java.util.List;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * 권한관리에 대한 Vo 클래스를 정의한다.
  * @author 공통서비스 개발팀 이문준
@@ -18,7 +21,8 @@ import java.util.List;
  *
  * </pre>
  */
-
+@Getter
+@Setter
 public class AuthorManageVO extends AuthorManage {
 
 	private static final long serialVersionUID = 1L;
@@ -26,21 +30,7 @@ public class AuthorManageVO extends AuthorManage {
 	List <AuthorManageVO> authorManageList;
 
 
-	/**
-	 * authorManageList attribute 를 리턴한다.
-	 * @return List<AuthorManageVO>
-	 */
-	public List<AuthorManageVO> getAuthorManageList() {
-		return authorManageList;
-	}
 
-	/**
-	 * authorManageList attribute 값을 설정한다.
-	 * @param authorManageList List<AuthorManageVO> 
-	 */
-	public void setAuthorManageList(List<AuthorManageVO> authorManageList) {
-		this.authorManageList = authorManageList;
-	}
 
 
 

--- a/src/main/java/egovframework/com/sec/ram/service/AuthorRoleManageVO.java
+++ b/src/main/java/egovframework/com/sec/ram/service/AuthorRoleManageVO.java
@@ -14,7 +14,7 @@ import lombok.Setter;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.03.20  이문준          최초 생성
@@ -27,10 +27,6 @@ public class AuthorRoleManageVO extends AuthorRoleManage {
 
 	private static final long serialVersionUID = 1L;
 
-	List <AuthorRoleManageVO> authorRoleList;
-	
-
-
-
+	List<AuthorRoleManageVO> authorRoleList;
 
 }

--- a/src/main/java/egovframework/com/sec/ram/service/AuthorRoleManageVO.java
+++ b/src/main/java/egovframework/com/sec/ram/service/AuthorRoleManageVO.java
@@ -2,6 +2,9 @@ package egovframework.com.sec.ram.service;
 
 import java.util.List;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * 권한별 롤 관리에 대한 Vo 클래스를 정의한다.
  * @author 공통서비스 개발팀 이문준
@@ -18,28 +21,15 @@ import java.util.List;
  *
  * </pre>
  */
-
+@Getter
+@Setter
 public class AuthorRoleManageVO extends AuthorRoleManage {
 
 	private static final long serialVersionUID = 1L;
 
 	List <AuthorRoleManageVO> authorRoleList;
 	
-	/**
-	 * authorRoleList attribute 를 리턴한다.
-	 * @return List<AuthorRoleManageVO>
-	 */
-	public List<AuthorRoleManageVO> getAuthorRoleList() {
-		return authorRoleList;
-	}
 
-	/**
-	 * authorRoleList attribute 값을 설정한다.
-	 * @param authorRoleList List<AuthorRoleManageVO> 
-	 */
-	public void setAuthorRoleList(List<AuthorRoleManageVO> authorRoleList) {
-		this.authorRoleList = authorRoleList;
-	}
 
 
 

--- a/src/main/java/egovframework/com/sec/rgm/service/AuthorGroupVO.java
+++ b/src/main/java/egovframework/com/sec/rgm/service/AuthorGroupVO.java
@@ -2,6 +2,9 @@ package egovframework.com.sec.rgm.service;
 
 import java.util.List;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * 권한그룹에 대한 Vo 클래스를 정의한다.
  * @author 공통서비스 개발팀 이문준
@@ -18,27 +21,15 @@ import java.util.List;
  *
  * </pre>
  */
-
+@Getter
+@Setter
 public class AuthorGroupVO extends AuthorGroup {
 
 	private static final long serialVersionUID = 1L;
 
 	List <AuthorGroupVO> authorGroupList;
 
-	/**
-	 * authorGroupList attribute 를 리턴한다.
-	 * @return List<AuthorGroupVO>
-	 */
-	public List<AuthorGroupVO> getAuthorGroupList() {
-		return authorGroupList;
-	}
-	/**
-	 * authorGroupList attribute 값을 설정한다.
-	 * @param authorGroupList List<AuthorGroupVO> 
-	 */
-	public void setAuthorGroupList(List<AuthorGroupVO> authorGroupList) {
-		this.authorGroupList = authorGroupList;
-	}
+
 	
 
 }

--- a/src/main/java/egovframework/com/sec/rgm/service/AuthorGroupVO.java
+++ b/src/main/java/egovframework/com/sec/rgm/service/AuthorGroupVO.java
@@ -14,7 +14,7 @@ import lombok.Setter;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.03.20  이문준          최초 생성
@@ -27,9 +27,6 @@ public class AuthorGroupVO extends AuthorGroup {
 
 	private static final long serialVersionUID = 1L;
 
-	List <AuthorGroupVO> authorGroupList;
-
-
-	
+	List<AuthorGroupVO> authorGroupList;
 
 }


### PR DESCRIPTION
## 목적
- egovframework.com.sec 패키지 핵심 VO에 대해 Lombok의 @Getter 및 @Setter 적용
- 불필요한 Getter/Setter 메소드를 제거하여 코드 가독성 향상

## 주요 변경사항
- `DeptAuthorVO`, `AuthorGroupVO`, `GroupManageVO`, `AuthorRoleManageVO`, `AuthorManageVO` 클래스에 `@Getter`, `@Setter` 애노테이션 적용
- 위 클래스들의 기존 getter/setter 메소드 삭제
- `pom.xml`의 `maven-compiler-plugin` 설정에 lombok `annotationProcessorPaths` 추가 (이전 PR 패턴 참고)

## 검증
- `mvn -B -ntp -DskipTests compile` 정상 빌드 확인