### PR TITLE
[refactor][공통컴포넌트] sym/sym/nwk NtwrkDAO @EgovMapper 인터페이스 매핑

### DIFF
--- a/src/main/java/egovframework/com/sym/sym/nwk/service/impl/NtwrkMapper.java
+++ b/src/main/java/egovframework/com/sym/sym/nwk/service/impl/NtwrkMapper.java
@@ -2,16 +2,15 @@ package egovframework.com.sym.sym.nwk.service.impl;
 
 import java.util.List;
 
-import org.springframework.stereotype.Repository;
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
 
 import egovframework.com.sym.sym.nwk.service.Ntwrk;
 import egovframework.com.sym.sym.nwk.service.NtwrkVO;
-import jakarta.annotation.Resource;
 
 /**
  * <pre>
  * 개요
- * - 네트워크에 대한 DAO 클래스를 정의한다.
+ * - 네트워크에 대한 Mapper 인터페이스를 정의한다.
  *
  * 상세내용
  * - 네트워크에 대한 등록, 수정, 삭제, 조회 기능을 제공한다.
@@ -29,16 +28,12 @@ import jakarta.annotation.Resource;
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.03.20  lee.m.j       최초 생성
- *   2025.07.23  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-UnnecessaryBoxing(불필요한 WrapperObject 생성)
  *   2026.05.26  dasomel       @EgovMapper 인터페이스 방식으로 전환
  *
  *      </pre>
  */
-@Repository("ntwrkDAO")
-public class NtwrkDAO {
-
-	@Resource(name = "ntwrkDAO")
-	private NtwrkMapper ntwrkMapper;
+@EgovMapper("ntwrkDAO")
+public interface NtwrkMapper {
 
 	/**
 	 * 네트워크를 관리하기 위해 등록된 네트워크목록을 조회한다.
@@ -46,9 +41,7 @@ public class NtwrkDAO {
 	 * @param ntwrkVO - 네트워크 Vo
 	 * @return List - 네트워크 목록
 	 */
-	public List<NtwrkVO> selectNtwrkList(NtwrkVO ntwrkVO) throws Exception {
-		return ntwrkMapper.selectNtwrkList(ntwrkVO);
-	}
+	List<NtwrkVO> selectNtwrkList(NtwrkVO ntwrkVO) throws Exception;
 
 	/**
 	 * 네트워크목록 총 개수를 조회한다.
@@ -56,9 +49,7 @@ public class NtwrkDAO {
 	 * @param ntwrkVO - 네트워크 Vo
 	 * @return int - 네트워크 카운트 수
 	 */
-	public int selectNtwrkListTotCnt(NtwrkVO ntwrkVO) throws Exception {
-		return ntwrkMapper.selectNtwrkListTotCnt(ntwrkVO);
-	}
+	int selectNtwrkListTotCnt(NtwrkVO ntwrkVO) throws Exception;
 
 	/**
 	 * 등록된 네트워크의 상세정보를 조회한다.
@@ -66,35 +57,27 @@ public class NtwrkDAO {
 	 * @param ntwrkVO - 네트워크 Vo
 	 * @return NtwrkVO - 네트워크 Vo
 	 */
-	public NtwrkVO selectNtwrk(NtwrkVO ntwrkVO) throws Exception {
-		return ntwrkMapper.selectNtwrk(ntwrkVO);
-	}
+	NtwrkVO selectNtwrk(NtwrkVO ntwrkVO) throws Exception;
 
 	/**
 	 * 네트워크정보를 신규로 등록한다.
 	 *
 	 * @param ntwrk - 네트워크 model
 	 */
-	public void insertNtwrk(Ntwrk ntwrk) throws Exception {
-		ntwrkMapper.insertNtwrk(ntwrk);
-	}
+	void insertNtwrk(Ntwrk ntwrk) throws Exception;
 
 	/**
 	 * 기 등록된 네트워크정보를 수정한다.
 	 *
 	 * @param ntwrk - 네트워크 model
 	 */
-	public void updateNtwrk(Ntwrk ntwrk) throws Exception {
-		ntwrkMapper.updateNtwrk(ntwrk);
-	}
+	void updateNtwrk(Ntwrk ntwrk) throws Exception;
 
 	/**
 	 * 기 등록된 네트워크정보를 삭제한다.
 	 *
 	 * @param ntwrk - 네트워크 model
 	 */
-	public void deleteNtwrk(Ntwrk ntwrk) throws Exception {
-		ntwrkMapper.deleteNtwrk(ntwrk);
-	}
+	void deleteNtwrk(Ntwrk ntwrk) throws Exception;
 
 }

--- a/src/main/resources/egovframework/mapper/com/sym/sym/nwk/EgovNtwrk_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/sym/nwk/EgovNtwrk_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ntwrkDAO">
+<mapper namespace="egovframework.com.sym.sym.nwk.service.impl.NtwrkMapper">
 
     <resultMap id="ntwrk" type="egovframework.com.sym.sym.nwk.service.NtwrkVO">
         <result property="ntwrkId" column="NTWRK_ID"/>

--- a/src/main/resources/egovframework/mapper/com/sym/sym/nwk/EgovNtwrk_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/sym/nwk/EgovNtwrk_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ntwrkDAO">
+<mapper namespace="egovframework.com.sym.sym.nwk.service.impl.NtwrkMapper">
 
     <resultMap id="ntwrk" type="egovframework.com.sym.sym.nwk.service.NtwrkVO">
         <result property="ntwrkId" column="NTWRK_ID"/>

--- a/src/main/resources/egovframework/mapper/com/sym/sym/nwk/EgovNtwrk_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/sym/nwk/EgovNtwrk_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ntwrkDAO">
+<mapper namespace="egovframework.com.sym.sym.nwk.service.impl.NtwrkMapper">
 
     <resultMap id="ntwrk" type="egovframework.com.sym.sym.nwk.service.NtwrkVO">
         <result property="ntwrkId" column="NTWRK_ID"/>

--- a/src/main/resources/egovframework/mapper/com/sym/sym/nwk/EgovNtwrk_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/sym/nwk/EgovNtwrk_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ntwrkDAO">
+<mapper namespace="egovframework.com.sym.sym.nwk.service.impl.NtwrkMapper">
 
     <resultMap id="ntwrk" type="egovframework.com.sym.sym.nwk.service.NtwrkVO">
         <result property="ntwrkId" column="NTWRK_ID"/>

--- a/src/main/resources/egovframework/mapper/com/sym/sym/nwk/EgovNtwrk_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/sym/nwk/EgovNtwrk_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ntwrkDAO">
+<mapper namespace="egovframework.com.sym.sym.nwk.service.impl.NtwrkMapper">
 
     <resultMap id="ntwrk" type="egovframework.com.sym.sym.nwk.service.NtwrkVO">
         <result property="ntwrkId" column="NTWRK_ID"/>

--- a/src/main/resources/egovframework/mapper/com/sym/sym/nwk/EgovNtwrk_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/sym/nwk/EgovNtwrk_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ntwrkDAO">
+<mapper namespace="egovframework.com.sym.sym.nwk.service.impl.NtwrkMapper">
     
     <resultMap id="ntwrk" type="egovframework.com.sym.sym.nwk.service.NtwrkVO">
         <result property="ntwrkId" column="NTWRK_ID"/>

--- a/src/main/resources/egovframework/mapper/com/sym/sym/nwk/EgovNtwrk_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/sym/nwk/EgovNtwrk_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ntwrkDAO">
+<mapper namespace="egovframework.com.sym.sym.nwk.service.impl.NtwrkMapper">
 
     <resultMap id="ntwrk" type="egovframework.com.sym.sym.nwk.service.NtwrkVO">
         <result property="ntwrkId" column="NTWRK_ID"/>

--- a/src/main/resources/egovframework/mapper/com/sym/sym/nwk/EgovNtwrk_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/sym/nwk/EgovNtwrk_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ntwrkDAO">
+<mapper namespace="egovframework.com.sym.sym.nwk.service.impl.NtwrkMapper">
 
     <resultMap id="ntwrk" type="egovframework.com.sym.sym.nwk.service.NtwrkVO">
         <result property="ntwrkId" column="NTWRK_ID"/>

--- a/src/main/resources/egovframework/spring/com/context-mapper.xml
+++ b/src/main/resources/egovframework/spring/com/context-mapper.xml
@@ -21,5 +21,12 @@
 	<bean id="egov.sqlSessionTemplate" class="org.mybatis.spring.SqlSessionTemplate">
 		<constructor-arg ref="egov.sqlSession"/>
 	</bean>
-	
+
+	<!-- @EgovMapper 어노테이션이 붙은 인터페이스를 자동으로 스캔하여 빈으로 등록 -->
+	<bean class="org.mybatis.spring.mapper.MapperScannerConfigurer">
+		<property name="basePackage" value="egovframework.com"/>
+		<property name="annotationClass" value="org.egovframe.rte.psl.dataaccess.mapper.EgovMapper"/>
+		<property name="sqlSessionFactoryBeanName" value="egov.sqlSession"/>
+	</bean>
+
 </beans>


### PR DESCRIPTION
## 변경 사유
eGovFrame 5.0 @EgovMapper 활용 확대. PR #806(cmm/use), #821(sym/mnu/stm) 동일 패턴.

## 변경 내용
- 신규 `NtwrkMapper` 인터페이스(@EgovMapper) 추가
- `NtwrkDAO`: `EgovComAbstractDAO` 상속 제거, `@Resource` 주입 방식으로 전환
- 8개 RDBMS XML namespace를 인터페이스 FQN으로 변경 (altibase/cubrid/goldilocks/maria/mysql/oracle/postgres/tibero)
- `context-mapper.xml`에 `MapperScannerConfigurer` 빈 추가 (PR #806, #821과 동일)
- SQL 무변경

## 영향 범위
- 외부 동작 변경 없음
- 타입 안전성 향상
- 베이스라인 컴파일 에러 수 변동 없음 (149개 → 149개, Ntwrk 관련 신규 에러 0건)

## 체크리스트
- [x] 단일 컴포넌트(sym/sym/nwk Ntwrk)
- [x] PR #806, #821과 다른 컴포넌트
- [x] context-mapper.xml 변경은 PR #806, #821과 동일
