### PR TITLE
[refactor][공통컴포넌트] cmm/use CmmUseDAO XML 매퍼 @EgovMapper 인터페이스 방식으로 전환

### DIFF
--- a/src/main/java/egovframework/com/cmm/service/impl/CmmUseDAO.java
+++ b/src/main/java/egovframework/com/cmm/service/impl/CmmUseDAO.java
@@ -2,14 +2,14 @@ package egovframework.com.cmm.service.impl;
 
 import java.util.List;
 
-import org.springframework.stereotype.Repository;
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
 
 import egovframework.com.cmm.ComDefaultCodeVO;
 import egovframework.com.cmm.service.CmmnDetailCode;
 
 /**
- * 공통코드등 전체 업무에서 공용해서 사용해야 하는 서비스를 정의하기위한 데이터 접근 클래스
- * 
+ * 공통코드등 전체 업무에서 공용해서 사용해야 하는 서비스를 정의하기위한 데이터 접근 인터페이스
+ *
  * @author 공통 서비스 개발팀 이삼섭
  * @since 2009.03.11
  * @version 1.0
@@ -22,39 +22,34 @@ import egovframework.com.cmm.service.CmmnDetailCode;
  *  -------    --------    ---------------------------
  *   2009.03.11  이삼섭          최초 생성
  *   2025.07.16  이백행          2025년 컨트리뷰션 `throws Exception` 제거
+ *   2026.05.25  dasomel        @EgovMapper 인터페이스 방식으로 전환
  *
  *      </pre>
  */
-@Repository("cmmUseDAO")
-public class CmmUseDAO extends EgovComAbstractDAO {
+@EgovMapper("cmmUseDAO")
+public interface CmmUseDAO {
 
 	/**
 	 * 주어진 조건에 따른 공통코드를 불러온다.
-	 * 
+	 *
 	 * @param comDefaultCodeVO
 	 * @return
 	 */
-	public List<CmmnDetailCode> selectCmmCodeDetail(ComDefaultCodeVO comDefaultCodeVO) {
-		return selectList("CmmUseDAO.selectCmmCodeDetail", comDefaultCodeVO);
-	}
+	List<CmmnDetailCode> selectCmmCodeDetail(ComDefaultCodeVO comDefaultCodeVO);
 
 	/**
 	 * 공통코드로 사용할 조직정보를 를 불러온다.
-	 * 
+	 *
 	 * @param comDefaultCodeVO
 	 * @return
 	 */
-	public List<CmmnDetailCode> selectOgrnztIdDetail(ComDefaultCodeVO comDefaultCodeVO) {
-		return selectList("CmmUseDAO.selectOgrnztIdDetail", comDefaultCodeVO);
-	}
+	List<CmmnDetailCode> selectOgrnztIdDetail(ComDefaultCodeVO comDefaultCodeVO);
 
 	/**
 	 * 공통코드로 사용할그룹정보를 를 불러온다.
-	 * 
+	 *
 	 * @param comDefaultCodeVO
 	 * @return
 	 */
-	public List<CmmnDetailCode> selectGroupIdDetail(ComDefaultCodeVO comDefaultCodeVO) {
-		return selectList("CmmUseDAO.selectGroupIdDetail", comDefaultCodeVO);
-	}
+	List<CmmnDetailCode> selectGroupIdDetail(ComDefaultCodeVO comDefaultCodeVO);
 }

--- a/src/main/resources/egovframework/mapper/com/cmm/use/EgovCmmUse_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/cmm/use/EgovCmmUse_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:49:38 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmUseDAO">
+<mapper namespace="egovframework.com.cmm.service.impl.CmmUseDAO">
 
 	<resultMap id="CmmCodeDetail" type="egovframework.com.cmm.service.CmmnDetailCode">
 		<result property="codeId" column="CODE_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cmm/use/EgovCmmUse_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/cmm/use/EgovCmmUse_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:49:39 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmUseDAO">
+<mapper namespace="egovframework.com.cmm.service.impl.CmmUseDAO">
 
 	<resultMap id="CmmCodeDetail" type="egovframework.com.cmm.service.CmmnDetailCode">
 		<result property="codeId" column="CODE_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cmm/use/EgovCmmUse_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/cmm/use/EgovCmmUse_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:49:38 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmUseDAO">
+<mapper namespace="egovframework.com.cmm.service.impl.CmmUseDAO">
 
 	<resultMap id="CmmCodeDetail" type="egovframework.com.cmm.service.CmmnDetailCode">
 		<result property="codeId" column="CODE_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cmm/use/EgovCmmUse_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/cmm/use/EgovCmmUse_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:49:39 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmUseDAO">
+<mapper namespace="egovframework.com.cmm.service.impl.CmmUseDAO">
 
 	<resultMap id="CmmCodeDetail" type="egovframework.com.cmm.service.CmmnDetailCode">
 		<result property="codeId" column="CODE_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cmm/use/EgovCmmUse_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/cmm/use/EgovCmmUse_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:49:39 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmUseDAO">
+<mapper namespace="egovframework.com.cmm.service.impl.CmmUseDAO">
 
 	<resultMap id="CmmCodeDetail" type="egovframework.com.cmm.service.CmmnDetailCode">
 		<result property="codeId" column="CODE_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cmm/use/EgovCmmUse_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/cmm/use/EgovCmmUse_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:49:39 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmUseDAO">
+<mapper namespace="egovframework.com.cmm.service.impl.CmmUseDAO">
 
 	<resultMap id="CmmCodeDetail" type="egovframework.com.cmm.service.CmmnDetailCode">
 		<result property="codeId" column="CODE_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cmm/use/EgovCmmUse_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/cmm/use/EgovCmmUse_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:49:39 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmUseDAO">
+<mapper namespace="egovframework.com.cmm.service.impl.CmmUseDAO">
 
 	<resultMap id="CmmCodeDetail" type="egovframework.com.cmm.service.CmmnDetailCode">
 		<result property="codeId" column="CODE_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cmm/use/EgovCmmUse_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/cmm/use/EgovCmmUse_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:49:39 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmUseDAO">
+<mapper namespace="egovframework.com.cmm.service.impl.CmmUseDAO">
 
 	<resultMap id="CmmCodeDetail" type="egovframework.com.cmm.service.CmmnDetailCode">
 		<result property="codeId" column="CODE_ID"/>

--- a/src/main/resources/egovframework/spring/com/context-mapper.xml
+++ b/src/main/resources/egovframework/spring/com/context-mapper.xml
@@ -21,5 +21,12 @@
 	<bean id="egov.sqlSessionTemplate" class="org.mybatis.spring.SqlSessionTemplate">
 		<constructor-arg ref="egov.sqlSession"/>
 	</bean>
-	
+
+	<!-- @EgovMapper 어노테이션이 붙은 인터페이스를 자동으로 스캔하여 빈으로 등록 -->
+	<bean class="org.mybatis.spring.mapper.MapperScannerConfigurer">
+		<property name="basePackage" value="egovframework.com"/>
+		<property name="annotationClass" value="org.egovframe.rte.psl.dataaccess.mapper.EgovMapper"/>
+		<property name="sqlSessionFactoryBeanName" value="egov.sqlSession"/>
+	</bean>
+
 </beans>


### PR DESCRIPTION
### 변경 사유

eGovFrame 5.0에서 도입된 `@EgovMapper` 어노테이션 방식을 공통컴포넌트에 적용한다.
기존 `EgovAbstractMapper` 상속 클래스 방식은 sqlSession을 직접 다루는 레거시 패턴으로,
인터페이스 기반 `@EgovMapper` 방식이 더 명확하고 유지보수성이 높다.

### 변경 내용

**대상 컴포넌트**: `cmm/use` — 공통코드 조회 (CmmUseDAO, SQL 3개)

1. `CmmUseDAO.java`: `@Repository` 클래스 → `@EgovMapper` 인터페이스로 전환
   - `EgovComAbstractDAO` 상속 제거
   - `selectList(...)` 직접 호출 제거, 메서드 시그니처만 선언
2. `EgovCmmUse_SQL_*.xml` (8개 DB): `namespace="CmmUseDAO"` → `namespace="egovframework.com.cmm.service.impl.CmmUseDAO"` (인터페이스 FQN)
   - SQL 내용 변경 없음
   - DB별 XML 유지 (altibase/goldilocks는 SQL 구조가 다름)
3. `context-mapper.xml`: `MapperScannerConfigurer` 빈 추가
   - `basePackage=egovframework.com`, `annotationClass=EgovMapper`

### 영향 범위

- `EgovCmmUseServiceImpl`의 `@Resource(name="cmmUseDAO")` 주입 구조는 변경 없음
- 다른 컴포넌트의 DAO 클래스에는 영향 없음
- `MapperScannerConfigurer`는 `@EgovMapper` 어노테이션이 붙은 인터페이스만 스캔하므로 기존 `@Repository` 클래스와 충돌 없음

### 변경 파일 / 라인 수

- 변경 파일 수: 10개
- 변경 라인 수: +28 / -26

단일 컴포넌트 시범 적용 — 추후 다른 컴포넌트로 확대 예정.

---

- [ ] 단일 주제만 다룸 (다른 변경 없음)
- [ ] 5.x 다른 브랜치용 PR이 필요한 경우 후속 PR 링크 명시
- [ ] 의존성 추가가 필요한 경우 선행 PR 링크 명시
- [ ] 기존 동작에 영향 없음 (MapperScannerConfigurer는 @EgovMapper 인터페이스만 대상)
- [ ] 컴파일 확인 (기존 베이스라인과 동일한 에러 수 유지)
