### PR TITLE
[refactor][공통컴포넌트] uss/ion (mtg/noi/ntr) 모듈 VO Lombok @Getter/@Setter 적용

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -597,6 +597,13 @@
 					<artifactId>maven-compiler-plugin</artifactId>
 					<configuration>
 						<release>${java.version}</release>
+						<annotationProcessorPaths>
+							<path>
+								<groupId>org.projectlombok</groupId>
+								<artifactId>lombok</artifactId>
+								<version>${lombok.version}</version>
+							</path>
+						</annotationProcessorPaths>
 					</configuration>
 				</plugin>
 				<plugin>

--- a/src/main/java/egovframework/com/uss/ion/mtg/service/MtgPlaceManageVO.java
+++ b/src/main/java/egovframework/com/uss/ion/mtg/service/MtgPlaceManageVO.java
@@ -3,6 +3,8 @@ package egovframework.com.uss.ion.mtg.service;
 import java.util.List;
 
 import egovframework.com.cmm.ComDefaultVO;
+import lombok.Getter;
+import lombok.Setter;
 import org.egovframe.rte.ptl.reactive.validation.EgovNullCheck;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.Min;
@@ -18,6 +20,8 @@ import jakarta.validation.constraints.Size;
  * @version 1.0
  * @created 06-15-2010 오후 2:08:56
  */
+@Getter
+@Setter
 public class MtgPlaceManageVO extends ComDefaultVO {
 
 	private static final long serialVersionUID = 1L;
@@ -137,121 +141,4 @@ public class MtgPlaceManageVO extends ComDefaultVO {
 
 	/** resveDeView 변수 */
 	private String resveDeView;
-
-	// --- getters/setters (MtgPlaceManage fields) ---
-	public String getMtgPlaceId() { return mtgPlaceId; }
-	public void setMtgPlaceId(String mtgPlaceId) { this.mtgPlaceId = mtgPlaceId; }
-	public String getMtgPlaceNm() { return mtgPlaceNm; }
-	public void setMtgPlaceNm(String mtgPlaceNm) { this.mtgPlaceNm = mtgPlaceNm; }
-	public String getOpnBeginTm() { return opnBeginTm; }
-	public void setOpnBeginTm(String opnBeginTm) { this.opnBeginTm = opnBeginTm; }
-	public String getOpnEndTm() { return opnEndTm; }
-	public void setOpnEndTm(String opnEndTm) { this.opnEndTm = opnEndTm; }
-	public int getAceptncPosblNmpr() { return aceptncPosblNmpr; }
-	public void setAceptncPosblNmpr(int aceptncPosblNmpr) { this.aceptncPosblNmpr = aceptncPosblNmpr; }
-	public String getLcSe() { return lcSe; }
-	public void setLcSe(String lcSe) { this.lcSe = lcSe; }
-	public String getLcDetail() { return lcDetail; }
-	public void setLcDetail(String lcDetail) { this.lcDetail = lcDetail; }
-	public String getAtchFileId() { return atchFileId; }
-	public void setAtchFileId(String atchFileId) { this.atchFileId = atchFileId; }
-	public String getFrstRegisterId() { return frstRegisterId; }
-	public void setFrstRegisterId(String frstRegisterId) { this.frstRegisterId = frstRegisterId; }
-	public String getFrstRegisterPnttm() { return frstRegisterPnttm; }
-	public void setFrstRegisterPnttm(String frstRegisterPnttm) { this.frstRegisterPnttm = frstRegisterPnttm; }
-	public String getLastUpdusrId() { return lastUpdusrId; }
-	public void setLastUpdusrId(String lastUpdusrId) { this.lastUpdusrId = lastUpdusrId; }
-	public String getLastUpdusrPnttm() { return lastUpdusrPnttm; }
-	public void setLastUpdusrPnttm(String lastUpdusrPnttm) { this.lastUpdusrPnttm = lastUpdusrPnttm; }
-
-	// --- VO/list/resve fields ---
-	public String getResveDeView() { return resveDeView; }
-	public void setResveDeView(String resveDeView) { this.resveDeView = resveDeView; }
-	public String getResveId() { return resveId; }
-	public void setResveId(String resveId) { this.resveId = resveId; }
-	public String getMtgSj() { return mtgSj; }
-	public void setMtgSj(String mtgSj) { this.mtgSj = mtgSj; }
-	public String getResveManId() { return resveManId; }
-	public void setResveManId(String resveManId) { this.resveManId = resveManId; }
-	public String getResveDe() { return resveDe; }
-	public void setResveDe(String resveDe) { this.resveDe = resveDe; }
-	public String getResveBeginTm() { return resveBeginTm; }
-	public void setResveBeginTm(String resveBeginTm) { this.resveBeginTm = resveBeginTm; }
-	public String getResveEndTm() { return resveEndTm; }
-	public void setResveEndTm(String resveEndTm) { this.resveEndTm = resveEndTm; }
-	public int getAtndncNmpr() { return atndncNmpr; }
-	public void setAtndncNmpr(int atndncNmpr) { this.atndncNmpr = atndncNmpr; }
-	public String getMtgCn() { return mtgCn; }
-	public void setMtgCn(String mtgCn) { this.mtgCn = mtgCn; }
-	public List<MtgPlaceManageVO> getMtgPlaceManageList() { return mtgPlaceManageList; }
-	public void setMtgPlaceManageList(List<MtgPlaceManageVO> mtgPlaceManageList) { this.mtgPlaceManageList = mtgPlaceManageList; }
-	public int getRowCount() { return rowCount; }
-	public void setRowCount(int rowCount) { this.rowCount = rowCount; }
-	public String getMtgPlaceTemp1() { return mtgPlaceTemp1; }
-	public void setMtgPlaceTemp1(String mtgPlaceTemp1) { this.mtgPlaceTemp1 = mtgPlaceTemp1; }
-	public String getMtgPlaceTemp2() { return mtgPlaceTemp2; }
-	public void setMtgPlaceTemp2(String mtgPlaceTemp2) { this.mtgPlaceTemp2 = mtgPlaceTemp2; }
-	public String getMtgPlaceTemp3() { return mtgPlaceTemp3; }
-	public void setMtgPlaceTemp3(String mtgPlaceTemp3) { this.mtgPlaceTemp3 = mtgPlaceTemp3; }
-	public String getMtgPlaceTemp4() { return mtgPlaceTemp4; }
-	public void setMtgPlaceTemp4(String mtgPlaceTemp4) { this.mtgPlaceTemp4 = mtgPlaceTemp4; }
-	public String getMtgPlaceTemp5() { return mtgPlaceTemp5; }
-	public void setMtgPlaceTemp5(String mtgPlaceTemp5) { this.mtgPlaceTemp5 = mtgPlaceTemp5; }
-	public String getUsidTemp() { return usidTemp; }
-	public void setUsidTemp(String usidTemp) { this.usidTemp = usidTemp; }
-
-	public String getResveTemp0800() { return resveTemp0800; }
-	public void setResveTemp0800(String v) { this.resveTemp0800 = v; }
-	public String getResveTemp0830() { return resveTemp0830; }
-	public void setResveTemp0830(String v) { this.resveTemp0830 = v; }
-	public String getResveTemp0900() { return resveTemp0900; }
-	public void setResveTemp0900(String v) { this.resveTemp0900 = v; }
-	public String getResveTemp0930() { return resveTemp0930; }
-	public void setResveTemp0930(String v) { this.resveTemp0930 = v; }
-	public String getResveTemp1000() { return resveTemp1000; }
-	public void setResveTemp1000(String v) { this.resveTemp1000 = v; }
-	public String getResveTemp1030() { return resveTemp1030; }
-	public void setResveTemp1030(String v) { this.resveTemp1030 = v; }
-	public String getResveTemp1100() { return resveTemp1100; }
-	public void setResveTemp1100(String v) { this.resveTemp1100 = v; }
-	public String getResveTemp1130() { return resveTemp1130; }
-	public void setResveTemp1130(String v) { this.resveTemp1130 = v; }
-	public String getResveTemp1200() { return resveTemp1200; }
-	public void setResveTemp1200(String v) { this.resveTemp1200 = v; }
-	public String getResveTemp1230() { return resveTemp1230; }
-	public void setResveTemp1230(String v) { this.resveTemp1230 = v; }
-	public String getResveTemp1300() { return resveTemp1300; }
-	public void setResveTemp1300(String v) { this.resveTemp1300 = v; }
-	public String getResveTemp1330() { return resveTemp1330; }
-	public void setResveTemp1330(String v) { this.resveTemp1330 = v; }
-	public String getResveTemp1400() { return resveTemp1400; }
-	public void setResveTemp1400(String v) { this.resveTemp1400 = v; }
-	public String getResveTemp1430() { return resveTemp1430; }
-	public void setResveTemp1430(String v) { this.resveTemp1430 = v; }
-	public String getResveTemp1500() { return resveTemp1500; }
-	public void setResveTemp1500(String v) { this.resveTemp1500 = v; }
-	public String getResveTemp1530() { return resveTemp1530; }
-	public void setResveTemp1530(String v) { this.resveTemp1530 = v; }
-	public String getResveTemp1600() { return resveTemp1600; }
-	public void setResveTemp1600(String v) { this.resveTemp1600 = v; }
-	public String getResveTemp1630() { return resveTemp1630; }
-	public void setResveTemp1630(String v) { this.resveTemp1630 = v; }
-	public String getResveTemp1700() { return resveTemp1700; }
-	public void setResveTemp1700(String v) { this.resveTemp1700 = v; }
-	public String getResveTemp1730() { return resveTemp1730; }
-	public void setResveTemp1730(String v) { this.resveTemp1730 = v; }
-	public String getResveTemp1800() { return resveTemp1800; }
-	public void setResveTemp1800(String v) { this.resveTemp1800 = v; }
-	public String getResveTemp1830() { return resveTemp1830; }
-	public void setResveTemp1830(String v) { this.resveTemp1830 = v; }
-	public String getResveTemp1900() { return resveTemp1900; }
-	public void setResveTemp1900(String v) { this.resveTemp1900 = v; }
-	public String getResveTemp1930() { return resveTemp1930; }
-	public void setResveTemp1930(String v) { this.resveTemp1930 = v; }
-	public String getResveTemp2000() { return resveTemp2000; }
-	public void setResveTemp2000(String v) { this.resveTemp2000 = v; }
-	public String getResveTemp2030() { return resveTemp2030; }
-	public void setResveTemp2030(String v) { this.resveTemp2030 = v; }
-	public String getResveTemp2100() { return resveTemp2100; }
-	public void setResveTemp2100(String v) { this.resveTemp2100 = v; }
 }

--- a/src/main/java/egovframework/com/uss/ion/mtg/service/MtgPlaceResveVO.java
+++ b/src/main/java/egovframework/com/uss/ion/mtg/service/MtgPlaceResveVO.java
@@ -3,6 +3,8 @@ package egovframework.com.uss.ion.mtg.service;
 import java.util.List;
 
 import egovframework.com.cmm.ComDefaultVO;
+import lombok.Getter;
+import lombok.Setter;
 import org.egovframe.rte.ptl.reactive.validation.EgovNullCheck;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.Pattern;
@@ -18,6 +20,8 @@ import jakarta.validation.constraints.Size;
  * @version 1.0
  * @created 06-15-2010 오후 2:08:56
  */
+@Getter
+@Setter
 public class MtgPlaceResveVO extends ComDefaultVO {
 
 	private static final long serialVersionUID = 1L;
@@ -99,33 +103,4 @@ public class MtgPlaceResveVO extends ComDefaultVO {
 
 	/** 예약 목록 */
 	private List<MtgPlaceResveVO> mtgPlaceResveList;
-
-	public String getResveId() { return resveId; }
-	public void setResveId(String resveId) { this.resveId = resveId; }
-	public String getMtgPlaceId() { return mtgPlaceId; }
-	public void setMtgPlaceId(String mtgPlaceId) { this.mtgPlaceId = mtgPlaceId; }
-	public String getMtgSj() { return mtgSj; }
-	public void setMtgSj(String mtgSj) { this.mtgSj = mtgSj; }
-	public String getResveManId() { return resveManId; }
-	public void setResveManId(String resveManId) { this.resveManId = resveManId; }
-	public String getResveDe() { return resveDe; }
-	public void setResveDe(String resveDe) { this.resveDe = resveDe; }
-	public String getResveBeginTm() { return resveBeginTm; }
-	public void setResveBeginTm(String resveBeginTm) { this.resveBeginTm = resveBeginTm; }
-	public String getResveEndTm() { return resveEndTm; }
-	public void setResveEndTm(String resveEndTm) { this.resveEndTm = resveEndTm; }
-	public int getAtndncNmpr() { return atndncNmpr; }
-	public void setAtndncNmpr(int atndncNmpr) { this.atndncNmpr = atndncNmpr; }
-	public String getMtgCn() { return mtgCn; }
-	public void setMtgCn(String mtgCn) { this.mtgCn = mtgCn; }
-	public String getFrstRegisterId() { return frstRegisterId; }
-	public void setFrstRegisterId(String frstRegisterId) { this.frstRegisterId = frstRegisterId; }
-	public String getFrstRegisterPnttm() { return frstRegisterPnttm; }
-	public void setFrstRegisterPnttm(String frstRegisterPnttm) { this.frstRegisterPnttm = frstRegisterPnttm; }
-	public String getLastUpdusrId() { return lastUpdusrId; }
-	public void setLastUpdusrId(String lastUpdusrId) { this.lastUpdusrId = lastUpdusrId; }
-	public String getLastUpdusrPnttm() { return lastUpdusrPnttm; }
-	public void setLastUpdusrPnttm(String lastUpdusrPnttm) { this.lastUpdusrPnttm = lastUpdusrPnttm; }
-	public List<MtgPlaceResveVO> getMtgPlaceResveList() { return mtgPlaceResveList; }
-	public void setMtgPlaceResveList(List<MtgPlaceResveVO> mtgPlaceResveList) { this.mtgPlaceResveList = mtgPlaceResveList; }
 }

--- a/src/main/java/egovframework/com/uss/ion/noi/service/NotificationVO.java
+++ b/src/main/java/egovframework/com/uss/ion/noi/service/NotificationVO.java
@@ -4,6 +4,9 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.egovframe.rte.ptl.reactive.validation.EgovNullCheck;
 
 import egovframework.com.cmm.ComDefaultVO;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.Setter;
 import jakarta.validation.constraints.Size;
 
 /**
@@ -23,6 +26,8 @@ import jakarta.validation.constraints.Size;
  *
  * </pre>
  */
+@Getter
+@Setter
 public class NotificationVO extends ComDefaultVO {
 
     /**
@@ -50,7 +55,9 @@ public class NotificationVO extends ComDefaultVO {
     /** 알림 시간 */
     private String ntfcTime = "";
 
-    /** 사전 알림 간격 (최소 1개 이상 선택) */
+    /** 사전 알림 간격 (최소 1개 이상 선택) - 방어적 복사를 위해 직접 구현 */
+    @Getter(AccessLevel.NONE)
+    @Setter(AccessLevel.NONE)
     @Size(min = 1, message = "{ussIonNoi.notificationVO.bhNtfcIntrvlRequired}")
     private String[] bhNtfcIntrvl = new String[0];
 
@@ -101,46 +108,6 @@ public class NotificationVO extends ComDefaultVO {
     /** 정보알림이 표시를 위한 종료일 및 종료시간 */
     private String endDateTime = "";
 
-    public String getNtfcNo() {
-        return ntfcNo;
-    }
-
-    public void setNtfcNo(String ntfcNo) {
-        this.ntfcNo = ntfcNo;
-    }
-
-    public String getNtfcSj() {
-        return ntfcSj;
-    }
-
-    public void setNtfcSj(String ntfcSj) {
-        this.ntfcSj = ntfcSj;
-    }
-
-    public String getNtfcCn() {
-        return ntfcCn;
-    }
-
-    public void setNtfcCn(String ntfcCn) {
-        this.ntfcCn = ntfcCn;
-    }
-
-    public String getNtfcDate() {
-        return ntfcDate;
-    }
-
-    public void setNtfcDate(String ntfcDate) {
-        this.ntfcDate = ntfcDate;
-    }
-
-    public String getNtfcTime() {
-        return ntfcTime;
-    }
-
-    public void setNtfcTime(String ntfcTime) {
-        this.ntfcTime = ntfcTime;
-    }
-
     public String[] getBhNtfcIntrvl() {
         if (this.bhNtfcIntrvl == null) {
             return null;
@@ -161,126 +128,6 @@ public class NotificationVO extends ComDefaultVO {
         for (int i = 0; i < bhNtfcIntrvl.length; i++) {
             this.bhNtfcIntrvl[i] = bhNtfcIntrvl[i];
         }
-    }
-
-    public String getBhNtfcIntrvlString() {
-        return bhNtfcIntrvlString;
-    }
-
-    public void setBhNtfcIntrvlString(String bhNtfcIntrvlString) {
-        this.bhNtfcIntrvlString = bhNtfcIntrvlString;
-    }
-
-    public String getFrstRegisterId() {
-        return frstRegisterId;
-    }
-
-    public void setFrstRegisterId(String frstRegisterId) {
-        this.frstRegisterId = frstRegisterId;
-    }
-
-    public String getFrstRegisterNm() {
-        return frstRegisterNm;
-    }
-
-    public void setFrstRegisterNm(String frstRegisterNm) {
-        this.frstRegisterNm = frstRegisterNm;
-    }
-
-    public String getFrstRegisterPnttm() {
-        return frstRegisterPnttm;
-    }
-
-    public void setFrstRegisterPnttm(String frstRegisterPnttm) {
-        this.frstRegisterPnttm = frstRegisterPnttm;
-    }
-
-    public String getLastUpdusrId() {
-        return lastUpdusrId;
-    }
-
-    public void setLastUpdusrId(String lastUpdusrId) {
-        this.lastUpdusrId = lastUpdusrId;
-    }
-
-    public String getLastUpdusrPnttm() {
-        return lastUpdusrPnttm;
-    }
-
-    public void setLastUpdusrPnttm(String lastUpdusrPnttm) {
-        this.lastUpdusrPnttm = lastUpdusrPnttm;
-    }
-
-    public String getUniqId() {
-        return uniqId;
-    }
-
-    public void setUniqId(String uniqId) {
-        this.uniqId = uniqId;
-    }
-
-    public String getNtfcHH() {
-        return ntfcHH;
-    }
-
-    public void setNtfcHH(String ntfcHH) {
-        this.ntfcHH = ntfcHH;
-    }
-
-    public String getNtfcMM() {
-        return ntfcMM;
-    }
-
-    public void setNtfcMM(String ntfcMM) {
-        this.ntfcMM = ntfcMM;
-    }
-
-    public String getSearchCnd() {
-        return searchCnd;
-    }
-
-    public void setSearchCnd(String searchCnd) {
-        this.searchCnd = searchCnd;
-    }
-
-    public String getSearchWrd() {
-        return searchWrd;
-    }
-
-    public void setSearchWrd(String searchWrd) {
-        this.searchWrd = searchWrd;
-    }
-
-    public String getSortOrdr() {
-        return sortOrdr;
-    }
-
-    public void setSortOrdr(String sortOrdr) {
-        this.sortOrdr = sortOrdr;
-    }
-
-    public int getRowNo() {
-        return rowNo;
-    }
-
-    public void setRowNo(int rowNo) {
-        this.rowNo = rowNo;
-    }
-
-    public String getStartDateTime() {
-        return startDateTime;
-    }
-
-    public void setStartDateTime(String startDateTime) {
-        this.startDateTime = startDateTime;
-    }
-
-    public String getEndDateTime() {
-        return endDateTime;
-    }
-
-    public void setEndDateTime(String endDateTime) {
-        this.endDateTime = endDateTime;
     }
 
     @Override


### PR DESCRIPTION
uss/ion 하위 mtg, noi 모듈의 VO 클래스에 Lombok @Getter/@Setter를 적용하여 반복적인 보일러플레이트 코드를 제거합니다.

**변경 내용**

- `MtgPlaceManageVO`: 클래스 레벨 `@Getter @Setter` 적용, 수동 getter/setter 전체 제거 (114줄 감소)
- `MtgPlaceResveVO`: 클래스 레벨 `@Getter @Setter` 적용, 수동 getter/setter 전체 제거 (29줄 감소)
- `NotificationVO`: 클래스 레벨 `@Getter @Setter` 적용, `bhNtfcIntrvl` 배열 필드는 보안상 방어적 복사가 필요하므로 `@Getter(AccessLevel.NONE)/@Setter(AccessLevel.NONE)`으로 제외 후 기존 구현 유지 (164줄 감소)
- `pom.xml`: maven-compiler-plugin에 `annotationProcessorPaths` 설정 추가 — Lombok annotation processing이 올바르게 동작하도록 함

**검증**

- `mvn -DskipTests compile` → BUILD SUCCESS

**체크리스트**

- [x] 단일 주제만 다룸 (Lombok VO 적용 + annotation processor 설정)
- [x] 기존 동작에 영향 없음 (getter/setter 시그니처 동일)
- [x] 빌드 통과 확인
