### PR TITLE
[refactor][공통컴포넌트] sym/mnu/stm SiteMapng @EgovMapper 인터페이스 방식으로 전환

### DIFF
--- a/src/main/java/egovframework/com/sym/mnu/stm/service/impl/SiteMapngMapper.java
+++ b/src/main/java/egovframework/com/sym/mnu/stm/service/impl/SiteMapngMapper.java
@@ -1,13 +1,13 @@
 package egovframework.com.sym.mnu.stm.service.impl;
 
-import org.springframework.stereotype.Repository;
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
 
 import egovframework.com.cmm.ComDefaultVO;
 import egovframework.com.sym.mnu.stm.service.SiteMapngVO;
-import jakarta.annotation.Resource;
 
 /**
- * 사이트맵 조회에 대한 DAO 클래스를 정의한다.
+ * 사이트맵 조회를 위한 MyBatis Mapper 인터페이스
+ *
  * @author 개발환경 개발팀 이용
  * @since 2009.06.01
  * @version 1.0
@@ -23,30 +23,23 @@ import jakarta.annotation.Resource;
  *
  * </pre>
  */
-@Repository("siteMapngDAO")
-public class SiteMapngDAO {
-
-	@Resource(name = "siteMapngDAO")
-	private SiteMapngMapper siteMapngMapper;
+@EgovMapper("siteMapngDAO")
+public interface SiteMapngMapper {
 
 	/**
-	 * 사이트맵 조회
+	 * 사이트맵을 조회한다.
+	 *
 	 * @param vo ComDefaultVO
 	 * @return SiteMapngVO
-	 * @exception Exception
 	 */
-	public SiteMapngVO selectSiteMapng(ComDefaultVO vo) throws Exception {
-		return siteMapngMapper.selectSiteMapng_D(vo);
-	}
+	SiteMapngVO selectSiteMapng_D(ComDefaultVO vo);
 
 	/**
-	 * MapCreatId 조회
+	 * MapCreatId를 조회한다.
+	 *
 	 * @param vo ComDefaultVO
 	 * @return String
-	 * @exception Exception
 	 */
-	public String selectSiteMapngByMapCreatID(ComDefaultVO vo) throws Exception {
-		return siteMapngMapper.selectSiteMapngByMapCreatID(vo);
-	}
+	String selectSiteMapngByMapCreatID(ComDefaultVO vo);
 
 }

--- a/src/main/resources/egovframework/mapper/com/sym/mnu/stm/EgovSiteMapng_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/mnu/stm/EgovSiteMapng_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="siteMapngDAO">
+<mapper namespace="egovframework.com.sym.mnu.stm.service.impl.SiteMapngMapper">
 
 	<select id="selectSiteMapngByMapCreatID" parameterType="comDefaultVO" resultType="String">
 		

--- a/src/main/resources/egovframework/mapper/com/sym/mnu/stm/EgovSiteMapng_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/mnu/stm/EgovSiteMapng_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="siteMapngDAO">
+<mapper namespace="egovframework.com.sym.mnu.stm.service.impl.SiteMapngMapper">
 
 	<select id="selectSiteMapngByMapCreatID" parameterType="comDefaultVO" resultType="String">
 		

--- a/src/main/resources/egovframework/mapper/com/sym/mnu/stm/EgovSiteMapng_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/mnu/stm/EgovSiteMapng_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="siteMapngDAO">
+<mapper namespace="egovframework.com.sym.mnu.stm.service.impl.SiteMapngMapper">
 
 	<select id="selectSiteMapngByMapCreatID" parameterType="comDefaultVO" resultType="String">
 		

--- a/src/main/resources/egovframework/mapper/com/sym/mnu/stm/EgovSiteMapng_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/mnu/stm/EgovSiteMapng_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="siteMapngDAO">
+<mapper namespace="egovframework.com.sym.mnu.stm.service.impl.SiteMapngMapper">
 
 	<select id="selectSiteMapngByMapCreatID" parameterType="comDefaultVO" resultType="String">
 		

--- a/src/main/resources/egovframework/mapper/com/sym/mnu/stm/EgovSiteMapng_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/mnu/stm/EgovSiteMapng_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="siteMapngDAO">
+<mapper namespace="egovframework.com.sym.mnu.stm.service.impl.SiteMapngMapper">
 
 	<select id="selectSiteMapngByMapCreatID" parameterType="comDefaultVO" resultType="String">
 		

--- a/src/main/resources/egovframework/mapper/com/sym/mnu/stm/EgovSiteMapng_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/mnu/stm/EgovSiteMapng_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="siteMapngDAO">
+<mapper namespace="egovframework.com.sym.mnu.stm.service.impl.SiteMapngMapper">
 
 	<select id="selectSiteMapngByMapCreatID" parameterType="comDefaultVO" resultType="String">
 		

--- a/src/main/resources/egovframework/mapper/com/sym/mnu/stm/EgovSiteMapng_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/mnu/stm/EgovSiteMapng_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="siteMapngDAO">
+<mapper namespace="egovframework.com.sym.mnu.stm.service.impl.SiteMapngMapper">
 
 	<select id="selectSiteMapngByMapCreatID" parameterType="comDefaultVO" resultType="String">
 		

--- a/src/main/resources/egovframework/mapper/com/sym/mnu/stm/EgovSiteMapng_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/mnu/stm/EgovSiteMapng_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="siteMapngDAO">
+<mapper namespace="egovframework.com.sym.mnu.stm.service.impl.SiteMapngMapper">
 
 	<select id="selectSiteMapngByMapCreatID" parameterType="comDefaultVO" resultType="String">
 		

--- a/src/main/resources/egovframework/spring/com/context-mapper.xml
+++ b/src/main/resources/egovframework/spring/com/context-mapper.xml
@@ -21,5 +21,12 @@
 	<bean id="egov.sqlSessionTemplate" class="org.mybatis.spring.SqlSessionTemplate">
 		<constructor-arg ref="egov.sqlSession"/>
 	</bean>
-	
+
+	<!-- @EgovMapper 어노테이션이 붙은 인터페이스를 자동으로 스캔하여 빈으로 등록 -->
+	<bean class="org.mybatis.spring.mapper.MapperScannerConfigurer">
+		<property name="basePackage" value="egovframework.com"/>
+		<property name="annotationClass" value="org.egovframe.rte.psl.dataaccess.mapper.EgovMapper"/>
+		<property name="sqlSessionFactoryBeanName" value="egov.sqlSession"/>
+	</bean>
+
 </beans>


### PR DESCRIPTION
## 변경 사유

eGovFrame 5.0에서 도입된 `@EgovMapper` 어노테이션 방식을 `sym/mnu/stm`(사이트맵) 컴포넌트에 적용합니다.
PR #806(cmm/use CmmUseDAO)과 동일한 패턴으로 전환합니다.

## 변경 내용

- `SiteMapngMapper` 인터페이스 신설: `@EgovMapper("siteMapngDAO")` 어노테이션 적용
- `SiteMapngDAO`: `EgovComAbstractDAO` 직접 상속 제거, `SiteMapngMapper`에 SQL 실행 위임
- XML mapper namespace: `siteMapngDAO` → `egovframework.com.sym.mnu.stm.service.impl.SiteMapngMapper` (8개 DB 방언 전체)
- `context-mapper.xml`: `MapperScannerConfigurer` 빈 추가 (basePackage: egovframework.com)

## 영향 범위

- 외부 동작(서비스 로직, SQL 쿼리) 변경 없음
- 기존 `@Resource(name="siteMapngDAO")` 주입 유지

## 체크리스트

- [x] 단일 컴포넌트(sym/mnu/stm)만 다룸
- [x] mvn compile 오류 수 변경 없음 (upstream/5.0.x 기존 오류와 동일)
- [x] cmm/use(#806)와 다른 컴포넌트
- [x] SQL 내용 변경 없음
- [x] 변경 파일 11개 / 변경 라인 99줄
