### PR TITLE
[refactor][공통컴포넌트] uss/ion (nws/pwm/rec) 모듈 VO Lombok @Getter/@Setter 적용

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -597,6 +597,13 @@
 					<artifactId>maven-compiler-plugin</artifactId>
 					<configuration>
 						<release>${java.version}</release>
+						<annotationProcessorPaths>
+							<path>
+								<groupId>org.projectlombok</groupId>
+								<artifactId>lombok</artifactId>
+								<version>${lombok.version}</version>
+							</path>
+						</annotationProcessorPaths>
 					</configuration>
 				</plugin>
 				<plugin>

--- a/src/main/java/egovframework/com/uss/ion/nws/service/NewsVO.java
+++ b/src/main/java/egovframework/com/uss/ion/nws/service/NewsVO.java
@@ -4,9 +4,11 @@ import org.egovframe.rte.ptl.reactive.validation.EgovNullCheck;
 
 import egovframework.com.cmm.ComDefaultVO;
 import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
 
 /**
- *  
+ *
  * 뉴스정보를 처리하는 VO 클래스
  * @author 공통서비스 개발팀 박정규
  * @since 2009.04.01
@@ -15,39 +17,41 @@ import jakarta.validation.constraints.Size;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.04.01  박정규          최초 생성
  *
  * </pre>
  */
+@Getter
+@Setter
 public class NewsVO extends ComDefaultVO {
-	
+
     private static final long serialVersionUID = 1L;
-    
+
     /** 뉴스 ID */
     private String newsId;
-    
+
     /** 뉴스제목 */
     @EgovNullCheck
     @Size(max=100)
     private String newsSj;
-    
+
     /** 뉴스내용 */
     @EgovNullCheck
     @Size(max=1000)
     private String newsCn;
-    
+
     /** 뉴스출처 */
     private String newsOrigin;
-    
+
     /** 게시일자 */
     private String ntceDe;
 
-    /** 첨부파일ID */ 
+    /** 첨부파일ID */
     private String atchFileId;
-    
+
     /** 최초등록시점 */
     private String frstRegisterPnttm;
 
@@ -60,165 +64,4 @@ public class NewsVO extends ComDefaultVO {
     /** 최종수정자ID */
     private String lastUpdusrId;
 
-	/**
-	 * newsId attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getNewsId() {
-		return newsId;
-	}
-
-	/**
-	 * newsId attribute 값을 설정한다.
-	 * @return newsId String
-	 */
-	public void setNewsId(String newsId) {
-		this.newsId = newsId;
-	}
-
-	/**
-	 * newsSj attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getNewsSj() {
-		return newsSj;
-	}
-
-	/**
-	 * newsSj attribute 값을 설정한다.
-	 * @return newsSj String
-	 */
-	public void setNewsSj(String newsSj) {
-		this.newsSj = newsSj;
-	}
-
-	/**
-	 * newsCn attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getNewsCn() {
-		return newsCn;
-	}
-
-	/**
-	 * newsCn attribute 값을 설정한다.
-	 * @return newsCn String
-	 */
-	public void setNewsCn(String newsCn) {
-		this.newsCn = newsCn;
-	}
-
-	/**
-	 * newsOrigin attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getNewsOrigin() {
-		return newsOrigin;
-	}
-
-	/**
-	 * newsOrigin attribute 값을 설정한다.
-	 * @return newsOrigin String
-	 */
-	public void setNewsOrigin(String newsOrigin) {
-		this.newsOrigin = newsOrigin;
-	}
-
-	/**
-	 * ntceDe attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getNtceDe() {
-		return ntceDe;
-	}
-
-	/**
-	 * ntceDe attribute 값을 설정한다.
-	 * @return ntceDe String
-	 */
-	public void setNtceDe(String ntceDe) {
-		this.ntceDe = ntceDe;
-	}
-
-	/**
-	 * atchFileId attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getAtchFileId() {
-		return atchFileId;
-	}
-
-	/**
-	 * atchFileId attribute 값을 설정한다.
-	 * @return atchFileId String
-	 */
-	public void setAtchFileId(String atchFileId) {
-		this.atchFileId = atchFileId;
-	}
-
-	/**
-	 * frstRegisterPnttm attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getFrstRegisterPnttm() {
-		return frstRegisterPnttm;
-	}
-
-	/**
-	 * frstRegisterPnttm attribute 값을 설정한다.
-	 * @return frstRegisterPnttm String
-	 */
-	public void setFrstRegisterPnttm(String frstRegisterPnttm) {
-		this.frstRegisterPnttm = frstRegisterPnttm;
-	}
-
-	/**
-	 * frstRegisterId attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getFrstRegisterId() {
-		return frstRegisterId;
-	}
-
-	/**
-	 * frstRegisterId attribute 값을 설정한다.
-	 * @return frstRegisterId String
-	 */
-	public void setFrstRegisterId(String frstRegisterId) {
-		this.frstRegisterId = frstRegisterId;
-	}
-
-	/**
-	 * lastUpdusrPnttm attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getLastUpdusrPnttm() {
-		return lastUpdusrPnttm;
-	}
-
-	/**
-	 * lastUpdusrPnttm attribute 값을 설정한다.
-	 * @return lastUpdusrPnttm String
-	 */
-	public void setLastUpdusrPnttm(String lastUpdusrPnttm) {
-		this.lastUpdusrPnttm = lastUpdusrPnttm;
-	}
-
-	/**
-	 * lastUpdusrId attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getLastUpdusrId() {
-		return lastUpdusrId;
-	}
-
-	/**
-	 * lastUpdusrId attribute 값을 설정한다.
-	 * @return lastUpdusrId String
-	 */
-	public void setLastUpdusrId(String lastUpdusrId) {
-		this.lastUpdusrId = lastUpdusrId;
-	}
-
-    
 }

--- a/src/main/java/egovframework/com/uss/ion/pwm/service/PopupManageVO.java
+++ b/src/main/java/egovframework/com/uss/ion/pwm/service/PopupManageVO.java
@@ -4,6 +4,8 @@ import egovframework.com.cmm.ComDefaultVO;
 import org.egovframe.rte.ptl.reactive.validation.EgovNullCheck;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * 개요
@@ -17,6 +19,8 @@ import jakarta.validation.constraints.Size;
  * @version 1.0
  * @created 05-8-2009 오후 2:21:04
  */
+@Getter
+@Setter
 public class PopupManageVO extends ComDefaultVO {
 
 	private static final long serialVersionUID = -4822974866080666897L;
@@ -118,155 +122,4 @@ public class PopupManageVO extends ComDefaultVO {
 	public PopupManageVO() {
 	}
 
-	public String getPopupId() {
-		return popupId;
-	}
-
-	public void setPopupId(String popupId) {
-		this.popupId = popupId;
-	}
-
-	public String getPopupTitleNm() {
-		return popupTitleNm;
-	}
-
-	public void setPopupTitleNm(String popupTitleNm) {
-		this.popupTitleNm = popupTitleNm;
-	}
-
-	public String getFileUrl() {
-		return fileUrl;
-	}
-
-	public void setFileUrl(String fileUrl) {
-		this.fileUrl = fileUrl;
-	}
-
-	public String getPopupWlc() {
-		return popupWlc;
-	}
-
-	public void setPopupWlc(String popupWlc) {
-		this.popupWlc = popupWlc;
-	}
-
-	public String getPopupHlc() {
-		return popupHlc;
-	}
-
-	public void setPopupHlc(String popupHlc) {
-		this.popupHlc = popupHlc;
-	}
-
-	public String getPopupHSize() {
-		return popupHSize;
-	}
-
-	public void setPopupHSize(String popupHSize) {
-		this.popupHSize = popupHSize;
-	}
-
-	public String getPopupWSize() {
-		return popupWSize;
-	}
-
-	public void setPopupWSize(String popupWSize) {
-		this.popupWSize = popupWSize;
-	}
-
-	public String getNtceBgnde() {
-		return ntceBgnde;
-	}
-
-	public void setNtceBgnde(String ntceBgnde) {
-		this.ntceBgnde = ntceBgnde;
-	}
-
-	public String getNtceEndde() {
-		return ntceEndde;
-	}
-
-	public void setNtceEndde(String ntceEndde) {
-		this.ntceEndde = ntceEndde;
-	}
-
-	public String getNtceBgndeHH() {
-		return ntceBgndeHH;
-	}
-
-	public void setNtceBgndeHH(String ntceBgndeHH) {
-		this.ntceBgndeHH = ntceBgndeHH;
-	}
-
-	public String getNtceBgndeMM() {
-		return ntceBgndeMM;
-	}
-
-	public void setNtceBgndeMM(String ntceBgndeMM) {
-		this.ntceBgndeMM = ntceBgndeMM;
-	}
-
-	public String getNtceEnddeHH() {
-		return ntceEnddeHH;
-	}
-
-	public void setNtceEnddeHH(String ntceEnddeHH) {
-		this.ntceEnddeHH = ntceEnddeHH;
-	}
-
-	public String getNtceEnddeMM() {
-		return ntceEnddeMM;
-	}
-
-	public void setNtceEnddeMM(String ntceEnddeMM) {
-		this.ntceEnddeMM = ntceEnddeMM;
-	}
-
-	public String getStopVewAt() {
-		return stopVewAt;
-	}
-
-	public void setStopVewAt(String stopVewAt) {
-		this.stopVewAt = stopVewAt;
-	}
-
-	public String getNtceAt() {
-		return ntceAt;
-	}
-
-	public void setNtceAt(String ntceAt) {
-		this.ntceAt = ntceAt;
-	}
-
-	public String getFrstRegisterPnttm() {
-		return frstRegisterPnttm;
-	}
-
-	public void setFrstRegisterPnttm(String frstRegisterPnttm) {
-		this.frstRegisterPnttm = frstRegisterPnttm;
-	}
-
-	public String getFrstRegisterId() {
-		return frstRegisterId;
-	}
-
-	public void setFrstRegisterId(String frstRegisterId) {
-		this.frstRegisterId = frstRegisterId;
-	}
-
-	public String getLastUpdusrPnttm() {
-		return lastUpdusrPnttm;
-	}
-
-	public void setLastUpdusrPnttm(String lastUpdusrPnttm) {
-		this.lastUpdusrPnttm = lastUpdusrPnttm;
-	}
-
-	public String getLastUpdusrId() {
-		return lastUpdusrId;
-	}
-
-	public void setLastUpdusrId(String lastUpdusrId) {
-		this.lastUpdusrId = lastUpdusrId;
-	}
 }

--- a/src/main/java/egovframework/com/uss/ion/rec/service/RecomendSiteVO.java
+++ b/src/main/java/egovframework/com/uss/ion/rec/service/RecomendSiteVO.java
@@ -5,10 +5,12 @@ import org.egovframe.rte.ptl.reactive.validation.EgovNullCheck;
 import egovframework.com.cmm.ComDefaultVO;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
 
 
 /**
- * 
+ *
  * 추천사이트정보를 처리하는 VO 클래스
  * @author 공통서비스 개발팀 박정규
  * @since 2009.04.01
@@ -17,35 +19,37 @@ import jakarta.validation.constraints.Size;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.04.01  박정규          최초 생성
  *
  * </pre>
  */
+@Getter
+@Setter
 public class RecomendSiteVO extends ComDefaultVO {
-	
+
     private static final long serialVersionUID = 1L;
-    
+
     /** 추천사이트 ID */
     private String recomendSiteId;
-    
+
     /** 추천사이트 URL */
     @EgovNullCheck
     @Size(max=250)
     private String recomendSiteUrl;
-    
+
     /** 추천사이트명 */
     @EgovNullCheck
     @Size(max=100)
     private String recomendSiteNm;
-    
+
     /** 추천사이트설명 */
     @EgovNullCheck
     @Size(max=1000)
     private String recomendSiteDc;
-    
+
     /** 추천사유내용 */
     @EgovNullCheck
     @Size(max=1000)
@@ -53,7 +57,7 @@ public class RecomendSiteVO extends ComDefaultVO {
 
     /** 추천승인여부 */
     private String recomendConfmAt;
-    
+
     /** 승인일자 */
     @Pattern(regexp="^\\d{4}-\\d{2}-\\d{2}$", message="{validation.pattern.date}")
     private String confmDe;
@@ -70,183 +74,4 @@ public class RecomendSiteVO extends ComDefaultVO {
     /** 최종수정자ID */
     private String lastUpdusrId;
 
-	/**
-	 * recomendSiteId attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getRecomendSiteId() {
-		return recomendSiteId;
-	}
-
-	/**
-	 * recomendSiteId attribute 값을 설정한다.
-	 * @return recomendSiteId String
-	 */
-	public void setRecomendSiteId(String recomendSiteId) {
-		this.recomendSiteId = recomendSiteId;
-	}
-
-	/**
-	 * recomendSiteUrl attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getRecomendSiteUrl() {
-		return recomendSiteUrl;
-	}
-
-	/**
-	 * recomendSiteUrl attribute 값을 설정한다.
-	 * @return recomendSiteUrl String
-	 */
-	public void setRecomendSiteUrl(String recomendSiteUrl) {
-		this.recomendSiteUrl = recomendSiteUrl;
-	}
-
-	/**
-	 * recomendSiteNm attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getRecomendSiteNm() {
-		return recomendSiteNm;
-	}
-
-	/**
-	 * recomendSiteNm attribute 값을 설정한다.
-	 * @return recomendSiteNm String
-	 */
-	public void setRecomendSiteNm(String recomendSiteNm) {
-		this.recomendSiteNm = recomendSiteNm;
-	}
-
-	/**
-	 * recomendSiteDc attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getRecomendSiteDc() {
-		return recomendSiteDc;
-	}
-
-	/**
-	 * recomendSiteDc attribute 값을 설정한다.
-	 * @return recomendSiteDc String
-	 */
-	public void setRecomendSiteDc(String recomendSiteDc) {
-		this.recomendSiteDc = recomendSiteDc;
-	}
-
-	/**
-	 * recomendResnCn attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getRecomendResnCn() {
-		return recomendResnCn;
-	}
-
-	/**
-	 * recomendResnCn attribute 값을 설정한다.
-	 * @return recomendResnCn String
-	 */
-	public void setRecomendResnCn(String recomendResnCn) {
-		this.recomendResnCn = recomendResnCn;
-	}
-
-	/**
-	 * recomendConfmAt attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getRecomendConfmAt() {
-		return recomendConfmAt;
-	}
-
-	/**
-	 * recomendConfmAt attribute 값을 설정한다.
-	 * @return recomendConfmAt String
-	 */
-	public void setRecomendConfmAt(String recomendConfmAt) {
-		this.recomendConfmAt = recomendConfmAt;
-	}
-
-	/**
-	 * confmDe attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getConfmDe() {
-		return confmDe;
-	}
-
-	/**
-	 * confmDe attribute 값을 설정한다.
-	 * @return confmDe String
-	 */
-	public void setConfmDe(String confmDe) {
-		this.confmDe = confmDe;
-	}
-
-	/**
-	 * frstRegisterPnttm attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getFrstRegisterPnttm() {
-		return frstRegisterPnttm;
-	}
-
-	/**
-	 * frstRegisterPnttm attribute 값을 설정한다.
-	 * @return frstRegisterPnttm String
-	 */
-	public void setFrstRegisterPnttm(String frstRegisterPnttm) {
-		this.frstRegisterPnttm = frstRegisterPnttm;
-	}
-
-	/**
-	 * frstRegisterId attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getFrstRegisterId() {
-		return frstRegisterId;
-	}
-
-	/**
-	 * frstRegisterId attribute 값을 설정한다.
-	 * @return frstRegisterId String
-	 */
-	public void setFrstRegisterId(String frstRegisterId) {
-		this.frstRegisterId = frstRegisterId;
-	}
-
-	/**
-	 * lastUpdusrPnttm attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getLastUpdusrPnttm() {
-		return lastUpdusrPnttm;
-	}
-
-	/**
-	 * lastUpdusrPnttm attribute 값을 설정한다.
-	 * @return lastUpdusrPnttm String
-	 */
-	public void setLastUpdusrPnttm(String lastUpdusrPnttm) {
-		this.lastUpdusrPnttm = lastUpdusrPnttm;
-	}
-
-	/**
-	 * lastUpdusrId attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getLastUpdusrId() {
-		return lastUpdusrId;
-	}
-
-	/**
-	 * lastUpdusrId attribute 값을 설정한다.
-	 * @return lastUpdusrId String
-	 */
-	public void setLastUpdusrId(String lastUpdusrId) {
-		this.lastUpdusrId = lastUpdusrId;
-	}
-
-    
-
-   
 }


### PR DESCRIPTION
## 변경 사유
uss/ion 하위 3 sub-package(nws/pwm/rec) VO에 수동 getter/setter가 작성되어 보일러플레이트가 많고 필드 추가시 누락 위험이 있다. Lombok 어노테이션으로 대체.

## 변경 내용
- `NewsVO`, `PopupManageVO`, `RecomendSiteVO`에 `@Getter @Setter` 적용
- 수동 getter/setter 제거, toString/equals/hashCode 보존
- `pom.xml`에 `annotationProcessorPaths` 추가 (PR #802와 완전 동일 7줄 — fast-forward 가능)

## 영향 범위
- 외부 API 변경 없음
- `mvn -DskipTests compile` BUILD SUCCESS

## 체크리스트
- [x] 3 sub-package(nws/pwm/rec)만 다룸
- [x] PR #802와 동일 pom 변경 — fast-forward 가능
- [x] 기존 동작에 영향 없음
- [x] mvn compile 통과
