### PR TITLE
[refactor][공통컴포넌트] sym 패키지 핵심 VO Lombok @Getter/@Setter 적용

### DIFF
--- a/src/main/java/egovframework/com/sym/sym/bak/service/BackupResult.java
+++ b/src/main/java/egovframework/com/sym/sym/bak/service/BackupResult.java
@@ -2,6 +2,9 @@ package egovframework.com.sym.sym.bak.service;
 
 import java.io.Serializable;
 
+import lombok.Getter;
+import lombok.Setter;
+
 import egovframework.com.cmm.ComDefaultVO;
 
 /**
@@ -18,8 +21,11 @@ import egovframework.com.cmm.ComDefaultVO;
  *   수정일       수정자           수정내용
  *  -------     --------    ---------------------------
  *  2010.06.17   김진만     최초 생성
+ *  2025.05.21   dasomel    Lombok @Getter/@Setter 적용
  * </pre>
  */
+@Getter
+@Setter
 public class BackupResult extends ComDefaultVO implements Serializable {
 
 	private static final long serialVersionUID = -743292072713546949L;
@@ -85,186 +91,5 @@ public class BackupResult extends ComDefaultVO implements Serializable {
 	 * 백업저장디렉토리
 	 */
 	private String backupStreDrctry;
-	/**
-	 * @return the backupResultId
-	 */
-	public String getBackupResultId() {
-		return backupResultId;
-	}
-	/**
-	 * @return the backupOpertId
-	 */
-	public String getBackupOpertId() {
-		return backupOpertId;
-	}
-	/**
-	 * @return the backupFile
-	 */
-	public String getBackupFile() {
-		return backupFile;
-	}
-	/**
-	 * @return the sttus
-	 */
-	public String getSttus() {
-		return sttus;
-	}
-	/**
-	 * @return the executBeginTime
-	 */
-	public String getExecutBeginTime() {
-		return executBeginTime;
-	}
-	/**
-	 * @return the executEndTime
-	 */
-	public String getExecutEndTime() {
-		return executEndTime;
-	}
-	/**
-	 * @return the lastUpdusrId
-	 */
-	public String getLastUpdusrId() {
-		return lastUpdusrId;
-	}
-	/**
-	 * @return the lastUpdusrPnttm
-	 */
-	public String getLastUpdusrPnttm() {
-		return lastUpdusrPnttm;
-	}
-	/**
-	 * @return the frstRegisterId
-	 */
-	public String getFrstRegisterId() {
-		return frstRegisterId;
-	}
-	/**
-	 * @return the frstRegisterPnttm
-	 */
-	public String getFrstRegisterPnttm() {
-		return frstRegisterPnttm;
-	}
-	/**
-	 * @return the errorInfo
-	 */
-	public String getErrorInfo() {
-		return errorInfo;
-	}
-	/**
-	 * @return the backupOpertNm
-	 */
-	public String getBackupOpertNm() {
-		return backupOpertNm;
-	}
-	/**
-	 * @return the sttusNm
-	 */
-	public String getSttusNm() {
-		return sttusNm;
-	}
-	/**
-	 * @return the backupOrginlDrctry
-	 */
-	public String getBackupOrginlDrctry() {
-		return backupOrginlDrctry;
-	}
-	/**
-	 * @return the backupStreDrctry
-	 */
-	public String getBackupStreDrctry() {
-		return backupStreDrctry;
-	}
-	/**
-	 * @param backupResultId the backupResultId to set
-	 */
-	public void setBackupResultId(String backupResultId) {
-		this.backupResultId = backupResultId;
-	}
-	/**
-	 * @param backupOpertId the backupOpertId to set
-	 */
-	public void setBackupOpertId(String backupOpertId) {
-		this.backupOpertId = backupOpertId;
-	}
-	/**
-	 * @param backupFile the backupFile to set
-	 */
-	public void setBackupFile(String backupFile) {
-		this.backupFile = backupFile;
-	}
-	/**
-	 * @param sttus the sttus to set
-	 */
-	public void setSttus(String sttus) {
-		this.sttus = sttus;
-	}
-	/**
-	 * @param executBeginTime the executBeginTime to set
-	 */
-	public void setExecutBeginTime(String executBeginTime) {
-		this.executBeginTime = executBeginTime;
-	}
-	/**
-	 * @param executEndTime the executEndTime to set
-	 */
-	public void setExecutEndTime(String executEndTime) {
-		this.executEndTime = executEndTime;
-	}
-	/**
-	 * @param lastUpdusrId the lastUpdusrId to set
-	 */
-	public void setLastUpdusrId(String lastUpdusrId) {
-		this.lastUpdusrId = lastUpdusrId;
-	}
-	/**
-	 * @param lastUpdusrPnttm the lastUpdusrPnttm to set
-	 */
-	public void setLastUpdusrPnttm(String lastUpdusrPnttm) {
-		this.lastUpdusrPnttm = lastUpdusrPnttm;
-	}
-	/**
-	 * @param frstRegisterId the frstRegisterId to set
-	 */
-	public void setFrstRegisterId(String frstRegisterId) {
-		this.frstRegisterId = frstRegisterId;
-	}
-	/**
-	 * @param frstRegisterPnttm the frstRegisterPnttm to set
-	 */
-	public void setFrstRegisterPnttm(String frstRegisterPnttm) {
-		this.frstRegisterPnttm = frstRegisterPnttm;
-	}
-	/**
-	 * @param errorInfo the errorInfo to set
-	 */
-	public void setErrorInfo(String errorInfo) {
-		this.errorInfo = errorInfo;
-	}
-	/**
-	 * @param backupOpertNm the backupOpertNm to set
-	 */
-	public void setBackupOpertNm(String backupOpertNm) {
-		this.backupOpertNm = backupOpertNm;
-	}
-	/**
-	 * @param sttusNm the sttusNm to set
-	 */
-	public void setSttusNm(String sttusNm) {
-		this.sttusNm = sttusNm;
-	}
-	/**
-	 * @param backupOrginlDrctry the backupOrginlDrctry to set
-	 */
-	public void setBackupOrginlDrctry(String backupOrginlDrctry) {
-		this.backupOrginlDrctry = backupOrginlDrctry;
-	}
-	/**
-	 * @param backupStreDrctry the backupStreDrctry to set
-	 */
-	public void setBackupStreDrctry(String backupStreDrctry) {
-		this.backupStreDrctry = backupStreDrctry;
-	}
-
 
 }

--- a/src/main/java/egovframework/com/sym/sym/bak/service/BackupSchdulDfk.java
+++ b/src/main/java/egovframework/com/sym/sym/bak/service/BackupSchdulDfk.java
@@ -2,6 +2,9 @@ package egovframework.com.sym.sym.bak.service;
 
 import java.io.Serializable;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * 백업스케줄요일에 대한 model 클래스
  *
@@ -14,8 +17,11 @@ import java.io.Serializable;
  *   수정일       수정자           수정내용
  *  -------     --------    ---------------------------
  *  2010.09.01   김진만     최초 생성
+ *  2025.05.21   dasomel    Lombok @Getter/@Setter 적용
  * </pre>
  */
+@Getter
+@Setter
 public class BackupSchdulDfk implements Serializable {
 
 	private static final long serialVersionUID = -6208617298024325398L;
@@ -34,45 +40,5 @@ public class BackupSchdulDfk implements Serializable {
 	 * 실행스케줄요일명
 	 */
 	private String executSchdulDfkSeNm;
-
-
-	/**
-	 * @return the backupOpertId
-	 */
-	public String getBackupOpertId() {
-		return backupOpertId;
-	}
-	/**
-	 * @return the executSchdulDfkSe
-	 */
-	public String getExecutSchdulDfkSe() {
-		return executSchdulDfkSe;
-	}
-	/**
-	 * @param backupOpertId the backupOpertId to set
-	 */
-	public void setBackupOpertId(String backupOpertId) {
-		this.backupOpertId = backupOpertId;
-	}
-	/**
-	 * @param executSchdulDfkSe the executSchdulDfkSe to set
-	 */
-	public void setExecutSchdulDfkSe(String executSchdulDfkSe) {
-		this.executSchdulDfkSe = executSchdulDfkSe;
-	}
-	/**
-	 * @return the executSchdulDfkSeNm
-	 */
-	public String getExecutSchdulDfkSeNm() {
-		return executSchdulDfkSeNm;
-	}
-	/**
-	 * @param executSchdulDfkSeNm the executSchdulDfkSeNm to set
-	 */
-	public void setExecutSchdulDfkSeNm(String executSchdulDfkSeNm) {
-		this.executSchdulDfkSeNm = executSchdulDfkSeNm;
-	}
-
-
 
 }

--- a/src/main/java/egovframework/com/sym/sym/nwk/service/Ntwrk.java
+++ b/src/main/java/egovframework/com/sym/sym/nwk/service/Ntwrk.java
@@ -8,6 +8,15 @@
  * @author lee.m.j
  * @version 1.0
  * @created 01-7-2010 오전 10:44:57
+ *
+ * <pre>
+ * == 개정이력(Modification Information) ==
+ *
+ *   수정일       수정자           수정내용
+ *  -------     --------    ---------------------------
+ *  2010.07.01   lee.m.j    최초 생성
+ *  2025.05.21   dasomel    Lombok @Getter/@Setter 적용
+ * </pre>
  */
 
 package egovframework.com.sym.sym.nwk.service;
@@ -15,8 +24,13 @@ package egovframework.com.sym.sym.nwk.service;
 import org.egovframe.rte.ptl.reactive.validation.EgovNullCheck;
 import jakarta.validation.constraints.Size;
 
+import lombok.Getter;
+import lombok.Setter;
+
 import egovframework.com.cmm.ComDefaultVO;
 
+@Getter
+@Setter
 public class Ntwrk extends ComDefaultVO {
 
     private static final long serialVersionUID = 1L;
@@ -85,160 +99,4 @@ public class Ntwrk extends ComDefaultVO {
 	 * 최종수정자ID
 	 */        
     private String lastUpdusrId;
-	/**
-	 * @return the ntwrkId
-	 */
-	public String getNtwrkId() {
-		return ntwrkId;
-	}
-	/**
-	 * @param ntwrkId the ntwrkId to set
-	 */
-	public void setNtwrkId(String ntwrkId) {
-		this.ntwrkId = ntwrkId;
-	}
-	/**
-	 * @return the ntwrkIp
-	 */
-	public String getNtwrkIp() {
-		return ntwrkIp;
-	}
-	/**
-	 * @param ntwrkIp the ntwrkIp to set
-	 */
-	public void setNtwrkIp(String ntwrkIp) {
-		this.ntwrkIp = ntwrkIp;
-	}
-	/**
-	 * @return the gtwy
-	 */
-	public String getGtwy() {
-		return gtwy;
-	}
-	/**
-	 * @param gtwy the gtwy to set
-	 */
-	public void setGtwy(String gtwy) {
-		this.gtwy = gtwy;
-	}
-	/**
-	 * @return the subnet
-	 */
-	public String getSubnet() {
-		return subnet;
-	}
-	/**
-	 * @param subnet the subnet to set
-	 */
-	public void setSubnet(String subnet) {
-		this.subnet = subnet;
-	}
-	/**
-	 * @return the domnServer
-	 */
-	public String getDomnServer() {
-		return domnServer;
-	}
-	/**
-	 * @param domnServer the domnServer to set
-	 */
-	public void setDomnServer(String domnServer) {
-		this.domnServer = domnServer;
-	}
-	/**
-	 * @return the manageIem
-	 */
-	public String getManageIem() {
-		return manageIem;
-	}
-	/**
-	 * @param manageIem the manageIem to set
-	 */
-	public void setManageIem(String manageIem) {
-		this.manageIem = manageIem;
-	}
-	/**
-	 * @return the userNm
-	 */
-	public String getUserNm() {
-		return userNm;
-	}
-	/**
-	 * @param userNm the userNm to set
-	 */
-	public void setUserNm(String userNm) {
-		this.userNm = userNm;
-	}
-	/**
-	 * @return the useAt
-	 */
-	public String getUseAt() {
-		return useAt;
-	}
-	/**
-	 * @param useAt the useAt to set
-	 */
-	public void setUseAt(String useAt) {
-		this.useAt = useAt;
-	}
-	/**
-	 * @return the regstYmd
-	 */
-	public String getRegstYmd() {
-		return regstYmd;
-	}
-	/**
-	 * @param regstYmd the regstYmd to set
-	 */
-	public void setRegstYmd(String regstYmd) {
-		this.regstYmd = regstYmd;
-	}
-	/**
-	 * @return the frstRegisterPnttm
-	 */
-	public String getFrstRegisterPnttm() {
-		return frstRegisterPnttm;
-	}
-	/**
-	 * @param frstRegisterPnttm the frstRegisterPnttm to set
-	 */
-	public void setFrstRegisterPnttm(String frstRegisterPnttm) {
-		this.frstRegisterPnttm = frstRegisterPnttm;
-	}
-	/**
-	 * @return the frstRegisterId
-	 */
-	public String getFrstRegisterId() {
-		return frstRegisterId;
-	}
-	/**
-	 * @param frstRegisterId the frstRegisterId to set
-	 */
-	public void setFrstRegisterId(String frstRegisterId) {
-		this.frstRegisterId = frstRegisterId;
-	}
-	/**
-	 * @return the lastUpdusrPnttm
-	 */
-	public String getLastUpdusrPnttm() {
-		return lastUpdusrPnttm;
-	}
-	/**
-	 * @param lastUpdusrPnttm the lastUpdusrPnttm to set
-	 */
-	public void setLastUpdusrPnttm(String lastUpdusrPnttm) {
-		this.lastUpdusrPnttm = lastUpdusrPnttm;
-	}
-	/**
-	 * @return the lastUpdusrId
-	 */
-	public String getLastUpdusrId() {
-		return lastUpdusrId;
-	}
-	/**
-	 * @param lastUpdusrId the lastUpdusrId to set
-	 */
-	public void setLastUpdusrId(String lastUpdusrId) {
-		this.lastUpdusrId = lastUpdusrId;
-	}
 }

--- a/src/main/java/egovframework/com/sym/sym/srv/service/Server.java
+++ b/src/main/java/egovframework/com/sym/sym/srv/service/Server.java
@@ -3,6 +3,9 @@ package egovframework.com.sym.sym.srv.service;
 import org.egovframe.rte.ptl.reactive.validation.EgovNullCheck;
 import jakarta.validation.constraints.Size;
 
+import lombok.Getter;
+import lombok.Setter;
+
 import egovframework.com.cmm.ComDefaultVO;
 
 /**
@@ -14,7 +17,18 @@ import egovframework.com.cmm.ComDefaultVO;
  * @author 이문준
  * @version 1.0
  * @created 28-6-2010 오전 10:44:54
+ *
+ * <pre>
+ * == 개정이력(Modification Information) ==
+ *
+ *   수정일       수정자           수정내용
+ *  -------     --------    ---------------------------
+ *  2010.06.28   이문준     최초 생성
+ *  2025.05.21   dasomel    Lombok @Getter/@Setter 적용
+ * </pre>
  */
+@Getter
+@Setter
 public class Server extends ComDefaultVO {
 
 	private static final long serialVersionUID = 1L;
@@ -57,113 +71,4 @@ public class Server extends ComDefaultVO {
 	 * 최종수정자ID
 	 */
 	private String lastUpdusrId;
-
-	/**
-	 * @return the serverId
-	 */
-	public String getServerId() {
-		return serverId;
-	}
-	/**
-	 * @param serverId the serverId to set
-	 */
-	public void setServerId(String serverId) {
-		this.serverId = serverId;
-	}
-	/**
-	 * @return the serverNm
-	 */
-	public String getServerNm() {
-		return serverNm;
-	}
-	/**
-	 * @param serverNm the serverNm to set
-	 */
-	public void setServerNm(String serverNm) {
-		this.serverNm = serverNm;
-	}
-	/**
-	 * @return the serverKnd
-	 */
-	public String getServerKnd() {
-		return serverKnd;
-	}
-	/**
-	 * @param serverKnd the serverKnd to set
-	 */
-	public void setServerKnd(String serverKnd) {
-		this.serverKnd = serverKnd;
-	}
-	/**
-	 * @return the serverKndNm
-	 */
-	public String getServerKndNm() {
-		return serverKndNm;
-	}
-	/**
-	 * @param serverKndNm the serverKndNm to set
-	 */
-	public void setServerKndNm(String serverKndNm) {
-		this.serverKndNm = serverKndNm;
-	}
-	/**
-	 * @return the regstYmd
-	 */
-	public String getRegstYmd() {
-		return regstYmd;
-	}
-	/**
-	 * @param regstYmd the regstYmd to set
-	 */
-	public void setRegstYmd(String regstYmd) {
-		this.regstYmd = regstYmd;
-	}
-	/**
-	 * @return the frstRegisterPnttm
-	 */
-	public String getFrstRegisterPnttm() {
-		return frstRegisterPnttm;
-	}
-	/**
-	 * @param frstRegisterPnttm the frstRegisterPnttm to set
-	 */
-	public void setFrstRegisterPnttm(String frstRegisterPnttm) {
-		this.frstRegisterPnttm = frstRegisterPnttm;
-	}
-	/**
-	 * @return the frstRegisterId
-	 */
-	public String getFrstRegisterId() {
-		return frstRegisterId;
-	}
-	/**
-	 * @param frstRegisterId the frstRegisterId to set
-	 */
-	public void setFrstRegisterId(String frstRegisterId) {
-		this.frstRegisterId = frstRegisterId;
-	}
-	/**
-	 * @return the lastUpdusrPnttm
-	 */
-	public String getLastUpdusrPnttm() {
-		return lastUpdusrPnttm;
-	}
-	/**
-	 * @param lastUpdusrPnttm the lastUpdusrPnttm to set
-	 */
-	public void setLastUpdusrPnttm(String lastUpdusrPnttm) {
-		this.lastUpdusrPnttm = lastUpdusrPnttm;
-	}
-	/**
-	 * @return the lastUpdusrId
-	 */
-	public String getLastUpdusrId() {
-		return lastUpdusrId;
-	}
-	/**
-	 * @param lastUpdusrId the lastUpdusrId to set
-	 */
-	public void setLastUpdusrId(String lastUpdusrId) {
-		this.lastUpdusrId = lastUpdusrId;
-	}
 }


### PR DESCRIPTION
## 변경 사유
sym 패키지의 BackupResult, BackupSchdulDfk, Ntwrk, Server VO가 수동 getter/setter로 작성되어 있어
보일러플레이트 코드 분량이 많고, 필드 추가·제거 시 메서드 누락 위험이 있다.
Lombok @Getter/@Setter 어노테이션으로 대체해 가독성과 유지보수성을 높인다.

## 변경 내용
- `BackupResult`: 수동 getter/setter 14쌍 제거 → @Getter @Setter 적용
- `BackupSchdulDfk`: 수동 getter/setter 3쌍 제거 → @Getter @Setter 적용
- `Ntwrk`: 수동 getter/setter 11쌍 제거 → @Getter @Setter 적용
- `Server`: 수동 getter/setter 8쌍 제거 → @Getter @Setter 적용

## 영향 범위
- 외부 동작 변경 없음 (getter/setter 메서드 시그니처 동일)
- 기존 호출부 수정 불필요

## 체크리스트
- [x] 단일 주제만 다룸 (다른 변경 없음)
- [x] 의존성 PR(Lombok) 선행 완료 — pom.xml에 lombok 의존성 이미 포함
- [x] 기존 동작에 영향 없음
- [x] 빌드 통과 확인
