### PR TITLE
[refactor] ext.ldapumt 패키지 VO에 Lombok @Getter/@Setter 적용

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -597,6 +597,12 @@
 					<artifactId>maven-compiler-plugin</artifactId>
 					<configuration>
 						<release>${java.version}</release>
+						<annotationProcessorPaths>
+							<path>
+								<groupId>org.projectlombok</groupId>
+								<artifactId>lombok</artifactId>
+							</path>
+						</annotationProcessorPaths>
 					</configuration>
 				</plugin>
 				<plugin>

--- a/src/main/java/egovframework/com/ext/ldapumt/service/UcorgVO.java
+++ b/src/main/java/egovframework/com/ext/ldapumt/service/UcorgVO.java
@@ -13,14 +13,17 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * 
+ *
  * @author 전우성(슈퍼개발자K3)
  */
 package egovframework.com.ext.ldapumt.service;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
 *
-* 부서 VO 객 체 
+* 부서 VO 객 체
 * @author 전우성
 * @since 2014.10.12
 * @version 1.0
@@ -35,7 +38,9 @@ package egovframework.com.ext.ldapumt.service;
 *
 * </pre>
 */
-public class UcorgVO extends LdapObject{
+@Getter
+@Setter
+public class UcorgVO extends LdapObject {
 	private String ou = "";
 	private String ouCode = "";
 	private String docSystemInfo = "";
@@ -59,183 +64,5 @@ public class UcorgVO extends LdapObject{
 	private Integer typeSml = null;
 
 	private String ouReceiveDocumentYN = "";
-	
-	public String getOuReceiveDocumentYN() {
-		return ouReceiveDocumentYN;
-	}
-
-	public void setOuReceiveDocumentYN(String ouReceiveDocumentYN) {
-		this.ouReceiveDocumentYN = ouReceiveDocumentYN;
-	}
-
-	public String getOuSendOutDocumentYN() {
-		return ouSendOutDocumentYN;
-	}
-
-	public void setOuSendOutDocumentYN(String ouSendOutDocumentYN) {
-		this.ouSendOutDocumentYN = ouSendOutDocumentYN;
-	}
-
 	private String ouSendOutDocumentYN = "";
-
-	public String getOu() {
-		return ou;
-	}
-
-	public void setOu(String ou) {
-		this.ou = ou;
-	}
-
-	public String getOuCode() {
-		return ouCode;
-	}
-
-	public void setOuCode(String ouCode) {
-		this.ouCode = ouCode;
-	}
-
-	public String getDocSystemInfo() {
-		return docSystemInfo;
-	}
-
-	public void setDocSystemInfo(String docSystemInfo) {
-		this.docSystemInfo = docSystemInfo;
-	}
-
-	public String getOuDocumentReceipientSymbol() {
-		return ouDocumentReceipientSymbol;
-	}
-
-	public void setOuDocumentReceipientSymbol(String ouDocumentReceipientSymbol) {
-		this.ouDocumentReceipientSymbol = ouDocumentReceipientSymbol;
-	}
-
-	public String getOuSMTPAddress() {
-		return ouSMTPAddress;
-	}
-
-	public void setOuSMTPAddress(String ouSMTPAddress) {
-		this.ouSMTPAddress = ouSMTPAddress;
-	}
-
-	public String getParentouCode() {
-		return parentouCode;
-	}
-
-	public void setParentouCode(String parentouCode) {
-		this.parentouCode = parentouCode;
-	}
-
-	public String getRepouCode() {
-		return repouCode;
-	}
-
-	public void setRepouCode(String repouCode) {
-		this.repouCode = repouCode;
-	}
-
-	public String getSignCertificate() {
-		return signCertificate;
-	}
-
-	public void setSignCertificate(String signCertificate) {
-		this.signCertificate = signCertificate;
-	}
-
-	public String getTopouCode() {
-		return topouCode;
-	}
-
-	public void setTopouCode(String topouCode) {
-		this.topouCode = topouCode;
-	}
-
-	public String getUcChieftitle() {
-		return ucChieftitle;
-	}
-
-	public void setUcChieftitle(String ucChieftitle) {
-		this.ucChieftitle = ucChieftitle;
-	}
-
-	public String getUcOrganizationalUnitName() {
-		return ucOrganizationalUnitName;
-	}
-
-	public void setUcOrganizationalUnitName(String ucOrganizationalUnitName) {
-		this.ucOrganizationalUnitName = ucOrganizationalUnitName;
-	}
-
-	public String getUcOrgFullName() {
-		return ucOrgFullName;
-	}
-
-	public void setUcOrgFullName(String ucOrgFullName) {
-		this.ucOrgFullName = ucOrgFullName;
-	}
-
-	public String getUseGroupware() {
-		return useGroupware;
-	}
-
-	public void setUseGroupware(String useGroupware) {
-		this.useGroupware = useGroupware;
-	}
-
-	public String getWsignCertificate() {
-		return wsignCertificate;
-	}
-
-	public void setWsignCertificate(String wsignCertificate) {
-		this.wsignCertificate = wsignCertificate;
-	}
-
-	public String getWuserCertificate() {
-		return wuserCertificate;
-	}
-
-	public void setWuserCertificate(String wuserCertificate) {
-		this.wuserCertificate = wuserCertificate;
-	}
-
-	public Integer getOuLevel() {
-		return ouLevel;
-	}
-
-	public void setOuLevel(Integer ouLevel) {
-		this.ouLevel = ouLevel;
-	}
-
-	public Integer getOuOrder() {
-		return ouOrder;
-	}
-
-	public void setOuOrder(Integer ouOrder) {
-		this.ouOrder = ouOrder;
-	}
-
-	public Integer getTypeBig() {
-		return typeBig;
-	}
-
-	public void setTypeBig(Integer typeBig) {
-		this.typeBig = typeBig;
-	}
-
-	public Integer getTypeMid() {
-		return typeMid;
-	}
-
-	public void setTypeMid(Integer typeMid) {
-		this.typeMid = typeMid;
-	}
-
-	public Integer getTypeSml() {
-		return typeSml;
-	}
-
-	public void setTypeSml(Integer typeSml) {
-		this.typeSml = typeSml;
-	}
-
 }

--- a/src/main/java/egovframework/com/ext/ldapumt/service/UserVO.java
+++ b/src/main/java/egovframework/com/ext/ldapumt/service/UserVO.java
@@ -13,14 +13,17 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * 
+ *
  * @author 전우성(슈퍼개발자K3)
  */
 package egovframework.com.ext.ldapumt.service;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
 *
-* 사용자 VO 객 체 
+* 사용자 VO 객 체
 * @author 전우성
 * @since 2014.10.12
 * @version 1.0
@@ -35,6 +38,8 @@ package egovframework.com.ext.ldapumt.service;
 *
 * </pre>
 */
+@Getter
+@Setter
 public class UserVO extends LdapObject {
 	private String ou = "";
 	private String cn = "";
@@ -51,116 +56,4 @@ public class UserVO extends LdapObject {
 
 	private Integer ouLevel = null;
 	private Integer ouOrder = null;
-
-	public String getOu() {
-		return ou;
-	}
-
-	public void setOu(String ou) {
-		this.ou = ou;
-	}
-
-	public String getCn() {
-		return cn;
-	}
-
-	public void setCn(String cn) {
-		this.cn = cn;
-	}
-
-	public String getDisplayName() {
-		return displayName;
-	}
-
-	public void setDisplayName(String displayName) {
-		this.displayName = displayName;
-	}
-
-	public String getCompanyName() {
-		return companyName;
-	}
-
-	public void setCompanyName(String companyName) {
-		this.companyName = companyName;
-	}
-
-	public String getDepartmentName() {
-		return departmentName;
-	}
-
-	public void setDepartmentName(String departmentName) {
-		this.departmentName = departmentName;
-	}
-
-	public String getGrade() {
-		return grade;
-	}
-
-	public void setGrade(String grade) {
-		this.grade = grade;
-	}
-
-	public String getInsayn() {
-		return insayn;
-	}
-
-	public void setInsayn(String insayn) {
-		this.insayn = insayn;
-	}
-
-	public String getOuCode() {
-		return ouCode;
-	}
-
-	public void setOuCode(String ouCode) {
-		this.ouCode = ouCode;
-	}
-
-	public String getParentouCode() {
-		return parentouCode;
-	}
-
-	public void setParentouCode(String parentouCode) {
-		this.parentouCode = parentouCode;
-	}
-
-	public String getTopouCode() {
-		return topouCode;
-	}
-
-	public void setTopouCode(String topouCode) {
-		this.topouCode = topouCode;
-	}
-
-	public String getUcOrgFullName() {
-		return ucOrgFullName;
-	}
-
-	public void setUcOrgFullName(String ucOrgFullName) {
-		this.ucOrgFullName = ucOrgFullName;
-	}
-
-	public String getUserFullName() {
-		return userFullName;
-	}
-
-	public void setUserFullName(String userFullName) {
-		this.userFullName = userFullName;
-	}
-
-	public Integer getOuLevel() {
-		return ouLevel;
-	}
-
-	public void setOuLevel(Integer ouLevel) {
-		this.ouLevel = ouLevel;
-	}
-
-	public Integer getOuOrder() {
-		return ouOrder;
-	}
-
-	public void setOuOrder(Integer ouOrder) {
-		this.ouOrder = ouOrder;
-	}
 }


### PR DESCRIPTION
## 변경 사유
`egovframework.com.ext.ldapumt.service` 패키지의 `UserVO`/`UcorgVO`는 수작업 getter/setter가 다수 존재. Lombok으로 정리해 보일러플레이트 제거.

(동일 패턴 선행 PR: #799 cmm, #800 cop, #801 sec, #802 uss, #803 utl)

## 변경 내용
- `UserVO` (LDAP 사용자 VO): `@Getter`/`@Setter` 추가, 수동 접근자 **28개** 제거
- `UcorgVO` (LDAP 조직 VO): `@Getter`/`@Setter` 추가, 수동 접근자 **38개** 제거
- `pom.xml`의 `maven-compiler-plugin`에 `annotationProcessorPaths`로 Lombok 등록 (Java 17 + Maven 3.9 환경에서 annotation processor 자동 디스커버리)

## 제외 사항
- `OAuthVO` (oauth 패키지): `setService(String)`이 `this.serviceName = service`로 다른 필드에 쓰는 패턴이라 Lombok `@Setter` 생성 메서드와 시그니처 불일치 → 본 PR 제외

## 영향 범위
- 호출부/JSP/MyBatis 매퍼 영향 없음 — 생성된 `getXxx`/`setXxx` 시그니처 동일
- `LdapObject` 상속/`@EgovNullCheck`/직렬화 동작 보존
- `mvn -B -ntp -DskipTests compile` BUILD SUCCESS 확인

## 체크리스트
- [x] 단일 주제 (ext.ldapumt VO Lombok 적용)
- [x] 5.0.x 브랜치 대상
- [x] 비즈니스 로직 있는 setter 보유 VO (OAuthVO) 제외
- [x] 외부 method 시그니처 미변경