### PR TITLE
[refactor][공통컴포넌트] uss/ion/ans 모듈 VO Lombok @Getter/@Setter 적용

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -597,6 +597,13 @@
 					<artifactId>maven-compiler-plugin</artifactId>
 					<configuration>
 						<release>${java.version}</release>
+						<annotationProcessorPaths>
+							<path>
+								<groupId>org.projectlombok</groupId>
+								<artifactId>lombok</artifactId>
+								<version>${lombok.version}</version>
+							</path>
+						</annotationProcessorPaths>
 					</configuration>
 				</plugin>
 				<plugin>

--- a/src/main/java/egovframework/com/uss/ion/ans/service/AnnvrsryManage.java
+++ b/src/main/java/egovframework/com/uss/ion/ans/service/AnnvrsryManage.java
@@ -5,11 +5,13 @@ import egovframework.com.cmm.ComDefaultVO;
 import org.egovframe.rte.ptl.reactive.validation.EgovNullCheck;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * 개요
  * - 기념일관리에 대한 model 클래스를 정의한다.
- * 
+ *
  * 상세내용
  * - 기념일관리의 사용자ID,기념일명,기념일자,달력구분,알림설정,알림시작일자,메모,최초등록자ID,최초등록시점,최종수정자ID,최종수정시점 항목을 관리한다.
  * @author 이용
@@ -17,6 +19,8 @@ import jakarta.validation.constraints.Size;
  * @created 06-15-2010 오후 2:08:56
  */
 
+@Getter
+@Setter
 public class AnnvrsryManage extends ComDefaultVO {
 
 	/**
@@ -108,208 +112,5 @@ public class AnnvrsryManage extends ComDefaultVO {
 	private String lastUpdusrPnttm;
 	
 
-	/**
-	 * @return the annId
-	 */
-	public String getAnnId() {
-		return annId;
-	}
 
-	/**
-	 * @param annId the annId to set
-	 */
-	public void setAnnId(String annId) {
-		this.annId = annId;
-	}
-
-	/**
-	 * @return the usid
-	 */
-	public String getUsid() {
-		return usid;
-	}
-
-	/**
-	 * @param usid the usid to set
-	 */
-	public void setUsid(String usid) {
-		this.usid = usid;
-	}
-
-	/**
-	 * @return the annvrsrySe
-	 */
-	public String getAnnvrsrySe() {
-		return annvrsrySe;
-	}
-
-	/**
-	 * @param annvrsrySe the annvrsrySe to set
-	 */
-	public void setAnnvrsrySe(String annvrsrySe) {
-		this.annvrsrySe = annvrsrySe;
-	}
-
-	/**
-	 * @return the annvrsryNm
-	 */
-	public String getAnnvrsryNm() {
-		return annvrsryNm;
-	}
-
-	/**
-	 * @param annvrsryNm the annvrsryNm to set
-	 */
-	public void setAnnvrsryNm(String annvrsryNm) {
-		this.annvrsryNm = annvrsryNm;
-	}
-
-	/**
-	 * @return the annvrsryDe
-	 */
-	public String getAnnvrsryDe() {
-		return annvrsryDe;
-	}
-
-	/**
-	 * @param annvrsryDe the annvrsryDe to set
-	 */
-	public void setAnnvrsryDe(String annvrsryDe) {
-		this.annvrsryDe = annvrsryDe;
-	}
-
-	/**
-	 * @return the cldrSe
-	 */
-	public String getCldrSe() {
-		return cldrSe;
-	}
-
-	/**
-	 * @param cldrSe the cldrSe to set
-	 */
-	public void setCldrSe(String cldrSe) {
-		this.cldrSe = cldrSe;
-	}
-
-	/**
-	 * @return the annvrsrySetup
-	 */
-	public String getAnnvrsrySetup() {
-		return annvrsrySetup;
-	}
-
-	/**
-	 * @param annvrsrySetup the annvrsrySetup to set
-	 */
-	public void setAnnvrsrySetup(String annvrsrySetup) {
-		this.annvrsrySetup = annvrsrySetup;
-	}
-
-	/**
-	 * @return the annvrsryBeginDe
-	 */
-	public String getAnnvrsryBeginDe() {
-		return annvrsryBeginDe;
-	}
-
-	/**
-	 * @param annvrsryBeginDe the annvrsryBeginDe to set
-	 */
-	public void setAnnvrsryBeginDe(String annvrsryBeginDe) {
-		this.annvrsryBeginDe = annvrsryBeginDe;
-	}
-
-	/**
-	 * @return the memo
-	 */
-	public String getMemo() {
-		return memo;
-	}
-
-	/**
-	 * @param memo the memo to set
-	 */
-	public void setMemo(String memo) {
-		this.memo = memo;
-	}
-
-	/**
-	 * @return the frstRegisterId
-	 */
-	public String getFrstRegisterId() {
-		return frstRegisterId;
-	}
-
-	/**
-	 * @param frstRegisterId the frstRegisterId to set
-	 */
-	public void setFrstRegisterId(String frstRegisterId) {
-		this.frstRegisterId = frstRegisterId;
-	}
-
-	/**
-	 * @return the frstRegisterPnttm
-	 */
-	public String getFrstRegisterPnttm() {
-		return frstRegisterPnttm;
-	}
-
-	/**
-	 * @param frstRegisterPnttm the frstRegisterPnttm to set
-	 */
-	public void setFrstRegisterPnttm(String frstRegisterPnttm) {
-		this.frstRegisterPnttm = frstRegisterPnttm;
-	}
-
-	/**
-	 * @return the lastUpdusrId
-	 */
-	public String getLastUpdusrId() {
-		return lastUpdusrId;
-	}
-
-	/**
-	 * @param lastUpdusrId the lastUpdusrId to set
-	 */
-	public void setLastUpdusrId(String lastUpdusrId) {
-		this.lastUpdusrId = lastUpdusrId;
-	}
-
-	/**
-	 * @return the lastUpdusrPnttm
-	 */
-	public String getLastUpdusrPnttm() {
-		return lastUpdusrPnttm;
-	}
-
-	/**
-	 * @param lastUpdusrPnttm the lastUpdusrPnttm to set
-	 */
-	public void setLastUpdusrPnttm(String lastUpdusrPnttm) {
-		this.lastUpdusrPnttm = lastUpdusrPnttm;
-	}
-
-	/**
-	 * @return the serialVersionUID
-	 */
-	public static long getSerialVersionUID() {
-		return serialVersionUID;
-	}
-
-	/**
-	 * @return the reptitSe
-	 */
-	public String getReptitSe() {
-		return reptitSe;
-	}
-
-	/**
-	 * @param reptitSe the reptitSe to set
-	 */
-	public void setReptitSe(String reptitSe) {
-		this.reptitSe = reptitSe;
-	}
-
-	
 }

--- a/src/main/java/egovframework/com/uss/ion/ans/service/AnnvrsryManageVO.java
+++ b/src/main/java/egovframework/com/uss/ion/ans/service/AnnvrsryManageVO.java
@@ -1,11 +1,13 @@
 package egovframework.com.uss.ion.ans.service;
 
 import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * 개요
  * - 기념일관리에 대한 Vo 클래스를 정의한다.
- * 
+ *
  * 상세내용
  * - 기념일관리의 목록 항목을 관리한다.
  * @author 이용
@@ -14,6 +16,8 @@ import java.util.List;
  */
 
 //public class AnnvrsryManageVO extends AnnvrsryManage implements Serializable {
+@Getter
+@Setter
 public class AnnvrsryManageVO extends AnnvrsryManage{
 
 	/**
@@ -54,91 +58,6 @@ public class AnnvrsryManageVO extends AnnvrsryManage{
 	*  출력 변수	5
 	*/ 
 	private String annvrsryTemp5;
-
-	/**
-	 * @return the annvrsryManageList
-	 */
-	public List<AnnvrsryManageVO> getAnnvrsryManageList() {
-		return annvrsryManageList;
-	}
-	/**
-	 * @param bannerList the bannerList to set
-	 */
-	public void setAnnvrsryManageList(List<AnnvrsryManageVO> annvrsryManageList) {
-		this.annvrsryManageList = annvrsryManageList;
-	}
-	/**
-	 * @return the rowCount
-	 */
-	public int getRowCount() {
-		return rowCount;
-	}
-	/**
-	 * @param rowCount the rowCount to set
-	 */
-	public void setRowCount(int rowCount) {
-		this.rowCount = rowCount;
-	}
-	/**
-	 * @return the annvrsryTemp1
-	 */
-	public String getAnnvrsryTemp1() {
-		return annvrsryTemp1;
-	}
-	/**
-	 * @param annvrsryTemp1 the annvrsryTemp1 to set
-	 */
-	public void setAnnvrsryTemp1(String annvrsryTemp1) {
-		this.annvrsryTemp1 = annvrsryTemp1;
-	}
-	/**
-	 * @return the annvrsryTemp2
-	 */
-	public String getAnnvrsryTemp2() {
-		return annvrsryTemp2;
-	}
-	/**
-	 * @param annvrsryTemp2 the annvrsryTemp2 to set
-	 */
-	public void setAnnvrsryTemp2(String annvrsryTemp2) {
-		this.annvrsryTemp2 = annvrsryTemp2;
-	}
-	/**
-	 * @return the annvrsryTemp3
-	 */
-	public String getAnnvrsryTemp3() {
-		return annvrsryTemp3;
-	}
-	/**
-	 * @param annvrsryTemp3 the annvrsryTemp3 to set
-	 */
-	public void setAnnvrsryTemp3(String annvrsryTemp3) {
-		this.annvrsryTemp3 = annvrsryTemp3;
-	}
-	/**
-	 * @return the annvrsryTemp4
-	 */
-	public String getAnnvrsryTemp4() {
-		return annvrsryTemp4;
-	}
-	/**
-	 * @param annvrsryTemp4 the annvrsryTemp4 to set
-	 */
-	public void setAnnvrsryTemp4(String annvrsryTemp4) {
-		this.annvrsryTemp4 = annvrsryTemp4;
-	}
-	/**
-	 * @return the annvrsryTemp5
-	 */
-	public String getAnnvrsryTemp5() {
-		return annvrsryTemp5;
-	}
-	/**
-	 * @param annvrsryTemp5 the annvrsryTemp5 to set
-	 */
-	public void setAnnvrsryTemp5(String annvrsryTemp5) {
-		this.annvrsryTemp5 = annvrsryTemp5;
-	}
 
 
 }


### PR DESCRIPTION
## 변경 사유
uss/ion/ans(기념일관리) 모듈 VO에 수동 작성된 boilerplate getter/setter가 있어
필드 추가·제거 시 누락 위험이 있다. Lombok 어노테이션으로 대체해 가독성과
유지보수성을 개선한다.

## 변경 내용
- `AnnvrsryManage`: `@Getter @Setter` 적용, 수동 getter/setter 약 200줄 제거
- `AnnvrsryManageVO`: `@Getter @Setter` 적용, 수동 getter/setter 약 90줄 제거
- `pom.xml`: `maven-compiler-plugin`의 `annotationProcessorPaths`에 Lombok APT 추가
  (PR #802와 완전히 동일한 7줄 변경 — 충돌 없이 fast-forward 가능)

## 영향 범위
- 외부 API(getter/setter 시그니처) 변경 없음
- 빌드 동작 변경 없음 — `mvn -DskipTests compile` BUILD SUCCESS 확인

## 체크리스트
- [x] 단일 하위 패키지(uss/ion/ans)만 다룸
- [x] 의존성 PR(#802)과 동일 pom 변경 — fast-forward 가능
- [x] 기존 동작에 영향 없음
- [x] mvn compile 통과
