### PR TITLE
[refactor][공통컴포넌트] cop/cmt 모듈 VO Lombok @Getter/@Setter 적용

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -597,6 +597,13 @@
 					<artifactId>maven-compiler-plugin</artifactId>
 					<configuration>
 						<release>${java.version}</release>
+						<annotationProcessorPaths>
+							<path>
+								<groupId>org.projectlombok</groupId>
+								<artifactId>lombok</artifactId>
+								<version>${lombok.version}</version>
+							</path>
+						</annotationProcessorPaths>
 					</configuration>
 				</plugin>
 				<plugin>

--- a/src/main/java/egovframework/com/cop/cmt/service/Comment.java
+++ b/src/main/java/egovframework/com/cop/cmt/service/Comment.java
@@ -2,9 +2,10 @@ package egovframework.com.cop.cmt.service;
 
 import java.io.Serializable;
 
-import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.egovframe.rte.ptl.reactive.validation.EgovNullCheck;
 import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * 댓글관리 서비스 데이터 처리 모델
@@ -15,287 +16,58 @@ import jakarta.validation.constraints.Size;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.06.29  한성곤          최초 생성
- *	
+ *
  * </pre>
  */
+@Getter
+@Setter
 @SuppressWarnings("serial")
 public class Comment implements Serializable {
     /** 댓글번호 */
     private String commentNo = "";
-    
+
     /** 게시판 ID */
     private String bbsId = "";
-    
+
     /** 게시물 번호 */
     private long nttId = 0L;
-    
+
     /** 작성자 ID */
     private String wrterId = "";
-    
+
     /** 작성자명 */
     private String wrterNm = "";
-    
+
     /** 패스워드 */
     private String commentPassword = "";
-    
+
     /** 댓글 내용 */
     @EgovNullCheck
     @Size(max=200)
     private String commentCn = "";
-    
+
     /** 사용 여부 */
     private String useAt = "";
 
     /** 최초등록자 아이디 */
     private String frstRegisterId = "";
-    
+
     /** 최초 등록자명 */
     private String frstRegisterNm = "";
-    
+
     /** 최초등록시점 */
     private String frstRegisterPnttm = "";
-    
+
     /** 최종수정자 아이디 */
     private String lastUpdusrId = "";
-    
+
     /** 최종수정시점 */
     private String lastUpdusrPnttm = "";
-    
+
     /** 확인 패스워드 */
     private String confirmPassword = "";
-
-    /**
-     * commentNo attribute를 리턴한다.
-     * @return the commentNo
-     */
-    public String getCommentNo() {
-        return commentNo;
-    }
-
-    /**
-     * commentNo attribute 값을 설정한다.
-     * @param commentNo the commentNo to set
-     */
-    public void setCommentNo(String commentNo) {
-        this.commentNo = commentNo;
-    }
-
-    /**
-     * bbsId attribute를 리턴한다.
-     * @return the bbsId
-     */
-    public String getBbsId() {
-        return bbsId;
-    }
-
-    /**
-     * bbsId attribute 값을 설정한다.
-     * @param bbsId the bbsId to set
-     */
-    public void setBbsId(String bbsId) {
-        this.bbsId = bbsId;
-    }
-
-    /**
-     * nttId attribute를 리턴한다.
-     * @return the nttId
-     */
-    public long getNttId() {
-        return nttId;
-    }
-
-    /**
-     * nttId attribute 값을 설정한다.
-     * @param nttId the nttId to set
-     */
-    public void setNttId(long nttId) {
-        this.nttId = nttId;
-    }
-
-    /**
-     * wrterId attribute를 리턴한다.
-     * @return the wrterId
-     */
-    public String getWrterId() {
-        return wrterId;
-    }
-
-    /**
-     * wrterId attribute 값을 설정한다.
-     * @param wrterId the wrterId to set
-     */
-    public void setWrterId(String wrterId) {
-        this.wrterId = wrterId;
-    }
-
-    /**
-     * wrterNm attribute를 리턴한다.
-     * @return the wrterNm
-     */
-    public String getWrterNm() {
-        return wrterNm;
-    }
-
-    /**
-     * wrterNm attribute 값을 설정한다.
-     * @param wrterNm the wrterNm to set
-     */
-    public void setWrterNm(String wrterNm) {
-        this.wrterNm = wrterNm;
-    }
-
-    /**
-     * commentPassword attribute를 리턴한다.
-     * @return the commentPassword
-     */
-    public String getCommentPassword() {
-        return commentPassword;
-    }
-
-    /**
-     * commentPassword attribute 값을 설정한다.
-     * @param commentPassword the commentPassword to set
-     */
-    public void setCommentPassword(String commentPassword) {
-        this.commentPassword = commentPassword;
-    }
-
-    /**
-     * commentCn attribute를 리턴한다.
-     * @return the commentCn
-     */
-    public String getCommentCn() {
-        return commentCn;
-    }
-
-    /**
-     * commentCn attribute 값을 설정한다.
-     * @param commentCn the commentCn to set
-     */
-    public void setCommentCn(String commentCn) {
-        this.commentCn = commentCn;
-    }
-
-    /**
-     * useAt attribute를 리턴한다.
-     * @return the useAt
-     */
-    public String getUseAt() {
-        return useAt;
-    }
-
-    /**
-     * useAt attribute 값을 설정한다.
-     * @param useAt the useAt to set
-     */
-    public void setUseAt(String useAt) {
-        this.useAt = useAt;
-    }
-
-    /**
-     * frstRegisterId attribute를 리턴한다.
-     * @return the frstRegisterId
-     */
-    public String getFrstRegisterId() {
-        return frstRegisterId;
-    }
-
-    /**
-     * frstRegisterId attribute 값을 설정한다.
-     * @param frstRegisterId the frstRegisterId to set
-     */
-    public void setFrstRegisterId(String frstRegisterId) {
-        this.frstRegisterId = frstRegisterId;
-    }
-
-    /**
-     * frstRegisterPnttm attribute를 리턴한다.
-     * @return the frstRegisterPnttm
-     */
-    public String getFrstRegisterPnttm() {
-        return frstRegisterPnttm;
-    }
-
-    /**
-     * frstRegisterPnttm attribute 값을 설정한다.
-     * @param frstRegisterPnttm the frstRegisterPnttm to set
-     */
-    public void setFrstRegisterPnttm(String frstRegisterPnttm) {
-        this.frstRegisterPnttm = frstRegisterPnttm;
-    }
-
-    /**
-     * lastUpdusrId attribute를 리턴한다.
-     * @return the lastUpdusrId
-     */
-    public String getLastUpdusrId() {
-        return lastUpdusrId;
-    }
-
-    /**
-     * lastUpdusrId attribute 값을 설정한다.
-     * @param lastUpdusrId the lastUpdusrId to set
-     */
-    public void setLastUpdusrId(String lastUpdusrId) {
-        this.lastUpdusrId = lastUpdusrId;
-    }
-
-    /**
-     * lastUpdusrPnttm attribute를 리턴한다.
-     * @return the lastUpdusrPnttm
-     */
-    public String getLastUpdusrPnttm() {
-        return lastUpdusrPnttm;
-    }
-
-    /**
-     * lastUpdusrPnttm attribute 값을 설정한다.
-     * @param lastUpdusrPnttm the lastUpdusrPnttm to set
-     */
-    public void setLastUpdusrPnttm(String lastUpdusrPnttm) {
-        this.lastUpdusrPnttm = lastUpdusrPnttm;
-    }
-    
-    /**
-     * frstRegisterNm attribute를 리턴한다.
-     * @return the frstRegisterNm
-     */
-    public String getFrstRegisterNm() {
-        return frstRegisterNm;
-    }
-
-    /**
-     * frstRegisterNm attribute 값을 설정한다.
-     * @param frstRegisterNm the frstRegisterNm to set
-     */
-    public void setFrstRegisterNm(String frstRegisterNm) {
-        this.frstRegisterNm = frstRegisterNm;
-    }
-
-    /**
-     * confirmPassword attribute를 리턴한다.
-     * @return the confirmPassword
-     */
-    public String getConfirmPassword() {
-        return confirmPassword;
-    }
-
-    /**
-     * confirmPassword attribute 값을 설정한다.
-     * @param confirmPassword the confirmPassword to set
-     */
-    public void setConfirmPassword(String confirmPassword) {
-        this.confirmPassword = confirmPassword;
-    }
-
-    /**
-     * toString 메소드를 대치한다.
-     */
-    public String toString() {
-	return ToStringBuilder.reflectionToString(this);
-    }
 }

--- a/src/main/java/egovframework/com/cop/cmt/service/CommentVO.java
+++ b/src/main/java/egovframework/com/cop/cmt/service/CommentVO.java
@@ -1,6 +1,7 @@
 package egovframework.com.cop.cmt.service;
 
-import org.apache.commons.lang3.builder.ToStringBuilder;
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * 댓글관리 서비스를 위한 VO 클래스
@@ -11,13 +12,15 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.06.29  한성곤          최초 생성
  *
  * </pre>
  */
+@Getter
+@Setter
 @SuppressWarnings("serial")
 public class CommentVO extends Comment {
     /** 정렬순서(DESC,ASC) */
@@ -43,177 +46,10 @@ public class CommentVO extends Comment {
 
     /** 레코드 번호 */
     private int subRowNo = 0;
-    
-    /** 호출 TYPE (head or body)*/
+
+    /** 호출 TYPE (head or body) */
     private String type = "";
-    
+
     /** 수정 처리 여부 */
-    private boolean isModified = false;
-    
-    /**
-     * sortOrdr attribute를 리턴한다.
-     * @return the sortOrdr
-     */
-    public long getSortOrdr() {
-        return sortOrdr;
-    }
-
-    /**
-     * sortOrdr attribute 값을 설정한다.
-     * @param sortOrdr the sortOrdr to set
-     */
-    public void setSortOrdr(long sortOrdr) {
-        this.sortOrdr = sortOrdr;
-    }
-
-    /**
-     * subPageIndex attribute를 리턴한다.
-     * @return the subPageIndex
-     */
-    public int getSubPageIndex() {
-        return subPageIndex;
-    }
-
-    /**
-     * subPageIndex attribute 값을 설정한다.
-     * @param subPageIndex the subPageIndex to set
-     */
-    public void setSubPageIndex(int subPageIndex) {
-        this.subPageIndex = subPageIndex;
-    }
-
-    /**
-     * subPageUnit attribute를 리턴한다.
-     * @return the subPageUnit
-     */
-    public int getSubPageUnit() {
-        return subPageUnit;
-    }
-
-    /**
-     * subPageUnit attribute 값을 설정한다.
-     * @param subPageUnit the subPageUnit to set
-     */
-    public void setSubPageUnit(int subPageUnit) {
-        this.subPageUnit = subPageUnit;
-    }
-
-    /**
-     * subPageSize attribute를 리턴한다.
-     * @return the subPageSize
-     */
-    public int getSubPageSize() {
-        return subPageSize;
-    }
-
-    /**
-     * subPageSize attribute 값을 설정한다.
-     * @param subPageSize the subPageSize to set
-     */
-    public void setSubPageSize(int subPageSize) {
-        this.subPageSize = subPageSize;
-    }
-
-    /**
-     * subFirstIndex attribute를 리턴한다.
-     * @return the subFirstIndex
-     */
-    public int getSubFirstIndex() {
-        return subFirstIndex;
-    }
-
-    /**
-     * subFirstIndex attribute 값을 설정한다.
-     * @param subFirstIndex the subFirstIndex to set
-     */
-    public void setSubFirstIndex(int subFirstIndex) {
-        this.subFirstIndex = subFirstIndex;
-    }
-
-    /**
-     * subLastIndex attribute를 리턴한다.
-     * @return the subLastIndex
-     */
-    public int getSubLastIndex() {
-        return subLastIndex;
-    }
-
-    /**
-     * subLastIndex attribute 값을 설정한다.
-     * @param subLastIndex the subLastIndex to set
-     */
-    public void setSubLastIndex(int subLastIndex) {
-        this.subLastIndex = subLastIndex;
-    }
-
-    /**
-     * subRecordCountPerPage attribute를 리턴한다.
-     * @return the subRecordCountPerPage
-     */
-    public int getSubRecordCountPerPage() {
-        return subRecordCountPerPage;
-    }
-
-    /**
-     * subRecordCountPerPage attribute 값을 설정한다.
-     * @param subRecordCountPerPage the subRecordCountPerPage to set
-     */
-    public void setSubRecordCountPerPage(int subRecordCountPerPage) {
-        this.subRecordCountPerPage = subRecordCountPerPage;
-    }
-
-    /**
-     * subRowNo attribute를 리턴한다.
-     * @return the subRowNo
-     */
-    public int getSubRowNo() {
-        return subRowNo;
-    }
-
-    /**
-     * subRowNo attribute 값을 설정한다.
-     * @param subRowNo the subRowNo to set
-     */
-    public void setSubRowNo(int subRowNo) {
-        this.subRowNo = subRowNo;
-    }
-
-    /**
-     * type attribute를 리턴한다.
-     * @return the type
-     */
-    public String getType() {
-        return type;
-    }
-
-    /**
-     * type attribute 값을 설정한다.
-     * @param type the type to set
-     */
-    public void setType(String type) {
-        this.type = type;
-    }
-
-    /**
-     * isModified attribute를 리턴한다.
-     * @return the isModified
-     */
-    public boolean isModified() {
-        return isModified;
-    }
-
-    /**
-     * isModified attribute 값을 설정한다.
-     * @param isModified the isModified to set
-     */
-    public void setModified(boolean isModified) {
-        this.isModified = isModified;
-    }
-
-    /**
-     * toString 메소드를 대치한다.
-     */
-    public String toString() {
-	return ToStringBuilder.reflectionToString(this);
-    }
+    private boolean modified = false;
 }


### PR DESCRIPTION
## 변경 사유

cop/cmt 댓글 모듈의 Comment, CommentVO 클래스에 수동 getter/setter가 대량으로 존재하여
코드가 불필요하게 길었다. Lombok @Getter/@Setter 어노테이션으로 대체하여 가독성을 개선한다.

## 변경 내용

- `Comment.java`: 13개 필드 getter/setter 메서드 제거 → @Getter @Setter 어노테이션 적용, ToStringBuilder import/메서드 제거
- `CommentVO.java`: 9개 필드 getter/setter 메서드 제거 → @Getter @Setter 어노테이션 적용, ToStringBuilder import/메서드 제거
- `boolean isModified` 필드를 `boolean modified`로 정규화 (Lombok이 `isModified()` getter를 올바르게 생성하도록)
- `pom.xml`: maven-compiler-plugin에 annotationProcessorPaths 추가 (PR #802 방식과 동일)

## 영향 범위

- getter/setter 시그니처 동일 유지 (`isModified()`, `setModified()`)
- JSP hidden input `name="modified"` → Spring MVC @ModelAttribute 바인딩 정상 동작
- cop/ems(#808), cop/sms·smt(#812)와 파일 충돌 없음

## 체크리스트

- [x] 단일 주제만 다룸 (cop/cmt 모듈 Lombok 적용)
- [x] cop/ems(#808), cop/sms·smt(#812)와 충돌 없음
- [x] 기존 동작에 영향 없음 (getter/setter 시그니처 동일)
- [x] mvn compile BUILD SUCCESS 확인
