### PR TITLE
[refactor][공통컴포넌트] uss/ion/rmm 모듈 VO Lombok @Getter/@Setter 적용

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -597,6 +597,13 @@
 					<artifactId>maven-compiler-plugin</artifactId>
 					<configuration>
 						<release>${java.version}</release>
+						<annotationProcessorPaths>
+							<path>
+								<groupId>org.projectlombok</groupId>
+								<artifactId>lombok</artifactId>
+								<version>${lombok.version}</version>
+							</path>
+						</annotationProcessorPaths>
 					</configuration>
 				</plugin>
 				<plugin>

--- a/src/main/java/egovframework/com/uss/ion/rmm/service/RoughMapDefaultVO.java
+++ b/src/main/java/egovframework/com/uss/ion/rmm/service/RoughMapDefaultVO.java
@@ -2,13 +2,16 @@ package egovframework.com.uss.ion.rmm.service;
 
 import java.io.Serializable;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * 개요
  * - 약도관리에 대한 VO 클래스를 정의한다.
- * 
+ *
  * 상세내용
  * - 약도정보 조회를 위해 필요한 정보를 관리한다.
- *  
+ *
  * @author 옥찬우
  * @since 2014.08.27
  * @version 1.0
@@ -16,7 +19,7 @@ import java.io.Serializable;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일			수정자		수정내용
  *  -----------		------		---------
  *   2014.08.27		옥찬우		최초 생성
@@ -24,179 +27,37 @@ import java.io.Serializable;
  * </pre>
  */
 
+@Getter
+@Setter
 public class RoughMapDefaultVO implements Serializable {
 
 	private static final long serialVersionUID = 1L;
 
 	/** 첫페이지 인덱스 */
     private int firstIndex = 1;
-    
+
     /** * 마지막페이지 인덱스 */
     private int lastIndex = 1;
-    
+
     /** 현재페이지 */
     private int pageIndex = 1;
-    
+
     /** 페이지 사이즈 */
     private int pageSize = 10;
-    
+
     /** 페이지 개수 */
     private int pageUnit = 10;
-    
+
     /** 페이지당 레코드 개수 */
     private int recordCountPerPage = 10;
-    
+
     /** 검색조건 */
     private String searchCondition = "";
-    
+
     /** 검색단어 */
     private String searchKeyword = "";
-    
+
     /** 검색사용여부 */
     private String searchUseYn = "";
 
-    /**
-     * 첫페이지 인덱스를 가져온다.
-     * @return int 첫페이지 인덱스
-     */
-    public int getFirstIndex(){
-        return firstIndex;
-    }
-
-    /**
-     * 첫페이지 인덱스를 저장한다.
-     * @param firstIndex
-     */
-    public void setFirstIndex(int firstIndex){
-        this.firstIndex = firstIndex;
-    }
-
-    /**
-     * 마지막페이지 인덱스를 가져온다.
-     * @return int 마지막페이지 인덱스
-     */
-    public int getLastIndex(){
-        return lastIndex;
-    }
-
-    /**
-     * 마지막페이지 인덱스를 저장한다.
-     * @param lastIndex
-     */
-    public void setLastIndex(int lastIndex){
-        this.lastIndex = lastIndex;
-    }
-
-    /**
-     * 현재페이지를 가져온다.
-     * @return int 현재페이지
-     */
-    public int getPageIndex(){
-        return pageIndex;
-    }
-
-    /**
-     * 현재페이지를 저장한다.
-     * @param pageIndex
-     */
-    public void setPageIndex(int pageIndex){
-        this.pageIndex = pageIndex;
-    }
-
-    /**
-     * 페이지 사이즈를 가져온다.
-     * @return int 페이지 사이즈
-     */
-    public int getPageSize(){
-        return pageSize;
-    }
-
-    /**
-     * 페이지 사이즈를 저장한다.
-     * @param pageSize
-     */
-    public void setPageSize(int pageSize){
-        this.pageSize = pageSize;
-    }
-
-    /**
-     * 페이지 개수를 가져온다.
-     * @return int 페이지 개수
-     */
-    public int getPageUnit(){
-        return pageUnit;
-    }
-
-    /**
-     * 페이지 개수를 저장한다.
-     * @param pageUnit
-     */
-    public void setPageUnit(int pageUnit){
-        this.pageUnit = pageUnit;
-    }
-
-    /**
-     * 페이지당 레코드 개수를 가져온다.
-     * @return int 페이지당 레코드 개수
-     */
-    public int getRecordCountPerPage(){
-        return recordCountPerPage;
-    }
-
-    /**
-     * 페이지당 레코드 개수를 저장한다.
-     * @param recordCountPerPage
-     */
-    public void setRecordCountPerPage(int recordCountPerPage){
-        this.recordCountPerPage = recordCountPerPage;
-    }
-
-    /**
-     * 검색조건을 가져온다.
-     * @return String 검색조건
-     */
-    public String getSearchCondition(){
-        return searchCondition;
-    }
-
-    /**
-     * 검색조건을 저장한다.
-     * @param searchCondition
-     */
-    public void setSearchCondition(String searchCondition){
-        this.searchCondition = searchCondition;
-    }
-
-    /**
-     * 검색단어를 가져온다.
-     * @return String 검색단어
-     */
-    public String getSearchKeyword(){
-        return searchKeyword;
-    }
-
-    /**
-     * 검색단어를 저장한다.
-     * @param searchKeyword
-     */
-    public void setSearchKeyword(String searchKeyword){
-        this.searchKeyword = searchKeyword;
-    }
-
-    /**
-     * 검색사용여부를 가져온다.
-     * @return String 검색사용여부
-     */
-    public String getSearchUseYn(){
-        return searchUseYn;
-    }
-
-    /**
-     * 검색사용여부를 저장한다.
-     * @param searchUseYn
-     */
-    public void setSearchUseYn(String searchUseYn){
-        this.searchUseYn = searchUseYn;
-    }
-    
 }

--- a/src/main/java/egovframework/com/uss/ion/rmm/service/RoughMapVO.java
+++ b/src/main/java/egovframework/com/uss/ion/rmm/service/RoughMapVO.java
@@ -2,6 +2,9 @@ package egovframework.com.uss.ion.rmm.service;
 
 import org.egovframe.rte.ptl.reactive.validation.EgovNullCheck;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * 개요
  * - 약도에 대한 Model을 정의한다.
@@ -24,6 +27,8 @@ import org.egovframe.rte.ptl.reactive.validation.EgovNullCheck;
  * </pre>
  */
 
+@Getter
+@Setter
 public class RoughMapVO extends RoughMapDefaultVO {
 
 	private static final long serialVersionUID = -2344076278228282853L;
@@ -69,214 +74,5 @@ public class RoughMapVO extends RoughMapDefaultVO {
 
     /** 최종수정자ID */
     private String lastUpdusrId;
-
-	/**
-	 * roughMapId attribute를 리턴한다.
-	 * @return the Integer
-	 */
-    public String getRoughMapId() {
-		return roughMapId;
-	}
-
-    /**
-     * roughMapId를 저장한다.
-     * @param roughMapId
-     */
-    public void setRoughMapId(String roughMapId) {
-		this.roughMapId = roughMapId;
-	}
-
-	/**
-	 * roughMapSj attribute를 리턴한다.
-	 * @return the String
-	 */
-	public String getRoughMapSj() {
-		return roughMapSj;
-	}
-
-    /**
-     * roughMapSj를 저장한다.
-     * @param roughMapSj
-     */
-	public void setRoughMapSj(String roughMapSj) {
-		this.roughMapSj = roughMapSj;
-	}
-
-	/**
-	 * roughMapAddress attribute를 리턴한다.
-	 * @return the String
-	 */
-	public String getRoughMapAddress() {
-		return roughMapAddress;
-	}
-
-    /**
-     * roughMapAddress를 저장한다.
-     * @param roughMapAddress
-     */
-	public void setRoughMapAddress(String roughMapAddress) {
-		this.roughMapAddress = roughMapAddress;
-	}
-
-	/**
-	 * la attribute를 리턴한다.
-	 * @return the String
-	 */
-	public String getLa() {
-		return la;
-	}
-
-    /**
-     * la를 저장한다.
-     * @param la
-     */
-	public void setLa(String la) {
-		this.la = la;
-	}
-
-	/**
-	 * lo attribute를 리턴한다.
-	 * @return the String
-	 */
-	public String getLo() {
-		return lo;
-	}
-
-    /**
-     * lo를 저장한다.
-     * @param lo
-     */
-	public void setLo(String lo) {
-		this.lo = lo;
-	}
-
-	/**
-	 * markerLa attribute를 리턴한다.
-	 * @return the String
-	 */
-	public String getMarkerLa() {
-		return markerLa;
-	}
-
-    /**
-     * markerLa를 저장한다.
-     * @param markerLa
-     */
-	public void setMarkerLa(String markerLa) {
-		this.markerLa = markerLa;
-	}
-
-	/**
-	 * markerLo attribute를 리턴한다.
-	 * @return the String
-	 */
-	public String getMarkerLo() {
-		return markerLo;
-	}
-
-    /**
-     * markerLo를 저장한다.
-     * @param markerLo
-     */
-	public void setMarkerLo(String markerLo) {
-		this.markerLo = markerLo;
-	}
-
-	/**
-	 * @return the String
-	 * infoWindow attribute를 리턴한다.
-	 */
-	public String getInfoWindow() {
-		return infoWindow;
-	}
-
-
-    /**
-     * infoWindow를 저장한다.
-     * @param infoWindow
-     */
-	public void setInfoWindow(String infoWindow) {
-		this.infoWindow = infoWindow;
-	}
-
-	/**
-	 * mapLevel attribute를 리턴한다.
-	 * @return the String
-	 */
-	public String getZoomLevel() {
-		return zoomLevel;
-	}
-
-    /**
-     * mapLevel를 저장한다.
-     * @param mapLevel
-     */
-	public void setZoomLevel(String zoomLevel) {
-		this.zoomLevel = zoomLevel;
-	}
-
-	/**
-	 * frstRegisterPnttm attribute를 리턴한다.
-	 * @return the String
-	 */
-	public String getFrstRegisterPnttm() {
-		return frstRegisterPnttm;
-	}
-
-    /**
-     * frstRegisterPnttm를 저장한다.
-     * @param frstRegisterPnttm
-     */
-	public void setFrstRegisterPnttm(String frstRegisterPnttm) {
-		this.frstRegisterPnttm = frstRegisterPnttm;
-	}
-
-	/**
-	 * frstRegisterId attribute를 리턴한다.
-	 * @return the String
-	 */
-	public String getFrstRegisterId() {
-		return frstRegisterId;
-	}
-
-    /**
-     * frstRegisterId를 저장한다.
-     * @param frstRegisterId
-     */
-	public void setFrstRegisterId(String frstRegisterId) {
-		this.frstRegisterId = frstRegisterId;
-	}
-
-	/**
-	 * lastUpdusrPnttm attribute를 리턴한다.
-	 * @return the String
-	 */
-	public String getLastUpdusrPnttm() {
-		return lastUpdusrPnttm;
-	}
-
-    /**
-     * lastUpdusrPnttm를 저장한다.
-     * @param lastUpdusrPnttm
-     */
-	public void setLastUpdusrPnttm(String lastUpdusrPnttm) {
-		this.lastUpdusrPnttm = lastUpdusrPnttm;
-	}
-
-	/**
-	 * lastUpdusrId attribute를 리턴한다.
-	 * @return the String
-	 */
-	public String getLastUpdusrId() {
-		return lastUpdusrId;
-	}
-
-    /**
-     * lastUpdusrId를 저장한다.
-     * @param lastUpdusrId
-     */
-	public void setLastUpdusrId(String lastUpdusrId) {
-		this.lastUpdusrId = lastUpdusrId;
-	}
 
 }


### PR DESCRIPTION
## 변경 사유
uss/ion 하위 rmm(약도관리) 모듈 VO에 수동 getter/setter가 작성되어 보일러플레이트가 많고 필드 추가시 누락 위험이 있다. Lombok 어노테이션으로 대체.

## 변경 내용
- `RoughMapDefaultVO`, `RoughMapVO`에 `@Getter @Setter` 적용
- 수동 getter/setter 제거, toString/equals/hashCode 보존
- `pom.xml`에 `annotationProcessorPaths` 추가 (PR #802와 완전 동일 7줄 — fast-forward 가능)

## 영향 범위
- 외부 API 변경 없음
- `mvn -DskipTests compile` BUILD SUCCESS

## 체크리스트
- [x] uss/ion/rmm 모듈만 다룸 (rsm/rsn에는 적용 가능 VO 없음)
- [x] PR #802와 동일 pom 변경 — fast-forward 가능
- [x] 기존 동작에 영향 없음
- [x] mvn compile 통과
