### PR TITLE
[refactor][공통컴포넌트] utl/fcc 모듈 VO Lombok @Getter/@Setter 적용

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -597,6 +597,13 @@
 					<artifactId>maven-compiler-plugin</artifactId>
 					<configuration>
 						<release>${java.version}</release>
+						<annotationProcessorPaths>
+							<path>
+								<groupId>org.projectlombok</groupId>
+								<artifactId>lombok</artifactId>
+								<version>${lombok.version}</version>
+							</path>
+						</annotationProcessorPaths>
 					</configuration>
 				</plugin>
 				<plugin>

--- a/src/main/java/egovframework/com/utl/fcc/service/EgovFormBasedFileVo.java
+++ b/src/main/java/egovframework/com/utl/fcc/service/EgovFormBasedFileVo.java
@@ -2,11 +2,14 @@ package egovframework.com.utl.fcc.service;
 
 import java.io.Serializable;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * @Class Name  : EgovFormBasedFileVo.java
  * @Description : Form-based File Upload VO
  * @Modification Information
- * 
+ *
  *     수정일         수정자                   수정내용
  *     -------          --------        ---------------------------
  *   2009.08.26       한성곤                  최초 생성
@@ -14,10 +17,12 @@ import java.io.Serializable;
  * @author 공통컴포넌트 개발팀 한성곤
  * @since 2009.08.26
  * @version 1.0
- * @see 
- * 
+ * @see
+ *
  *  Copyright (C) 2008 by MOPAS  All rights reserved.
  */
+@Getter
+@Setter
 @SuppressWarnings("serial")
 public class EgovFormBasedFileVo implements Serializable {
     /** 파일명 */
@@ -30,75 +35,4 @@ public class EgovFormBasedFileVo implements Serializable {
     private String physicalName = "";
     /** 파일 사이즈 */
     private long size = 0L;
-    
-    /**
-     * fileName attribute를 리턴한다.
-     * @return the fileName
-     */
-    public String getFileName() {
-        return fileName;
-    }
-    /**
-     * fileName attribute 값을 설정한다.
-     * @param fileName the fileName to set
-     */
-    public void setFileName(String fileName) {
-        this.fileName = fileName;
-    }
-    /**
-     * contentType attribute를 리턴한다.
-     * @return the contentType
-     */
-    public String getContentType() {
-        return contentType;
-    }
-    /**
-     * contentType attribute 값을 설정한다.
-     * @param contentType the contentType to set
-     */
-    public void setContentType(String contentType) {
-        this.contentType = contentType;
-    }
-    /**
-     * serverSubPath attribute를 리턴한다.
-     * @return the serverSubPath
-     */
-    public String getServerSubPath() {
-        return serverSubPath;
-    }
-    /**
-     * serverSubPath attribute 값을 설정한다.
-     * @param serverSubPath the serverSubPath to set
-     */
-    public void setServerSubPath(String serverSubPath) {
-        this.serverSubPath = serverSubPath;
-    }
-    /**
-     * physicalName attribute를 리턴한다.
-     * @return the physicalName
-     */
-    public String getPhysicalName() {
-        return physicalName;
-    }
-    /**
-     * physicalName attribute 값을 설정한다.
-     * @param physicalName the physicalName to set
-     */
-    public void setPhysicalName(String physicalName) {
-        this.physicalName = physicalName;
-    }
-    /**
-     * size attribute를 리턴한다.
-     * @return the size
-     */
-    public long getSize() {
-        return size;
-    }
-    /**
-     * size attribute 값을 설정한다.
-     * @param size the size to set
-     */
-    public void setSize(long size) {
-        this.size = size;
-    }
 }


### PR DESCRIPTION
utl/fcc 모듈의 EgovFormBasedFileVo 클래스에 Lombok @Getter/@Setter 어노테이션을 적용합니다.

**변경 내용**
- `EgovFormBasedFileVo`: 수동 getter/setter 5쌍(fileName, contentType, serverSubPath, physicalName, size) 제거 후 @Getter/@Setter 적용
- `pom.xml`: maven-compiler-plugin에 annotationProcessorPaths 추가 (Lombok 어노테이션 처리기 등록)

**영향 범위**
- 기존 getter/setter 시그니처 동일하게 유지되어 호환성 문제 없음
- pom.xml 변경은 컴파일 단계에만 영향

**검증**
- `mvn -DskipTests compile` BUILD SUCCESS 확인

- [ ] 단일 주제만 다룸 (다른 변경 없음)
- [ ] 5.x 다른 브랜치용 PR이 필요한 경우 후속 PR 링크 명시
- [ ] 기존 동작에 영향 없음
- [ ] 빌드 통과 확인
