### PR TITLE
[refactor] uss 패키지 핵심 VO에 Lombok @Getter/@Setter 적용

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -597,6 +597,13 @@
 					<artifactId>maven-compiler-plugin</artifactId>
 					<configuration>
 						<release>${java.version}</release>
+						<annotationProcessorPaths>
+							<path>
+								<groupId>org.projectlombok</groupId>
+								<artifactId>lombok</artifactId>
+								<version>${lombok.version}</version>
+							</path>
+						</annotationProcessorPaths>
 					</configuration>
 				</plugin>
 				<plugin>

--- a/src/main/java/egovframework/com/uss/ion/nws/service/NewsVO.java
+++ b/src/main/java/egovframework/com/uss/ion/nws/service/NewsVO.java
@@ -4,9 +4,11 @@ import org.egovframe.rte.ptl.reactive.validation.EgovNullCheck;
 
 import egovframework.com.cmm.ComDefaultVO;
 import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
 
 /**
- *  
+ *
  * 뉴스정보를 처리하는 VO 클래스
  * @author 공통서비스 개발팀 박정규
  * @since 2009.04.01
@@ -15,39 +17,42 @@ import jakarta.validation.constraints.Size;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.04.01  박정규          최초 생성
+ *   2025.05.20  기여자          Lombok @Getter/@Setter 적용으로 보일러플레이트 제거
  *
  * </pre>
  */
+@Getter
+@Setter
 public class NewsVO extends ComDefaultVO {
-	
+
     private static final long serialVersionUID = 1L;
-    
+
     /** 뉴스 ID */
     private String newsId;
-    
+
     /** 뉴스제목 */
     @EgovNullCheck
     @Size(max=100)
     private String newsSj;
-    
+
     /** 뉴스내용 */
     @EgovNullCheck
     @Size(max=1000)
     private String newsCn;
-    
+
     /** 뉴스출처 */
     private String newsOrigin;
-    
+
     /** 게시일자 */
     private String ntceDe;
 
-    /** 첨부파일ID */ 
+    /** 첨부파일ID */
     private String atchFileId;
-    
+
     /** 최초등록시점 */
     private String frstRegisterPnttm;
 
@@ -60,165 +65,4 @@ public class NewsVO extends ComDefaultVO {
     /** 최종수정자ID */
     private String lastUpdusrId;
 
-	/**
-	 * newsId attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getNewsId() {
-		return newsId;
-	}
-
-	/**
-	 * newsId attribute 값을 설정한다.
-	 * @return newsId String
-	 */
-	public void setNewsId(String newsId) {
-		this.newsId = newsId;
-	}
-
-	/**
-	 * newsSj attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getNewsSj() {
-		return newsSj;
-	}
-
-	/**
-	 * newsSj attribute 값을 설정한다.
-	 * @return newsSj String
-	 */
-	public void setNewsSj(String newsSj) {
-		this.newsSj = newsSj;
-	}
-
-	/**
-	 * newsCn attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getNewsCn() {
-		return newsCn;
-	}
-
-	/**
-	 * newsCn attribute 값을 설정한다.
-	 * @return newsCn String
-	 */
-	public void setNewsCn(String newsCn) {
-		this.newsCn = newsCn;
-	}
-
-	/**
-	 * newsOrigin attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getNewsOrigin() {
-		return newsOrigin;
-	}
-
-	/**
-	 * newsOrigin attribute 값을 설정한다.
-	 * @return newsOrigin String
-	 */
-	public void setNewsOrigin(String newsOrigin) {
-		this.newsOrigin = newsOrigin;
-	}
-
-	/**
-	 * ntceDe attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getNtceDe() {
-		return ntceDe;
-	}
-
-	/**
-	 * ntceDe attribute 값을 설정한다.
-	 * @return ntceDe String
-	 */
-	public void setNtceDe(String ntceDe) {
-		this.ntceDe = ntceDe;
-	}
-
-	/**
-	 * atchFileId attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getAtchFileId() {
-		return atchFileId;
-	}
-
-	/**
-	 * atchFileId attribute 값을 설정한다.
-	 * @return atchFileId String
-	 */
-	public void setAtchFileId(String atchFileId) {
-		this.atchFileId = atchFileId;
-	}
-
-	/**
-	 * frstRegisterPnttm attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getFrstRegisterPnttm() {
-		return frstRegisterPnttm;
-	}
-
-	/**
-	 * frstRegisterPnttm attribute 값을 설정한다.
-	 * @return frstRegisterPnttm String
-	 */
-	public void setFrstRegisterPnttm(String frstRegisterPnttm) {
-		this.frstRegisterPnttm = frstRegisterPnttm;
-	}
-
-	/**
-	 * frstRegisterId attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getFrstRegisterId() {
-		return frstRegisterId;
-	}
-
-	/**
-	 * frstRegisterId attribute 값을 설정한다.
-	 * @return frstRegisterId String
-	 */
-	public void setFrstRegisterId(String frstRegisterId) {
-		this.frstRegisterId = frstRegisterId;
-	}
-
-	/**
-	 * lastUpdusrPnttm attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getLastUpdusrPnttm() {
-		return lastUpdusrPnttm;
-	}
-
-	/**
-	 * lastUpdusrPnttm attribute 값을 설정한다.
-	 * @return lastUpdusrPnttm String
-	 */
-	public void setLastUpdusrPnttm(String lastUpdusrPnttm) {
-		this.lastUpdusrPnttm = lastUpdusrPnttm;
-	}
-
-	/**
-	 * lastUpdusrId attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getLastUpdusrId() {
-		return lastUpdusrId;
-	}
-
-	/**
-	 * lastUpdusrId attribute 값을 설정한다.
-	 * @return lastUpdusrId String
-	 */
-	public void setLastUpdusrId(String lastUpdusrId) {
-		this.lastUpdusrId = lastUpdusrId;
-	}
-
-    
 }

--- a/src/main/java/egovframework/com/uss/ion/pwm/service/PopupManageVO.java
+++ b/src/main/java/egovframework/com/uss/ion/pwm/service/PopupManageVO.java
@@ -4,6 +4,8 @@ import egovframework.com.cmm.ComDefaultVO;
 import org.egovframe.rte.ptl.reactive.validation.EgovNullCheck;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * 개요
@@ -16,7 +18,19 @@ import jakarta.validation.constraints.Size;
  * @author 이창원
  * @version 1.0
  * @created 05-8-2009 오후 2:21:04
+ *
+ * <pre>
+ * == 개정이력(Modification Information) ==
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2009.08.05  이창원          최초 생성
+ *   2025.05.20  기여자          Lombok @Getter/@Setter 적용으로 보일러플레이트 제거
+ *
+ * </pre>
  */
+@Getter
+@Setter
 public class PopupManageVO extends ComDefaultVO {
 
 	private static final long serialVersionUID = -4822974866080666897L;
@@ -115,158 +129,4 @@ public class PopupManageVO extends ComDefaultVO {
 	/** 최종수정자 아이디 */
 	private String lastUpdusrId;
 
-	public PopupManageVO() {
-	}
-
-	public String getPopupId() {
-		return popupId;
-	}
-
-	public void setPopupId(String popupId) {
-		this.popupId = popupId;
-	}
-
-	public String getPopupTitleNm() {
-		return popupTitleNm;
-	}
-
-	public void setPopupTitleNm(String popupTitleNm) {
-		this.popupTitleNm = popupTitleNm;
-	}
-
-	public String getFileUrl() {
-		return fileUrl;
-	}
-
-	public void setFileUrl(String fileUrl) {
-		this.fileUrl = fileUrl;
-	}
-
-	public String getPopupWlc() {
-		return popupWlc;
-	}
-
-	public void setPopupWlc(String popupWlc) {
-		this.popupWlc = popupWlc;
-	}
-
-	public String getPopupHlc() {
-		return popupHlc;
-	}
-
-	public void setPopupHlc(String popupHlc) {
-		this.popupHlc = popupHlc;
-	}
-
-	public String getPopupHSize() {
-		return popupHSize;
-	}
-
-	public void setPopupHSize(String popupHSize) {
-		this.popupHSize = popupHSize;
-	}
-
-	public String getPopupWSize() {
-		return popupWSize;
-	}
-
-	public void setPopupWSize(String popupWSize) {
-		this.popupWSize = popupWSize;
-	}
-
-	public String getNtceBgnde() {
-		return ntceBgnde;
-	}
-
-	public void setNtceBgnde(String ntceBgnde) {
-		this.ntceBgnde = ntceBgnde;
-	}
-
-	public String getNtceEndde() {
-		return ntceEndde;
-	}
-
-	public void setNtceEndde(String ntceEndde) {
-		this.ntceEndde = ntceEndde;
-	}
-
-	public String getNtceBgndeHH() {
-		return ntceBgndeHH;
-	}
-
-	public void setNtceBgndeHH(String ntceBgndeHH) {
-		this.ntceBgndeHH = ntceBgndeHH;
-	}
-
-	public String getNtceBgndeMM() {
-		return ntceBgndeMM;
-	}
-
-	public void setNtceBgndeMM(String ntceBgndeMM) {
-		this.ntceBgndeMM = ntceBgndeMM;
-	}
-
-	public String getNtceEnddeHH() {
-		return ntceEnddeHH;
-	}
-
-	public void setNtceEnddeHH(String ntceEnddeHH) {
-		this.ntceEnddeHH = ntceEnddeHH;
-	}
-
-	public String getNtceEnddeMM() {
-		return ntceEnddeMM;
-	}
-
-	public void setNtceEnddeMM(String ntceEnddeMM) {
-		this.ntceEnddeMM = ntceEnddeMM;
-	}
-
-	public String getStopVewAt() {
-		return stopVewAt;
-	}
-
-	public void setStopVewAt(String stopVewAt) {
-		this.stopVewAt = stopVewAt;
-	}
-
-	public String getNtceAt() {
-		return ntceAt;
-	}
-
-	public void setNtceAt(String ntceAt) {
-		this.ntceAt = ntceAt;
-	}
-
-	public String getFrstRegisterPnttm() {
-		return frstRegisterPnttm;
-	}
-
-	public void setFrstRegisterPnttm(String frstRegisterPnttm) {
-		this.frstRegisterPnttm = frstRegisterPnttm;
-	}
-
-	public String getFrstRegisterId() {
-		return frstRegisterId;
-	}
-
-	public void setFrstRegisterId(String frstRegisterId) {
-		this.frstRegisterId = frstRegisterId;
-	}
-
-	public String getLastUpdusrPnttm() {
-		return lastUpdusrPnttm;
-	}
-
-	public void setLastUpdusrPnttm(String lastUpdusrPnttm) {
-		this.lastUpdusrPnttm = lastUpdusrPnttm;
-	}
-
-	public String getLastUpdusrId() {
-		return lastUpdusrId;
-	}
-
-	public void setLastUpdusrId(String lastUpdusrId) {
-		this.lastUpdusrId = lastUpdusrId;
-	}
 }

--- a/src/main/java/egovframework/com/uss/ion/sit/service/SiteVO.java
+++ b/src/main/java/egovframework/com/uss/ion/sit/service/SiteVO.java
@@ -4,9 +4,11 @@ import org.egovframe.rte.ptl.reactive.validation.EgovNullCheck;
 
 import egovframework.com.cmm.ComDefaultVO;
 import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
 
 /**
- * 
+ *
  * 사이트정보를 처리하는 VO 클래스
  * @author 공통서비스 개발팀 박정규
  * @since 2009.04.01
@@ -15,56 +17,59 @@ import jakarta.validation.constraints.Size;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.04.01  박정규          최초 생성
+ *   2025.05.20  기여자          Lombok @Getter/@Setter 적용으로 보일러플레이트 제거
  *
  * </pre>
  */
+@Getter
+@Setter
 public class SiteVO extends ComDefaultVO {
-	
+
     private static final long serialVersionUID = 1L;
-    
+
     /** 사이트 ID */
     private String siteId;
-    
+
     /** 사이트 URL */
     @EgovNullCheck
     @Size(max=100)
     private String siteUrl;
-    
+
     /** 사이트명 */
     @EgovNullCheck
     @Size(max=100)
     private String siteNm;
-    
+
     /** 사이트설명 */
     @EgovNullCheck
     @Size(max=1000)
     private String siteDc;
-    
+
     /** 사이트주제분류코드 */
     @EgovNullCheck
     private String siteThemaClCode;
 
     /** 사이트주제분류명 */
     private String siteThemaClNm;
-    
+
     /** 활성여부 */
     private String actvtyAt;
 
     /** 활성여부명 */
     private String actvtyAtNm;
-    
+
     /** 사용여부 */
     private String useAt;
-    
+
     /** 사용여부명 */
     private String useAtNm;
-    
+
     /** 등록자명 */
-    private String emplyrNm;        
+    private String emplyrNm;
 
     /** 최초등록시점 */
     private String frstRegisterPnttm;
@@ -78,247 +83,4 @@ public class SiteVO extends ComDefaultVO {
     /** 최종수정자ID */
     private String lastUpdusrId;
 
-	/**
-	 * siteId attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getSiteId() {
-		return siteId;
-	}
-
-	/**
-	 * siteId attribute 값을 설정한다.
-	 * @return siteId String
-	 */
-	public void setSiteId(String siteId) {
-		this.siteId = siteId;
-	}
-
-	/**
-	 * siteUrl attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getSiteUrl() {
-		return siteUrl;
-	}
-
-	/**
-	 * siteUrl attribute 값을 설정한다.
-	 * @return siteUrl String
-	 */
-	public void setSiteUrl(String siteUrl) {
-		this.siteUrl = siteUrl;
-	}
-
-	/**
-	 * siteNm attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getSiteNm() {
-		return siteNm;
-	}
-
-	/**
-	 * siteNm attribute 값을 설정한다.
-	 * @return siteNm String
-	 */
-	public void setSiteNm(String siteNm) {
-		this.siteNm = siteNm;
-	}
-
-	/**
-	 * siteDc attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getSiteDc() {
-		return siteDc;
-	}
-
-	/**
-	 * siteDc attribute 값을 설정한다.
-	 * @return siteDc String
-	 */
-	public void setSiteDc(String siteDc) {
-		this.siteDc = siteDc;
-	}
-
-	/**
-	 * siteThemaClCode attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getSiteThemaClCode() {
-		return siteThemaClCode;
-	}
-
-	/**
-	 * siteThemaClCode attribute 값을 설정한다.
-	 * @return siteThemaClCode String
-	 */
-	public void setSiteThemaClCode(String siteThemaClCode) {
-		this.siteThemaClCode = siteThemaClCode;
-	}
-
-	/**
-	 * siteThemaClNm attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getSiteThemaClNm() {
-		return siteThemaClNm;
-	}
-
-	/**
-	 * siteThemaClNm attribute 값을 설정한다.
-	 * @return siteThemaClNm String
-	 */
-	public void setSiteThemaClNm(String siteThemaClNm) {
-		this.siteThemaClNm = siteThemaClNm;
-	}
-
-	/**
-	 * actvtyAt attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getActvtyAt() {
-		return actvtyAt;
-	}
-
-	/**
-	 * actvtyAt attribute 값을 설정한다.
-	 * @return actvtyAt String
-	 */
-	public void setActvtyAt(String actvtyAt) {
-		this.actvtyAt = actvtyAt;
-	}
-
-	/**
-	 * actvtyAtNm attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getActvtyAtNm() {
-		return actvtyAtNm;
-	}
-
-	/**
-	 * actvtyAtNm attribute 값을 설정한다.
-	 * @return actvtyAtNm String
-	 */
-	public void setActvtyAtNm(String actvtyAtNm) {
-		this.actvtyAtNm = actvtyAtNm;
-	}
-
-	/**
-	 * useAt attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getUseAt() {
-		return useAt;
-	}
-
-	/**
-	 * useAt attribute 값을 설정한다.
-	 * @return useAt String
-	 */
-	public void setUseAt(String useAt) {
-		this.useAt = useAt;
-	}
-
-	/**
-	 * useAtNm attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getUseAtNm() {
-		return useAtNm;
-	}
-
-	/**
-	 * useAtNm attribute 값을 설정한다.
-	 * @return useAtNm String
-	 */
-	public void setUseAtNm(String useAtNm) {
-		this.useAtNm = useAtNm;
-	}
-
-	/**
-	 * emplyrNm attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getEmplyrNm() {
-		return emplyrNm;
-	}
-
-	/**
-	 * emplyrNm attribute 값을 설정한다.
-	 * @return emplyrNm String
-	 */
-	public void setEmplyrNm(String emplyrNm) {
-		this.emplyrNm = emplyrNm;
-	}
-
-	/**
-	 * frstRegisterPnttm attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getFrstRegisterPnttm() {
-		return frstRegisterPnttm;
-	}
-
-	/**
-	 * frstRegisterPnttm attribute 값을 설정한다.
-	 * @return frstRegisterPnttm String
-	 */
-	public void setFrstRegisterPnttm(String frstRegisterPnttm) {
-		this.frstRegisterPnttm = frstRegisterPnttm;
-	}
-
-	/**
-	 * frstRegisterId attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getFrstRegisterId() {
-		return frstRegisterId;
-	}
-
-	/**
-	 * frstRegisterId attribute 값을 설정한다.
-	 * @return frstRegisterId String
-	 */
-	public void setFrstRegisterId(String frstRegisterId) {
-		this.frstRegisterId = frstRegisterId;
-	}
-
-	/**
-	 * lastUpdusrPnttm attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getLastUpdusrPnttm() {
-		return lastUpdusrPnttm;
-	}
-
-	/**
-	 * lastUpdusrPnttm attribute 값을 설정한다.
-	 * @return lastUpdusrPnttm String
-	 */
-	public void setLastUpdusrPnttm(String lastUpdusrPnttm) {
-		this.lastUpdusrPnttm = lastUpdusrPnttm;
-	}
-
-	/**
-	 * lastUpdusrId attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getLastUpdusrId() {
-		return lastUpdusrId;
-	}
-
-	/**
-	 * lastUpdusrId attribute 값을 설정한다.
-	 * @return lastUpdusrId String
-	 */
-	public void setLastUpdusrId(String lastUpdusrId) {
-		this.lastUpdusrId = lastUpdusrId;
-	}
-
-    
-    
-   
 }

--- a/src/main/java/egovframework/com/uss/olh/faq/service/FaqVO.java
+++ b/src/main/java/egovframework/com/uss/olh/faq/service/FaqVO.java
@@ -4,6 +4,8 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 
 import org.egovframe.rte.ptl.reactive.validation.EgovNullCheck;
 import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  *
@@ -19,9 +21,12 @@ import jakarta.validation.constraints.Size;
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.04.01  박정규          최초 생성
+ *   2025.05.20  기여자          Lombok @Getter/@Setter 적용으로 보일러플레이트 제거
  *
  * </pre>
  */
+@Getter
+@Setter
 public class FaqVO extends FaqDefaultVO {
 
 	private static final long serialVersionUID = 1L;
@@ -61,166 +66,6 @@ public class FaqVO extends FaqDefaultVO {
 
 	/** 최종수정자ID */
 	private String lastUpdusrId;
-
-	/**
-	 * faqId attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getFaqId() {
-		return faqId;
-	}
-
-	/**
-	 * faqId attribute 값을 설정한다.
-	 * @return faqId String
-	 */
-	public void setFaqId(String faqId) {
-		this.faqId = faqId;
-	}
-
-	/**
-	 * qestnSj attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getQestnSj() {
-		return qestnSj;
-	}
-
-	/**
-	 * qestnSj attribute 값을 설정한다.
-	 * @return qestnSj String
-	 */
-	public void setQestnSj(String qestnSj) {
-		this.qestnSj = qestnSj;
-	}
-
-	/**
-	 * qestnCn attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getQestnCn() {
-		return qestnCn;
-	}
-
-	/**
-	 * qestnCn attribute 값을 설정한다.
-	 * @return qestnCn String
-	 */
-	public void setQestnCn(String qestnCn) {
-		this.qestnCn = qestnCn;
-	}
-
-	/**
-	 * answerCn attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getAnswerCn() {
-		return answerCn;
-	}
-
-	/**
-	 * answerCn attribute 값을 설정한다.
-	 * @return answerCn String
-	 */
-	public void setAnswerCn(String answerCn) {
-		this.answerCn = answerCn;
-	}
-
-	/**
-	 * inqireCo attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getInqireCo() {
-		return inqireCo;
-	}
-
-	/**
-	 * inqireCo attribute 값을 설정한다.
-	 * @return inqireCo String
-	 */
-	public void setInqireCo(String inqireCo) {
-		this.inqireCo = inqireCo;
-	}
-
-	/**
-	 * atchFileId attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getAtchFileId() {
-		return atchFileId;
-	}
-
-	/**
-	 * atchFileId attribute 값을 설정한다.
-	 * @return atchFileId String
-	 */
-	public void setAtchFileId(String atchFileId) {
-		this.atchFileId = atchFileId;
-	}
-
-	/**
-	 * frstRegisterPnttm attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getFrstRegisterPnttm() {
-		return frstRegisterPnttm;
-	}
-
-	/**
-	 * frstRegisterPnttm attribute 값을 설정한다.
-	 * @return frstRegisterPnttm String
-	 */
-	public void setFrstRegisterPnttm(String frstRegisterPnttm) {
-		this.frstRegisterPnttm = frstRegisterPnttm;
-	}
-
-	/**
-	 * frstRegisterId attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getFrstRegisterId() {
-		return frstRegisterId;
-	}
-
-	/**
-	 * frstRegisterId attribute 값을 설정한다.
-	 * @return frstRegisterId String
-	 */
-	public void setFrstRegisterId(String frstRegisterId) {
-		this.frstRegisterId = frstRegisterId;
-	}
-
-	/**
-	 * lastUpdusrPnttm attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getLastUpdusrPnttm() {
-		return lastUpdusrPnttm;
-	}
-
-	/**
-	 * lastUpdusrPnttm attribute 값을 설정한다.
-	 * @return lastUpdusrPnttm String
-	 */
-	public void setLastUpdusrPnttm(String lastUpdusrPnttm) {
-		this.lastUpdusrPnttm = lastUpdusrPnttm;
-	}
-
-	/**
-	 * lastUpdusrId attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getLastUpdusrId() {
-		return lastUpdusrId;
-	}
-
-	/**
-	 * lastUpdusrId attribute 값을 설정한다.
-	 * @return lastUpdusrId String
-	 */
-	public void setLastUpdusrId(String lastUpdusrId) {
-		this.lastUpdusrId = lastUpdusrId;
-	}
 
 	/**
 	 * toString 메소드를 대치한다.


### PR DESCRIPTION
## 변경 사유

uss 패키지 내 수작업으로 작성된 getter/setter 메서드가 코드량을 불필요하게 늘리고 있어
Lombok 어노테이션으로 대체하여 가독성과 유지보수성을 개선했다.

## 변경 내용

| 파일 | 제거된 메서드 수 |
|------|----------------|
| `uss/ion/nws/service/NewsVO.java` | getter 10 + setter 10 = 20 |
| `uss/ion/pwm/service/PopupManageVO.java` | getter 14 + setter 14 = 28 (기본 생성자 유지 불필요하여 제거) |
| `uss/ion/sit/service/SiteVO.java` | getter 14 + setter 14 = 28 |
| `uss/olh/faq/service/FaqVO.java` | getter 10 + setter 10 = 20 (toString() 보존) |

- 클래스 레벨 `@Getter` + `@Setter` 적용
- `serialVersionUID`, validation 어노테이션(`@EgovNullCheck`, `@Size`, `@Pattern`) 그대로 보존
- `FaqVO`의 `ToStringBuilder` 기반 `toString()` 보존
- `pom.xml` maven-compiler-plugin에 `annotationProcessorPaths` 추가 (컴파일 시 Lombok 어노테이션 프로세서 명시 등록)

## 테스트

`mvn -B -ntp -DskipTests compile` 성공 확인 (BUILD SUCCESS)

## 체크리스트

- [x] 단일 주제만 다룸 (uss 패키지 VO Lombok 적용)
- [x] 기존 동작에 영향 없음 (getter/setter 시그니처 동일)
- [x] 빌드 통과 확인
- [x] 5.1.x, 5.2.x 브랜치용 후속 PR 예정