### PR TITLE
[refactor][공통컴포넌트] utl/sys 모듈 VO Lombok @Getter/@Setter 적용

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -597,6 +597,13 @@
 					<artifactId>maven-compiler-plugin</artifactId>
 					<configuration>
 						<release>${java.version}</release>
+						<annotationProcessorPaths>
+							<path>
+								<groupId>org.projectlombok</groupId>
+								<artifactId>lombok</artifactId>
+								<version>${lombok.version}</version>
+							</path>
+						</annotationProcessorPaths>
 					</configuration>
 				</plugin>
 				<plugin>

--- a/src/main/java/egovframework/com/utl/sys/fsm/service/FileSysMntrngLogVO.java
+++ b/src/main/java/egovframework/com/utl/sys/fsm/service/FileSysMntrngLogVO.java
@@ -1,5 +1,8 @@
 package egovframework.com.utl.sys.fsm.service;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * 개요
  * - 파일시스템 모니터링 로그에 대한 Vo 클래스를 정의한다.
@@ -10,6 +13,8 @@ package egovframework.com.utl.sys.fsm.service;
  * @version 1.0
  * @created 28-6-2010 오전 11:33:26
  */
+@Getter
+@Setter
 @SuppressWarnings("serial")
 public class FileSysMntrngLogVO extends FileSysMntrngLog {
 
@@ -54,203 +59,5 @@ public class FileSysMntrngLogVO extends FileSysMntrngLog {
 
     /** 페이지당 레코드 개수 */
     private int recordCountPerPage = 10;
-
-	/**
-	 * 검색 조건 반환
-	 */
-	public String getSearchCnd() {
-		return searchCnd;
-	}
-
-	/**
-	 * 검색 조건 설정
-	 */
-	public void setSearchCnd(String searchCnd) {
-		this.searchCnd = searchCnd;
-	}
-
-	/**
-	 * 검색어 반환
-	 */
-	public String getSearchWrd() {
-		return searchWrd;
-	}
-
-	/**
-	 * 검색어 설정
-	 */
-	public void setSearchWrd(String searchWrd) {
-		this.searchWrd = searchWrd;
-	}
-
-	/**
-	 * 검색 시작일 반환
-	 */
-	public String getSearchBgnDe() {
-		return searchBgnDe;
-	}
-
-	/**
-	 * 검색 시작일 설정
-	 */
-	public void setSearchBgnDe(String searchBgnDe) {
-		this.searchBgnDe = searchBgnDe;
-	}
-
-	/**
-	 * 검색 시작 시간 반환
-	 */
-	public String getSearchBgnHour() {
-		return searchBgnHour;
-	}
-
-	/**
-	 * 검색 시작 시간 설정
-	 */
-	public void setSearchBgnHour(String searchBgnHour) {
-		this.searchBgnHour = searchBgnHour;
-	}
-
-	/**
-	 * 검색 시작 일시 반환
-	 */
-	public String getSearchBgnDt() {
-		return searchBgnDt;
-	}
-
-	/**
-	 * 검색 시작 일시 설정
-	 */
-	public void setSearchBgnDt(String searchBgnDt) {
-		this.searchBgnDt = searchBgnDt;
-	}
-
-	/**
-	 * 검색 종료일 반환
-	 */
-	public String getSearchEndDe() {
-		return searchEndDe;
-	}
-
-	/**
-	 * 검색 종료일 설정
-	 */
-	public void setSearchEndDe(String searchEndDe) {
-		this.searchEndDe = searchEndDe;
-	}
-
-	/**
-	 * 검색 종료 시간 반환
-	 */
-	public String getSearchEndHour() {
-		return searchEndHour;
-	}
-
-	/**
-	 * 검색 종료 시간 설정
-	 */
-	public void setSearchEndHour(String searchEndHour) {
-		this.searchEndHour = searchEndHour;
-	}
-
-	/**
-	 * 검색 종료 일시 반환
-	 */
-	public String getSearchEndDt() {
-		return searchEndDt;
-	}
-
-	/**
-	 * 검색 종료 일시 설정
-	 */
-	public void setSearchEndDt(String searchEndDt) {
-		this.searchEndDt = searchEndDt;
-	}
-
-	/**
-	 * 페이지 인덱스 반환
-	 */
-	public int getPageIndex() {
-		return pageIndex;
-	}
-
-	/**
-	 * 페이지 인덱스 설정
-	 */
-	public void setPageIndex(int pageIndex) {
-		this.pageIndex = pageIndex;
-	}
-
-	/**
-	 * 페이지 단위 반환
-	 */
-	public int getPageUnit() {
-		return pageUnit;
-	}
-
-	/**
-	 * 페이지 단위 설정
-	 */
-	public void setPageUnit(int pageUnit) {
-		this.pageUnit = pageUnit;
-	}
-
-	/**
-	 * 페이지 크기 반환
-	 */
-	public int getPageSize() {
-		return pageSize;
-	}
-
-	/**
-	 * 페이지 크기 설정
-	 */
-	public void setPageSize(int pageSize) {
-		this.pageSize = pageSize;
-	}
-
-	/**
-	 * 첫 페이지 인덱스 반환
-	 */
-	public int getFirstIndex() {
-		return firstIndex;
-	}
-
-	/**
-	 * 첫 페이지 인덱스 설정
-	 */
-	public void setFirstIndex(int firstIndex) {
-		this.firstIndex = firstIndex;
-	}
-
-	/**
-	 * 마지막 페이지 인덱스 반환
-	 */
-	public int getLastIndex() {
-		return lastIndex;
-	}
-
-	/**
-	 * 마지막 페이지 인덱스 설정
-	 */
-	public void setLastIndex(int lastIndex) {
-		this.lastIndex = lastIndex;
-	}
-
-	/**
-	 * 페이지당 레코드 수 반환
-	 */
-	public int getRecordCountPerPage() {
-		return recordCountPerPage;
-	}
-
-	/**
-	 * 페이지당 레코드 수 설정
-	 */
-	public void setRecordCountPerPage(int recordCountPerPage) {
-		this.recordCountPerPage = recordCountPerPage;
-	}
-
-
 
 }

--- a/src/main/java/egovframework/com/utl/sys/fsm/service/FileSysMntrngVO.java
+++ b/src/main/java/egovframework/com/utl/sys/fsm/service/FileSysMntrngVO.java
@@ -1,5 +1,8 @@
 package egovframework.com.utl.sys.fsm.service;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * 개요
  * - 파일시스템 모니터링대상에 대한 Vo 클래스를 정의한다.
@@ -10,6 +13,8 @@ package egovframework.com.utl.sys.fsm.service;
  * @version 1.0
  * @created 28-6-2010 오전 11:33:26
  */
+@Getter
+@Setter
 @SuppressWarnings("serial")
 public class FileSysMntrngVO extends FileSysMntrng {
 
@@ -36,117 +41,5 @@ public class FileSysMntrngVO extends FileSysMntrng {
 
     /** 페이지당 레코드 개수 */
     private int recordCountPerPage = 10;
-	/**
-	 * 검색 조건을 가져옵니다.
-	 */
-	public String getSearchCnd() {
-		return searchCnd;
-	}
-
-	/**
-	 * 검색 조건을 설정합니다.
-	 */
-	public void setSearchCnd(String searchCnd) {
-		this.searchCnd = searchCnd;
-	}
-
-	/**
-	 * 검색어를 가져옵니다.
-	 */
-	public String getSearchWrd() {
-		return searchWrd;
-	}
-
-	/**
-	 * 검색어를 설정합니다.
-	 */
-	public void setSearchWrd(String searchWrd) {
-		this.searchWrd = searchWrd;
-	}
-
-	/**
-	 * 현재 페이지 인덱스를 가져옵니다.
-	 */
-	public int getPageIndex() {
-		return pageIndex;
-	}
-
-	/**
-	 * 현재 페이지 인덱스를 설정합니다.
-	 */
-	public void setPageIndex(int pageIndex) {
-		this.pageIndex = pageIndex;
-	}
-
-	/**
-	 * 페이지 단위를 가져옵니다.
-	 */
-	public int getPageUnit() {
-		return pageUnit;
-	}
-
-	/**
-	 * 페이지 단위를 설정합니다.
-	 */
-	public void setPageUnit(int pageUnit) {
-		this.pageUnit = pageUnit;
-	}
-
-	/**
-	 * 한 페이지의 최대 크기를 가져옵니다.
-	 */
-	public int getPageSize() {
-		return pageSize;
-	}
-
-	/**
-	 * 한 페이지의 최대 크기를 설정합니다.
-	 */
-	public void setPageSize(int pageSize) {
-		this.pageSize = pageSize;
-	}
-
-	/**
-	 * 페이지 범위 내의 첫번째 인덱스를 가져옵니다.
-	 */
-	public int getFirstIndex() {
-		return firstIndex;
-	}
-
-	/**
-	 * 페이지 범위 내의 첫번째 인덱스를 설정합니다.
-	 */
-	public void setFirstIndex(int firstIndex) {
-		this.firstIndex = firstIndex;
-	}
-
-	/**
-	 * 페이지 범위 내의 마지막 인덱스를 가져옵니다.
-	 */
-	public int getLastIndex() {
-		return lastIndex;
-	}
-
-	/**
-	 * 페이지 범위 내의 마지막 인덱스를 설정합니다.
-	 */
-	public void setLastIndex(int lastIndex) {
-		this.lastIndex = lastIndex;
-	}
-
-	/**
-	 * 페이지당 기록(레코드) 수를 가져옵니다.
-	 */
-	public int getRecordCountPerPage() {
-		return recordCountPerPage;
-	}
-
-	/**
-	 * 페이지당 기록(레코드) 수를 설정합니다.
-	 */
-	public void setRecordCountPerPage(int recordCountPerPage) {
-		this.recordCountPerPage = recordCountPerPage;
-	}
-
 
 }

--- a/src/main/java/egovframework/com/utl/sys/htm/service/HttpMonLogVO.java
+++ b/src/main/java/egovframework/com/utl/sys/htm/service/HttpMonLogVO.java
@@ -1,5 +1,8 @@
 package egovframework.com.utl.sys.htm.service;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * 개요
  * - HTTP서비스 모니터링 로그에 대한 Vo 클래스를 정의한다.
@@ -10,7 +13,8 @@ package egovframework.com.utl.sys.htm.service;
  * @version 1.0
  * @created 08-9-2010 오후 3:54:47
  */
-
+@Getter
+@Setter
 public class HttpMonLogVO extends HttpMonLog {
 
 	private static final long serialVersionUID = -1694305124506077939L;
@@ -56,201 +60,5 @@ public class HttpMonLogVO extends HttpMonLog {
 
     /** 페이지당 레코드 개수 */
     private int recordCountPerPage = 10;
-
-	/**
-	 * @return the searchCondition
-	 */
-	public String getSearchCondition() {
-		return searchCondition;
-	}
-
-	/**
-	 * @param searchCondition the searchCondition to set
-	 */
-	public void setSearchCondition(String searchCondition) {
-		this.searchCondition = searchCondition;
-	}
-
-	/**
-	 * @return the searchKeyword
-	 */
-	public String getSearchKeyword() {
-		return searchKeyword;
-	}
-
-	/**
-	 * @param searchKeyword the searchKeyword to set
-	 */
-	public void setSearchKeyword(String searchKeyword) {
-		this.searchKeyword = searchKeyword;
-	}
-
-	/**
-	 * @return the searchBgnDe
-	 */
-	public String getSearchBgnDe() {
-		return searchBgnDe;
-	}
-
-	/**
-	 * @param searchBgnDe the searchBgnDe to set
-	 */
-	public void setSearchBgnDe(String searchBgnDe) {
-		this.searchBgnDe = searchBgnDe;
-	}
-
-	/**
-	 * @return the searchBgnHour
-	 */
-	public String getSearchBgnHour() {
-		return searchBgnHour;
-	}
-
-	/**
-	 * @param searchBgnHour the searchBgnHour to set
-	 */
-	public void setSearchBgnHour(String searchBgnHour) {
-		this.searchBgnHour = searchBgnHour;
-	}
-
-	/**
-	 * @return the searchBgnDt
-	 */
-	public String getSearchBgnDt() {
-		return searchBgnDt;
-	}
-
-	/**
-	 * @param searchBgnDt the searchBgnDt to set
-	 */
-	public void setSearchBgnDt(String searchBgnDt) {
-		this.searchBgnDt = searchBgnDt;
-	}
-
-	/**
-	 * @return the searchEndDe
-	 */
-	public String getSearchEndDe() {
-		return searchEndDe;
-	}
-
-	/**
-	 * @param searchEndDe the searchEndDe to set
-	 */
-	public void setSearchEndDe(String searchEndDe) {
-		this.searchEndDe = searchEndDe;
-	}
-
-	/**
-	 * @return the searchEndHour
-	 */
-	public String getSearchEndHour() {
-		return searchEndHour;
-	}
-
-	/**
-	 * @param searchEndHour the searchEndHour to set
-	 */
-	public void setSearchEndHour(String searchEndHour) {
-		this.searchEndHour = searchEndHour;
-	}
-
-	/**
-	 * @return the searchEndDt
-	 */
-	public String getSearchEndDt() {
-		return searchEndDt;
-	}
-
-	/**
-	 * @param searchEndDt the searchEndDt to set
-	 */
-	public void setSearchEndDt(String searchEndDt) {
-		this.searchEndDt = searchEndDt;
-	}
-
-	/**
-	 * @return the pageIndex
-	 */
-	public int getPageIndex() {
-		return pageIndex;
-	}
-
-	/**
-	 * @param pageIndex the pageIndex to set
-	 */
-	public void setPageIndex(int pageIndex) {
-		this.pageIndex = pageIndex;
-	}
-
-	/**
-	 * @return the pageUnit
-	 */
-	public int getPageUnit() {
-		return pageUnit;
-	}
-
-	/**
-	 * @param pageUnit the pageUnit to set
-	 */
-	public void setPageUnit(int pageUnit) {
-		this.pageUnit = pageUnit;
-	}
-
-	/**
-	 * @return the pageSize
-	 */
-	public int getPageSize() {
-		return pageSize;
-	}
-
-	/**
-	 * @param pageSize the pageSize to set
-	 */
-	public void setPageSize(int pageSize) {
-		this.pageSize = pageSize;
-	}
-
-	/**
-	 * @return the firstIndex
-	 */
-	public int getFirstIndex() {
-		return firstIndex;
-	}
-
-	/**
-	 * @param firstIndex the firstIndex to set
-	 */
-	public void setFirstIndex(int firstIndex) {
-		this.firstIndex = firstIndex;
-	}
-
-	/**
-	 * @return the lastIndex
-	 */
-	public int getLastIndex() {
-		return lastIndex;
-	}
-
-	/**
-	 * @param lastIndex the lastIndex to set
-	 */
-	public void setLastIndex(int lastIndex) {
-		this.lastIndex = lastIndex;
-	}
-
-	/**
-	 * @return the recordCountPerPage
-	 */
-	public int getRecordCountPerPage() {
-		return recordCountPerPage;
-	}
-
-	/**
-	 * @param recordCountPerPage the recordCountPerPage to set
-	 */
-	public void setRecordCountPerPage(int recordCountPerPage) {
-		this.recordCountPerPage = recordCountPerPage;
-	}
 
 }

--- a/src/main/java/egovframework/com/utl/sys/htm/service/HttpMonVO.java
+++ b/src/main/java/egovframework/com/utl/sys/htm/service/HttpMonVO.java
@@ -1,5 +1,8 @@
 package egovframework.com.utl.sys.htm.service;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * 개요
  * - HTTP서비스모니터링에 대한 Vo 클래스를 정의한다.
@@ -10,6 +13,8 @@ package egovframework.com.utl.sys.htm.service;
  * @version 1.0
  * @created 17-6-2010 오후 5:12:45
  */
+@Getter
+@Setter
 public class HttpMonVO extends HttpMon {
 
 	private static final long serialVersionUID = 4909404979727991138L;
@@ -40,150 +45,5 @@ public class HttpMonVO extends HttpMon {
 
     /** recordCountPerPage */
     private int recordCountPerPage = 10;
-
-	/**
-	 * searchCondition attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getSearchCondition() {
-		return searchCondition;
-	}
-
-	/**
-	 * searchCondition attribute 값을 설정한다.
-	 * @param searchCondition String
-	 */
-	public void setSearchCondition(String searchCondition) {
-		this.searchCondition = searchCondition;
-	}
-
-	/**
-	 * searchKeyword attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getSearchKeyword() {
-		return searchKeyword;
-	}
-
-	/**
-	 * searchKeyword attribute 값을 설정한다.
-	 * @param searchKeyword String
-	 */
-	public void setSearchKeyword(String searchKeyword) {
-		this.searchKeyword = searchKeyword;
-	}
-
-	/**
-	 * searchUseYn attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getSearchUseYn() {
-		return searchUseYn;
-	}
-
-	/**
-	 * searchUseYn attribute 값을 설정한다.
-	 * @param searchUseYn String
-	 */
-	public void setSearchUseYn(String searchUseYn) {
-		this.searchUseYn = searchUseYn;
-	}
-
-	/**
-	 * pageIndex attribute 를 리턴한다.
-	 * @return int
-	 */
-	public int getPageIndex() {
-		return pageIndex;
-	}
-
-	/**
-	 * pageIndex attribute 값을 설정한다.
-	 * @param pageIndex int
-	 */
-	public void setPageIndex(int pageIndex) {
-		this.pageIndex = pageIndex;
-	}
-
-	/**
-	 * pageUnit attribute 를 리턴한다.
-	 * @return int
-	 */
-	public int getPageUnit() {
-		return pageUnit;
-	}
-
-	/**
-	 * pageUnit attribute 값을 설정한다.
-	 * @param pageUnit int
-	 */
-	public void setPageUnit(int pageUnit) {
-		this.pageUnit = pageUnit;
-	}
-
-	/**
-	 * pageSize attribute 를 리턴한다.
-	 * @return int
-	 */
-	public int getPageSize() {
-		return pageSize;
-	}
-
-	/**
-	 * pageSize attribute 값을 설정한다.
-	 * @param pageSize int
-	 */
-	public void setPageSize(int pageSize) {
-		this.pageSize = pageSize;
-	}
-
-	/**
-	 * firstIndex attribute 를 리턴한다.
-	 * @return int
-	 */
-	public int getFirstIndex() {
-		return firstIndex;
-	}
-
-	/**
-	 * firstIndex attribute 값을 설정한다.
-	 * @param firstIndex int
-	 */
-	public void setFirstIndex(int firstIndex) {
-		this.firstIndex = firstIndex;
-	}
-
-	/**
-	 * lastIndex attribute 를 리턴한다.
-	 * @return int
-	 */
-	public int getLastIndex() {
-		return lastIndex;
-	}
-
-	/**
-	 * lastIndex attribute 값을 설정한다.
-	 * @param lastIndex int
-	 */
-	public void setLastIndex(int lastIndex) {
-		this.lastIndex = lastIndex;
-	}
-
-	/**
-	 * recordCountPerPage attribute 를 리턴한다.
-	 * @return int
-	 */
-	public int getRecordCountPerPage() {
-		return recordCountPerPage;
-	}
-
-	/**
-	 * recordCountPerPage attribute 값을 설정한다.
-	 * @param recordCountPerPage int
-	 */
-	public void setRecordCountPerPage(int recordCountPerPage) {
-		this.recordCountPerPage = recordCountPerPage;
-	}
-
 
 }

--- a/src/main/java/egovframework/com/utl/sys/nsm/service/NtwrkSvcMntrngLogVO.java
+++ b/src/main/java/egovframework/com/utl/sys/nsm/service/NtwrkSvcMntrngLogVO.java
@@ -1,5 +1,8 @@
 package egovframework.com.utl.sys.nsm.service;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * 개요
  * - 네트워크서비스 모니터링 로그에 대한 Vo 클래스를 정의한다.
@@ -10,6 +13,8 @@ package egovframework.com.utl.sys.nsm.service;
  * @version 1.0
  * @created 28-6-2010 오전 11:33:43
  */
+@Getter
+@Setter
 @SuppressWarnings("serial")
 public class NtwrkSvcMntrngLogVO extends NtwrkSvcMntrngLog {
 
@@ -54,199 +59,5 @@ public class NtwrkSvcMntrngLogVO extends NtwrkSvcMntrngLog {
 
     /** 페이지당 레코드 개수 */
     private int recordCountPerPage = 10;
-	/**
-	 * 검색 조건을 반환합니다.
-	 */
-	public String getSearchCnd() {
-		return searchCnd;
-	}
 
-	/**
-	 * 검색 조건을 설정합니다.
-	 */
-	public void setSearchCnd(String searchCnd) {
-		this.searchCnd = searchCnd;
-	}
-
-	/**
-	 * 검색어를 반환합니다.
-	 */
-	public String getSearchWrd() {
-		return searchWrd;
-	}
-
-	/**
-	 * 검색어를 설정합니다.
-	 */
-	public void setSearchWrd(String searchWrd) {
-		this.searchWrd = searchWrd;
-	}
-
-	/**
-	 * 검색 시작일을 반환합니다.
-	 */
-	public String getSearchBgnDe() {
-		return searchBgnDe;
-	}
-
-	/**
-	 * 검색 시작일을 설정합니다.
-	 */
-	public void setSearchBgnDe(String searchBgnDe) {
-		this.searchBgnDe = searchBgnDe;
-	}
-
-	/**
-	 * 검색 시작 시간을 반환합니다.
-	 */
-	public String getSearchBgnHour() {
-		return searchBgnHour;
-	}
-
-	/**
-	 * 검색 시작 시간을 설정합니다.
-	 */
-	public void setSearchBgnHour(String searchBgnHour) {
-		this.searchBgnHour = searchBgnHour;
-	}
-
-	/**
-	 * 검색 시작 날짜와 시간을 반환합니다.
-	 */
-	public String getSearchBgnDt() {
-		return searchBgnDt;
-	}
-
-	/**
-	 * 검색 시작 날짜와 시간을 설정합니다.
-	 */
-	public void setSearchBgnDt(String searchBgnDt) {
-		this.searchBgnDt = searchBgnDt;
-	}
-
-	/**
-	 * 검색 종료일을 반환합니다.
-	 */
-	public String getSearchEndDe() {
-		return searchEndDe;
-	}
-
-	/**
-	 * 검색 종료일을 설정합니다.
-	 */
-	public void setSearchEndDe(String searchEndDe) {
-		this.searchEndDe = searchEndDe;
-	}
-
-	/**
-	 * 검색 종료 시간을 반환합니다.
-	 */
-	public String getSearchEndHour() {
-		return searchEndHour;
-	}
-
-	/**
-	 * 검색 종료 시간을 설정합니다.
-	 */
-	public void setSearchEndHour(String searchEndHour) {
-		this.searchEndHour = searchEndHour;
-	}
-
-	/**
-	 * 검색 종료 날짜와 시간을 반환합니다.
-	 */
-	public String getSearchEndDt() {
-		return searchEndDt;
-	}
-
-	/**
-	 * 검색 종료 날짜와 시간을 설정합니다.
-	 */
-	public void setSearchEndDt(String searchEndDt) {
-		this.searchEndDt = searchEndDt;
-	}
-
-	/**
-	 * 현재 페이지 인덱스를 반환합니다.
-	 */
-	public int getPageIndex() {
-		return pageIndex;
-	}
-
-	/**
-	 * 현재 페이지 인덱스를 설정합니다.
-	 */
-	public void setPageIndex(int pageIndex) {
-		this.pageIndex = pageIndex;
-	}
-
-	/**
-	 * 페이지 당 보여질 항목의 수를 반환합니다.
-	 */
-	public int getPageUnit() {
-		return pageUnit;
-	}
-
-	/**
-	 * 페이지 당 보여질 항목의 수를 설정합니다.
-	 */
-	public void setPageUnit(int pageUnit) {
-		this.pageUnit = pageUnit;
-	}
-
-	/**
-	 * 페이지 크기를 반환합니다.
-	 */
-	public int getPageSize() {
-		return pageSize;
-	}
-
-	/**
-	 * 페이지 크기를 설정합니다.
-	 */
-	public void setPageSize(int pageSize) {
-		this.pageSize = pageSize;
-	}
-
-	/**
-	 * 첫번째 인덱스를 반환합니다.
-	 */
-	public int getFirstIndex() {
-		return firstIndex;
-	}
-
-	/**
-	 * 첫번째 인덱스를 설정합니다.
-	 */
-	public void setFirstIndex(int firstIndex) {
-		this.firstIndex = firstIndex;
-	}
-
-	/**
-	 * 마지막 인덱스를 반환합니다.
-	 */
-	public int getLastIndex() {
-		return lastIndex;
-	}
-
-	/**
-	 * 마지막 인덱스를 설정합니다.
-	 */
-	public void setLastIndex(int lastIndex) {
-		this.lastIndex = lastIndex;
-	}
-
-	/**
-	 * 페이지당 레코드 수를 반환합니다.
-	 */
-	public int getRecordCountPerPage() {
-		return recordCountPerPage;
-	}
-
-	/**
-	 * 페이지당 레코드 수를 설정합니다.
-	 */
-	public void setRecordCountPerPage(int recordCountPerPage) {
-		this.recordCountPerPage = recordCountPerPage;
-	}
 }

--- a/src/main/java/egovframework/com/utl/sys/nsm/service/NtwrkSvcMntrngVO.java
+++ b/src/main/java/egovframework/com/utl/sys/nsm/service/NtwrkSvcMntrngVO.java
@@ -1,5 +1,7 @@
 package egovframework.com.utl.sys.nsm.service;
 
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * 개요
@@ -11,6 +13,8 @@ package egovframework.com.utl.sys.nsm.service;
  * @version 1.0
  * @created 28-6-2010 오전 11:33:43
  */
+@Getter
+@Setter
 @SuppressWarnings("serial")
 public class NtwrkSvcMntrngVO extends NtwrkSvcMntrng {
 
@@ -37,148 +41,5 @@ public class NtwrkSvcMntrngVO extends NtwrkSvcMntrng {
 
     /** 페이지당 레코드 개수 */
     private int recordCountPerPage = 10;
-	/**
-	 * 검색 조건을 반환합니다.
-	 *
-	 * @return 검색 조건
-	 */
-	public String getSearchCnd() {
-		return searchCnd;
-	}
-
-	/**
-	 * 검색 조건을 설정합니다.
-	 *
-	 * @param searchCnd 설정할 검색 조건
-	 */
-	public void setSearchCnd(String searchCnd) {
-		this.searchCnd = searchCnd;
-	}
-
-	/**
-	 * 검색어를 반환합니다.
-	 *
-	 * @return 검색어
-	 */
-	public String getSearchWrd() {
-		return searchWrd;
-	}
-
-	/**
-	 * 검색어를 설정합니다.
-	 *
-	 * @param searchWrd 설정할 검색어
-	 */
-	public void setSearchWrd(String searchWrd) {
-		this.searchWrd = searchWrd;
-	}
-
-	/**
-	 * 현재 페이지 인덱스를 반환합니다.
-	 *
-	 * @return 페이지 인덱스
-	 */
-	public int getPageIndex() {
-		return pageIndex;
-	}
-
-	/**
-	 * 현재 페이지 인덱스를 설정합니다.
-	 *
-	 * @param pageIndex 설정할 페이지 인덱스
-	 */
-	public void setPageIndex(int pageIndex) {
-		this.pageIndex = pageIndex;
-	}
-
-	/**
-	 * 페이지 당 보여질 항목의 수를 반환합니다.
-	 *
-	 * @return 페이지 당 항목 수
-	 */
-	public int getPageUnit() {
-		return pageUnit;
-	}
-
-	/**
-	 * 페이지 당 보여질 항목의 수를 설정합니다.
-	 *
-	 * @param pageUnit 설정할 페이지 당 항목 수
-	 */
-	public void setPageUnit(int pageUnit) {
-		this.pageUnit = pageUnit;
-	}
-
-	/**
-	 * 페이지 크기를 반환합니다.
-	 *
-	 * @return 페이지 크기
-	 */
-	public int getPageSize() {
-		return pageSize;
-	}
-
-	/**
-	 * 페이지 크기를 설정합니다.
-	 *
-	 * @param pageSize 설정할 페이지 크기
-	 */
-	public void setPageSize(int pageSize) {
-		this.pageSize = pageSize;
-	}
-
-	/**
-	 * 첫번째 인덱스를 반환합니다.
-	 *
-	 * @return 첫번째 인덱스
-	 */
-	public int getFirstIndex() {
-		return firstIndex;
-	}
-
-	/**
-	 * 첫번째 인덱스를 설정합니다.
-	 *
-	 * @param firstIndex 설정할 첫번째 인덱스
-	 */
-	public void setFirstIndex(int firstIndex) {
-		this.firstIndex = firstIndex;
-	}
-
-	/**
-	 * 마지막 인덱스를 반환합니다.
-	 *
-	 * @return 마지막 인덱스
-	 */
-	public int getLastIndex() {
-		return lastIndex;
-	}
-
-	/**
-	 * 마지막 인덱스를 설정합니다.
-	 *
-	 * @param lastIndex 설정할 마지막 인덱스
-	 */
-	public void setLastIndex(int lastIndex) {
-		this.lastIndex = lastIndex;
-	}
-
-	/**
-	 * 페이지당 레코드 수를 반환합니다.
-	 *
-	 * @return 페이지당 레코드 수
-	 */
-	public int getRecordCountPerPage() {
-		return recordCountPerPage;
-	}
-
-	/**
-	 * 페이지당 레코드 수를 설정합니다.
-	 *
-	 * @param recordCountPerPage 설정할 페이지당 레코드 수
-	 */
-	public void setRecordCountPerPage(int recordCountPerPage) {
-		this.recordCountPerPage = recordCountPerPage;
-	}
 
 }

--- a/src/main/java/egovframework/com/utl/sys/prm/service/ProcessMonLogVO.java
+++ b/src/main/java/egovframework/com/utl/sys/prm/service/ProcessMonLogVO.java
@@ -1,5 +1,8 @@
 package egovframework.com.utl.sys.prm.service;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * 개요
  * - PROCESS모니터링 로그에 대한 Vo 클래스를 정의한다.
@@ -10,7 +13,8 @@ package egovframework.com.utl.sys.prm.service;
  * @version 1.0
  * @created 08-9-2010 오후 3:54:47
  */
-
+@Getter
+@Setter
 public class ProcessMonLogVO extends ProcessMonLog {
 
 	private static final long serialVersionUID = -7374180958172370475L;
@@ -56,201 +60,5 @@ public class ProcessMonLogVO extends ProcessMonLog {
 
     /** 페이지당 레코드 개수 */
     private int recordCountPerPage = 10;
-
-	/**
-	 * @return the searchCondition
-	 */
-	public String getSearchCondition() {
-		return searchCondition;
-	}
-
-	/**
-	 * @param searchCondition the searchCondition to set
-	 */
-	public void setSearchCondition(String searchCondition) {
-		this.searchCondition = searchCondition;
-	}
-
-	/**
-	 * @return the searchKeyword
-	 */
-	public String getSearchKeyword() {
-		return searchKeyword;
-	}
-
-	/**
-	 * @param searchKeyword the searchKeyword to set
-	 */
-	public void setSearchKeyword(String searchKeyword) {
-		this.searchKeyword = searchKeyword;
-	}
-
-	/**
-	 * @return the searchBgnDe
-	 */
-	public String getSearchBgnDe() {
-		return searchBgnDe;
-	}
-
-	/**
-	 * @param searchBgnDe the searchBgnDe to set
-	 */
-	public void setSearchBgnDe(String searchBgnDe) {
-		this.searchBgnDe = searchBgnDe;
-	}
-
-	/**
-	 * @return the searchBgnHour
-	 */
-	public String getSearchBgnHour() {
-		return searchBgnHour;
-	}
-
-	/**
-	 * @param searchBgnHour the searchBgnHour to set
-	 */
-	public void setSearchBgnHour(String searchBgnHour) {
-		this.searchBgnHour = searchBgnHour;
-	}
-
-	/**
-	 * @return the searchBgnDt
-	 */
-	public String getSearchBgnDt() {
-		return searchBgnDt;
-	}
-
-	/**
-	 * @param searchBgnDt the searchBgnDt to set
-	 */
-	public void setSearchBgnDt(String searchBgnDt) {
-		this.searchBgnDt = searchBgnDt;
-	}
-
-	/**
-	 * @return the searchEndDe
-	 */
-	public String getSearchEndDe() {
-		return searchEndDe;
-	}
-
-	/**
-	 * @param searchEndDe the searchEndDe to set
-	 */
-	public void setSearchEndDe(String searchEndDe) {
-		this.searchEndDe = searchEndDe;
-	}
-
-	/**
-	 * @return the searchEndHour
-	 */
-	public String getSearchEndHour() {
-		return searchEndHour;
-	}
-
-	/**
-	 * @param searchEndHour the searchEndHour to set
-	 */
-	public void setSearchEndHour(String searchEndHour) {
-		this.searchEndHour = searchEndHour;
-	}
-
-	/**
-	 * @return the searchEndDt
-	 */
-	public String getSearchEndDt() {
-		return searchEndDt;
-	}
-
-	/**
-	 * @param searchEndDt the searchEndDt to set
-	 */
-	public void setSearchEndDt(String searchEndDt) {
-		this.searchEndDt = searchEndDt;
-	}
-
-	/**
-	 * @return the pageIndex
-	 */
-	public int getPageIndex() {
-		return pageIndex;
-	}
-
-	/**
-	 * @param pageIndex the pageIndex to set
-	 */
-	public void setPageIndex(int pageIndex) {
-		this.pageIndex = pageIndex;
-	}
-
-	/**
-	 * @return the pageUnit
-	 */
-	public int getPageUnit() {
-		return pageUnit;
-	}
-
-	/**
-	 * @param pageUnit the pageUnit to set
-	 */
-	public void setPageUnit(int pageUnit) {
-		this.pageUnit = pageUnit;
-	}
-
-	/**
-	 * @return the pageSize
-	 */
-	public int getPageSize() {
-		return pageSize;
-	}
-
-	/**
-	 * @param pageSize the pageSize to set
-	 */
-	public void setPageSize(int pageSize) {
-		this.pageSize = pageSize;
-	}
-
-	/**
-	 * @return the firstIndex
-	 */
-	public int getFirstIndex() {
-		return firstIndex;
-	}
-
-	/**
-	 * @param firstIndex the firstIndex to set
-	 */
-	public void setFirstIndex(int firstIndex) {
-		this.firstIndex = firstIndex;
-	}
-
-	/**
-	 * @return the lastIndex
-	 */
-	public int getLastIndex() {
-		return lastIndex;
-	}
-
-	/**
-	 * @param lastIndex the lastIndex to set
-	 */
-	public void setLastIndex(int lastIndex) {
-		this.lastIndex = lastIndex;
-	}
-
-	/**
-	 * @return the recordCountPerPage
-	 */
-	public int getRecordCountPerPage() {
-		return recordCountPerPage;
-	}
-
-	/**
-	 * @param recordCountPerPage the recordCountPerPage to set
-	 */
-	public void setRecordCountPerPage(int recordCountPerPage) {
-		this.recordCountPerPage = recordCountPerPage;
-	}
 
 }

--- a/src/main/java/egovframework/com/utl/sys/prm/service/ProcessMonVO.java
+++ b/src/main/java/egovframework/com/utl/sys/prm/service/ProcessMonVO.java
@@ -1,5 +1,8 @@
 package egovframework.com.utl.sys.prm.service;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * 개요
  * - PROCESS모니터링에 대한 Vo 클래스를 정의한다.
@@ -10,6 +13,8 @@ package egovframework.com.utl.sys.prm.service;
  * @version 1.0
  * @created 08-9-2010 오후 3:54:47
  */
+@Getter
+@Setter
 public class ProcessMonVO extends ProcessMon {
 
 	private static final long serialVersionUID = 1449367210024945087L;
@@ -38,115 +43,4 @@ public class ProcessMonVO extends ProcessMon {
 	/** recordCountPerPage */
     private int recordCountPerPage = 10;
 
-	/**
-	 * @return the searchCondition
-	 */
-	public String getSearchCondition() {
-		return searchCondition;
-	}
-
-	/**
-	 * @param searchCondition the searchCondition to set
-	 */
-	public void setSearchCondition(String searchCondition) {
-		this.searchCondition = searchCondition;
-	}
-
-	/**
-	 * @return the searchKeyword
-	 */
-	public String getSearchKeyword() {
-		return searchKeyword;
-	}
-
-	/**
-	 * @param searchKeyword the searchKeyword to set
-	 */
-	public void setSearchKeyword(String searchKeyword) {
-		this.searchKeyword = searchKeyword;
-	}
-
-	/**
-	 * @return the pageUnit
-	 */
-	public int getPageUnit() {
-		return pageUnit;
-	}
-
-	/**
-	 * @param pageUnit the pageUnit to set
-	 */
-	public void setPageUnit(int pageUnit) {
-		this.pageUnit = pageUnit;
-	}
-
-	/**
-	 * @return the pageSize
-	 */
-	public int getPageSize() {
-		return pageSize;
-	}
-
-	/**
-	 * @param pageSize the pageSize to set
-	 */
-	public void setPageSize(int pageSize) {
-		this.pageSize = pageSize;
-	}
-
-	/**
-	 * @return the pageIndex
-	 */
-	public int getPageIndex() {
-		return pageIndex;
-	}
-
-	/**
-	 * @param pageIndex the pageIndex to set
-	 */
-	public void setPageIndex(int pageIndex) {
-		this.pageIndex = pageIndex;
-	}
-
-	/**
-	 * @return the firstIndex
-	 */
-	public int getFirstIndex() {
-		return firstIndex;
-	}
-
-	/**
-	 * @param firstIndex the firstIndex to set
-	 */
-	public void setFirstIndex(int firstIndex) {
-		this.firstIndex = firstIndex;
-	}
-
-	/**
-	 * @return the lastIndex
-	 */
-	public int getLastIndex() {
-		return lastIndex;
-	}
-
-	/**
-	 * @param lastIndex the lastIndex to set
-	 */
-	public void setLastIndex(int lastIndex) {
-		this.lastIndex = lastIndex;
-	}
-
-	/**
-	 * @return the recordCountPerPage
-	 */
-	public int getRecordCountPerPage() {
-		return recordCountPerPage;
-	}
-
-	/**
-	 * @param recordCountPerPage the recordCountPerPage to set
-	 */
-	public void setRecordCountPerPage(int recordCountPerPage) {
-		this.recordCountPerPage = recordCountPerPage;
-	}
 }


### PR DESCRIPTION
## 변경 사유

utl/sys 패키지(fsm, htm, nsm, prm)의 8개 VO에 수동 getter/setter가 작성되어
보일러플레이트가 많고 필드 추가/제거 시 누락 위험이 있다.
Lombok 어노테이션으로 대체해 가독성과 유지보수성을 개선한다.

## 변경 내용

- pom.xml: maven-compiler-plugin annotationProcessorPaths에 lombok 경로 추가
- FileSysMntrngVO: @Getter @Setter 적용, 수동 getter/setter 제거
- FileSysMntrngLogVO: @Getter @Setter 적용, 수동 getter/setter 제거
- HttpMonVO: @Getter @Setter 적용, 수동 getter/setter 제거
- HttpMonLogVO: @Getter @Setter 적용, 수동 getter/setter 제거
- NtwrkSvcMntrngVO: @Getter @Setter 적용, 수동 getter/setter 제거
- NtwrkSvcMntrngLogVO: @Getter @Setter 적용, 수동 getter/setter 제거
- ProcessMonVO: @Getter @Setter 적용, 수동 getter/setter 제거
- ProcessMonLogVO: @Getter @Setter 적용, 수동 getter/setter 제거

## 영향 범위

- 외부 동작 변경 없음 (getter/setter 시그니처 동일)
- utl/sys 패키지 8개 VO만 변경

## 비고

pom.xml의 annotationProcessorPaths 설정은 동일 리포 내 타 Lombok PR(예: #807)과
내용이 겹칠 수 있으므로 먼저 머지된 PR 기준으로 충돌 발생 시 재조정 가능하다.

## 체크리스트

- [x] 단일 주제만 다룸 (utl/sys VO Lombok 적용)
- [x] 기존 동작에 영향 없음 (getter/setter 시그니처 동일)
- [x] 테스트 통과 확인 (mvn compile -DskipTests: BUILD SUCCESS)
- [x] toString/equals/hashCode 수동 구현 없음 — 해당 없음
