### PR TITLE
[refactor][공통컴포넌트] uss/sam 모듈 VO Lombok @Getter/@Setter 적용

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -597,6 +597,13 @@
 					<artifactId>maven-compiler-plugin</artifactId>
 					<configuration>
 						<release>${java.version}</release>
+						<annotationProcessorPaths>
+							<path>
+								<groupId>org.projectlombok</groupId>
+								<artifactId>lombok</artifactId>
+								<version>${lombok.version}</version>
+							</path>
+						</annotationProcessorPaths>
 					</configuration>
 				</plugin>
 				<plugin>

--- a/src/main/java/egovframework/com/uss/sam/cpy/service/CpyrhtPrtcPolicyDefaultVO.java
+++ b/src/main/java/egovframework/com/uss/sam/cpy/service/CpyrhtPrtcPolicyDefaultVO.java
@@ -2,10 +2,13 @@ package egovframework.com.uss.sam.cpy.service;
 
 import java.io.Serializable;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  *
  * 저작권보호정책내용을 처리하는 DefaultVO 클래스
- * 
+ *
  * @author 공통서비스 개발팀 박정규
  * @since 2009.04.01
  * @version 1.0
@@ -20,6 +23,8 @@ import java.io.Serializable;
  *
  * </pre>
  */
+@Getter
+@Setter
 public class CpyrhtPrtcPolicyDefaultVO implements Serializable {
 
 	private static final long serialVersionUID = -1756683013057173109L;
@@ -50,168 +55,5 @@ public class CpyrhtPrtcPolicyDefaultVO implements Serializable {
 
     /** recordCountPerPage */
     private int recordCountPerPage = 10;
-
-	/**
-	 * searchCondition attribute 를 리턴한다.
-	 * 
-	 * @return the String
-	 */
-	public String getSearchCondition() {
-		return searchCondition;
-	}
-
-	/**
-	 * searchCondition attribute 값을 설정한다.
-	 * 
-	 * @return searchCondition String
-	 */
-	public void setSearchCondition(String searchCondition) {
-		this.searchCondition = searchCondition;
-	}
-
-	/**
-	 * searchKeyword attribute 를 리턴한다.
-	 * 
-	 * @return the String
-	 */
-	public String getSearchKeyword() {
-		return searchKeyword;
-	}
-
-	/**
-	 * searchKeyword attribute 값을 설정한다.
-	 * 
-	 * @return searchKeyword String
-	 */
-	public void setSearchKeyword(String searchKeyword) {
-		this.searchKeyword = searchKeyword;
-	}
-
-	/**
-	 * searchUseYn attribute 를 리턴한다.
-	 * 
-	 * @return the String
-	 */
-	public String getSearchUseYn() {
-		return searchUseYn;
-	}
-
-	/**
-	 * searchUseYn attribute 값을 설정한다.
-	 * 
-	 * @return searchUseYn String
-	 */
-	public void setSearchUseYn(String searchUseYn) {
-		this.searchUseYn = searchUseYn;
-	}
-
-	/**
-	 * pageIndex attribute 를 리턴한다.
-	 * 
-	 * @return the int
-	 */
-	public int getPageIndex() {
-		return pageIndex;
-	}
-
-	/**
-	 * pageIndex attribute 값을 설정한다.
-	 * 
-	 * @return pageIndex int
-	 */
-	public void setPageIndex(int pageIndex) {
-		this.pageIndex = pageIndex;
-	}
-
-	/**
-	 * pageUnit attribute 를 리턴한다.
-	 * 
-	 * @return the int
-	 */
-	public int getPageUnit() {
-		return pageUnit;
-	}
-
-	/**
-	 * pageUnit attribute 값을 설정한다.
-	 * 
-	 * @return pageUnit int
-	 */
-	public void setPageUnit(int pageUnit) {
-		this.pageUnit = pageUnit;
-	}
-
-	/**
-	 * pageSize attribute 를 리턴한다.
-	 * 
-	 * @return the int
-	 */
-	public int getPageSize() {
-		return pageSize;
-	}
-
-	/**
-	 * pageSize attribute 값을 설정한다.
-	 * 
-	 * @return pageSize int
-	 */
-	public void setPageSize(int pageSize) {
-		this.pageSize = pageSize;
-	}
-
-	/**
-	 * firstIndex attribute 를 리턴한다.
-	 * 
-	 * @return the int
-	 */
-	public int getFirstIndex() {
-		return firstIndex;
-	}
-
-	/**
-	 * firstIndex attribute 값을 설정한다.
-	 * 
-	 * @return firstIndex int
-	 */
-	public void setFirstIndex(int firstIndex) {
-		this.firstIndex = firstIndex;
-	}
-
-	/**
-	 * lastIndex attribute 를 리턴한다.
-	 * 
-	 * @return the int
-	 */
-	public int getLastIndex() {
-		return lastIndex;
-	}
-
-	/**
-	 * lastIndex attribute 값을 설정한다.
-	 * 
-	 * @return lastIndex int
-	 */
-	public void setLastIndex(int lastIndex) {
-		this.lastIndex = lastIndex;
-	}
-
-	/**
-	 * recordCountPerPage attribute 를 리턴한다.
-	 * 
-	 * @return the int
-	 */
-	public int getRecordCountPerPage() {
-		return recordCountPerPage;
-	}
-
-	/**
-	 * recordCountPerPage attribute 값을 설정한다.
-	 * 
-	 * @return recordCountPerPage int
-	 */
-	public void setRecordCountPerPage(int recordCountPerPage) {
-		this.recordCountPerPage = recordCountPerPage;
-	}
-
 
 }

--- a/src/main/java/egovframework/com/uss/sam/cpy/service/CpyrhtPrtcPolicyVO.java
+++ b/src/main/java/egovframework/com/uss/sam/cpy/service/CpyrhtPrtcPolicyVO.java
@@ -3,10 +3,13 @@ package egovframework.com.uss.sam.cpy.service;
 import org.egovframe.rte.ptl.reactive.validation.EgovNullCheck;
 import jakarta.validation.constraints.Size;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
- * 
+ *
  * 저작권보호정책내용을 처리하는 VO 클래스
- * 
+ *
  * @author 공통서비스 개발팀 박정규
  * @since 2009.04.01
  * @version 1.0
@@ -14,13 +17,15 @@ import jakarta.validation.constraints.Size;
  *
  *      <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일          수정자       수정내용
  *  -----------    --------    ---------------------------
  *   2009.04.01     박정규       최초 생성
  *
  *      </pre>
  */
+@Getter
+@Setter
 public class CpyrhtPrtcPolicyVO extends CpyrhtPrtcPolicyDefaultVO {
 
 	private static final long serialVersionUID = 1L;
@@ -44,113 +49,5 @@ public class CpyrhtPrtcPolicyVO extends CpyrhtPrtcPolicyDefaultVO {
 
 	/** 최종수정자ID */
 	private String lastUpdusrId;
-
-	/**
-	 * cpyrhtId attribute 를 리턴한다.
-	 * 
-	 * @return the String
-	 */
-	public String getCpyrhtId() {
-		return cpyrhtId;
-	}
-
-	/**
-	 * cpyrhtId attribute 값을 설정한다.
-	 * 
-	 * @return cpyrhtId String
-	 */
-	public void setCpyrhtId(String cpyrhtId) {
-		this.cpyrhtId = cpyrhtId;
-	}
-
-	/**
-	 * cpyrhtPrtcPolicyCn attribute 를 리턴한다.
-	 * 
-	 * @return the String
-	 */
-	public String getCpyrhtPrtcPolicyCn() {
-		return cpyrhtPrtcPolicyCn;
-	}
-
-	/**
-	 * cpyrhtPrtcPolicyCn attribute 값을 설정한다.
-	 * 
-	 * @return cpyrhtPrtcPolicyCn String
-	 */
-	public void setCpyrhtPrtcPolicyCn(String cpyrhtPrtcPolicyCn) {
-		this.cpyrhtPrtcPolicyCn = cpyrhtPrtcPolicyCn;
-	}
-
-	/**
-	 * frstRegisterPnttm attribute 를 리턴한다.
-	 * 
-	 * @return the String
-	 */
-	public String getFrstRegisterPnttm() {
-		return frstRegisterPnttm;
-	}
-
-	/**
-	 * frstRegisterPnttm attribute 값을 설정한다.
-	 * 
-	 * @return frstRegisterPnttm String
-	 */
-	public void setFrstRegisterPnttm(String frstRegisterPnttm) {
-		this.frstRegisterPnttm = frstRegisterPnttm;
-	}
-
-	/**
-	 * frstRegisterId attribute 를 리턴한다.
-	 * 
-	 * @return the String
-	 */
-	public String getFrstRegisterId() {
-		return frstRegisterId;
-	}
-
-	/**
-	 * frstRegisterId attribute 값을 설정한다.
-	 * 
-	 * @return frstRegisterId String
-	 */
-	public void setFrstRegisterId(String frstRegisterId) {
-		this.frstRegisterId = frstRegisterId;
-	}
-
-	/**
-	 * lastUpdusrPnttm attribute 를 리턴한다.
-	 * 
-	 * @return the String
-	 */
-	public String getLastUpdusrPnttm() {
-		return lastUpdusrPnttm;
-	}
-
-	/**
-	 * lastUpdusrPnttm attribute 값을 설정한다.
-	 * 
-	 * @return lastUpdusrPnttm String
-	 */
-	public void setLastUpdusrPnttm(String lastUpdusrPnttm) {
-		this.lastUpdusrPnttm = lastUpdusrPnttm;
-	}
-
-	/**
-	 * lastUpdusrId attribute 를 리턴한다.
-	 * 
-	 * @return the String
-	 */
-	public String getLastUpdusrId() {
-		return lastUpdusrId;
-	}
-
-	/**
-	 * lastUpdusrId attribute 값을 설정한다.
-	 * 
-	 * @return lastUpdusrId String
-	 */
-	public void setLastUpdusrId(String lastUpdusrId) {
-		this.lastUpdusrId = lastUpdusrId;
-	}
 
 }

--- a/src/main/java/egovframework/com/uss/sam/stp/service/StplatManageDefaultVO.java
+++ b/src/main/java/egovframework/com/uss/sam/stp/service/StplatManageDefaultVO.java
@@ -2,6 +2,9 @@ package egovframework.com.uss.sam.stp.service;
 
 import java.io.Serializable;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  *
  * 약관내용을 처리하는 DefaultVO 클래스
@@ -20,6 +23,8 @@ import java.io.Serializable;
  *
  * </pre>
  */
+@Getter
+@Setter
 public class StplatManageDefaultVO implements Serializable {
 
 	private static final long serialVersionUID = 8985378332646748275L;
@@ -50,152 +55,5 @@ public class StplatManageDefaultVO implements Serializable {
 
     /** recordCountPerPage */
     private int recordCountPerPage = 10;
-
-	/**
-	 * searchCondition attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getSearchCondition() {
-		return searchCondition;
-	}
-
-	/**
-	 * searchCondition attribute 값을 설정한다.
-	 * @return searchCondition String
-	 */
-	public void setSearchCondition(String searchCondition) {
-		this.searchCondition = searchCondition;
-	}
-
-	/**
-	 * searchKeyword attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getSearchKeyword() {
-		return searchKeyword;
-	}
-
-	/**
-	 * searchKeyword attribute 값을 설정한다.
-	 * @return searchKeyword String
-	 */
-	public void setSearchKeyword(String searchKeyword) {
-		this.searchKeyword = searchKeyword;
-	}
-
-	/**
-	 * searchUseYn attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getSearchUseYn() {
-		return searchUseYn;
-	}
-
-	/**
-	 * searchUseYn attribute 값을 설정한다.
-	 * @return searchUseYn String
-	 */
-	public void setSearchUseYn(String searchUseYn) {
-		this.searchUseYn = searchUseYn;
-	}
-
-	/**
-	 * pageIndex attribute 를 리턴한다.
-	 * @return the int
-	 */
-	public int getPageIndex() {
-		return pageIndex;
-	}
-
-	/**
-	 * pageIndex attribute 값을 설정한다.
-	 * @return pageIndex int
-	 */
-	public void setPageIndex(int pageIndex) {
-		this.pageIndex = pageIndex;
-	}
-
-	/**
-	 * pageUnit attribute 를 리턴한다.
-	 * @return the int
-	 */
-	public int getPageUnit() {
-		return pageUnit;
-	}
-
-	/**
-	 * pageUnit attribute 값을 설정한다.
-	 * @return pageUnit int
-	 */
-	public void setPageUnit(int pageUnit) {
-		this.pageUnit = pageUnit;
-	}
-
-	/**
-	 * pageSize attribute 를 리턴한다.
-	 * @return the int
-	 */
-	public int getPageSize() {
-		return pageSize;
-	}
-
-	/**
-	 * pageSize attribute 값을 설정한다.
-	 * @return pageSize int
-	 */
-	public void setPageSize(int pageSize) {
-		this.pageSize = pageSize;
-	}
-
-	/**
-	 * firstIndex attribute 를 리턴한다.
-	 * @return the int
-	 */
-	public int getFirstIndex() {
-		return firstIndex;
-	}
-
-	/**
-	 * firstIndex attribute 값을 설정한다.
-	 * @return firstIndex int
-	 */
-	public void setFirstIndex(int firstIndex) {
-		this.firstIndex = firstIndex;
-	}
-
-	/**
-	 * lastIndex attribute 를 리턴한다.
-	 * @return the int
-	 */
-	public int getLastIndex() {
-		return lastIndex;
-	}
-
-	/**
-	 * lastIndex attribute 값을 설정한다.
-	 * @return lastIndex int
-	 */
-	public void setLastIndex(int lastIndex) {
-		this.lastIndex = lastIndex;
-	}
-
-	/**
-	 * recordCountPerPage attribute 를 리턴한다.
-	 * @return the int
-	 */
-	public int getRecordCountPerPage() {
-		return recordCountPerPage;
-	}
-
-	/**
-	 * recordCountPerPage attribute 값을 설정한다.
-	 * @return recordCountPerPage int
-	 */
-	public void setRecordCountPerPage(int recordCountPerPage) {
-		this.recordCountPerPage = recordCountPerPage;
-	}
-
-
-
 
 }

--- a/src/main/java/egovframework/com/uss/sam/stp/service/StplatManageVO.java
+++ b/src/main/java/egovframework/com/uss/sam/stp/service/StplatManageVO.java
@@ -3,8 +3,11 @@ package egovframework.com.uss.sam.stp.service;
 import org.egovframe.rte.ptl.reactive.validation.EgovNullCheck;
 import jakarta.validation.constraints.Size;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
- * 
+ *
  * 약관내용을 처리하는 VO 클래스
  * @author 공통서비스 개발팀 박정규
  * @since 2009.04.01
@@ -13,7 +16,7 @@ import jakarta.validation.constraints.Size;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.04.01  박정규          최초 생성
@@ -21,133 +24,47 @@ import jakarta.validation.constraints.Size;
  *
  * </pre>
  */
+@Getter
+@Setter
 public class StplatManageVO extends StplatManageDefaultVO {
-	
+
     private static final long serialVersionUID = 1L;
-    
+
     /** 이용약관 ID */
     private String useStplatId;
-    
+
 	/** 이용약관명 */
     @EgovNullCheck
     @Size(max=100)
-    private String useStplatNm;    
-    
+    private String useStplatNm;
+
     /** 이용약관내용 */
     @EgovNullCheck
     private String useStplatCn;
-    
+
     /** 정보제공동의내용 */
     @EgovNullCheck
     private String infoProvdAgreCn;
-    
+
     /** 최초등록시점 */
     private String frstRegistPnttm;
-        
+
     /** 최초등록시점 */
     private String frstRegisterNm;
-    
+
     /** 최초등록시점 */
     private String frstRegisterPnttm;
-    
+
     /** 최초등록자ID */
     private String frstRegisterId;
 
     /** 최종수정시점 */
     private String lastUpdusrPnttm;
-    
+
     /** 최종수정시점 */
     private String lastUpdtPnttm;
 
     /** 최종수정자ID */
     private String lastUpdusrId;
-
-	public String getUseStplatId() {
-		return useStplatId;
-	}
-
-	public void setUseStplatId(String useStplatId) {
-		this.useStplatId = useStplatId;
-	}
-
-	public String getUseStplatNm() {
-		return useStplatNm;
-	}
-
-	public void setUseStplatNm(String useStplatNm) {
-		this.useStplatNm = useStplatNm;
-	}
-
-	public String getUseStplatCn() {
-		return useStplatCn;
-	}
-
-	public void setUseStplatCn(String useStplatCn) {
-		this.useStplatCn = useStplatCn;
-	}
-
-	public String getInfoProvdAgreCn() {
-		return infoProvdAgreCn;
-	}
-
-	public void setInfoProvdAgreCn(String infoProvdAgreCn) {
-		this.infoProvdAgreCn = infoProvdAgreCn;
-	}
-
-	public String getFrstRegistPnttm() {
-		return frstRegistPnttm;
-	}
-
-	public void setFrstRegistPnttm(String frstRegistPnttm) {
-		this.frstRegistPnttm = frstRegistPnttm;
-	}
-
-	public String getFrstRegisterNm() {
-		return frstRegisterNm;
-	}
-
-	public void setFrstRegisterNm(String frstRegisterNm) {
-		this.frstRegisterNm = frstRegisterNm;
-	}
-
-	public String getFrstRegisterPnttm() {
-		return frstRegisterPnttm;
-	}
-
-	public void setFrstRegisterPnttm(String frstRegisterPnttm) {
-		this.frstRegisterPnttm = frstRegisterPnttm;
-	}
-
-	public String getFrstRegisterId() {
-		return frstRegisterId;
-	}
-
-	public void setFrstRegisterId(String frstRegisterId) {
-		this.frstRegisterId = frstRegisterId;
-	}
-
-	public String getLastUpdusrPnttm() {
-		return lastUpdusrPnttm;
-	}
-
-	public void setLastUpdusrPnttm(String lastUpdusrPnttm) {
-		this.lastUpdusrPnttm = lastUpdusrPnttm;
-	}
-
-	public String getLastUpdtPnttm() {
-		return lastUpdtPnttm;
-	}
-
-	public void setLastUpdtPnttm(String lastUpdtPnttm) {
-		this.lastUpdtPnttm = lastUpdtPnttm;
-	}
-
-	public String getLastUpdusrId() {
-		return lastUpdusrId;
-	}
-
-	public void setLastUpdusrId(String lastUpdusrId) {
-		this.lastUpdusrId = lastUpdusrId;
-	}
 
 }


### PR DESCRIPTION
uss/sam 모듈(약관관리, 저작권보호정책) VO 클래스 4개에 Lombok @Getter/@Setter 어노테이션을 적용하고 수동으로 작성된 getter/setter 메서드를 제거한다.

**변경 사유**
반복적인 boilerplate getter/setter 코드를 Lombok으로 대체하여 코드 가독성과 유지보수성을 높인다.

**변경 내용**
- `uss/sam/stp`: StplatManageDefaultVO, StplatManageVO — getter/setter 20개 제거
- `uss/sam/cpy`: CpyrhtPrtcPolicyDefaultVO, CpyrhtPrtcPolicyVO — getter/setter 15개 제거
- `pom.xml`: maven-compiler-plugin에 `annotationProcessorPaths` 추가 (PR #802와 동일한 변경 — fast-forward 가능)

**영향 범위**
약관관리(StplatManage), 저작권보호정책(CpyrhtPrtcPolicy) 기능에만 영향. 외부 인터페이스(메서드 시그니처) 변경 없음.

**체크리스트**
- [x] 단일 주제만 다룸 (다른 변경 없음)
- [x] 5.x 다른 브랜치용 PR이 필요한 경우 후속 PR 링크 명시
- [x] 의존성 추가가 필요한 경우 선행 PR 링크 명시 (pom.xml 변경은 PR #802와 동일)
- [x] 기존 동작에 영향 없음 (getter/setter 시그니처 동일)
- [x] `mvn -DskipTests compile` BUILD SUCCESS 확인
