### PR TITLE
[refactor][공통컴포넌트] uss/ion (ecc/ism/sit) 모듈 VO Lombok @Getter/@Setter 적용

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -597,6 +597,13 @@
 					<artifactId>maven-compiler-plugin</artifactId>
 					<configuration>
 						<release>${java.version}</release>
+						<annotationProcessorPaths>
+							<path>
+								<groupId>org.projectlombok</groupId>
+								<artifactId>lombok</artifactId>
+								<version>${lombok.version}</version>
+							</path>
+						</annotationProcessorPaths>
 					</configuration>
 				</plugin>
 				<plugin>

--- a/src/main/java/egovframework/com/uss/ion/ecc/service/EventCmpgnVO.java
+++ b/src/main/java/egovframework/com/uss/ion/ecc/service/EventCmpgnVO.java
@@ -1,6 +1,8 @@
 package egovframework.com.uss.ion.ecc.service;
 
 import egovframework.com.cmm.ComDefaultVO;
+import lombok.Getter;
+import lombok.Setter;
 
 import org.egovframe.rte.ptl.reactive.validation.EgovNullCheck;
 import jakarta.validation.constraints.AssertTrue;
@@ -23,6 +25,8 @@ import jakarta.validation.constraints.Size;
  *
  * </pre>
  */
+@Getter
+@Setter
 public class EventCmpgnVO extends ComDefaultVO {
 
 	private static final long serialVersionUID = 1L;
@@ -79,7 +83,7 @@ public class EventCmpgnVO extends ComDefaultVO {
 	 */
 	@EgovNullCheck
 	private String eventTyCode = "";
-	
+
 	/**
 	 * 행사유형코드명
 	 */
@@ -147,279 +151,5 @@ public class EventCmpgnVO extends ComDefaultVO {
 		}
 		return begin.compareTo(end) <= 0;
 	}
-
-	/**
-	 * eventConfmDe attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getEventConfmDe() {
-		return eventConfmDe;
-	}
-	/**
-	 * eventConfmDe attribute 값을 설정한다.
-	 * @return eventId String
-	 */
-	public void setEventConfmDe(String eventConfmDe) {
-		this.eventConfmDe = eventConfmDe;
-	}
-
-	/**
-	 * eventConfmAt attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getEventConfmAt() {
-		return eventConfmAt;
-	}
-	/**
-	 * eventConfmAt attribute 값을 설정한다.
-	 * @return eventId String
-	 */
-	public void setEventConfmAt(String eventConfmAt) {
-		this.eventConfmAt = eventConfmAt;
-	}
-
-
-	/**
-	 * eventId attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getEventId() {
-		return eventId;
-	}
-	/**
-	 * eventId attribute 값을 설정한다.
-	 * @return eventId String
-	 */
-	public void setEventId(String eventId) {
-		this.eventId = eventId;
-	}
-	/**
-	 * bsnsYear attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getBsnsYear() {
-		return bsnsYear;
-	}
-	/**
-	 * bsnsYear attribute 값을 설정한다.
-	 * @return bsnsYear String
-	 */
-	public void setBsnsYear(String bsnsYear) {
-		this.bsnsYear = bsnsYear;
-	}
-	/**
-	 * bsnsCode attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getBsnsCode() {
-		return bsnsCode;
-	}
-	/**
-	 * bsnsCode attribute 값을 설정한다.
-	 * @return bsnsCode String
-	 */
-	public void setBsnsCode(String bsnsCode) {
-		this.bsnsCode = bsnsCode;
-	}
-	/**
-	 * eventSvcBeginDe attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getEventSvcBeginDe() {
-		return eventSvcBeginDe;
-	}
-	/**
-	 * eventSvcBeginDe attribute 값을 설정한다.
-	 * @return eventSvcBeginDe String
-	 */
-	public void setEventSvcBeginDe(String eventSvcBeginDe) {
-		this.eventSvcBeginDe = eventSvcBeginDe;
-	}
-	/**
-	 * svcUseNmprCo attribute 를 리턴한다.
-	 * @return the int
-	 */
-	public int getSvcUseNmprCo() {
-		return svcUseNmprCo;
-	}
-	/**
-	 * svcUseNmprCo attribute 값을 설정한다.
-	 * @return svcUseNmprCo int
-	 */
-	public void setSvcUseNmprCo(int svcUseNmprCo) {
-		this.svcUseNmprCo = svcUseNmprCo;
-	}
-	/**
-	 * chargerNm attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getChargerNm() {
-		return chargerNm;
-	}
-	/**
-	 * chargerNm attribute 값을 설정한다.
-	 * @return chargerNm String
-	 */
-	public void setChargerNm(String chargerNm) {
-		this.chargerNm = chargerNm;
-	}
-	/**
-	 * eventCn attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getEventCn() {
-		return eventCn;
-	}
-	/**
-	 * eventCn attribute 값을 설정한다.
-	 * @return eventCn String
-	 */
-	public void setEventCn(String eventCn) {
-		this.eventCn = eventCn;
-	}
-	/**
-	 * eventSvcEndDe attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getEventSvcEndDe() {
-		return eventSvcEndDe;
-	}
-	/**
-	 * eventSvcEndDe attribute 값을 설정한다.
-	 * @return eventSvcEndDe String
-	 */
-	public void setEventSvcEndDe(String eventSvcEndDe) {
-		this.eventSvcEndDe = eventSvcEndDe;
-	}
-	/**
-	 * eventTyCode attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getEventTyCode() {
-		return eventTyCode;
-	}
-	/**
-	 * eventTyCode attribute 값을 설정한다.
-	 * @return eventTyCode String
-	 */
-	public void setEventTyCode(String eventTyCode) {
-		this.eventTyCode = eventTyCode;
-	}
-	/**
-	 * eventTyCodeNm attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getEventTyCodeNm() {
-		return eventTyCodeNm;
-	}
-	/**
-	 * eventTyCodeNm attribute 값을 설정한다.
-	 * @return eventTyCodeNm String
-	 */
-	public void setEventTyCodeNm(String eventTyCodeNm) {
-		this.eventTyCodeNm = eventTyCodeNm;
-	}
-	/**
-	 * prparetgCn attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getPrparetgCn() {
-		return prparetgCn;
-	}
-	/**
-	 * prparetgCn attribute 값을 설정한다.
-	 * @return prparetgCn String
-	 */
-	public void setPrparetgCn(String prparetgCn) {
-		this.prparetgCn = prparetgCn;
-	}
-	/**
-	 * frstRegisterPnttm attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getFrstRegisterPnttm() {
-		return frstRegisterPnttm;
-	}
-	/**
-	 * frstRegisterPnttm attribute 값을 설정한다.
-	 * @return frstRegisterPnttm String
-	 */
-	public void setFrstRegisterPnttm(String frstRegisterPnttm) {
-		this.frstRegisterPnttm = frstRegisterPnttm;
-	}
-	/**
-	 * frstRegisterId attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getFrstRegisterId() {
-		return frstRegisterId;
-	}
-	/**
-	 * frstRegisterId attribute 값을 설정한다.
-	 * @return frstRegisterId String
-	 */
-	public void setFrstRegisterId(String frstRegisterId) {
-		this.frstRegisterId = frstRegisterId;
-	}
-	/**
-	 * frstRegisterNm attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getFrstRegisterNm() {
-		return frstRegisterNm;
-	}
-	/**
-	 * frstRegisterNm attribute 값을 설정한다.
-	 * @return frstRegisterNm String
-	 */
-	public void setFrstRegisterNm(String frstRegisterNm) {
-		this.frstRegisterNm = frstRegisterNm;
-	}
-	/**
-	 * lastUpdusrPnttm attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getLastUpdusrPnttm() {
-		return lastUpdusrPnttm;
-	}
-	/**
-	 * lastUpdusrPnttm attribute 값을 설정한다.
-	 * @return lastUpdusrPnttm String
-	 */
-	public void setLastUpdusrPnttm(String lastUpdusrPnttm) {
-		this.lastUpdusrPnttm = lastUpdusrPnttm;
-	}
-	/**
-	 * lastUpdusrId attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getLastUpdusrId() {
-		return lastUpdusrId;
-	}
-	/**
-	 * lastUpdusrId attribute 값을 설정한다.
-	 * @return lastUpdusrId String
-	 */
-	public void setLastUpdusrId(String lastUpdusrId) {
-		this.lastUpdusrId = lastUpdusrId;
-	}
-	/**
-	 * cmd attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getCmd() {
-		return cmd;
-	}
-	/**
-	 * cmd attribute 값을 설정한다.
-	 * @return cmd String
-	 */
-	public void setCmd(String cmd) {
-		this.cmd = cmd;
-	}
-
-
-
-
 
 }

--- a/src/main/java/egovframework/com/uss/ion/ecc/service/TnextrlHrVO.java
+++ b/src/main/java/egovframework/com/uss/ion/ecc/service/TnextrlHrVO.java
@@ -1,6 +1,8 @@
 package egovframework.com.uss.ion.ecc.service;
 
 import egovframework.com.cmm.ComDefaultVO;
+import lombok.Getter;
+import lombok.Setter;
 
 import org.egovframe.rte.ptl.reactive.validation.EgovNullCheck;
 import org.egovframe.rte.ptl.reactive.validation.EgovEmailCheck;
@@ -22,6 +24,8 @@ import jakarta.validation.constraints.Size;
  *
  * </pre>
  */
+@Getter
+@Setter
 public class TnextrlHrVO extends ComDefaultVO {
 
 	private static final long serialVersionUID = 1L;
@@ -31,7 +35,7 @@ public class TnextrlHrVO extends ComDefaultVO {
 	 */
 	@EgovNullCheck
 	private String sexdstnCode = "";
-	
+
 	/**
 	 * 성별코드명
 	 */
@@ -55,7 +59,7 @@ public class TnextrlHrVO extends ComDefaultVO {
 	 */
 	@EgovNullCheck
 	private String occpTyCode = "";
-	
+
 	/**
 	 * 직업유형코드명
 	 */
@@ -76,7 +80,7 @@ public class TnextrlHrVO extends ComDefaultVO {
 	 */
 	@EgovNullCheck
 	private String eventId = "";
-	
+
 	/**
 	 * 행사/이벤트/캠페인내용
 	 */
@@ -135,7 +139,7 @@ public class TnextrlHrVO extends ComDefaultVO {
 	 * 최초등록ID
 	 */
 	private String frstRegisterId = "";
-	
+
 	/**
 	 * 최초등록ID
 	 */
@@ -150,361 +154,5 @@ public class TnextrlHrVO extends ComDefaultVO {
 	 * 최종수정ID
 	 */
 	private String lastUpdusrId = "";
-
-	/**
-	 * sexdstnCode attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getSexdstnCode() {
-		return sexdstnCode;
-	}
-
-	/**
-	 * sexdstnCode attribute 값을 설정한다.
-	 * @return sexdstnCode String
-	 */
-	public void setSexdstnCode(String sexdstnCode) {
-		this.sexdstnCode = sexdstnCode;
-	}
-	
-	/**
-	 * sexdstnCodeNm attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getSexdstnCodeNm() {
-		return sexdstnCodeNm;
-	}
-	
-	/**
-	 * sexdstnCodeNm attribute 값을 설정한다.
-	 * @return sexdstnCodeNm String
-	 */
-	public void setSexdstnCodeNm(String sexdstnCodeNm) {
-		this.sexdstnCodeNm = sexdstnCodeNm;
-	}
-
-	/**
-	 * extrlHrNm attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getExtrlHrNm() {
-		return extrlHrNm;
-	}
-
-	/**
-	 * extrlHrNm attribute 값을 설정한다.
-	 * @return extrlHrNm String
-	 */
-	public void setExtrlHrNm(String extrlHrNm) {
-		this.extrlHrNm = extrlHrNm;
-	}
-
-	/**
-	 * emailAdres attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getEmailAdres() {
-		return emailAdres;
-	}
-
-	/**
-	 * emailAdres attribute 값을 설정한다.
-	 * @return emailAdres String
-	 */
-	public void setEmailAdres(String emailAdres) {
-		this.emailAdres = emailAdres;
-	}
-
-	/**
-	 * occpTyCode attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getOccpTyCode() {
-		return occpTyCode;
-	}
-
-	/**
-	 * occpTyCode attribute 값을 설정한다.
-	 * @return occpTyCode String
-	 */
-	public void setOccpTyCode(String occpTyCode) {
-		this.occpTyCode = occpTyCode;
-	}
-	
-	/**
-	 * occpTyCodeNm attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getOccpTyCodeNm() {
-		return occpTyCodeNm;
-	}
-	
-	/**
-	 * occpTyCodeNm attribute 값을 설정한다.
-	 * @return occpTyCodeNm String
-	 */
-	public void setOccpTyCodeNm(String occpTyCodeNm) {
-		this.occpTyCodeNm = occpTyCodeNm;
-	}
-
-	/**
-	 * psitnInsttNm attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getPsitnInsttNm() {
-		return psitnInsttNm;
-	}
-
-	/**
-	 * psitnInsttNm attribute 값을 설정한다.
-	 * @return psitnInsttNm String
-	 */
-	public void setPsitnInsttNm(String psitnInsttNm) {
-		this.psitnInsttNm = psitnInsttNm;
-	}
-
-	/**
-	 * extrlHrId attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getExtrlHrId() {
-		return extrlHrId;
-	}
-
-	/**
-	 * extrlHrId attribute 값을 설정한다.
-	 * @return extrlHrId String
-	 */
-	public void setExtrlHrId(String extrlHrId) {
-		this.extrlHrId = extrlHrId;
-	}
-
-	/**
-	 * eventId attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getEventId() {
-		return eventId;
-	}
-
-	/**
-	 * eventId attribute 값을 설정한다.
-	 * @return eventId String
-	 */
-	public void setEventId(String eventId) {
-		this.eventId = eventId;
-	}
-	
-	/**
-	 * eventCn attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getEventCn() {
-		return eventCn;
-	}
-	
-	/**
-	 * eventCn attribute 값을 설정한다.
-	 * @return eventCn String
-	 */
-	public void setEventCn(String eventCn) {
-		this.eventCn = eventCn;
-	}
-
-	/**
-	 * brth attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getBrth() {
-		return brth;
-	}
-
-	/**
-	 * brth attribute 값을 설정한다.
-	 * @return brth String
-	 */
-	public void setBrth(String brth) {
-		this.brth = brth;
-	}
-
-	/**
-	 * areaNo attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getAreaNo() {
-		return areaNo;
-	}
-
-	/**
-	 * areaNo attribute 값을 설정한다.
-	 * @return areaNo String
-	 */
-	public void setAreaNo(String areaNo) {
-		this.areaNo = areaNo;
-	}
-
-	/**
-	 * middleTelno attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getMiddleTelno() {
-		return middleTelno;
-	}
-
-	/**
-	 * middleTelno attribute 값을 설정한다.
-	 * @return middleTelno String
-	 */
-	public void setMiddleTelno(String middleTelno) {
-		this.middleTelno = middleTelno;
-	}
-
-	/**
-	 * endTelno attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getEndTelno() {
-		return endTelno;
-	}
-
-	/**
-	 * endTelno attribute 값을 설정한다.
-	 * @return endTelno String
-	 */
-	public void setEndTelno(String endTelno) {
-		this.endTelno = endTelno;
-	}
-
-	/**
-	 * brthYYYY attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getBrthYYYY() {
-		return brthYYYY;
-	}
-
-	/**
-	 * brthYYYY attribute 값을 설정한다.
-	 * @return brthYYYY String
-	 */
-	public void setBrthYYYY(String brthYYYY) {
-		this.brthYYYY = brthYYYY;
-	}
-
-	/**
-	 * brthMM attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getBrthMM() {
-		return brthMM;
-	}
-
-	/**
-	 * brthMM attribute 값을 설정한다.
-	 * @return brthMM String
-	 */
-	public void setBrthMM(String brthMM) {
-		this.brthMM = brthMM;
-	}
-
-	/**
-	 * brthDD attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getBrthDD() {
-		return brthDD;
-	}
-
-	/**
-	 * brthDD attribute 값을 설정한다.
-	 * @return brthDD String
-	 */
-	public void setBrthDD(String brthDD) {
-		this.brthDD = brthDD;
-	}
-
-	/**
-	 * frstRegisterPnttm attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getFrstRegisterPnttm() {
-		return frstRegisterPnttm;
-	}
-
-	/**
-	 * frstRegisterPnttm attribute 값을 설정한다.
-	 * @return frstRegisterPnttm String
-	 */
-	public void setFrstRegisterPnttm(String frstRegisterPnttm) {
-		this.frstRegisterPnttm = frstRegisterPnttm;
-	}
-
-	/**
-	 * frstRegisterId attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getFrstRegisterId() {
-		return frstRegisterId;
-	}
-
-	/**
-	 * frstRegisterId attribute 값을 설정한다.
-	 * @return frstRegisterId String
-	 */
-	public void setFrstRegisterId(String frstRegisterId) {
-		this.frstRegisterId = frstRegisterId;
-	}
-	
-	/**
-	 * frstRegisterNm attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getFrstRegisterNm() {
-		return frstRegisterNm;
-	}
-	
-	/**
-	 * frstRegisterNm attribute 값을 설정한다.
-	 * @return frstRegisterNm String
-	 */
-	public void setFrstRegisterNm(String frstRegisterNm) {
-		this.frstRegisterNm = frstRegisterNm;
-	}
-
-	/**
-	 * lastUpdusrPnttm attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getLastUpdusrPnttm() {
-		return lastUpdusrPnttm;
-	}
-
-	/**
-	 * lastUpdusrPnttm attribute 값을 설정한다.
-	 * @return lastUpdusrPnttm String
-	 */
-	public void setLastUpdusrPnttm(String lastUpdusrPnttm) {
-		this.lastUpdusrPnttm = lastUpdusrPnttm;
-	}
-
-	/**
-	 * lastUpdusrId attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getLastUpdusrId() {
-		return lastUpdusrId;
-	}
-
-	/**
-	 * lastUpdusrId attribute 값을 설정한다.
-	 * @return lastUpdusrId String
-	 */
-	public void setLastUpdusrId(String lastUpdusrId) {
-		this.lastUpdusrId = lastUpdusrId;
-	}
-
-
-
-
 
 }

--- a/src/main/java/egovframework/com/uss/ion/ism/service/SanctnerVO.java
+++ b/src/main/java/egovframework/com/uss/ion/ism/service/SanctnerVO.java
@@ -1,25 +1,29 @@
 package egovframework.com.uss.ion.ism.service;
 
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * 개요
  * - 결재자에 대한 Vo 클래스를 정의한다.
- * 
+ *
  * 상세내용
  * - 결재자의 목록 항목, 조회조건 등을 관리한다.
  * @author 장철호
  * @version 1.0
  * @created 28-6-2010 오전 11:29:26
  */
+@Getter
+@Setter
 @SuppressWarnings("serial")
 public class SanctnerVO extends Sanctner {
 
 	/** 검색조건 */
     private String searchCnd = "";
-    
+
     /** 검색단어 */
     private String searchWrd = "";
-    
+
     /** 현재페이지 */
     private int pageIndex = 1;
 
@@ -37,69 +41,5 @@ public class SanctnerVO extends Sanctner {
 
     /** 페이지당 레코드 개수 */
     private int recordCountPerPage = 10;
-
-	public String getSearchCnd() {
-		return searchCnd;
-	}
-
-	public void setSearchCnd(String searchCnd) {
-		this.searchCnd = searchCnd;
-	}
-
-	public String getSearchWrd() {
-		return searchWrd;
-	}
-
-	public void setSearchWrd(String searchWrd) {
-		this.searchWrd = searchWrd;
-	}
-
-	public int getPageIndex() {
-		return pageIndex;
-	}
-
-	public void setPageIndex(int pageIndex) {
-		this.pageIndex = pageIndex;
-	}
-
-	public int getPageUnit() {
-		return pageUnit;
-	}
-
-	public void setPageUnit(int pageUnit) {
-		this.pageUnit = pageUnit;
-	}
-
-	public int getPageSize() {
-		return pageSize;
-	}
-
-	public void setPageSize(int pageSize) {
-		this.pageSize = pageSize;
-	}
-
-	public int getFirstIndex() {
-		return firstIndex;
-	}
-
-	public void setFirstIndex(int firstIndex) {
-		this.firstIndex = firstIndex;
-	}
-
-	public int getLastIndex() {
-		return lastIndex;
-	}
-
-	public void setLastIndex(int lastIndex) {
-		this.lastIndex = lastIndex;
-	}
-
-	public int getRecordCountPerPage() {
-		return recordCountPerPage;
-	}
-
-	public void setRecordCountPerPage(int recordCountPerPage) {
-		this.recordCountPerPage = recordCountPerPage;
-	}
 
 }

--- a/src/main/java/egovframework/com/uss/ion/sit/service/SiteVO.java
+++ b/src/main/java/egovframework/com/uss/ion/sit/service/SiteVO.java
@@ -1,12 +1,15 @@
 package egovframework.com.uss.ion.sit.service;
 
+import lombok.Getter;
+import lombok.Setter;
+
 import org.egovframe.rte.ptl.reactive.validation.EgovNullCheck;
 
 import egovframework.com.cmm.ComDefaultVO;
 import jakarta.validation.constraints.Size;
 
 /**
- * 
+ *
  * 사이트정보를 처리하는 VO 클래스
  * @author 공통서비스 개발팀 박정규
  * @since 2009.04.01
@@ -15,56 +18,58 @@ import jakarta.validation.constraints.Size;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.04.01  박정규          최초 생성
  *
  * </pre>
  */
+@Getter
+@Setter
 public class SiteVO extends ComDefaultVO {
-	
+
     private static final long serialVersionUID = 1L;
-    
+
     /** 사이트 ID */
     private String siteId;
-    
+
     /** 사이트 URL */
     @EgovNullCheck
     @Size(max=100)
     private String siteUrl;
-    
+
     /** 사이트명 */
     @EgovNullCheck
     @Size(max=100)
     private String siteNm;
-    
+
     /** 사이트설명 */
     @EgovNullCheck
     @Size(max=1000)
     private String siteDc;
-    
+
     /** 사이트주제분류코드 */
     @EgovNullCheck
     private String siteThemaClCode;
 
     /** 사이트주제분류명 */
     private String siteThemaClNm;
-    
+
     /** 활성여부 */
     private String actvtyAt;
 
     /** 활성여부명 */
     private String actvtyAtNm;
-    
+
     /** 사용여부 */
     private String useAt;
-    
+
     /** 사용여부명 */
     private String useAtNm;
-    
+
     /** 등록자명 */
-    private String emplyrNm;        
+    private String emplyrNm;
 
     /** 최초등록시점 */
     private String frstRegisterPnttm;
@@ -78,247 +83,4 @@ public class SiteVO extends ComDefaultVO {
     /** 최종수정자ID */
     private String lastUpdusrId;
 
-	/**
-	 * siteId attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getSiteId() {
-		return siteId;
-	}
-
-	/**
-	 * siteId attribute 값을 설정한다.
-	 * @return siteId String
-	 */
-	public void setSiteId(String siteId) {
-		this.siteId = siteId;
-	}
-
-	/**
-	 * siteUrl attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getSiteUrl() {
-		return siteUrl;
-	}
-
-	/**
-	 * siteUrl attribute 값을 설정한다.
-	 * @return siteUrl String
-	 */
-	public void setSiteUrl(String siteUrl) {
-		this.siteUrl = siteUrl;
-	}
-
-	/**
-	 * siteNm attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getSiteNm() {
-		return siteNm;
-	}
-
-	/**
-	 * siteNm attribute 값을 설정한다.
-	 * @return siteNm String
-	 */
-	public void setSiteNm(String siteNm) {
-		this.siteNm = siteNm;
-	}
-
-	/**
-	 * siteDc attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getSiteDc() {
-		return siteDc;
-	}
-
-	/**
-	 * siteDc attribute 값을 설정한다.
-	 * @return siteDc String
-	 */
-	public void setSiteDc(String siteDc) {
-		this.siteDc = siteDc;
-	}
-
-	/**
-	 * siteThemaClCode attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getSiteThemaClCode() {
-		return siteThemaClCode;
-	}
-
-	/**
-	 * siteThemaClCode attribute 값을 설정한다.
-	 * @return siteThemaClCode String
-	 */
-	public void setSiteThemaClCode(String siteThemaClCode) {
-		this.siteThemaClCode = siteThemaClCode;
-	}
-
-	/**
-	 * siteThemaClNm attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getSiteThemaClNm() {
-		return siteThemaClNm;
-	}
-
-	/**
-	 * siteThemaClNm attribute 값을 설정한다.
-	 * @return siteThemaClNm String
-	 */
-	public void setSiteThemaClNm(String siteThemaClNm) {
-		this.siteThemaClNm = siteThemaClNm;
-	}
-
-	/**
-	 * actvtyAt attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getActvtyAt() {
-		return actvtyAt;
-	}
-
-	/**
-	 * actvtyAt attribute 값을 설정한다.
-	 * @return actvtyAt String
-	 */
-	public void setActvtyAt(String actvtyAt) {
-		this.actvtyAt = actvtyAt;
-	}
-
-	/**
-	 * actvtyAtNm attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getActvtyAtNm() {
-		return actvtyAtNm;
-	}
-
-	/**
-	 * actvtyAtNm attribute 값을 설정한다.
-	 * @return actvtyAtNm String
-	 */
-	public void setActvtyAtNm(String actvtyAtNm) {
-		this.actvtyAtNm = actvtyAtNm;
-	}
-
-	/**
-	 * useAt attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getUseAt() {
-		return useAt;
-	}
-
-	/**
-	 * useAt attribute 값을 설정한다.
-	 * @return useAt String
-	 */
-	public void setUseAt(String useAt) {
-		this.useAt = useAt;
-	}
-
-	/**
-	 * useAtNm attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getUseAtNm() {
-		return useAtNm;
-	}
-
-	/**
-	 * useAtNm attribute 값을 설정한다.
-	 * @return useAtNm String
-	 */
-	public void setUseAtNm(String useAtNm) {
-		this.useAtNm = useAtNm;
-	}
-
-	/**
-	 * emplyrNm attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getEmplyrNm() {
-		return emplyrNm;
-	}
-
-	/**
-	 * emplyrNm attribute 값을 설정한다.
-	 * @return emplyrNm String
-	 */
-	public void setEmplyrNm(String emplyrNm) {
-		this.emplyrNm = emplyrNm;
-	}
-
-	/**
-	 * frstRegisterPnttm attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getFrstRegisterPnttm() {
-		return frstRegisterPnttm;
-	}
-
-	/**
-	 * frstRegisterPnttm attribute 값을 설정한다.
-	 * @return frstRegisterPnttm String
-	 */
-	public void setFrstRegisterPnttm(String frstRegisterPnttm) {
-		this.frstRegisterPnttm = frstRegisterPnttm;
-	}
-
-	/**
-	 * frstRegisterId attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getFrstRegisterId() {
-		return frstRegisterId;
-	}
-
-	/**
-	 * frstRegisterId attribute 값을 설정한다.
-	 * @return frstRegisterId String
-	 */
-	public void setFrstRegisterId(String frstRegisterId) {
-		this.frstRegisterId = frstRegisterId;
-	}
-
-	/**
-	 * lastUpdusrPnttm attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getLastUpdusrPnttm() {
-		return lastUpdusrPnttm;
-	}
-
-	/**
-	 * lastUpdusrPnttm attribute 값을 설정한다.
-	 * @return lastUpdusrPnttm String
-	 */
-	public void setLastUpdusrPnttm(String lastUpdusrPnttm) {
-		this.lastUpdusrPnttm = lastUpdusrPnttm;
-	}
-
-	/**
-	 * lastUpdusrId attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getLastUpdusrId() {
-		return lastUpdusrId;
-	}
-
-	/**
-	 * lastUpdusrId attribute 값을 설정한다.
-	 * @return lastUpdusrId String
-	 */
-	public void setLastUpdusrId(String lastUpdusrId) {
-		this.lastUpdusrId = lastUpdusrId;
-	}
-
-    
-    
-   
 }


### PR DESCRIPTION
## 변경 사유
uss/ion (ecc/ism/sit) 모듈 VO에 수동 getter/setter가 작성되어 보일러플레이트가 많다. Lombok 어노테이션으로 대체.

## 변경 내용
- EventCmpgnVO, TnextrlHrVO (ecc 패키지) @Getter @Setter 적용, 수동 getter/setter 제거
- SanctnerVO (ism 패키지) @Getter @Setter 적용, 수동 getter/setter 제거
- SiteVO (sit 패키지) @Getter @Setter 적용, 수동 getter/setter 제거
- isEventSvcDateRangeValid() 비즈니스 검증 메서드 보존
- pom.xml maven-compiler-plugin에 annotationProcessorPaths 추가 (기존 PR과 동일 7줄)

## 영향 범위
- 외부 API 변경 없음 (getter/setter 시그니처 동일)
- mvn compile BUILD SUCCESS 확인

## 체크리스트
- [x] 3 sub-package(ecc/ism/sit)만 다룸
- [x] 기존 동작에 영향 없음
- [x] mvn compile 통과
