### PR TITLE
[refactor][공통컴포넌트] dam/sec 소규모 모듈 VO Lombok @Getter/@Setter 적용

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -597,6 +597,13 @@
 					<artifactId>maven-compiler-plugin</artifactId>
 					<configuration>
 						<release>${java.version}</release>
+						<annotationProcessorPaths>
+							<path>
+								<groupId>org.projectlombok</groupId>
+								<artifactId>lombok</artifactId>
+								<version>${lombok.version}</version>
+							</path>
+						</annotationProcessorPaths>
 					</configuration>
 				</plugin>
 				<plugin>

--- a/src/main/java/egovframework/com/dam/app/service/KnoAppraisalVO.java
+++ b/src/main/java/egovframework/com/dam/app/service/KnoAppraisalVO.java
@@ -1,32 +1,37 @@
 package egovframework.com.dam.app.service;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * 개요
  * - 지식정보평가에 대한 Vo 클래스를 정의한다.
- * 
+ *
  * 상세내용
  * - 지식정보평가의 목록 항목, 조회조건 등을 관리한다.
  * @author 박종선
  * @version 1.0
  * @created 12-8-2010 오후 3:44:48
  */
+@Getter
+@Setter
 public class KnoAppraisalVO extends KnoAppraisal {
 
 	/** 검색조건 */
     private String searchCondition = "";
-    
+
     /** 검색Keyword */
-    private String searchKeyword = "";    
+    private String searchKeyword = "";
 
     /** 페이지개수 */
     private int pageUnit = 10;
 
 	/** 페이지사이즈 */
     private int pageSize = 10;
-    
+
     /** 현재페이지 */
     private int pageIndex = 1;
-    
+
     /** firstIndex */
     private int firstIndex = 1;
 
@@ -36,115 +41,4 @@ public class KnoAppraisalVO extends KnoAppraisal {
 	/** recordCountPerPage */
     private int recordCountPerPage = 10;
 
-	/**
-	 * @return the searchCondition
-	 */
-	public String getSearchCondition() {
-		return searchCondition;
-	}
-
-	/**
-	 * @param searchCondition the searchCondition to set
-	 */
-	public void setSearchCondition(String searchCondition) {
-		this.searchCondition = searchCondition;
-	}
-
-	/**
-	 * @return the searchKeyword
-	 */
-	public String getSearchKeyword() {
-		return searchKeyword;
-	}
-
-	/**
-	 * @param searchKeyword the searchKeyword to set
-	 */
-	public void setSearchKeyword(String searchKeyword) {
-		this.searchKeyword = searchKeyword;
-	}
-
-	/**
-	 * @return the pageUnit
-	 */
-	public int getPageUnit() {
-		return pageUnit;
-	}
-
-	/**
-	 * @param pageUnit the pageUnit to set
-	 */
-	public void setPageUnit(int pageUnit) {
-		this.pageUnit = pageUnit;
-	}
-
-	/**
-	 * @return the pageSize
-	 */
-	public int getPageSize() {
-		return pageSize;
-	}
-
-	/**
-	 * @param pageSize the pageSize to set
-	 */
-	public void setPageSize(int pageSize) {
-		this.pageSize = pageSize;
-	}
-
-	/**
-	 * @return the pageIndex
-	 */
-	public int getPageIndex() {
-		return pageIndex;
-	}
-
-	/**
-	 * @param pageIndex the pageIndex to set
-	 */
-	public void setPageIndex(int pageIndex) {
-		this.pageIndex = pageIndex;
-	}
-
-	/**
-	 * @return the firstIndex
-	 */
-	public int getFirstIndex() {
-		return firstIndex;
-	}
-
-	/**
-	 * @param firstIndex the firstIndex to set
-	 */
-	public void setFirstIndex(int firstIndex) {
-		this.firstIndex = firstIndex;
-	}
-
-	/**
-	 * @return the lastIndex
-	 */
-	public int getLastIndex() {
-		return lastIndex;
-	}
-
-	/**
-	 * @param lastIndex the lastIndex to set
-	 */
-	public void setLastIndex(int lastIndex) {
-		this.lastIndex = lastIndex;
-	}
-
-	/**
-	 * @return the recordCountPerPage
-	 */
-	public int getRecordCountPerPage() {
-		return recordCountPerPage;
-	}
-
-	/**
-	 * @param recordCountPerPage the recordCountPerPage to set
-	 */
-	public void setRecordCountPerPage(int recordCountPerPage) {
-		this.recordCountPerPage = recordCountPerPage;
-	}
 }

--- a/src/main/java/egovframework/com/dam/map/mat/service/MapMaterialVO.java
+++ b/src/main/java/egovframework/com/dam/map/mat/service/MapMaterialVO.java
@@ -1,33 +1,37 @@
 package egovframework.com.dam.map.mat.service;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * 개요
  * - 지식맵(지식유형)에 대한 Vo 클래스를 정의한다.
- * 
+ *
  * 상세내용
  * - 지식맵(지식유형)의 목록 항목, 조회조건 등을 관리한다.
  * @author 박종선
  * @version 1.0
  * @created 12-8-2010 오후 3:44:53
  */
-
+@Getter
+@Setter
 public class MapMaterialVO extends MapMaterial {
 
 	/** 검색조건 */
     private String searchCondition = "";
-    
+
     /** 검색Keyword */
-    private String searchKeyword = "";    
+    private String searchKeyword = "";
 
     /** 페이지개수 */
     private int pageUnit = 10;
 
 	/** 페이지사이즈 */
     private int pageSize = 10;
-    
+
     /** 현재페이지 */
     private int pageIndex = 1;
-    
+
     /** firstIndex */
     private int firstIndex = 1;
 
@@ -37,68 +41,4 @@ public class MapMaterialVO extends MapMaterial {
 	/** recordCountPerPage */
     private int recordCountPerPage = 10;
 
-	public String getSearchCondition() {
-		return searchCondition;
-	}
-
-	public void setSearchCondition(String searchCondition) {
-		this.searchCondition = searchCondition;
-	}
-
-	public String getSearchKeyword() {
-		return searchKeyword;
-	}
-
-	public void setSearchKeyword(String searchKeyword) {
-		this.searchKeyword = searchKeyword;
-	}
-
-	public int getPageUnit() {
-		return pageUnit;
-	}
-
-	public void setPageUnit(int pageUnit) {
-		this.pageUnit = pageUnit;
-	}
-
-	public int getPageSize() {
-		return pageSize;
-	}
-
-	public void setPageSize(int pageSize) {
-		this.pageSize = pageSize;
-	}
-
-	public int getPageIndex() {
-		return pageIndex;
-	}
-
-	public void setPageIndex(int pageIndex) {
-		this.pageIndex = pageIndex;
-	}
-
-	public int getFirstIndex() {
-		return firstIndex;
-	}
-
-	public void setFirstIndex(int firstIndex) {
-		this.firstIndex = firstIndex;
-	}
-
-	public int getLastIndex() {
-		return lastIndex;
-	}
-
-	public void setLastIndex(int lastIndex) {
-		this.lastIndex = lastIndex;
-	}
-
-	public int getRecordCountPerPage() {
-		return recordCountPerPage;
-	}
-
-	public void setRecordCountPerPage(int recordCountPerPage) {
-		this.recordCountPerPage = recordCountPerPage;
-	}
-    
 }

--- a/src/main/java/egovframework/com/dam/map/tea/service/MapTeamVO.java
+++ b/src/main/java/egovframework/com/dam/map/tea/service/MapTeamVO.java
@@ -1,33 +1,37 @@
 package egovframework.com.dam.map.tea.service;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * 개요
  * - 지식맵(조직별)에 대한 Vo 클래스를 정의한다.
- * 
+ *
  * 상세내용
  * - 지식맵(조직별)의 목록 항목, 조회조건 등을 관리한다.
  * @author 박종선
  * @version 1.0
  * @created 22-7-2010 오전 10:57:44
  */
-
+@Getter
+@Setter
 public class MapTeamVO extends MapTeam {
-	
+
 	/** 검색조건 */
     private String searchCondition = "";
-    
+
     /** 검색Keyword */
-    private String searchKeyword = "";    
+    private String searchKeyword = "";
 
     /** 페이지개수 */
     private int pageUnit = 10;
 
 	/** 페이지사이즈 */
     private int pageSize = 10;
-    
+
     /** 현재페이지 */
     private int pageIndex = 1;
-    
+
     /** firstIndex */
     private int firstIndex = 1;
 
@@ -36,69 +40,5 @@ public class MapTeamVO extends MapTeam {
 
 	/** recordCountPerPage */
     private int recordCountPerPage = 10;
-    
-    public int getFirstIndex() {
-		return firstIndex;
-	}
-    
-    public String getSearchCondition() {
-		return searchCondition;
-	}
-
-	public void setSearchCondition(String searchCondition) {
-		this.searchCondition = searchCondition;
-	}
-	
-    public String getSearchKeyword() {
-		return searchKeyword;
-	}
-
-	public void setSearchKeyword(String searchKeyword) {
-		this.searchKeyword = searchKeyword;
-	}	
-
-	public void setFirstIndex(int firstIndex) {
-		this.firstIndex = firstIndex;
-	}
-
-	public int getLastIndex() {
-		return lastIndex;
-	}
-
-	public void setLastIndex(int lastIndex) {
-		this.lastIndex = lastIndex;
-	}
-
-	public int getRecordCountPerPage() {
-		return recordCountPerPage;
-	}
-
-	public void setRecordCountPerPage(int recordCountPerPage) {
-		this.recordCountPerPage = recordCountPerPage;
-	}
-
-	public int getPageIndex() {
-		return pageIndex;
-	}
-
-	public void setPageIndex(int pageIndex) {
-		this.pageIndex = pageIndex;
-	}
-
-	public int getPageSize() {
-		return pageSize;
-	}
-
-	public void setPageSize(int pageSize) {
-		this.pageSize = pageSize;
-	}
-
-	public int getPageUnit() {
-		return pageUnit;
-	}
-
-	public void setPageUnit(int pageUnit) {
-		this.pageUnit = pageUnit;
-	}
 
 }

--- a/src/main/java/egovframework/com/dam/mgm/service/KnoManagementVO.java
+++ b/src/main/java/egovframework/com/dam/mgm/service/KnoManagementVO.java
@@ -1,5 +1,8 @@
 package egovframework.com.dam.mgm.service;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * 개요
  * - 지식정보에 대한 VO 클래스를 정의한다.
@@ -10,23 +13,25 @@ package egovframework.com.dam.mgm.service;
  * @version 1.0
  * @created 12-8-2010 오후 3:44:49
  */
+@Getter
+@Setter
 public class KnoManagementVO extends KnoManagement {
 
 	/** 검색조건 */
     private String searchCondition = "";
-    
+
     /** 검색Keyword */
-    private String searchKeyword = "";    
+    private String searchKeyword = "";
 
     /** 페이지개수 */
     private int pageUnit = 10;
 
 	/** 페이지사이즈 */
     private int pageSize = 10;
-    
+
     /** 현재페이지 */
     private int pageIndex = 1;
-    
+
     /** firstIndex */
     private int firstIndex = 1;
 
@@ -35,117 +40,5 @@ public class KnoManagementVO extends KnoManagement {
 
 	/** recordCountPerPage */
     private int recordCountPerPage = 10;
-
-	/**
-	 * @return the searchCondition
-	 */
-	public String getSearchCondition() {
-		return searchCondition;
-	}
-
-	/**
-	 * @param searchCondition the searchCondition to set
-	 */
-	public void setSearchCondition(String searchCondition) {
-		this.searchCondition = searchCondition;
-	}
-
-	/**
-	 * @return the searchKeyword
-	 */
-	public String getSearchKeyword() {
-		return searchKeyword;
-	}
-
-	/**
-	 * @param searchKeyword the searchKeyword to set
-	 */
-	public void setSearchKeyword(String searchKeyword) {
-		this.searchKeyword = searchKeyword;
-	}
-
-	/**
-	 * @return the pageUnit
-	 */
-	public int getPageUnit() {
-		return pageUnit;
-	}
-
-	/**
-	 * @param pageUnit the pageUnit to set
-	 */
-	public void setPageUnit(int pageUnit) {
-		this.pageUnit = pageUnit;
-	}
-
-	/**
-	 * @return the pageSize
-	 */
-	public int getPageSize() {
-		return pageSize;
-	}
-
-	/**
-	 * @param pageSize the pageSize to set
-	 */
-	public void setPageSize(int pageSize) {
-		this.pageSize = pageSize;
-	}
-
-	/**
-	 * @return the pageIndex
-	 */
-	public int getPageIndex() {
-		return pageIndex;
-	}
-
-	/**
-	 * @param pageIndex the pageIndex to set
-	 */
-	public void setPageIndex(int pageIndex) {
-		this.pageIndex = pageIndex;
-	}
-
-	/**
-	 * @return the firstIndex
-	 */
-	public int getFirstIndex() {
-		return firstIndex;
-	}
-
-	/**
-	 * @param firstIndex the firstIndex to set
-	 */
-	public void setFirstIndex(int firstIndex) {
-		this.firstIndex = firstIndex;
-	}
-
-	/**
-	 * @return the lastIndex
-	 */
-	public int getLastIndex() {
-		return lastIndex;
-	}
-
-	/**
-	 * @param lastIndex the lastIndex to set
-	 */
-	public void setLastIndex(int lastIndex) {
-		this.lastIndex = lastIndex;
-	}
-
-	/**
-	 * @return the recordCountPerPage
-	 */
-	public int getRecordCountPerPage() {
-		return recordCountPerPage;
-	}
-
-	/**
-	 * @param recordCountPerPage the recordCountPerPage to set
-	 */
-	public void setRecordCountPerPage(int recordCountPerPage) {
-		this.recordCountPerPage = recordCountPerPage;
-	}	
 
 }

--- a/src/main/java/egovframework/com/dam/per/service/KnoPersonalVO.java
+++ b/src/main/java/egovframework/com/dam/per/service/KnoPersonalVO.java
@@ -1,33 +1,37 @@
 package egovframework.com.dam.per.service;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * 개요
  * - 개인지식정보에 대한 Vo 클래스를 정의한다.
- * 
+ *
  * 상세내용
  * - 개인지식정보의 목록 항목, 조회조건 등을 관리한다.
  * @author 박종선
  * @version 1.0
  * @created 12-8-2010 오후 3:44:50
  */
-
+@Getter
+@Setter
 public class KnoPersonalVO extends KnoPersonal {
 
 	/** 검색조건 */
     private String searchCondition = "";
-    
+
     /** 검색Keyword */
-    private String searchKeyword = "";    
+    private String searchKeyword = "";
 
     /** 페이지개수 */
     private int pageUnit = 10;
 
 	/** 페이지사이즈 */
     private int pageSize = 10;
-    
+
     /** 현재페이지 */
     private int pageIndex = 1;
-    
+
     /** firstIndex */
     private int firstIndex = 1;
 
@@ -37,116 +41,4 @@ public class KnoPersonalVO extends KnoPersonal {
 	/** recordCountPerPage */
     private int recordCountPerPage = 10;
 
-	/**
-	 * @return the searchCondition
-	 */
-	public String getSearchCondition() {
-		return searchCondition;
-	}
-
-	/**
-	 * @param searchCondition the searchCondition to set
-	 */
-	public void setSearchCondition(String searchCondition) {
-		this.searchCondition = searchCondition;
-	}
-
-	/**
-	 * @return the searchKeyword
-	 */
-	public String getSearchKeyword() {
-		return searchKeyword;
-	}
-
-	/**
-	 * @param searchKeyword the searchKeyword to set
-	 */
-	public void setSearchKeyword(String searchKeyword) {
-		this.searchKeyword = searchKeyword;
-	}
-
-	/**
-	 * @return the pageUnit
-	 */
-	public int getPageUnit() {
-		return pageUnit;
-	}
-
-	/**
-	 * @param pageUnit the pageUnit to set
-	 */
-	public void setPageUnit(int pageUnit) {
-		this.pageUnit = pageUnit;
-	}
-
-	/**
-	 * @return the pageSize
-	 */
-	public int getPageSize() {
-		return pageSize;
-	}
-
-	/**
-	 * @param pageSize the pageSize to set
-	 */
-	public void setPageSize(int pageSize) {
-		this.pageSize = pageSize;
-	}
-
-	/**
-	 * @return the pageIndex
-	 */
-	public int getPageIndex() {
-		return pageIndex;
-	}
-
-	/**
-	 * @param pageIndex the pageIndex to set
-	 */
-	public void setPageIndex(int pageIndex) {
-		this.pageIndex = pageIndex;
-	}
-
-	/**
-	 * @return the firstIndex
-	 */
-	public int getFirstIndex() {
-		return firstIndex;
-	}
-
-	/**
-	 * @param firstIndex the firstIndex to set
-	 */
-	public void setFirstIndex(int firstIndex) {
-		this.firstIndex = firstIndex;
-	}
-
-	/**
-	 * @return the lastIndex
-	 */
-	public int getLastIndex() {
-		return lastIndex;
-	}
-
-	/**
-	 * @param lastIndex the lastIndex to set
-	 */
-	public void setLastIndex(int lastIndex) {
-		this.lastIndex = lastIndex;
-	}
-
-	/**
-	 * @return the recordCountPerPage
-	 */
-	public int getRecordCountPerPage() {
-		return recordCountPerPage;
-	}
-
-	/**
-	 * @param recordCountPerPage the recordCountPerPage to set
-	 */
-	public void setRecordCountPerPage(int recordCountPerPage) {
-		this.recordCountPerPage = recordCountPerPage;
-	}
-    
 }

--- a/src/main/java/egovframework/com/dam/spe/req/service/RequestOfferVO.java
+++ b/src/main/java/egovframework/com/dam/spe/req/service/RequestOfferVO.java
@@ -1,5 +1,7 @@
 package egovframework.com.dam.spe.req.service;
 
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * 지식정보제공/지식정보요청 Model and VO Class 구현
@@ -15,7 +17,9 @@ package egovframework.com.dam.spe.req.service;
  *
  * </pre>
  */
-public class RequestOfferVO extends RequestOffer{
+@Getter
+@Setter
+public class RequestOfferVO extends RequestOffer {
 
 	/** 명령어 */
     private String cmd = "";
@@ -43,133 +47,6 @@ public class RequestOfferVO extends RequestOffer{
 
 	/** recordCountPerPage */
     private int recordCountPerPage = 10;
-
-	/**
-	 * @return the cmd
-	 */
-	public String getCmd() {
-		return cmd;
-	}
-
-	/**
-	 * @param cmd the cmd to set
-	 */
-	public void setCmd(String cmd) {
-		this.cmd = cmd;
-	}
-
-	/**
-	 * @return the searchCondition
-	 */
-	public String getSearchCondition() {
-		return searchCondition;
-	}
-
-	/**
-	 * @param searchCondition the searchCondition to set
-	 */
-	public void setSearchCondition(String searchCondition) {
-		this.searchCondition = searchCondition;
-	}
-
-	/**
-	 * @return the searchKeyword
-	 */
-	public String getSearchKeyword() {
-		return searchKeyword;
-	}
-
-	/**
-	 * @param searchKeyword the searchKeyword to set
-	 */
-	public void setSearchKeyword(String searchKeyword) {
-		this.searchKeyword = searchKeyword;
-	}
-
-	/**
-	 * @return the pageUnit
-	 */
-	public int getPageUnit() {
-		return pageUnit;
-	}
-
-	/**
-	 * @param pageUnit the pageUnit to set
-	 */
-	public void setPageUnit(int pageUnit) {
-		this.pageUnit = pageUnit;
-	}
-
-	/**
-	 * @return the pageSize
-	 */
-	public int getPageSize() {
-		return pageSize;
-	}
-
-	/**
-	 * @param pageSize the pageSize to set
-	 */
-	public void setPageSize(int pageSize) {
-		this.pageSize = pageSize;
-	}
-
-	/**
-	 * @return the pageIndex
-	 */
-	public int getPageIndex() {
-		return pageIndex;
-	}
-
-	/**
-	 * @param pageIndex the pageIndex to set
-	 */
-	public void setPageIndex(int pageIndex) {
-		this.pageIndex = pageIndex;
-	}
-
-	/**
-	 * @return the firstIndex
-	 */
-	public int getFirstIndex() {
-		return firstIndex;
-	}
-
-	/**
-	 * @param firstIndex the firstIndex to set
-	 */
-	public void setFirstIndex(int firstIndex) {
-		this.firstIndex = firstIndex;
-	}
-
-	/**
-	 * @return the lastIndex
-	 */
-	public int getLastIndex() {
-		return lastIndex;
-	}
-
-	/**
-	 * @param lastIndex the lastIndex to set
-	 */
-	public void setLastIndex(int lastIndex) {
-		this.lastIndex = lastIndex;
-	}
-
-	/**
-	 * @return the recordCountPerPage
-	 */
-	public int getRecordCountPerPage() {
-		return recordCountPerPage;
-	}
-
-	/**
-	 * @param recordCountPerPage the recordCountPerPage to set
-	 */
-	public void setRecordCountPerPage(int recordCountPerPage) {
-		this.recordCountPerPage = recordCountPerPage;
-	}
-
 
 }
 

--- a/src/main/java/egovframework/com/dam/spe/spe/service/KnoSpecialistVO.java
+++ b/src/main/java/egovframework/com/dam/spe/spe/service/KnoSpecialistVO.java
@@ -1,32 +1,37 @@
 package egovframework.com.dam.spe.spe.service;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * 개요
  * - 지식전문가에 대한 Vo 클래스를 정의한다.
- * 
+ *
  * 상세내용
  * - 지식전문가의 목록 항목, 조회조건 등을 관리한다.
  * @author 박종선
  * @version 1.0
  * @created 12-8-2010 오후 3:44:52
  */
+@Getter
+@Setter
 public class KnoSpecialistVO extends KnoSpecialist {
 
 	/** 검색조건 */
     private String searchCondition = "";
-    
+
     /** 검색Keyword */
-    private String searchKeyword = "";    
+    private String searchKeyword = "";
 
     /** 페이지개수 */
     private int pageUnit = 10;
 
 	/** 페이지사이즈 */
     private int pageSize = 10;
-    
+
     /** 현재페이지 */
     private int pageIndex = 1;
-    
+
     /** firstIndex */
     private int firstIndex = 1;
 
@@ -35,117 +40,5 @@ public class KnoSpecialistVO extends KnoSpecialist {
 
 	/** recordCountPerPage */
     private int recordCountPerPage = 10;
-
-	/**
-	 * @return the searchCondition
-	 */
-	public String getSearchCondition() {
-		return searchCondition;
-	}
-
-	/**
-	 * @param searchCondition the searchCondition to set
-	 */
-	public void setSearchCondition(String searchCondition) {
-		this.searchCondition = searchCondition;
-	}
-
-	/**
-	 * @return the searchKeyword
-	 */
-	public String getSearchKeyword() {
-		return searchKeyword;
-	}
-
-	/**
-	 * @param searchKeyword the searchKeyword to set
-	 */
-	public void setSearchKeyword(String searchKeyword) {
-		this.searchKeyword = searchKeyword;
-	}
-
-	/**
-	 * @return the pageUnit
-	 */
-	public int getPageUnit() {
-		return pageUnit;
-	}
-
-	/**
-	 * @param pageUnit the pageUnit to set
-	 */
-	public void setPageUnit(int pageUnit) {
-		this.pageUnit = pageUnit;
-	}
-
-	/**
-	 * @return the pageSize
-	 */
-	public int getPageSize() {
-		return pageSize;
-	}
-
-	/**
-	 * @param pageSize the pageSize to set
-	 */
-	public void setPageSize(int pageSize) {
-		this.pageSize = pageSize;
-	}
-
-	/**
-	 * @return the pageIndex
-	 */
-	public int getPageIndex() {
-		return pageIndex;
-	}
-
-	/**
-	 * @param pageIndex the pageIndex to set
-	 */
-	public void setPageIndex(int pageIndex) {
-		this.pageIndex = pageIndex;
-	}
-
-	/**
-	 * @return the firstIndex
-	 */
-	public int getFirstIndex() {
-		return firstIndex;
-	}
-
-	/**
-	 * @param firstIndex the firstIndex to set
-	 */
-	public void setFirstIndex(int firstIndex) {
-		this.firstIndex = firstIndex;
-	}
-
-	/**
-	 * @return the lastIndex
-	 */
-	public int getLastIndex() {
-		return lastIndex;
-	}
-
-	/**
-	 * @param lastIndex the lastIndex to set
-	 */
-	public void setLastIndex(int lastIndex) {
-		this.lastIndex = lastIndex;
-	}
-
-	/**
-	 * @return the recordCountPerPage
-	 */
-	public int getRecordCountPerPage() {
-		return recordCountPerPage;
-	}
-
-	/**
-	 * @param recordCountPerPage the recordCountPerPage to set
-	 */
-	public void setRecordCountPerPage(int recordCountPerPage) {
-		this.recordCountPerPage = recordCountPerPage;
-	}
 
 }

--- a/src/main/java/egovframework/com/sec/rmt/service/RoleManageVO.java
+++ b/src/main/java/egovframework/com/sec/rmt/service/RoleManageVO.java
@@ -7,7 +7,7 @@ import lombok.Setter;
 
 /**
  * 롤관리에 대한 Vo 클래스를 정의한다.
- * 
+ *
  * @author 공통서비스 개발팀 이문준
  * @since 2009.06.01
  * @version 1.0
@@ -23,6 +23,8 @@ import lombok.Setter;
  *
  *      </pre>
  */
+@Getter
+@Setter
 public class RoleManageVO extends RoleManage {
 	/**
 	 * serialVersionUID
@@ -35,26 +37,6 @@ public class RoleManageVO extends RoleManage {
 	/**
 	 * 삭제대상 목록
 	 */
-	@Getter
-	@Setter
 	String[] delYn;
-
-	/**
-	 * roleManageList attribute 를 리턴한다.
-	 * 
-	 * @return List<RoleManageVO>
-	 */
-	public List<RoleManageVO> getRoleManageList() {
-		return roleManageList;
-	}
-
-	/**
-	 * roleManageList attribute 값을 설정한다.
-	 * 
-	 * @param roleManageList List<RoleManageVO>
-	 */
-	public void setRoleManageList(List<RoleManageVO> roleManageList) {
-		this.roleManageList = roleManageList;
-	}
 
 }


### PR DESCRIPTION
## 변경 사유

dam 모듈(지식관리) 및 sec/rmt 모듈 VO 클래스에 수동으로 작성된 getter/setter 메서드를 Lombok `@Getter`/`@Setter` 어노테이션으로 대체하여 코드 가독성을 높이고 보일러플레이트를 줄인다.

## 변경 내용

**dam 모듈 (7개 VO)**
- `KnoAppraisalVO` — 지식정보평가
- `MapMaterialVO` — 지식맵(지식유형)
- `MapTeamVO` — 지식맵(조직별)
- `KnoManagementVO` — 지식정보
- `KnoPersonalVO` — 개인지식정보
- `RequestOfferVO` — 지식정보제공/요청
- `KnoSpecialistVO` — 지식전문가

**sec 모듈 (1개 VO)**
- `RoleManageVO` (sec/rmt) — 롤관리. 기존에 `delYn` 필드에만 개별 `@Getter`/`@Setter`가 붙어 있던 것을 클래스 레벨로 통합

**pom.xml**
- `maven-compiler-plugin`에 `annotationProcessorPaths` 추가 (PR #802와 동일 — fast-forward 가능)

## 영향 범위

- PR #801 (sec drm/gmt/ram/rgm VO) 및 PR #799 (cmm 핵심 VO)와 겹치는 파일 없음
- sec/rmt RoleManageVO는 PR #801 대상 외 파일로 충돌 없음
- 기존 getter/setter 시그니처 동일 유지 — 호출부 변경 불필요

## 체크리스트

- [x] 단일 주제만 다룸 (Lombok 적용, 다른 변경 없음)
- [x] `mvn -DskipTests compile` BUILD SUCCESS 확인
- [x] PR #799, #801, #802 등 기존 PR과 파일 중복 없음
- [x] 기존 동작에 영향 없음 (getter/setter 시그니처 동일)
