### PR TITLE
[refactor][공통컴포넌트] uss/ion (lsi/msi/ntm) 모듈 VO Lombok @Getter/@Setter 적용

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -597,6 +597,13 @@
 					<artifactId>maven-compiler-plugin</artifactId>
 					<configuration>
 						<release>${java.version}</release>
+						<annotationProcessorPaths>
+							<path>
+								<groupId>org.projectlombok</groupId>
+								<artifactId>lombok</artifactId>
+								<version>1.18.42</version>
+							</path>
+						</annotationProcessorPaths>
 					</configuration>
 				</plugin>
 				<plugin>

--- a/src/main/java/egovframework/com/uss/ion/lsi/service/LoginScrinImageVO.java
+++ b/src/main/java/egovframework/com/uss/ion/lsi/service/LoginScrinImageVO.java
@@ -12,12 +12,12 @@ import jakarta.validation.constraints.Size;
  * <pre>
  * 개요
  * - 로그인화면이미지에 대한 Vo 클래스를 정의한다.
- * 
+ *
  * 상세내용
  * - 로그인화면이미지의 목록 항목을 관리한다.
  * - 로그인화면이미지의 일련번호, 이미지명, 링크URL, 이미지설명, 반영여부 항목을 관리한다.
  * </pre>
- * 
+ *
  * @author 이문준
  * @since 2010.08.03
  * @version 1.0
@@ -31,9 +31,12 @@ import jakarta.validation.constraints.Size;
  *   2010.08.03  이문준          최초 생성
  *   2025.08.07  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-MethodReturnsInternalArray(Private 배열에 Public 데이터 할당)
  *   2025.08.07  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-ArrayIsStoredDirectly(Public 메소드부터 반환된 Private 배열)
+ *   2026.05.26  기여자          Lombok @Getter/@Setter 적용으로 보일러플레이트 코드 제거
  *
  *      </pre>
  */
+@Getter
+@Setter
 public class LoginScrinImageVO extends ComDefaultVO {
 
 	/**
@@ -45,45 +48,45 @@ public class LoginScrinImageVO extends ComDefaultVO {
 	 * 이미지 ID
 	 */
 	private String imageId;
-	
+
 	/**
 	 * 이미지명
-	 */	
+	 */
 	@EgovNullCheck
 	@Size(max=10)
 	private String imageNm;
-	
+
 	/**
 	 * 로그인 이미지
-	 */	
+	 */
 	@EgovNullCheck
 	private String image;
-	
+
 	/**
 	 * 로그인 이미지 파일
-	 */	
+	 */
 	private String imageFile;
-	
+
 	/**
 	 * 이미지 설명
-	 */	
+	 */
 	private String imageDc;
-	
+
 	/**
 	 * 반영여부
 	 */
 	private String reflctAt;
-	
+
 	/**
 	 * 사용자 ID
 	 */
 	private String userId;
-	
+
 	/**
 	 * 등록일자
 	 */
 	private String regDate;
-	
+
 	/**
 	 * 파일첨부여부
 	 */
@@ -97,148 +100,6 @@ public class LoginScrinImageVO extends ComDefaultVO {
 	/**
 	 * 삭제대상 목록
 	 */
-	@Getter
-	@Setter
 	private String[] delYn;
-
-	/**
-	 * @return the imageId
-	 */
-	public String getImageId() {
-		return imageId;
-	}
-	
-	/**
-	 * @param imageId the imageId to set
-	 */
-	public void setImageId(String imageId) {
-		this.imageId = imageId;
-	}
-	
-	/**
-	 * @return the imageNm
-	 */
-	public String getImageNm() {
-		return imageNm;
-	}
-	
-	/**
-	 * @param imageNm the imageNm to set
-	 */
-	public void setImageNm(String imageNm) {
-		this.imageNm = imageNm;
-	}
-	
-	/**
-	 * @return the image
-	 */
-	public String getImage() {
-		return image;
-	}
-	
-	/**
-	 * @param image the image to set
-	 */
-	public void setImage(String image) {
-		this.image = image;
-	}
-	
-	/**
-	 * @return the imageFile
-	 */
-	public String getImageFile() {
-		return imageFile;
-	}
-	
-	/**
-	 * @param imageFile the imageFile to set
-	 */
-	public void setImageFile(String imageFile) {
-		this.imageFile = imageFile;
-	}
-	
-	/**
-	 * @return the imageDc
-	 */
-	public String getImageDc() {
-		return imageDc;
-	}
-	
-	/**
-	 * @param imageDc the imageDc to set
-	 */
-	public void setImageDc(String imageDc) {
-		this.imageDc = imageDc;
-	}
-	
-	/**
-	 * @return the reflctAt
-	 */
-	public String getReflctAt() {
-		return reflctAt;
-	}
-	
-	/**
-	 * @param reflctAt the reflctAt to set
-	 */
-	public void setReflctAt(String reflctAt) {
-		this.reflctAt = reflctAt;
-	}
-	
-	/**
-	 * @return the userId
-	 */
-	public String getUserId() {
-		return userId;
-	}
-	
-	/**
-	 * @param userId the userId to set
-	 */
-	public void setUserId(String userId) {
-		this.userId = userId;
-	}
-	
-	/**
-	 * @return the regDate
-	 */
-	public String getRegDate() {
-		return regDate;
-	}
-	
-	/**
-	 * @param regDate the regDate to set
-	 */
-	public void setRegDate(String regDate) {
-		this.regDate = regDate;
-	}
-	
-	/**
-	 * @return the isAtchFile
-	 */
-	public boolean isAtchFile() {
-		return isAtchFile;
-	}
-	
-	/**
-	 * @param isAtchFile the isAtchFile to set
-	 */
-	public void setAtchFile(boolean isAtchFile) {
-		this.isAtchFile = isAtchFile;
-	}
-
-	/**
-	 * @return the loginScrinImageList
-	 */
-	public List<LoginScrinImageVO> getLoginScrinImageList() {
-		return loginScrinImageList;
-	}
-
-	/**
-	 * @param loginScrinImageList the loginScrinImageList to set
-	 */
-	public void setLoginScrinImageList(List<LoginScrinImageVO> loginScrinImageList) {
-		this.loginScrinImageList = loginScrinImageList;
-	}
 
 }

--- a/src/main/java/egovframework/com/uss/ion/msi/service/MainImageVO.java
+++ b/src/main/java/egovframework/com/uss/ion/msi/service/MainImageVO.java
@@ -3,11 +3,11 @@ package egovframework.com.uss.ion.msi.service;
 import java.util.List;
 
 import egovframework.com.cmm.ComDefaultVO;
+import lombok.Getter;
+import lombok.Setter;
 import org.egovframe.rte.ptl.reactive.validation.EgovNullCheck;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
-import lombok.Getter;
-import lombok.Setter;
 
 /**
  * 개요
@@ -19,7 +19,20 @@ import lombok.Setter;
  * @author 이문준
  * @since 2010.08.03
  * @version 1.0
+ * @see
+ *
+ *      <pre>
+ *  == 개정이력(Modification Information) ==
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2010.08.03  이문준          최초 생성
+ *   2026.05.26  기여자          Lombok @Getter/@Setter 적용으로 보일러플레이트 코드 제거
+ *
+ *      </pre>
  */
+@Getter
+@Setter
 public class MainImageVO extends ComDefaultVO {
 
 	private static final long serialVersionUID = 1L;
@@ -58,28 +71,6 @@ public class MainImageVO extends ComDefaultVO {
 	private List<MainImageVO> mainImageList;
 
 	/** 삭제대상 목록 */
-	@Getter
-	@Setter
 	private String[] delYn;
 
-	public String getImageId() { return imageId; }
-	public void setImageId(String imageId) { this.imageId = imageId; }
-	public String getImageNm() { return imageNm; }
-	public void setImageNm(String imageNm) { this.imageNm = imageNm; }
-	public String getImage() { return image; }
-	public void setImage(String image) { this.image = image; }
-	public String getImageFile() { return imageFile; }
-	public void setImageFile(String imageFile) { this.imageFile = imageFile; }
-	public String getImageDc() { return imageDc; }
-	public void setImageDc(String imageDc) { this.imageDc = imageDc; }
-	public String getReflctAt() { return reflctAt; }
-	public void setReflctAt(String reflctAt) { this.reflctAt = reflctAt; }
-	public String getUserId() { return userId; }
-	public void setUserId(String userId) { this.userId = userId; }
-	public String getRegDate() { return regDate; }
-	public void setRegDate(String regDate) { this.regDate = regDate; }
-	public boolean isAtchFile() { return isAtchFile; }
-	public void setAtchFile(boolean atchFile) { this.isAtchFile = atchFile; }
-	public List<MainImageVO> getMainImageList() { return mainImageList; }
-	public void setMainImageList(List<MainImageVO> mainImageList) { this.mainImageList = mainImageList; }
 }

--- a/src/main/java/egovframework/com/uss/ion/ntm/service/NoteManageVO.java
+++ b/src/main/java/egovframework/com/uss/ion/ntm/service/NoteManageVO.java
@@ -6,10 +6,12 @@ import org.egovframe.rte.ptl.reactive.validation.EgovNullCheck;
 
 import egovframework.com.cmm.ComDefaultVO;
 import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * 쪽지 관리(보내기) Model and VO Class 구현
- * 
+ *
  * @author 공통서비스 장동한
  * @since 2010.06.16
  * @version 1.0
@@ -22,14 +24,14 @@ import jakarta.validation.constraints.Size;
  *  -------    --------    ---------------------------
  *   2010.06.16  장동한          최초 생성
  *   2025.08.08  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-AvoidArrayLoops(배열의 값을 루프문을 이용하여 복사하는 것 보다, System.arraycopy() 메소드를 이용하여 복사하는 것이 효율적이며 수행 속도가 빠름)
+ *   2026.05.26  기여자          Lombok @Getter/@Setter 적용으로 보일러플레이트 코드 제거 (atchFile 필드는 방어적 복사 유지)
  *
  *      </pre>
  */
+@Getter
+@Setter
 public class NoteManageVO extends ComDefaultVO {
 
-	/**
-	 * 
-	 */
 	private static final long serialVersionUID = 1L;
 
 	/** 쪽지 ID */
@@ -71,6 +73,8 @@ public class NoteManageVO extends ComDefaultVO {
 	private String atchFileId;
 
 	/** 쪽지 첨부파일 */
+	@Getter(lombok.AccessLevel.NONE)
+	@Setter(lombok.AccessLevel.NONE)
 	private byte[] atchFile;
 
 	/** 최초등록시점 */
@@ -84,160 +88,6 @@ public class NoteManageVO extends ComDefaultVO {
 
 	/** 최종수정자 아이디 */
 	private String lastUpdusrId;
-
-	/**
-	 * @return the noteId
-	 */
-	public String getNoteId() {
-		return noteId;
-	}
-
-	/**
-	 * @param noteId the noteId to set
-	 */
-	public void setNoteId(String noteId) {
-		this.noteId = noteId;
-	}
-
-	/**
-	 * @return the noteTrnsmitId
-	 */
-	public String getNoteTrnsmitId() {
-		return noteTrnsmitId;
-	}
-
-	/**
-	 * @param noteTrnsmitId the noteTrnsmitId to set
-	 */
-	public void setNoteTrnsmitId(String noteTrnsmitId) {
-		this.noteTrnsmitId = noteTrnsmitId;
-	}
-
-	/**
-	 * @return the noteRecptnId
-	 */
-	public String getNoteRecptnId() {
-		return noteRecptnId;
-	}
-
-	/**
-	 * @param noteRecptnId the noteRecptnId to set
-	 */
-	public void setNoteRecptnId(String noteRecptnId) {
-		this.noteRecptnId = noteRecptnId;
-	}
-
-	/**
-	 * @return the rcverId
-	 */
-	public String getRcverId() {
-		return rcverId;
-	}
-
-	/**
-	 * @param rcverId the rcverId to set
-	 */
-	public void setRcverId(String rcverId) {
-		this.rcverId = rcverId;
-	}
-
-	/**
-	 * @return the openYn
-	 */
-	public String getOpenYn() {
-		return openYn;
-	}
-
-	/**
-	 * @param openYn the openYn to set
-	 */
-	public void setOpenYn(String openYn) {
-		this.openYn = openYn;
-	}
-
-	/**
-	 * @return the recptnSe
-	 */
-	public String getRecptnSe() {
-		return recptnSe;
-	}
-
-	/**
-	 * @param recptnSe the recptnSe to set
-	 */
-	public void setRecptnSe(String recptnSe) {
-		this.recptnSe = recptnSe;
-	}
-
-	/**
-	 * @return the noteCn
-	 */
-	public String getNoteCn() {
-		return noteCn;
-	}
-
-	/**
-	 * @param noteCn the noteCn to set
-	 */
-	public void setNoteCn(String noteCn) {
-		this.noteCn = noteCn;
-	}
-
-	/**
-	 * @return the noteSj
-	 */
-	public String getNoteSj() {
-		return noteSj;
-	}
-
-	/**
-	 * @param noteSj the noteSj to set
-	 */
-	public void setNoteSj(String noteSj) {
-		this.noteSj = noteSj;
-	}
-
-	/**
-	 * @return the trnsmiterId
-	 */
-	public String getTrnsmiterId() {
-		return trnsmiterId;
-	}
-
-	/**
-	 * @param trnsmiterId the trnsmiterId to set
-	 */
-	public void setTrnsmiterId(String trnsmiterId) {
-		this.trnsmiterId = trnsmiterId;
-	}
-
-	/**
-	 * @return the recptnEmpList
-	 */
-	public String getRecptnEmpList() {
-		return recptnEmpList;
-	}
-
-	/**
-	 * @param recptnEmpList the recptnEmpList to set
-	 */
-	public void setRecptnEmpList(String recptnEmpList) {
-		this.recptnEmpList = recptnEmpList;
-	}
-
-	/**
-	 * @return the atchFileId
-	 */
-	public String getAtchFileId() {
-		return atchFileId;
-	}
-
-	/**
-	 * @param atchFileId the atchFileId to set
-	 */
-	public void setAtchFileId(String atchFileId) {
-		this.atchFileId = atchFileId;
-	}
 
 	/**
 	 * @return the atchFile
@@ -255,62 +105,6 @@ public class NoteManageVO extends ComDefaultVO {
 		} else {
 			this.atchFile = Arrays.copyOf(atchFile, atchFile.length);
 		}
-	}
-
-	/**
-	 * @return the frstRegisterPnttm
-	 */
-	public String getFrstRegisterPnttm() {
-		return frstRegisterPnttm;
-	}
-
-	/**
-	 * @param frstRegisterPnttm the frstRegisterPnttm to set
-	 */
-	public void setFrstRegisterPnttm(String frstRegisterPnttm) {
-		this.frstRegisterPnttm = frstRegisterPnttm;
-	}
-
-	/**
-	 * @return the frstRegisterId
-	 */
-	public String getFrstRegisterId() {
-		return frstRegisterId;
-	}
-
-	/**
-	 * @param frstRegisterId the frstRegisterId to set
-	 */
-	public void setFrstRegisterId(String frstRegisterId) {
-		this.frstRegisterId = frstRegisterId;
-	}
-
-	/**
-	 * @return the lastUpdusrPnttm
-	 */
-	public String getLastUpdusrPnttm() {
-		return lastUpdusrPnttm;
-	}
-
-	/**
-	 * @param lastUpdusrPnttm the lastUpdusrPnttm to set
-	 */
-	public void setLastUpdusrPnttm(String lastUpdusrPnttm) {
-		this.lastUpdusrPnttm = lastUpdusrPnttm;
-	}
-
-	/**
-	 * @return the lastUpdusrId
-	 */
-	public String getLastUpdusrId() {
-		return lastUpdusrId;
-	}
-
-	/**
-	 * @param lastUpdusrId the lastUpdusrId to set
-	 */
-	public void setLastUpdusrId(String lastUpdusrId) {
-		this.lastUpdusrId = lastUpdusrId;
 	}
 
 }


### PR DESCRIPTION
## 변경 사유

uss/ion 하위 lsi, msi, ntm 모듈의 VO 클래스에 수작업으로 작성된 getter/setter 메서드가
코드량을 불필요하게 늘리고 있어 Lombok 어노테이션으로 대체하여 가독성과 유지보수성을 개선했다.

## 변경 내용

| 파일 | 제거된 메서드 수 |
|------|----------------|
| `uss/ion/lsi/service/LoginScrinImageVO.java` | getter 10 + setter 10 = 20 |
| `uss/ion/msi/service/MainImageVO.java` | getter 10 + setter 10 = 20 |
| `uss/ion/ntm/service/NoteManageVO.java` | getter 13 + setter 13 = 26 (atchFile 수동 접근자 유지) |

- 클래스 레벨 `@Getter` + `@Setter` 적용
- `serialVersionUID`, validation 어노테이션(`@EgovNullCheck`, `@Size`, `@NotBlank`) 그대로 보존
- `NoteManageVO`의 `atchFile(byte[])` 필드는 PMD 방어적 복사 로직 보존을 위해 수동 접근자 유지
  (`@Getter(AccessLevel.NONE)` + `@Setter(AccessLevel.NONE)`으로 Lombok 생성 억제)
- `pom.xml` maven-compiler-plugin에 `annotationProcessorPaths` 추가
  (컴파일 시 Lombok 어노테이션 프로세서 명시 등록 — PR #802와 동일 패턴)

## 테스트

`mvn -DskipTests compile` BUILD SUCCESS 확인

## 영향 범위

getter/setter 시그니처 동일하여 기존 동작에 영향 없음

## 체크리스트

- [x] 단일 주제만 다룸 (uss/ion lsi·msi·ntm 모듈 VO Lombok 적용)
- [x] 5.1.x, 5.2.x 브랜치용 후속 PR 예정
- [x] 의존성(Lombok)은 기존 pom.xml에 이미 선언되어 있음
- [x] 기존 동작에 영향 없음 (getter/setter 시그니처 동일)
- [x] 빌드 통과 확인
