### PR TITLE
[refactor][공통컴포넌트] cop/sms·smt(djm·lsm·mrm) 모듈 VO Lombok @Getter/@Setter 적용

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -597,6 +597,13 @@
 					<artifactId>maven-compiler-plugin</artifactId>
 					<configuration>
 						<release>${java.version}</release>
+						<annotationProcessorPaths>
+							<path>
+								<groupId>org.projectlombok</groupId>
+								<artifactId>lombok</artifactId>
+								<version>${lombok.version}</version>
+							</path>
+						</annotationProcessorPaths>
 					</configuration>
 				</plugin>
 				<plugin>

--- a/src/main/java/egovframework/com/cop/sms/service/SmsVO.java
+++ b/src/main/java/egovframework/com/cop/sms/service/SmsVO.java
@@ -1,5 +1,7 @@
 package egovframework.com.cop.sms.service;
 
+import lombok.Getter;
+import lombok.Setter;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
 /**
@@ -11,24 +13,27 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.06.18  한성곤          최초 생성
+ *   2025.05.26  기여자          Lombok @Getter/@Setter 적용으로 보일러플레이트 제거
  *
  * </pre>
  */
+@Getter
+@Setter
 @SuppressWarnings("serial")
 public class SmsVO extends Sms {
     /** 검색조건 */
     private String searchCnd = "";
-    
+
     /** 검색단어 */
     private String searchWrd = "";
-    
+
     /** 정렬순서(DESC,ASC) */
     private String sortOrdr = "";
-    
+
     /** 현재페이지 */
     private int pageIndex = 1;
 
@@ -51,169 +56,10 @@ public class SmsVO extends Sms {
     private int rowNo = 0;
 
     /**
-     * searchCnd attribute를 리턴한다.
-     * @return the searchCnd
-     */
-    public String getSearchCnd() {
-        return searchCnd;
-    }
-
-    /**
-     * searchCnd attribute 값을 설정한다.
-     * @param searchCnd the searchCnd to set
-     */
-    public void setSearchCnd(String searchCnd) {
-        this.searchCnd = searchCnd;
-    }
-
-    /**
-     * searchWrd attribute를 리턴한다.
-     * @return the searchWrd
-     */
-    public String getSearchWrd() {
-        return searchWrd;
-    }
-
-    /**
-     * searchWrd attribute 값을 설정한다.
-     * @param searchWrd the searchWrd to set
-     */
-    public void setSearchWrd(String searchWrd) {
-        this.searchWrd = searchWrd;
-    }
-
-    /**
-     * sortOrdr attribute를 리턴한다.
-     * @return the sortOrdr
-     */
-    public String getSortOrdr() {
-        return sortOrdr;
-    }
-
-    /**
-     * sortOrdr attribute 값을 설정한다.
-     * @param sortOrdr the sortOrdr to set
-     */
-    public void setSortOrdr(String sortOrdr) {
-        this.sortOrdr = sortOrdr;
-    }
-
-    /**
-     * pageIndex attribute를 리턴한다.
-     * @return the pageIndex
-     */
-    public int getPageIndex() {
-        return pageIndex;
-    }
-
-    /**
-     * pageIndex attribute 값을 설정한다.
-     * @param pageIndex the pageIndex to set
-     */
-    public void setPageIndex(int pageIndex) {
-        this.pageIndex = pageIndex;
-    }
-
-    /**
-     * pageUnit attribute를 리턴한다.
-     * @return the pageUnit
-     */
-    public int getPageUnit() {
-        return pageUnit;
-    }
-
-    /**
-     * pageUnit attribute 값을 설정한다.
-     * @param pageUnit the pageUnit to set
-     */
-    public void setPageUnit(int pageUnit) {
-        this.pageUnit = pageUnit;
-    }
-
-    /**
-     * pageSize attribute를 리턴한다.
-     * @return the pageSize
-     */
-    public int getPageSize() {
-        return pageSize;
-    }
-
-    /**
-     * pageSize attribute 값을 설정한다.
-     * @param pageSize the pageSize to set
-     */
-    public void setPageSize(int pageSize) {
-        this.pageSize = pageSize;
-    }
-
-    /**
-     * firstIndex attribute를 리턴한다.
-     * @return the firstIndex
-     */
-    public int getFirstIndex() {
-        return firstIndex;
-    }
-
-    /**
-     * firstIndex attribute 값을 설정한다.
-     * @param firstIndex the firstIndex to set
-     */
-    public void setFirstIndex(int firstIndex) {
-        this.firstIndex = firstIndex;
-    }
-
-    /**
-     * lastIndex attribute를 리턴한다.
-     * @return the lastIndex
-     */
-    public int getLastIndex() {
-        return lastIndex;
-    }
-
-    /**
-     * lastIndex attribute 값을 설정한다.
-     * @param lastIndex the lastIndex to set
-     */
-    public void setLastIndex(int lastIndex) {
-        this.lastIndex = lastIndex;
-    }
-
-    /**
-     * recordCountPerPage attribute를 리턴한다.
-     * @return the recordCountPerPage
-     */
-    public int getRecordCountPerPage() {
-        return recordCountPerPage;
-    }
-
-    /**
-     * recordCountPerPage attribute 값을 설정한다.
-     * @param recordCountPerPage the recordCountPerPage to set
-     */
-    public void setRecordCountPerPage(int recordCountPerPage) {
-        this.recordCountPerPage = recordCountPerPage;
-    }
-
-    /**
-     * rowNo attribute를 리턴한다.
-     * @return the rowNo
-     */
-    public int getRowNo() {
-        return rowNo;
-    }
-
-    /**
-     * rowNo attribute 값을 설정한다.
-     * @param rowNo the rowNo to set
-     */
-    public void setRowNo(int rowNo) {
-        this.rowNo = rowNo;
-    }
-    
-    /**
      * toString 메소드를 대치한다.
      */
+    @Override
     public String toString() {
-	return ToStringBuilder.reflectionToString(this);
+        return ToStringBuilder.reflectionToString(this);
     }
 }

--- a/src/main/java/egovframework/com/cop/smt/djm/service/ChargerVO.java
+++ b/src/main/java/egovframework/com/cop/smt/djm/service/ChargerVO.java
@@ -1,10 +1,12 @@
 package egovframework.com.cop.smt.djm.service;
 
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * 개요
  * - 담당자자에 대한 Vo 클래스를 정의한다.
- * 
+ *
  * 상세내용
  * - 담당자의 목록 항목, 조회조건 등을 관리한다.
  * @author 장철호
@@ -15,19 +17,22 @@ package egovframework.com.cop.smt.djm.service;
  *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
- *   2010.6.28	장철호          최초 생성
+ *   2010.6.28  장철호          최초 생성
+ *   2025.05.26  기여자          Lombok @Getter/@Setter 적용으로 보일러플레이트 제거
  *
  * </pre>
  */
+@Getter
+@Setter
 @SuppressWarnings("serial")
 public class ChargerVO extends Charger {
 
-	/** 검색조건 */
+    /** 검색조건 */
     private String searchCnd = "";
-    
+
     /** 검색단어 */
     private String searchWrd = "";
-    
+
     /** 현재페이지 */
     private int pageIndex = 1;
 
@@ -45,70 +50,5 @@ public class ChargerVO extends Charger {
 
     /** 페이지당 레코드 개수 */
     private int recordCountPerPage = 10;
-
-	public String getSearchCnd() {
-		return searchCnd;
-	}
-
-	public void setSearchCnd(String searchCnd) {
-		this.searchCnd = searchCnd;
-	}
-
-	public String getSearchWrd() {
-		return searchWrd;
-	}
-
-	public void setSearchWrd(String searchWrd) {
-		this.searchWrd = searchWrd;
-	}
-
-	public int getPageIndex() {
-		return pageIndex;
-	}
-
-	public void setPageIndex(int pageIndex) {
-		this.pageIndex = pageIndex;
-	}
-
-	public int getPageUnit() {
-		return pageUnit;
-	}
-
-	public void setPageUnit(int pageUnit) {
-		this.pageUnit = pageUnit;
-	}
-
-	public int getPageSize() {
-		return pageSize;
-	}
-
-	public void setPageSize(int pageSize) {
-		this.pageSize = pageSize;
-	}
-
-	public int getFirstIndex() {
-		return firstIndex;
-	}
-
-	public void setFirstIndex(int firstIndex) {
-		this.firstIndex = firstIndex;
-	}
-
-	public int getLastIndex() {
-		return lastIndex;
-	}
-
-	public void setLastIndex(int lastIndex) {
-		this.lastIndex = lastIndex;
-	}
-
-	public int getRecordCountPerPage() {
-		return recordCountPerPage;
-	}
-
-	public void setRecordCountPerPage(int recordCountPerPage) {
-		this.recordCountPerPage = recordCountPerPage;
-	}
-
 
 }

--- a/src/main/java/egovframework/com/cop/smt/djm/service/DeptJobBxVO.java
+++ b/src/main/java/egovframework/com/cop/smt/djm/service/DeptJobBxVO.java
@@ -1,9 +1,12 @@
 package egovframework.com.cop.smt.djm.service;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * 개요
  * - 부서업무함에 대한 Vo 클래스를 정의한다.
- * 
+ *
  * 상세내용
  * - 부서업무함의 목록 항목, 조회조건 등을 관리한다.
  * @author 장철호
@@ -14,19 +17,22 @@ package egovframework.com.cop.smt.djm.service;
  *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
- *   2010.6.28	장철호          최초 생성
+ *   2010.6.28  장철호          최초 생성
+ *   2025.05.26  기여자          Lombok @Getter/@Setter 적용으로 보일러플레이트 제거
  *
  * </pre>
  */
+@Getter
+@Setter
 @SuppressWarnings("serial")
 public class DeptJobBxVO extends DeptJobBx {
 
-	/** 검색조건 */
+    /** 검색조건 */
     private String searchCnd = "";
-    
+
     /** 검색단어 */
     private String searchWrd = "";
-    
+
     /** 현재페이지 */
     private int pageIndex = 1;
 
@@ -45,90 +51,10 @@ public class DeptJobBxVO extends DeptJobBx {
     /** 페이지당 레코드 개수 */
     private int recordCountPerPage = 10;
 
-    /** 표시순서 변경 조건*/
+    /** 표시순서 변경 조건 */
     private String ordrCnd = "";
-    
-    /** 팝업 조건*/
+
+    /** 팝업 조건 */
     private String popupCnd = "";
-
-	public String getSearchCnd() {
-		return searchCnd;
-	}
-
-	public void setSearchCnd(String searchCnd) {
-		this.searchCnd = searchCnd;
-	}
-
-	public String getSearchWrd() {
-		return searchWrd;
-	}
-
-	public void setSearchWrd(String searchWrd) {
-		this.searchWrd = searchWrd;
-	}
-
-	public int getPageIndex() {
-		return pageIndex;
-	}
-
-	public void setPageIndex(int pageIndex) {
-		this.pageIndex = pageIndex;
-	}
-
-	public int getPageUnit() {
-		return pageUnit;
-	}
-
-	public void setPageUnit(int pageUnit) {
-		this.pageUnit = pageUnit;
-	}
-
-	public int getPageSize() {
-		return pageSize;
-	}
-
-	public void setPageSize(int pageSize) {
-		this.pageSize = pageSize;
-	}
-
-	public int getFirstIndex() {
-		return firstIndex;
-	}
-
-	public void setFirstIndex(int firstIndex) {
-		this.firstIndex = firstIndex;
-	}
-
-	public int getLastIndex() {
-		return lastIndex;
-	}
-
-	public void setLastIndex(int lastIndex) {
-		this.lastIndex = lastIndex;
-	}
-
-	public int getRecordCountPerPage() {
-		return recordCountPerPage;
-	}
-
-	public void setRecordCountPerPage(int recordCountPerPage) {
-		this.recordCountPerPage = recordCountPerPage;
-	}
-
-	public String getOrdrCnd() {
-		return ordrCnd;
-	}
-
-	public void setOrdrCnd(String ordrCnd) {
-		this.ordrCnd = ordrCnd;
-	}
-
-	public String getPopupCnd() {
-		return popupCnd;
-	}
-
-	public void setPopupCnd(String popupCnd) {
-		this.popupCnd = popupCnd;
-	}
 
 }

--- a/src/main/java/egovframework/com/cop/smt/djm/service/DeptJobVO.java
+++ b/src/main/java/egovframework/com/cop/smt/djm/service/DeptJobVO.java
@@ -1,9 +1,12 @@
 package egovframework.com.cop.smt.djm.service;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * 개요
  * - 부서업무에 대한 Vo 클래스를 정의한다.
- * 
+ *
  * 상세내용
  * - 부서업무의 목록 항목, 조회조건 등을 관리한다.
  * @author 장철호
@@ -14,22 +17,25 @@ package egovframework.com.cop.smt.djm.service;
  *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
- *   2010.6.28	장철호          최초 생성
+ *   2010.6.28  장철호          최초 생성
+ *   2025.05.26  기여자          Lombok @Getter/@Setter 적용으로 보일러플레이트 제거
  *
  * </pre>
  */
+@Getter
+@Setter
 @SuppressWarnings("serial")
 public class DeptJobVO extends DeptJob {
 
-	/** 검색조건 */
+    /** 검색조건 */
     private String searchCnd = "";
-    
+
     /** 검색단어 */
     private String searchWrd = "";
-    
+
     /** 부서ID조회조건 */
     private String searchDeptId = "";
-    
+
     /** 부서업무함ID조회조건 */
     private String searchDeptJobBxId = "";
 
@@ -51,84 +57,4 @@ public class DeptJobVO extends DeptJob {
     /** 페이지당 레코드 개수 */
     private int recordCountPerPage = 10;
 
-	public String getSearchCnd() {
-		return searchCnd;
-	}
-
-	public void setSearchCnd(String searchCnd) {
-		this.searchCnd = searchCnd;
-	}
-
-	public String getSearchWrd() {
-		return searchWrd;
-	}
-
-	public void setSearchWrd(String searchWrd) {
-		this.searchWrd = searchWrd;
-	}
-
-	public String getSearchDeptId() {
-		return searchDeptId;
-	}
-
-	public void setSearchDeptId(String searchDeptId) {
-		this.searchDeptId = searchDeptId;
-	}
-
-	public String getSearchDeptJobBxId() {
-		return searchDeptJobBxId;
-	}
-
-	public void setSearchDeptJobBxId(String searchDeptJobBxId) {
-		this.searchDeptJobBxId = searchDeptJobBxId;
-	}
-
-	public int getPageIndex() {
-		return pageIndex;
-	}
-
-	public void setPageIndex(int pageIndex) {
-		this.pageIndex = pageIndex;
-	}
-
-	public int getPageUnit() {
-		return pageUnit;
-	}
-
-	public void setPageUnit(int pageUnit) {
-		this.pageUnit = pageUnit;
-	}
-
-	public int getPageSize() {
-		return pageSize;
-	}
-
-	public void setPageSize(int pageSize) {
-		this.pageSize = pageSize;
-	}
-
-	public int getFirstIndex() {
-		return firstIndex;
-	}
-
-	public void setFirstIndex(int firstIndex) {
-		this.firstIndex = firstIndex;
-	}
-
-	public int getLastIndex() {
-		return lastIndex;
-	}
-
-	public void setLastIndex(int lastIndex) {
-		this.lastIndex = lastIndex;
-	}
-
-	public int getRecordCountPerPage() {
-		return recordCountPerPage;
-	}
-
-	public void setRecordCountPerPage(int recordCountPerPage) {
-		this.recordCountPerPage = recordCountPerPage;
-	}
-	
 }

--- a/src/main/java/egovframework/com/cop/smt/djm/service/DeptVO.java
+++ b/src/main/java/egovframework/com/cop/smt/djm/service/DeptVO.java
@@ -1,8 +1,12 @@
 package egovframework.com.cop.smt.djm.service;
+
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * 개요
  * - 부서에 대한 VO 클래스를 정의한다.
- * 
+ *
  * 상세내용
  * - 부서의 목록 항목, 조회조건 등을 관리한다.
  * @author 장철호
@@ -13,18 +17,22 @@ package egovframework.com.cop.smt.djm.service;
  *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
- *   2010.6.28	장철호          최초 생성
+ *   2010.6.28  장철호          최초 생성
+ *   2025.05.26  기여자          Lombok @Getter/@Setter 적용으로 보일러플레이트 제거
  *
  * </pre>
  */
+@Getter
+@Setter
 @SuppressWarnings("serial")
 public class DeptVO extends Dept {
-	/** 검색조건 */
+
+    /** 검색조건 */
     private String searchCnd = "";
-    
+
     /** 검색단어 */
     private String searchWrd = "";
-    
+
     /** 현재페이지 */
     private int pageIndex = 1;
 
@@ -42,69 +50,5 @@ public class DeptVO extends Dept {
 
     /** 페이지당 레코드 개수 */
     private int recordCountPerPage = 10;
-
-    public String getSearchCnd() {
-		return searchCnd;
-	}
-
-	public void setSearchCnd(String searchCnd) {
-		this.searchCnd = searchCnd;
-	}
-
-	public String getSearchWrd() {
-		return searchWrd;
-	}
-
-	public void setSearchWrd(String searchWrd) {
-		this.searchWrd = searchWrd;
-	}
-
-	public int getPageIndex() {
-		return pageIndex;
-	}
-
-	public void setPageIndex(int pageIndex) {
-		this.pageIndex = pageIndex;
-	}
-
-	public int getPageUnit() {
-		return pageUnit;
-	}
-
-	public void setPageUnit(int pageUnit) {
-		this.pageUnit = pageUnit;
-	}
-
-	public int getPageSize() {
-		return pageSize;
-	}
-
-	public void setPageSize(int pageSize) {
-		this.pageSize = pageSize;
-	}
-
-	public int getFirstIndex() {
-		return firstIndex;
-	}
-
-	public void setFirstIndex(int firstIndex) {
-		this.firstIndex = firstIndex;
-	}
-
-	public int getLastIndex() {
-		return lastIndex;
-	}
-
-	public void setLastIndex(int lastIndex) {
-		this.lastIndex = lastIndex;
-	}
-
-	public int getRecordCountPerPage() {
-		return recordCountPerPage;
-	}
-
-	public void setRecordCountPerPage(int recordCountPerPage) {
-		this.recordCountPerPage = recordCountPerPage;
-	}
 
 }

--- a/src/main/java/egovframework/com/cop/smt/lsm/service/EmplyrVO.java
+++ b/src/main/java/egovframework/com/cop/smt/lsm/service/EmplyrVO.java
@@ -1,10 +1,12 @@
 package egovframework.com.cop.smt.lsm.service;
 
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * 개요
  * - 사용자에 대한 Vo 클래스를 정의한다.
- * 
+ *
  * 상세내용
  * - 사용자의 목록 항목, 조회조건 등을 관리한다.
  * @author 장철호
@@ -12,22 +14,25 @@ package egovframework.com.cop.smt.lsm.service;
  * @created 28-6-2010 오전 11:29:26
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
- *   2010.6.28	장철호          최초 생성
+ *   2010.6.28  장철호          최초 생성
+ *   2025.05.26  기여자          Lombok @Getter/@Setter 적용으로 보일러플레이트 제거
  *
  * </pre>
  */
+@Getter
+@Setter
 @SuppressWarnings("serial")
 public class EmplyrVO extends Emplyr {
 
-	/** 검색조건 */
+    /** 검색조건 */
     private String searchCnd = "";
-    
+
     /** 검색단어 */
     private String searchWrd = "";
-    
+
     /** 현재페이지 */
     private int pageIndex = 1;
 
@@ -46,69 +51,4 @@ public class EmplyrVO extends Emplyr {
     /** 페이지당 레코드 개수 */
     private int recordCountPerPage = 10;
 
-	public String getSearchCnd() {
-		return searchCnd;
-	}
-
-	public void setSearchCnd(String searchCnd) {
-		this.searchCnd = searchCnd;
-	}
-
-	public String getSearchWrd() {
-		return searchWrd;
-	}
-
-	public void setSearchWrd(String searchWrd) {
-		this.searchWrd = searchWrd;
-	}
-
-	public int getPageIndex() {
-		return pageIndex;
-	}
-
-	public void setPageIndex(int pageIndex) {
-		this.pageIndex = pageIndex;
-	}
-
-	public int getPageUnit() {
-		return pageUnit;
-	}
-
-	public void setPageUnit(int pageUnit) {
-		this.pageUnit = pageUnit;
-	}
-
-	public int getPageSize() {
-		return pageSize;
-	}
-
-	public void setPageSize(int pageSize) {
-		this.pageSize = pageSize;
-	}
-
-	public int getFirstIndex() {
-		return firstIndex;
-	}
-
-	public void setFirstIndex(int firstIndex) {
-		this.firstIndex = firstIndex;
-	}
-
-	public int getLastIndex() {
-		return lastIndex;
-	}
-
-	public void setLastIndex(int lastIndex) {
-		this.lastIndex = lastIndex;
-	}
-
-	public int getRecordCountPerPage() {
-		return recordCountPerPage;
-	}
-
-	public void setRecordCountPerPage(int recordCountPerPage) {
-		this.recordCountPerPage = recordCountPerPage;
-	}
-
-    
 }

--- a/src/main/java/egovframework/com/cop/smt/lsm/service/LeaderSchdulVO.java
+++ b/src/main/java/egovframework/com/cop/smt/lsm/service/LeaderSchdulVO.java
@@ -1,9 +1,12 @@
 package egovframework.com.cop.smt.lsm.service;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * 개요
  * - 간부일정에 대한 Vo 클래스를 정의한다.
- * 
+ *
  * 상세내용
  * - 간부일정의 목록 항목, 조회조건 등을 관리한다.
  * @author 장철호
@@ -11,114 +14,42 @@ package egovframework.com.cop.smt.lsm.service;
  * @created 28-6-2010 오전 10:59:06
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
- *   2010.6.28	장철호          최초 생성
+ *   2010.6.28  장철호          최초 생성
+ *   2025.05.26  기여자          Lombok @Getter/@Setter 적용으로 보일러플레이트 제거
  *
  * </pre>
  */
+@Getter
+@Setter
 @SuppressWarnings("serial")
 public class LeaderSchdulVO extends LeaderSchdul {
-	
-	/** 월별/주별/일별 일정조회 조회조건 */
-	private String searchMode;
-	/** 월 조회조건	 */
-	private String searchMonth;
-	/** 시작일자 조회조건 */
-	private String searchBgnDe;
-	/** 종료일자 조회조건	*/
-	private String searchEndDe;
-	/** 일자 조회조건 */
-	private String searchDay;
-	/** 년 조회조건 */
-	private String year;
-	/** 월 조회조건 */
-	private String month;
-	/** 주 조회조건 */
-	private String week;
-	/** 일 조회조건 */
-	private String day;
-	/** 검색조건 */
-	private String searchCondition;
-	/** 검색단어 */
-	private String searchKeyword;
-	/** 보조검색단어 */
-	private String searchKeywordEx;
-	
-	public String getSearchMode() {
-		return searchMode;
-	}
-	public void setSearchMode(String searchMode) {
-		this.searchMode = searchMode;
-	}
-	public String getSearchMonth() {
-		return searchMonth;
-	}
-	public void setSearchMonth(String searchMonth) {
-		this.searchMonth = searchMonth;
-	}
-	public String getSearchBgnDe() {
-		return searchBgnDe;
-	}
-	public void setSearchBgnDe(String searchBgnDe) {
-		this.searchBgnDe = searchBgnDe;
-	}
-	public String getSearchEndDe() {
-		return searchEndDe;
-	}
-	public void setSearchEndDe(String searchEndDe) {
-		this.searchEndDe = searchEndDe;
-	}
-	public String getSearchDay() {
-		return searchDay;
-	}
-	public void setSearchDay(String searchDay) {
-		this.searchDay = searchDay;
-	}
-	public String getYear() {
-		return year;
-	}
-	public void setYear(String year) {
-		this.year = year;
-	}
-	public String getMonth() {
-		return month;
-	}
-	public void setMonth(String month) {
-		this.month = month;
-	}
-	public String getWeek() {
-		return week;
-	}
-	public void setWeek(String week) {
-		this.week = week;
-	}
-	public String getDay() {
-		return day;
-	}
-	public void setDay(String day) {
-		this.day = day;
-	}
-	public String getSearchCondition() {
-		return searchCondition;
-	}
-	public void setSearchCondition(String searchCondition) {
-		this.searchCondition = searchCondition;
-	}
-	public String getSearchKeyword() {
-		return searchKeyword;
-	}
-	public void setSearchKeyword(String searchKeyword) {
-		this.searchKeyword = searchKeyword;
-	}
-	public String getSearchKeywordEx() {
-		return searchKeywordEx;
-	}
-	public void setSearchKeywordEx(String searchKeywordEx) {
-		this.searchKeywordEx = searchKeywordEx;
-	}
 
+    /** 월별/주별/일별 일정조회 조회조건 */
+    private String searchMode;
+    /** 월 조회조건 */
+    private String searchMonth;
+    /** 시작일자 조회조건 */
+    private String searchBgnDe;
+    /** 종료일자 조회조건 */
+    private String searchEndDe;
+    /** 일자 조회조건 */
+    private String searchDay;
+    /** 년 조회조건 */
+    private String year;
+    /** 월 조회조건 */
+    private String month;
+    /** 주 조회조건 */
+    private String week;
+    /** 일 조회조건 */
+    private String day;
+    /** 검색조건 */
+    private String searchCondition;
+    /** 검색단어 */
+    private String searchKeyword;
+    /** 보조검색단어 */
+    private String searchKeywordEx;
 
-	
 }

--- a/src/main/java/egovframework/com/cop/smt/lsm/service/LeaderSttusVO.java
+++ b/src/main/java/egovframework/com/cop/smt/lsm/service/LeaderSttusVO.java
@@ -1,9 +1,12 @@
 package egovframework.com.cop.smt.lsm.service;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * 개요
  * - 간부상태에 대한 Vo 클래스를 정의한다.
- * 
+ *
  * 상세내용
  * - 간부상태의 목록 항목, 조회조건 등을 관리한다.
  * @author 장철호
@@ -11,23 +14,26 @@ package egovframework.com.cop.smt.lsm.service;
  * @created 28-6-2010 오전 10:59:06
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
- *   2010.6.28	장철호          최초 생성
+ *   2010.6.28  장철호          최초 생성
+ *   2025.05.26  기여자          Lombok @Getter/@Setter 적용으로 보일러플레이트 제거
  *
  * </pre>
  */
+@Getter
+@Setter
 @SuppressWarnings("serial")
 public class LeaderSttusVO extends LeaderSttus {
-	
-	/** 검색조건 */
+
+    /** 검색조건 */
     private String searchCnd = "";
-    
+
     /** 검색단어 */
     private String searchWrd = "";
-    
-	 /** 현재페이지 */
+
+    /** 현재페이지 */
     private int pageIndex = 1;
 
     /** 페이지개수 */
@@ -45,69 +51,4 @@ public class LeaderSttusVO extends LeaderSttus {
     /** 페이지당 레코드 개수 */
     private int recordCountPerPage = 10;
 
-	public String getSearchCnd() {
-		return searchCnd;
-	}
-
-	public void setSearchCnd(String searchCnd) {
-		this.searchCnd = searchCnd;
-	}
-
-	public String getSearchWrd() {
-		return searchWrd;
-	}
-
-	public void setSearchWrd(String searchWrd) {
-		this.searchWrd = searchWrd;
-	}
-
-	public int getPageIndex() {
-		return pageIndex;
-	}
-
-	public void setPageIndex(int pageIndex) {
-		this.pageIndex = pageIndex;
-	}
-
-	public int getPageUnit() {
-		return pageUnit;
-	}
-
-	public void setPageUnit(int pageUnit) {
-		this.pageUnit = pageUnit;
-	}
-
-	public int getPageSize() {
-		return pageSize;
-	}
-
-	public void setPageSize(int pageSize) {
-		this.pageSize = pageSize;
-	}
-
-	public int getFirstIndex() {
-		return firstIndex;
-	}
-
-	public void setFirstIndex(int firstIndex) {
-		this.firstIndex = firstIndex;
-	}
-
-	public int getLastIndex() {
-		return lastIndex;
-	}
-
-	public void setLastIndex(int lastIndex) {
-		this.lastIndex = lastIndex;
-	}
-
-	public int getRecordCountPerPage() {
-		return recordCountPerPage;
-	}
-
-	public void setRecordCountPerPage(int recordCountPerPage) {
-		this.recordCountPerPage = recordCountPerPage;
-	}
-
-	
 }

--- a/src/main/java/egovframework/com/cop/smt/mrm/service/MemoReprtVO.java
+++ b/src/main/java/egovframework/com/cop/smt/mrm/service/MemoReprtVO.java
@@ -1,9 +1,12 @@
 package egovframework.com.cop.smt.mrm.service;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * 개요
  * - 메모보고에 대한 Vo 클래스를 정의한다.
- * 
+ *
  * 상세내용
  * - 메모보고의 목록 항목, 조회조건 등을 관리한다.
  * @author 장철호
@@ -11,34 +14,37 @@ package egovframework.com.cop.smt.mrm.service;
  * @created 19-7-2010 오전 10:14:53
  *  <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
- *   2010.7.19	장철호          최초 생성
+ *   2010.7.19  장철호          최초 생성
+ *   2025.05.26  기여자          Lombok @Getter/@Setter 적용으로 보일러플레이트 제거
  *
  * </pre>
  */
+@Getter
+@Setter
 @SuppressWarnings("serial")
 public class MemoReprtVO extends MemoReprt {
 
-	/** 검색조건 */
+    /** 검색조건 */
     private String searchCnd = "";
-    
+
     /** 검색단어 */
     private String searchWrd = "";
-    
+
     /** 사용자ID조회조건 */
     private String searchId = "";
-    
+
     /** 시작일자 조회조건 */
     private String searchBgnDe = "";
-    
+
     /** 종료일자 조회조건 */
     private String searchEndDe = "";
-    
+
     /** 메모보고서 상태 조회조건 */
     private String searchSttus = "";
-    
+
     /** 메모보고서 의견사항등록 조회조건 */
     private String searchDrctMatter = "";
 
@@ -59,109 +65,5 @@ public class MemoReprtVO extends MemoReprt {
 
     /** 페이지당 레코드 개수 */
     private int recordCountPerPage = 10;
-
-	public String getSearchCnd() {
-		return searchCnd;
-	}
-
-	public void setSearchCnd(String searchCnd) {
-		this.searchCnd = searchCnd;
-	}
-
-	public String getSearchWrd() {
-		return searchWrd;
-	}
-
-	public void setSearchWrd(String searchWrd) {
-		this.searchWrd = searchWrd;
-	}
-
-	public String getSearchId() {
-		return searchId;
-	}
-
-	public void setSearchId(String searchId) {
-		this.searchId = searchId;
-	}
-
-	public String getSearchBgnDe() {
-		return searchBgnDe;
-	}
-
-	public void setSearchBgnDe(String searchBgnDe) {
-		this.searchBgnDe = searchBgnDe;
-	}
-
-	public String getSearchEndDe() {
-		return searchEndDe;
-	}
-
-	public void setSearchEndDe(String searchEndDe) {
-		this.searchEndDe = searchEndDe;
-	}
-
-	public String getSearchSttus() {
-		return searchSttus;
-	}
-
-	public void setSearchSttus(String searchSttus) {
-		this.searchSttus = searchSttus;
-	}
-
-	public String getSearchDrctMatter() {
-		return searchDrctMatter;
-	}
-
-	public void setSearchDrctMatter(String searchDrctMatter) {
-		this.searchDrctMatter = searchDrctMatter;
-	}
-
-	public int getPageIndex() {
-		return pageIndex;
-	}
-
-	public void setPageIndex(int pageIndex) {
-		this.pageIndex = pageIndex;
-	}
-
-	public int getPageUnit() {
-		return pageUnit;
-	}
-
-	public void setPageUnit(int pageUnit) {
-		this.pageUnit = pageUnit;
-	}
-
-	public int getPageSize() {
-		return pageSize;
-	}
-
-	public void setPageSize(int pageSize) {
-		this.pageSize = pageSize;
-	}
-
-	public int getFirstIndex() {
-		return firstIndex;
-	}
-
-	public void setFirstIndex(int firstIndex) {
-		this.firstIndex = firstIndex;
-	}
-
-	public int getLastIndex() {
-		return lastIndex;
-	}
-
-	public void setLastIndex(int lastIndex) {
-		this.lastIndex = lastIndex;
-	}
-
-	public int getRecordCountPerPage() {
-		return recordCountPerPage;
-	}
-
-	public void setRecordCountPerPage(int recordCountPerPage) {
-		this.recordCountPerPage = recordCountPerPage;
-	}
 
 }

--- a/src/main/java/egovframework/com/cop/smt/mrm/service/ReportrVO.java
+++ b/src/main/java/egovframework/com/cop/smt/mrm/service/ReportrVO.java
@@ -1,10 +1,12 @@
 package egovframework.com.cop.smt.mrm.service;
 
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * 개요
  * - 보고자에 대한 Vo 클래스를 정의한다.
- * 
+ *
  * 상세내용
  * - 보고자의 목록 항목, 조회조건 등을 관리한다.
  * @author 장철호
@@ -12,23 +14,26 @@ package egovframework.com.cop.smt.mrm.service;
  * @created 28-6-2010 오전 11:29:26
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
- *   2010.6.28	장철호          최초 생성
+ *   2010.6.28  장철호          최초 생성
+ *   2025.05.26  기여자          Lombok @Getter/@Setter 적용으로 보일러플레이트 제거
  *
  * </pre>
  */
+@Getter
+@Setter
 @SuppressWarnings("serial")
 public class ReportrVO extends Reportr {
 
-	/** 검색조건 */
+    /** 검색조건 */
     private String searchCnd = "";
-    
+
     /** 검색단어 */
     private String searchWrd = "";
-    
-     /** 현재페이지 */
+
+    /** 현재페이지 */
     private int pageIndex = 1;
 
     /** 페이지개수 */
@@ -46,69 +51,4 @@ public class ReportrVO extends Reportr {
     /** 페이지당 레코드 개수 */
     private int recordCountPerPage = 10;
 
-	public String getSearchCnd() {
-		return searchCnd;
-	}
-
-	public void setSearchCnd(String searchCnd) {
-		this.searchCnd = searchCnd;
-	}
-
-	public String getSearchWrd() {
-		return searchWrd;
-	}
-
-	public void setSearchWrd(String searchWrd) {
-		this.searchWrd = searchWrd;
-	}
-
-	public int getPageIndex() {
-		return pageIndex;
-	}
-
-	public void setPageIndex(int pageIndex) {
-		this.pageIndex = pageIndex;
-	}
-
-	public int getPageUnit() {
-		return pageUnit;
-	}
-
-	public void setPageUnit(int pageUnit) {
-		this.pageUnit = pageUnit;
-	}
-
-	public int getPageSize() {
-		return pageSize;
-	}
-
-	public void setPageSize(int pageSize) {
-		this.pageSize = pageSize;
-	}
-
-	public int getFirstIndex() {
-		return firstIndex;
-	}
-
-	public void setFirstIndex(int firstIndex) {
-		this.firstIndex = firstIndex;
-	}
-
-	public int getLastIndex() {
-		return lastIndex;
-	}
-
-	public void setLastIndex(int lastIndex) {
-		this.lastIndex = lastIndex;
-	}
-
-	public int getRecordCountPerPage() {
-		return recordCountPerPage;
-	}
-
-	public void setRecordCountPerPage(int recordCountPerPage) {
-		this.recordCountPerPage = recordCountPerPage;
-	}
-
- 
 }


### PR DESCRIPTION
## 변경 사유

cop/sms 및 cop/smt(djm·lsm·mrm) 하위 모듈 VO 클래스에 수백 줄 분량의 수동 getter/setter 보일러플레이트가 존재한다. Lombok @Getter/@Setter 적용으로 코드 가독성을 높이고 유지보수 부담을 줄인다.

## 변경 내용

- `pom.xml`: maven-compiler-plugin에 `annotationProcessorPaths` 추가 (PR #802와 동일 구성)
- `cop/sms/SmsVO`: @Getter/@Setter 적용, 수동 getter/setter 제거
- `cop/smt/djm`: ChargerVO, DeptJobBxVO, DeptJobVO, DeptVO (4개)
- `cop/smt/lsm`: EmplyrVO, LeaderSchdulVO, LeaderSttusVO (3개)
- `cop/smt/mrm`: MemoReprtVO, ReportrVO (2개)

총 10개 VO, 11개 파일 변경 (+161 / -918 라인)

## 영향 범위

- 기존 동작에 영향 없음: Lombok이 컴파일 시점에 동일한 getter/setter를 생성하므로 바이트코드 수준 호환성 유지
- cop/ems(#808)와 다른 하위 패키지 대상

## 참고

- pom 변경은 PR #802와 동일 — fast-forward 가능
- cop/ems(#808)와 충돌 없음

## 체크리스트

- [x] 단일 주제만 다룸 (Lombok 적용 외 다른 변경 없음)
- [x] 의존성 추가 선행 PR 내용 포함 (annotationProcessorPaths)
- [x] 기존 동작에 영향 없음
- [x] `mvn -DskipTests compile` 통과 확인
