### PR TITLE
[refactor][공통컴포넌트] cop/scp, cop/ncm, cop/tpl 모듈 VO Lombok @Getter/@Setter 적용

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -597,6 +597,13 @@
 					<artifactId>maven-compiler-plugin</artifactId>
 					<configuration>
 						<release>${java.version}</release>
+						<annotationProcessorPaths>
+							<path>
+								<groupId>org.projectlombok</groupId>
+								<artifactId>lombok</artifactId>
+								<version>${lombok.version}</version>
+							</path>
+						</annotationProcessorPaths>
 					</configuration>
 				</plugin>
 				<plugin>

--- a/src/main/java/egovframework/com/cop/ncm/service/NameCardVO.java
+++ b/src/main/java/egovframework/com/cop/ncm/service/NameCardVO.java
@@ -2,7 +2,8 @@ package egovframework.com.cop.ncm.service;
 
 import java.io.Serializable;
 
-import org.apache.commons.lang3.builder.ToStringBuilder;
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * 명함정보 관리를 위한 VO 클래스
@@ -13,37 +14,39 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.3.28  이삼섭          최초 생성
  *
  * </pre>
  */
+@Getter
+@Setter
 @SuppressWarnings("serial")
 public class NameCardVO extends NameCard implements Serializable {
 
     /** 최초 등록자명 */
     private String frstRegisterNm = "";
-    
+
     /** 최종 수정자명 */
     private String lastUpdusrNm = "";
-    
+
     /** 템플릿 구분 코드명 */
     private String tmplatSeCodeNm = "";
 
     /** 검색시작일 */
     private String searchBgnDe = "";
-    
+
     /** 검색조건 */
     private String searchCnd = "";
-    
+
     /** 검색종료일 */
     private String searchEndDe = "";
-    
+
     /** 검색단어 */
     private String searchWrd = "";
-    
+
     /** 정렬순서(DESC,ASC) */
     private String sortOrdr = "";
 
@@ -73,334 +76,4 @@ public class NameCardVO extends NameCard implements Serializable {
 
     /** 사용자 아이디 */
     private String emplyrId = "";
-
-    /**
-     * frstRegisterNm attribute를 리턴한다.
-     * 
-     * @return the frstRegisterNm
-     */
-    public String getFrstRegisterNm() {
-	return frstRegisterNm;
-    }
-
-    /**
-     * frstRegisterNm attribute 값을 설정한다.
-     * 
-     * @param frstRegisterNm
-     *            the frstRegisterNm to set
-     */
-    public void setFrstRegisterNm(String frstRegisterNm) {
-	this.frstRegisterNm = frstRegisterNm;
-    }
-
-    /**
-     * lastUpdusrNm attribute를 리턴한다.
-     * 
-     * @return the lastUpdusrNm
-     */
-    public String getLastUpdusrNm() {
-	return lastUpdusrNm;
-    }
-
-    /**
-     * lastUpdusrNm attribute 값을 설정한다.
-     * 
-     * @param lastUpdusrNm
-     *            the lastUpdusrNm to set
-     */
-    public void setLastUpdusrNm(String lastUpdusrNm) {
-	this.lastUpdusrNm = lastUpdusrNm;
-    }
-
-    /**
-     * tmplatSeCodeNm attribute를 리턴한다.
-     * 
-     * @return the tmplatSeCodeNm
-     */
-    public String getTmplatSeCodeNm() {
-	return tmplatSeCodeNm;
-    }
-
-    /**
-     * tmplatSeCodeNm attribute 값을 설정한다.
-     * 
-     * @param tmplatSeCodeNm
-     *            the tmplatSeCodeNm to set
-     */
-    public void setTmplatSeCodeNm(String tmplatSeCodeNm) {
-	this.tmplatSeCodeNm = tmplatSeCodeNm;
-    }
-
-    /**
-     * searchBgnDe attribute를 리턴한다.
-     * 
-     * @return the searchBgnDe
-     */
-    public String getSearchBgnDe() {
-	return searchBgnDe;
-    }
-
-    /**
-     * searchBgnDe attribute 값을 설정한다.
-     * 
-     * @param searchBgnDe
-     *            the searchBgnDe to set
-     */
-    public void setSearchBgnDe(String searchBgnDe) {
-	this.searchBgnDe = searchBgnDe;
-    }
-
-    /**
-     * searchCnd attribute를 리턴한다.
-     * 
-     * @return the searchCnd
-     */
-    public String getSearchCnd() {
-	return searchCnd;
-    }
-
-    /**
-     * searchCnd attribute 값을 설정한다.
-     * 
-     * @param searchCnd
-     *            the searchCnd to set
-     */
-    public void setSearchCnd(String searchCnd) {
-	this.searchCnd = searchCnd;
-    }
-
-    /**
-     * searchEndDe attribute를 리턴한다.
-     * 
-     * @return the searchEndDe
-     */
-    public String getSearchEndDe() {
-	return searchEndDe;
-    }
-
-    /**
-     * searchEndDe attribute 값을 설정한다.
-     * 
-     * @param searchEndDe
-     *            the searchEndDe to set
-     */
-    public void setSearchEndDe(String searchEndDe) {
-	this.searchEndDe = searchEndDe;
-    }
-
-    /**
-     * searchWrd attribute를 리턴한다.
-     * 
-     * @return the searchWrd
-     */
-    public String getSearchWrd() {
-	return searchWrd;
-    }
-
-    /**
-     * searchWrd attribute 값을 설정한다.
-     * 
-     * @param searchWrd
-     *            the searchWrd to set
-     */
-    public void setSearchWrd(String searchWrd) {
-	this.searchWrd = searchWrd;
-    }
-
-    /**
-     * sortOrdr attribute를 리턴한다.
-     * 
-     * @return the sortOrdr
-     */
-    public String getSortOrdr() {
-	return sortOrdr;
-    }
-
-    /**
-     * sortOrdr attribute 값을 설정한다.
-     * 
-     * @param sortOrdr
-     *            the sortOrdr to set
-     */
-    public void setSortOrdr(String sortOrdr) {
-	this.sortOrdr = sortOrdr;
-    }
-
-    /**
-     * searchUseYn attribute를 리턴한다.
-     * 
-     * @return the searchUseYn
-     */
-    public String getSearchUseYn() {
-	return searchUseYn;
-    }
-
-    /**
-     * searchUseYn attribute 값을 설정한다.
-     * 
-     * @param searchUseYn
-     *            the searchUseYn to set
-     */
-    public void setSearchUseYn(String searchUseYn) {
-	this.searchUseYn = searchUseYn;
-    }
-
-    /**
-     * pageIndex attribute를 리턴한다.
-     * 
-     * @return the pageIndex
-     */
-    public int getPageIndex() {
-	return pageIndex;
-    }
-
-    /**
-     * pageIndex attribute 값을 설정한다.
-     * 
-     * @param pageIndex
-     *            the pageIndex to set
-     */
-    public void setPageIndex(int pageIndex) {
-	this.pageIndex = pageIndex;
-    }
-
-    /**
-     * pageUnit attribute를 리턴한다.
-     * 
-     * @return the pageUnit
-     */
-    public int getPageUnit() {
-	return pageUnit;
-    }
-
-    /**
-     * pageUnit attribute 값을 설정한다.
-     * 
-     * @param pageUnit
-     *            the pageUnit to set
-     */
-    public void setPageUnit(int pageUnit) {
-	this.pageUnit = pageUnit;
-    }
-
-    /**
-     * pageSize attribute를 리턴한다.
-     * 
-     * @return the pageSize
-     */
-    public int getPageSize() {
-	return pageSize;
-    }
-
-    /**
-     * pageSize attribute 값을 설정한다.
-     * 
-     * @param pageSize
-     *            the pageSize to set
-     */
-    public void setPageSize(int pageSize) {
-	this.pageSize = pageSize;
-    }
-
-    /**
-     * firstIndex attribute를 리턴한다.
-     * 
-     * @return the firstIndex
-     */
-    public int getFirstIndex() {
-	return firstIndex;
-    }
-
-    /**
-     * firstIndex attribute 값을 설정한다.
-     * 
-     * @param firstIndex
-     *            the firstIndex to set
-     */
-    public void setFirstIndex(int firstIndex) {
-	this.firstIndex = firstIndex;
-    }
-
-    /**
-     * lastIndex attribute를 리턴한다.
-     * 
-     * @return the lastIndex
-     */
-    public int getLastIndex() {
-	return lastIndex;
-    }
-
-    /**
-     * lastIndex attribute 값을 설정한다.
-     * 
-     * @param lastIndex
-     *            the lastIndex to set
-     */
-    public void setLastIndex(int lastIndex) {
-	this.lastIndex = lastIndex;
-    }
-
-    /**
-     * recordCountPerPage attribute를 리턴한다.
-     * 
-     * @return the recordCountPerPage
-     */
-    public int getRecordCountPerPage() {
-	return recordCountPerPage;
-    }
-
-    /**
-     * recordCountPerPage attribute 값을 설정한다.
-     * 
-     * @param recordCountPerPage
-     *            the recordCountPerPage to set
-     */
-    public void setRecordCountPerPage(int recordCountPerPage) {
-	this.recordCountPerPage = recordCountPerPage;
-    }
-
-    /**
-     * rowNo attribute를 리턴한다.
-     * 
-     * @return the rowNo
-     */
-    public int getRowNo() {
-	return rowNo;
-    }
-
-    /**
-     * rowNo attribute 값을 설정한다.
-     * 
-     * @param rowNo
-     *            the rowNo to set
-     */
-    public void setRowNo(int rowNo) {
-	this.rowNo = rowNo;
-    }
-
-    /**
-     * emplyrId attribute를 리턴한다.
-     * 
-     * @return the emplyrId
-     */
-    public String getEmplyrId() {
-	return emplyrId;
-    }
-
-    /**
-     * emplyrId attribute 값을 설정한다.
-     * 
-     * @param emplyrId
-     *            the emplyrId to set
-     */
-    public void setEmplyrId(String emplyrId) {
-	this.emplyrId = emplyrId;
-    }
-
-    /**
-     * toString 메소드를 대치한다.
-     */
-    public String toString() {
-	return ToStringBuilder.reflectionToString(this);
-    }
 }

--- a/src/main/java/egovframework/com/cop/scp/service/ScrapVO.java
+++ b/src/main/java/egovframework/com/cop/scp/service/ScrapVO.java
@@ -1,6 +1,7 @@
 package egovframework.com.cop.scp.service;
 
-import org.apache.commons.lang3.builder.ToStringBuilder;
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * 스크랩 서비스를 위한 VO 클래스
@@ -11,21 +12,23 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.07.10  한성곤          최초 생성
  *
  * </pre>
  */
+@Getter
+@Setter
 @SuppressWarnings("serial")
 public class ScrapVO extends Scrap {
     /** 검색조건 */
     private String searchCnd = "";
-    
+
     /** 검색단어 */
     private String searchWrd = "";
-    
+
     /** 정렬순서(DESC,ASC) */
     private long sortOrdr = 0L;
 
@@ -58,219 +61,4 @@ public class ScrapVO extends Scrap {
 
     /** 최종 수정자명 */
     private String lastUpdusrNm = "";
-
-    /**
-     * searchCnd attribute를 리턴한다.
-     * @return the searchCnd
-     */
-    public String getSearchCnd() {
-        return searchCnd;
-    }
-
-    /**
-     * searchCnd attribute 값을 설정한다.
-     * @param searchCnd the searchCnd to set
-     */
-    public void setSearchCnd(String searchCnd) {
-        this.searchCnd = searchCnd;
-    }
-
-    /**
-     * searchWrd attribute를 리턴한다.
-     * @return the searchWrd
-     */
-    public String getSearchWrd() {
-        return searchWrd;
-    }
-
-    /**
-     * searchWrd attribute 값을 설정한다.
-     * @param searchWrd the searchWrd to set
-     */
-    public void setSearchWrd(String searchWrd) {
-        this.searchWrd = searchWrd;
-    }
-
-    /**
-     * sortOrdr attribute를 리턴한다.
-     * @return the sortOrdr
-     */
-    public long getSortOrdr() {
-        return sortOrdr;
-    }
-
-    /**
-     * sortOrdr attribute 값을 설정한다.
-     * @param sortOrdr the sortOrdr to set
-     */
-    public void setSortOrdr(long sortOrdr) {
-        this.sortOrdr = sortOrdr;
-    }
-
-    /**
-     * searchUseYn attribute를 리턴한다.
-     * @return the searchUseYn
-     */
-    public String getSearchUseYn() {
-        return searchUseYn;
-    }
-
-    /**
-     * searchUseYn attribute 값을 설정한다.
-     * @param searchUseYn the searchUseYn to set
-     */
-    public void setSearchUseYn(String searchUseYn) {
-        this.searchUseYn = searchUseYn;
-    }
-
-    /**
-     * pageIndex attribute를 리턴한다.
-     * @return the pageIndex
-     */
-    public int getPageIndex() {
-        return pageIndex;
-    }
-
-    /**
-     * pageIndex attribute 값을 설정한다.
-     * @param pageIndex the pageIndex to set
-     */
-    public void setPageIndex(int pageIndex) {
-        this.pageIndex = pageIndex;
-    }
-
-    /**
-     * pageUnit attribute를 리턴한다.
-     * @return the pageUnit
-     */
-    public int getPageUnit() {
-        return pageUnit;
-    }
-
-    /**
-     * pageUnit attribute 값을 설정한다.
-     * @param pageUnit the pageUnit to set
-     */
-    public void setPageUnit(int pageUnit) {
-        this.pageUnit = pageUnit;
-    }
-
-    /**
-     * pageSize attribute를 리턴한다.
-     * @return the pageSize
-     */
-    public int getPageSize() {
-        return pageSize;
-    }
-
-    /**
-     * pageSize attribute 값을 설정한다.
-     * @param pageSize the pageSize to set
-     */
-    public void setPageSize(int pageSize) {
-        this.pageSize = pageSize;
-    }
-
-    /**
-     * firstIndex attribute를 리턴한다.
-     * @return the firstIndex
-     */
-    public int getFirstIndex() {
-        return firstIndex;
-    }
-
-    /**
-     * firstIndex attribute 값을 설정한다.
-     * @param firstIndex the firstIndex to set
-     */
-    public void setFirstIndex(int firstIndex) {
-        this.firstIndex = firstIndex;
-    }
-
-    /**
-     * lastIndex attribute를 리턴한다.
-     * @return the lastIndex
-     */
-    public int getLastIndex() {
-        return lastIndex;
-    }
-
-    /**
-     * lastIndex attribute 값을 설정한다.
-     * @param lastIndex the lastIndex to set
-     */
-    public void setLastIndex(int lastIndex) {
-        this.lastIndex = lastIndex;
-    }
-
-    /**
-     * recordCountPerPage attribute를 리턴한다.
-     * @return the recordCountPerPage
-     */
-    public int getRecordCountPerPage() {
-        return recordCountPerPage;
-    }
-
-    /**
-     * recordCountPerPage attribute 값을 설정한다.
-     * @param recordCountPerPage the recordCountPerPage to set
-     */
-    public void setRecordCountPerPage(int recordCountPerPage) {
-        this.recordCountPerPage = recordCountPerPage;
-    }
-
-    /**
-     * rowNo attribute를 리턴한다.
-     * @return the rowNo
-     */
-    public int getRowNo() {
-        return rowNo;
-    }
-
-    /**
-     * rowNo attribute 값을 설정한다.
-     * @param rowNo the rowNo to set
-     */
-    public void setRowNo(int rowNo) {
-        this.rowNo = rowNo;
-    }
-
-    /**
-     * frstRegisterNm attribute를 리턴한다.
-     * @return the frstRegisterNm
-     */
-    public String getFrstRegisterNm() {
-        return frstRegisterNm;
-    }
-
-    /**
-     * frstRegisterNm attribute 값을 설정한다.
-     * @param frstRegisterNm the frstRegisterNm to set
-     */
-    public void setFrstRegisterNm(String frstRegisterNm) {
-        this.frstRegisterNm = frstRegisterNm;
-    }
-
-    /**
-     * lastUpdusrNm attribute를 리턴한다.
-     * @return the lastUpdusrNm
-     */
-    public String getLastUpdusrNm() {
-        return lastUpdusrNm;
-    }
-
-    /**
-     * lastUpdusrNm attribute 값을 설정한다.
-     * @param lastUpdusrNm the lastUpdusrNm to set
-     */
-    public void setLastUpdusrNm(String lastUpdusrNm) {
-        this.lastUpdusrNm = lastUpdusrNm;
-    }
-    
-    /**
-     * toString 메소드를 대치한다.
-     */
-    public String toString() {
-	return ToStringBuilder.reflectionToString(this);
-    }
 }

--- a/src/main/java/egovframework/com/cop/tpl/service/TemplateInfVO.java
+++ b/src/main/java/egovframework/com/cop/tpl/service/TemplateInfVO.java
@@ -2,8 +2,8 @@ package egovframework.com.cop.tpl.service;
 
 import java.io.Serializable;
 
-import org.apache.commons.lang3.builder.ToStringBuilder;
-
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * 템플릿 정보 관리를 위한 VO 클래스
@@ -14,16 +14,18 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.3.17  이삼섭          최초 생성
  *
  * </pre>
  */
+@Getter
+@Setter
 @SuppressWarnings("serial")
 public class TemplateInfVO extends TemplateInf implements Serializable {
-	
+
     /** 최초 등록자명 */
     private String frstRegisterNm = "";
 
@@ -35,16 +37,16 @@ public class TemplateInfVO extends TemplateInf implements Serializable {
 
     /** 검색시작일 */
     private String searchBgnDe = "";
-    
+
     /** 검색조건 */
     private String searchCnd = "";
-    
+
     /** 검색종료일 */
     private String searchEndDe = "";
-    
+
     /** 검색단어 */
     private String searchWrd = "";
-    
+
     /** 정렬순서(DESC,ASC) */
     private String sortOrdr = "";
 
@@ -74,334 +76,4 @@ public class TemplateInfVO extends TemplateInf implements Serializable {
 
     /** 구분 유형 */
     private String typeFlag = "";
-
-    /**
-     * frstRegisterNm attribute를 리턴한다.
-     * 
-     * @return the frstRegisterNm
-     */
-    public String getFrstRegisterNm() {
-	return frstRegisterNm;
-    }
-
-    /**
-     * frstRegisterNm attribute 값을 설정한다.
-     * 
-     * @param frstRegisterNm
-     *            the frstRegisterNm to set
-     */
-    public void setFrstRegisterNm(String frstRegisterNm) {
-	this.frstRegisterNm = frstRegisterNm;
-    }
-
-    /**
-     * lastUpdusrNm attribute를 리턴한다.
-     * 
-     * @return the lastUpdusrNm
-     */
-    public String getLastUpdusrNm() {
-	return lastUpdusrNm;
-    }
-
-    /**
-     * lastUpdusrNm attribute 값을 설정한다.
-     * 
-     * @param lastUpdusrNm
-     *            the lastUpdusrNm to set
-     */
-    public void setLastUpdusrNm(String lastUpdusrNm) {
-	this.lastUpdusrNm = lastUpdusrNm;
-    }
-
-    /**
-     * tmplatSeCodeNm attribute를 리턴한다.
-     * 
-     * @return the tmplatSeCodeNm
-     */
-    public String getTmplatSeCodeNm() {
-	return tmplatSeCodeNm;
-    }
-
-    /**
-     * tmplatSeCodeNm attribute 값을 설정한다.
-     * 
-     * @param tmplatSeCodeNm
-     *            the tmplatSeCodeNm to set
-     */
-    public void setTmplatSeCodeNm(String tmplatSeCodeNm) {
-	this.tmplatSeCodeNm = tmplatSeCodeNm;
-    }
-
-    /**
-     * searchBgnDe attribute를 리턴한다.
-     * 
-     * @return the searchBgnDe
-     */
-    public String getSearchBgnDe() {
-	return searchBgnDe;
-    }
-
-    /**
-     * searchBgnDe attribute 값을 설정한다.
-     * 
-     * @param searchBgnDe
-     *            the searchBgnDe to set
-     */
-    public void setSearchBgnDe(String searchBgnDe) {
-	this.searchBgnDe = searchBgnDe;
-    }
-
-    /**
-     * searchCnd attribute를 리턴한다.
-     * 
-     * @return the searchCnd
-     */
-    public String getSearchCnd() {
-	return searchCnd;
-    }
-
-    /**
-     * searchCnd attribute 값을 설정한다.
-     * 
-     * @param searchCnd
-     *            the searchCnd to set
-     */
-    public void setSearchCnd(String searchCnd) {
-	this.searchCnd = searchCnd;
-    }
-
-    /**
-     * searchEndDe attribute를 리턴한다.
-     * 
-     * @return the searchEndDe
-     */
-    public String getSearchEndDe() {
-	return searchEndDe;
-    }
-
-    /**
-     * searchEndDe attribute 값을 설정한다.
-     * 
-     * @param searchEndDe
-     *            the searchEndDe to set
-     */
-    public void setSearchEndDe(String searchEndDe) {
-	this.searchEndDe = searchEndDe;
-    }
-
-    /**
-     * searchWrd attribute를 리턴한다.
-     * 
-     * @return the searchWrd
-     */
-    public String getSearchWrd() {
-	return searchWrd;
-    }
-
-    /**
-     * searchWrd attribute 값을 설정한다.
-     * 
-     * @param searchWrd
-     *            the searchWrd to set
-     */
-    public void setSearchWrd(String searchWrd) {
-	this.searchWrd = searchWrd;
-    }
-
-    /**
-     * sortOrdr attribute를 리턴한다.
-     * 
-     * @return the sortOrdr
-     */
-    public String getSortOrdr() {
-	return sortOrdr;
-    }
-
-    /**
-     * sortOrdr attribute 값을 설정한다.
-     * 
-     * @param sortOrdr
-     *            the sortOrdr to set
-     */
-    public void setSortOrdr(String sortOrdr) {
-	this.sortOrdr = sortOrdr;
-    }
-
-    /**
-     * searchUseYn attribute를 리턴한다.
-     * 
-     * @return the searchUseYn
-     */
-    public String getSearchUseYn() {
-	return searchUseYn;
-    }
-
-    /**
-     * searchUseYn attribute 값을 설정한다.
-     * 
-     * @param searchUseYn
-     *            the searchUseYn to set
-     */
-    public void setSearchUseYn(String searchUseYn) {
-	this.searchUseYn = searchUseYn;
-    }
-
-    /**
-     * pageIndex attribute를 리턴한다.
-     * 
-     * @return the pageIndex
-     */
-    public int getPageIndex() {
-	return pageIndex;
-    }
-
-    /**
-     * pageIndex attribute 값을 설정한다.
-     * 
-     * @param pageIndex
-     *            the pageIndex to set
-     */
-    public void setPageIndex(int pageIndex) {
-	this.pageIndex = pageIndex;
-    }
-
-    /**
-     * pageUnit attribute를 리턴한다.
-     * 
-     * @return the pageUnit
-     */
-    public int getPageUnit() {
-	return pageUnit;
-    }
-
-    /**
-     * pageUnit attribute 값을 설정한다.
-     * 
-     * @param pageUnit
-     *            the pageUnit to set
-     */
-    public void setPageUnit(int pageUnit) {
-	this.pageUnit = pageUnit;
-    }
-
-    /**
-     * pageSize attribute를 리턴한다.
-     * 
-     * @return the pageSize
-     */
-    public int getPageSize() {
-	return pageSize;
-    }
-
-    /**
-     * pageSize attribute 값을 설정한다.
-     * 
-     * @param pageSize
-     *            the pageSize to set
-     */
-    public void setPageSize(int pageSize) {
-	this.pageSize = pageSize;
-    }
-
-    /**
-     * firstIndex attribute를 리턴한다.
-     * 
-     * @return the firstIndex
-     */
-    public int getFirstIndex() {
-	return firstIndex;
-    }
-
-    /**
-     * firstIndex attribute 값을 설정한다.
-     * 
-     * @param firstIndex
-     *            the firstIndex to set
-     */
-    public void setFirstIndex(int firstIndex) {
-	this.firstIndex = firstIndex;
-    }
-
-    /**
-     * lastIndex attribute를 리턴한다.
-     * 
-     * @return the lastIndex
-     */
-    public int getLastIndex() {
-	return lastIndex;
-    }
-
-    /**
-     * lastIndex attribute 값을 설정한다.
-     * 
-     * @param lastIndex
-     *            the lastIndex to set
-     */
-    public void setLastIndex(int lastIndex) {
-	this.lastIndex = lastIndex;
-    }
-
-    /**
-     * recordCountPerPage attribute를 리턴한다.
-     * 
-     * @return the recordCountPerPage
-     */
-    public int getRecordCountPerPage() {
-	return recordCountPerPage;
-    }
-
-    /**
-     * recordCountPerPage attribute 값을 설정한다.
-     * 
-     * @param recordCountPerPage
-     *            the recordCountPerPage to set
-     */
-    public void setRecordCountPerPage(int recordCountPerPage) {
-	this.recordCountPerPage = recordCountPerPage;
-    }
-
-    /**
-     * rowNo attribute를 리턴한다.
-     * 
-     * @return the rowNo
-     */
-    public int getRowNo() {
-	return rowNo;
-    }
-
-    /**
-     * rowNo attribute 값을 설정한다.
-     * 
-     * @param rowNo
-     *            the rowNo to set
-     */
-    public void setRowNo(int rowNo) {
-	this.rowNo = rowNo;
-    }
-
-    /**
-     * typeFlag attribute를 리턴한다.
-     * 
-     * @return the typeFlag
-     */
-    public String getTypeFlag() {
-	return typeFlag;
-    }
-
-    /**
-     * typeFlag attribute 값을 설정한다.
-     * 
-     * @param typeFlag
-     *            the typeFlag to set
-     */
-    public void setTypeFlag(String typeFlag) {
-	this.typeFlag = typeFlag;
-    }
-
-    /**
-     * toString 메소드를 대치한다.
-     */
-    public String toString() {
-	return ToStringBuilder.reflectionToString(this);
-    }
 }


### PR DESCRIPTION
cop/scp(스크랩), cop/ncm(명함), cop/tpl(템플릿) 모듈의 VO 클래스에 수동으로 작성된 getter/setter 메서드와 ToStringBuilder를 제거하고 Lombok @Getter/@Setter 어노테이션으로 대체했다.

변경 내용:
- `ScrapVO`: 11개 필드 getter/setter 및 `ToStringBuilder.reflectionToString()` 제거, `@Getter`/`@Setter` 적용
- `NameCardVO`: 14개 필드 getter/setter 및 `ToStringBuilder.reflectionToString()` 제거, `@Getter`/`@Setter` 적용
- `TemplateInfVO`: 13개 필드 getter/setter 및 `ToStringBuilder.reflectionToString()` 제거, `@Getter`/`@Setter` 적용
- `pom.xml`: maven-compiler-plugin에 `annotationProcessorPaths` 추가 (Lombok 어노테이션 처리 명시적 구성)

- [x] 단일 주제만 다룸 (다른 변경 없음)
- [x] 기존 동작에 영향 없음 (getter/setter API 동일하게 유지)
- [x] 빌드 통과 확인 (`mvn compile` BUILD SUCCESS)
