### PR TITLE
[refactor][공통컴포넌트] cop/ems 모듈 VO Lombok @Getter/@Setter 적용

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -597,6 +597,13 @@
 					<artifactId>maven-compiler-plugin</artifactId>
 					<configuration>
 						<release>${java.version}</release>
+						<annotationProcessorPaths>
+							<path>
+								<groupId>org.projectlombok</groupId>
+								<artifactId>lombok</artifactId>
+								<version>${lombok.version}</version>
+							</path>
+						</annotationProcessorPaths>
 					</configuration>
 				</plugin>
 				<plugin>

--- a/src/main/java/egovframework/com/cop/ems/service/AtchmnFileVO.java
+++ b/src/main/java/egovframework/com/cop/ems/service/AtchmnFileVO.java
@@ -1,5 +1,8 @@
 package egovframework.com.cop.ems.service;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * 발송메일에 첨부되는 파일 VO 클래스
  * @author 공통서비스 개발팀 박지욱
@@ -16,6 +19,8 @@ package egovframework.com.cop.ems.service;
  *
  *  </pre>
  */
+@Getter
+@Setter
 public class AtchmnFileVO {
 
 	/** 첨부파일ID */
@@ -32,116 +37,4 @@ public class AtchmnFileVO {
 	private String fileExtsn;
 	/** 파일크기 */
 	private int fileMg;
-
-	/**
-	 * atchFileId attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getAtchFileId() {
-		return atchFileId;
-	}
-
-	/**
-	 * atchFileId attribute 값을 설정한다.
-	 * @param atchFileId String
-	 */
-	public void setAtchFileId(String atchFileId) {
-		this.atchFileId = atchFileId;
-	}
-
-	/**
-	 * fileSn attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getFileSn() {
-		return fileSn;
-	}
-
-	/**
-	 * fileSn attribute 값을 설정한다.
-	 * @param fileSn String
-	 */
-	public void setFileSn(String fileSn) {
-		this.fileSn = fileSn;
-	}
-
-	/**
-	 * orignlFileNm attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getOrignlFileNm() {
-		return orignlFileNm;
-	}
-
-	/**
-	 * orignlFileNm attribute 값을 설정한다.
-	 * @param orignlFileNm String
-	 */
-	public void setOrignlFileNm(String orignlFileNm) {
-		this.orignlFileNm = orignlFileNm;
-	}
-
-	/**
-	 * streFileNm attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getStreFileNm() {
-		return streFileNm;
-	}
-
-	/**
-	 * streFileNm attribute 값을 설정한다.
-	 * @param streFileNm String
-	 */
-	public void setStreFileNm(String streFileNm) {
-		this.streFileNm = streFileNm;
-	}
-
-	/**
-	 * fileStreCours attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getFileStreCours() {
-		return fileStreCours;
-	}
-
-	/**
-	 * fileStreCours attribute 값을 설정한다.
-	 * @param fileStreCours String
-	 */
-	public void setFileStreCours(String fileStreCours) {
-		this.fileStreCours = fileStreCours;
-	}
-
-	/**
-	 * fileExtsn attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getFileExtsn() {
-		return fileExtsn;
-	}
-
-	/**
-	 * fileExtsn attribute 값을 설정한다.
-	 * @param fileExtsn String
-	 */
-	public void setFileExtsn(String fileExtsn) {
-		this.fileExtsn = fileExtsn;
-	}
-
-	/**
-	 * fileMg attribute 를 리턴한다.
-	 * @return int
-	 */
-	public int getFileMg() {
-		return fileMg;
-	}
-
-	/**
-	 * fileMg attribute 값을 설정한다.
-	 * @param fileMg int
-	 */
-	public void setFileMg(int fileMg) {
-		this.fileMg = fileMg;
-	}
 }

--- a/src/main/java/egovframework/com/cop/ems/service/SndngMailVO.java
+++ b/src/main/java/egovframework/com/cop/ems/service/SndngMailVO.java
@@ -3,6 +3,8 @@ package egovframework.com.cop.ems.service;
 import org.egovframe.rte.ptl.reactive.validation.EgovNullCheck;
 
 import jakarta.validation.constraints.Email;
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * 발송메일 VO 클래스
@@ -21,6 +23,8 @@ import jakarta.validation.constraints.Email;
  *
  *  </pre>
  */
+@Getter
+@Setter
 public class SndngMailVO {
 
 	/** 메세지ID */
@@ -53,196 +57,4 @@ public class SndngMailVO {
 	private String xmlContent;
 	/** 팝업링크여부(Y/N) */
 	private String link;
-
-	/**
-	 * mssageId attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getMssageId() {
-		return mssageId;
-	}
-
-	/**
-	 * mssageId attribute 값을 설정한다.
-	 * @param mssageId String
-	 */
-	public void setMssageId(String mssageId) {
-		this.mssageId = mssageId;
-	}
-
-	/**
-	 * dsptchPerson attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getDsptchPerson() {
-		return dsptchPerson;
-	}
-
-	/**
-	 * dsptchPerson attribute 값을 설정한다.
-	 * @param dsptchPerson String
-	 */
-	public void setDsptchPerson(String dsptchPerson) {
-		this.dsptchPerson = dsptchPerson;
-	}
-
-	/**
-	 * recptnPerson attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getRecptnPerson() {
-		return recptnPerson;
-	}
-
-	/**
-	 * recptnPerson attribute 값을 설정한다.
-	 * @param recptnPerson String
-	 */
-	public void setRecptnPerson(String recptnPerson) {
-		this.recptnPerson = recptnPerson;
-	}
-
-	/**
-	 * sj attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getSj() {
-		return sj;
-	}
-
-	/**
-	 * sj attribute 값을 설정한다.
-	 * @param sj String
-	 */
-	public void setSj(String sj) {
-		this.sj = sj;
-	}
-
-	/**
-	 * sndngResultCode attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getSndngResultCode() {
-		return sndngResultCode;
-	}
-
-	/**
-	 * sndngResultCode attribute 값을 설정한다.
-	 * @param sndngResultCode String
-	 */
-	public void setSndngResultCode(String sndngResultCode) {
-		this.sndngResultCode = sndngResultCode;
-	}
-
-	/**
-	 * emailCn attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getEmailCn() {
-		return emailCn;
-	}
-
-	/**
-	 * emailCn attribute 값을 설정한다.
-	 * @param emailCn String
-	 */
-	public void setEmailCn(String emailCn) {
-		this.emailCn = emailCn;
-	}
-
-	/**
-	 * atchFileId attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getAtchFileId() {
-		return atchFileId;
-	}
-
-	/**
-	 * atchFileId attribute 값을 설정한다.
-	 * @param atchFileId String
-	 */
-	public void setAtchFileId(String atchFileId) {
-		this.atchFileId = atchFileId;
-	}
-
-	public String getFileStreCours() {
-		return fileStreCours;
-	}
-
-	public void setFileStreCours(String fileStreCours) {
-		this.fileStreCours = fileStreCours;
-	}
-
-	public String getOrignlFileNm() {
-		return orignlFileNm;
-	}
-
-	public void setOrignlFileNm(String orignlFileNm) {
-		this.orignlFileNm = orignlFileNm;
-	}
-
-	/**
-	 * sndngDe attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getSndngDe() {
-		return sndngDe;
-	}
-
-	/**
-	 * sndngDe attribute 값을 설정한다.
-	 * @param sndngDe String
-	 */
-	public void setSndngDe(String sndngDe) {
-		this.sndngDe = sndngDe;
-	}
-
-	/**
-	 * atchFileIdList attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getAtchFileIdList() {
-		return atchFileIdList;
-	}
-
-	/**
-	 * atchFileIdList attribute 값을 설정한다.
-	 * @param atchFileIdList String
-	 */
-	public void setAtchFileIdList(String atchFileIdList) {
-		this.atchFileIdList = atchFileIdList;
-	}
-
-	/**
-	 * xmlContent attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getXmlContent() {
-		return xmlContent;
-	}
-
-	/**
-	 * xmlContent attribute 값을 설정한다.
-	 * @param xmlContent String
-	 */
-	public void setXmlContent(String xmlContent) {
-		this.xmlContent = xmlContent;
-	}
-
-	/**
-	 * link attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getLink() {
-		return link;
-	}
-
-	/**
-	 * link attribute 값을 설정한다.
-	 * @param link String
-	 */
-	public void setLink(String link) {
-		this.link = link;
-	}
 }


### PR DESCRIPTION
## 변경 개요

`egovframework.com.cop.ems` 하위 2개 VO 클래스의 단순 getter/setter를 Lombok `@Getter`/`@Setter` 어노테이션으로 교체한다.
비즈니스 로직이 없는 순수 필드 접근자만 제거 대상으로 선정했으며, 기존 코드 동작은 변경되지 않는다.

## 변경 파일 및 제거된 접근자 수

| 파일 | 제거된 메서드 수 |
|------|----------------|
| `cop/ems/service/AtchmnFileVO.java` | 14개 (getter 7 + setter 7) |
| `cop/ems/service/SndngMailVO.java` | 24개 (getter 12 + setter 12) |

합계: **38개** 접근자 메서드 제거

## pom.xml 변경

`maven-compiler-plugin`에 `annotationProcessorPaths`를 추가해 Lombok 어노테이션 프로세서가 Maven 빌드 시 정상 동작하도록 설정한다.
(`provided` 스코프만으로는 annotation processor가 classpath에 포함되지 않아 컴파일 오류가 발생함)

> 선행 PR: #800 (`cop` 패키지 핵심 VO Lombok 적용) — 동일한 `pom.xml` 변경을 포함하며, 두 PR 중 먼저 머지되는 쪽이 반영되면 나머지는 충돌 해소 후 반영 가능하다.

## 검증

- `mvn -DskipTests compile` — BUILD SUCCESS, 오류 0건 확인

## 체크리스트

- [x] 단일 주제만 다룸 (cop/ems 모듈 VO만 변경)
- [x] 5.x 다른 브랜치용 PR이 필요한 경우 후속 PR 링크 명시 (해당 없음 — 현재 5.0.x만 존재)
- [x] 기존 동작에 영향 없음 (getter/setter 시그니처 동일, Lombok이 동일 메서드 생성)
- [x] 테스트 통과 확인 (컴파일 성공)
