### PR TITLE
[refactor][공통컴포넌트] sym/ccm 모듈 VO Lombok @Getter/@Setter 적용

### DIFF
--- a/src/main/java/egovframework/com/sym/ccm/acr/service/AdministCodeRecptnVO.java
+++ b/src/main/java/egovframework/com/sym/ccm/acr/service/AdministCodeRecptnVO.java
@@ -2,6 +2,9 @@ package egovframework.com.sym.ccm.acr.service;
 
 import java.io.Serializable;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  *
  * 법정동코드 VO 클래스
@@ -20,6 +23,8 @@ import java.io.Serializable;
  * Copyright (C) 2009 by MOPAS  All rights reserved.
  * </pre>
  */
+@Getter
+@Setter
 public class AdministCodeRecptnVO extends AdministCodeRecptn implements Serializable {
 
 	private static final long serialVersionUID = 8718522735836192467L;
@@ -50,150 +55,5 @@ public class AdministCodeRecptnVO extends AdministCodeRecptn implements Serializ
 
     /** recordCountPerPage */
     private int recordCountPerPage = 10;
-
-	/**
-	 * searchCondition attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getSearchCondition() {
-		return searchCondition;
-	}
-
-	/**
-	 * searchCondition attribute 값을 설정한다.
-	 * @param searchCondition String
-	 */
-	public void setSearchCondition(String searchCondition) {
-		this.searchCondition = searchCondition;
-	}
-
-	/**
-	 * searchKeyword attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getSearchKeyword() {
-		return searchKeyword;
-	}
-
-	/**
-	 * searchKeyword attribute 값을 설정한다.
-	 * @param searchKeyword String
-	 */
-	public void setSearchKeyword(String searchKeyword) {
-		this.searchKeyword = searchKeyword;
-	}
-
-	/**
-	 * searchUseYn attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getSearchUseYn() {
-		return searchUseYn;
-	}
-
-	/**
-	 * searchUseYn attribute 값을 설정한다.
-	 * @param searchUseYn String
-	 */
-	public void setSearchUseYn(String searchUseYn) {
-		this.searchUseYn = searchUseYn;
-	}
-
-	/**
-	 * pageIndex attribute 를 리턴한다.
-	 * @return int
-	 */
-	public int getPageIndex() {
-		return pageIndex;
-	}
-
-	/**
-	 * pageIndex attribute 값을 설정한다.
-	 * @param pageIndex int
-	 */
-	public void setPageIndex(int pageIndex) {
-		this.pageIndex = pageIndex;
-	}
-
-	/**
-	 * pageUnit attribute 를 리턴한다.
-	 * @return int
-	 */
-	public int getPageUnit() {
-		return pageUnit;
-	}
-
-	/**
-	 * pageUnit attribute 값을 설정한다.
-	 * @param pageUnit int
-	 */
-	public void setPageUnit(int pageUnit) {
-		this.pageUnit = pageUnit;
-	}
-
-	/**
-	 * pageSize attribute 를 리턴한다.
-	 * @return int
-	 */
-	public int getPageSize() {
-		return pageSize;
-	}
-
-	/**
-	 * pageSize attribute 값을 설정한다.
-	 * @param pageSize int
-	 */
-	public void setPageSize(int pageSize) {
-		this.pageSize = pageSize;
-	}
-
-	/**
-	 * firstIndex attribute 를 리턴한다.
-	 * @return int
-	 */
-	public int getFirstIndex() {
-		return firstIndex;
-	}
-
-	/**
-	 * firstIndex attribute 값을 설정한다.
-	 * @param firstIndex int
-	 */
-	public void setFirstIndex(int firstIndex) {
-		this.firstIndex = firstIndex;
-	}
-
-	/**
-	 * lastIndex attribute 를 리턴한다.
-	 * @return int
-	 */
-	public int getLastIndex() {
-		return lastIndex;
-	}
-
-	/**
-	 * lastIndex attribute 값을 설정한다.
-	 * @param lastIndex int
-	 */
-	public void setLastIndex(int lastIndex) {
-		this.lastIndex = lastIndex;
-	}
-
-	/**
-	 * recordCountPerPage attribute 를 리턴한다.
-	 * @return int
-	 */
-	public int getRecordCountPerPage() {
-		return recordCountPerPage;
-	}
-
-	/**
-	 * recordCountPerPage attribute 값을 설정한다.
-	 * @param recordCountPerPage int
-	 */
-	public void setRecordCountPerPage(int recordCountPerPage) {
-		this.recordCountPerPage = recordCountPerPage;
-	}
-
 
 }

--- a/src/main/java/egovframework/com/sym/ccm/adc/service/AdministCodeVO.java
+++ b/src/main/java/egovframework/com/sym/ccm/adc/service/AdministCodeVO.java
@@ -2,6 +2,9 @@ package egovframework.com.sym.ccm.adc.service;
 
 import java.io.Serializable;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  *
  * 행정코드 VO 클래스
@@ -19,6 +22,8 @@ import java.io.Serializable;
  *
  * </pre>
  */
+@Getter
+@Setter
 public class AdministCodeVO extends AdministCode implements Serializable {
 
 	private static final long serialVersionUID = 3232859721751526210L;
@@ -49,150 +54,5 @@ public class AdministCodeVO extends AdministCode implements Serializable {
 
     /** recordCountPerPage */
     private int recordCountPerPage = 10;
-
-	/**
-	 * searchCondition attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getSearchCondition() {
-		return searchCondition;
-	}
-
-	/**
-	 * searchCondition attribute 값을 설정한다.
-	 * @param searchCondition String
-	 */
-	public void setSearchCondition(String searchCondition) {
-		this.searchCondition = searchCondition;
-	}
-
-	/**
-	 * searchKeyword attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getSearchKeyword() {
-		return searchKeyword;
-	}
-
-	/**
-	 * searchKeyword attribute 값을 설정한다.
-	 * @param searchKeyword String
-	 */
-	public void setSearchKeyword(String searchKeyword) {
-		this.searchKeyword = searchKeyword;
-	}
-
-	/**
-	 * searchUseYn attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getSearchUseYn() {
-		return searchUseYn;
-	}
-
-	/**
-	 * searchUseYn attribute 값을 설정한다.
-	 * @param searchUseYn String
-	 */
-	public void setSearchUseYn(String searchUseYn) {
-		this.searchUseYn = searchUseYn;
-	}
-
-	/**
-	 * pageIndex attribute 를 리턴한다.
-	 * @return int
-	 */
-	public int getPageIndex() {
-		return pageIndex;
-	}
-
-	/**
-	 * pageIndex attribute 값을 설정한다.
-	 * @param pageIndex int
-	 */
-	public void setPageIndex(int pageIndex) {
-		this.pageIndex = pageIndex;
-	}
-
-	/**
-	 * pageUnit attribute 를 리턴한다.
-	 * @return int
-	 */
-	public int getPageUnit() {
-		return pageUnit;
-	}
-
-	/**
-	 * pageUnit attribute 값을 설정한다.
-	 * @param pageUnit int
-	 */
-	public void setPageUnit(int pageUnit) {
-		this.pageUnit = pageUnit;
-	}
-
-	/**
-	 * pageSize attribute 를 리턴한다.
-	 * @return int
-	 */
-	public int getPageSize() {
-		return pageSize;
-	}
-
-	/**
-	 * pageSize attribute 값을 설정한다.
-	 * @param pageSize int
-	 */
-	public void setPageSize(int pageSize) {
-		this.pageSize = pageSize;
-	}
-
-	/**
-	 * firstIndex attribute 를 리턴한다.
-	 * @return int
-	 */
-	public int getFirstIndex() {
-		return firstIndex;
-	}
-
-	/**
-	 * firstIndex attribute 값을 설정한다.
-	 * @param firstIndex int
-	 */
-	public void setFirstIndex(int firstIndex) {
-		this.firstIndex = firstIndex;
-	}
-
-	/**
-	 * lastIndex attribute 를 리턴한다.
-	 * @return int
-	 */
-	public int getLastIndex() {
-		return lastIndex;
-	}
-
-	/**
-	 * lastIndex attribute 값을 설정한다.
-	 * @param lastIndex int
-	 */
-	public void setLastIndex(int lastIndex) {
-		this.lastIndex = lastIndex;
-	}
-
-	/**
-	 * recordCountPerPage attribute 를 리턴한다.
-	 * @return int
-	 */
-	public int getRecordCountPerPage() {
-		return recordCountPerPage;
-	}
-
-	/**
-	 * recordCountPerPage attribute 값을 설정한다.
-	 * @param recordCountPerPage int
-	 */
-	public void setRecordCountPerPage(int recordCountPerPage) {
-		this.recordCountPerPage = recordCountPerPage;
-	}
-
 
 }

--- a/src/main/java/egovframework/com/sym/ccm/cca/service/CmmnCodeVO.java
+++ b/src/main/java/egovframework/com/sym/ccm/cca/service/CmmnCodeVO.java
@@ -2,6 +2,9 @@ package egovframework.com.sym.ccm.cca.service;
 
 import java.io.Serializable;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
 *
 * 공통코드 VO 클래스
@@ -19,7 +22,8 @@ import java.io.Serializable;
 *
 * </pre>
 */
-
+@Getter
+@Setter
 public class CmmnCodeVO extends CmmnCode implements Serializable {
 
 	private static final long serialVersionUID = -4184057693049713450L;
@@ -50,149 +54,5 @@ public class CmmnCodeVO extends CmmnCode implements Serializable {
 
     /** recordCountPerPage */
     private int recordCountPerPage = 10;
-
-	/**
-	 * searchCondition attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getSearchCondition() {
-		return searchCondition;
-	}
-
-	/**
-	 * searchCondition attribute 값을 설정한다.
-	 * @param searchCondition String
-	 */
-	public void setSearchCondition(String searchCondition) {
-		this.searchCondition = searchCondition;
-	}
-
-	/**
-	 * searchKeyword attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getSearchKeyword() {
-		return searchKeyword;
-	}
-
-	/**
-	 * searchKeyword attribute 값을 설정한다.
-	 * @param searchKeyword String
-	 */
-	public void setSearchKeyword(String searchKeyword) {
-		this.searchKeyword = searchKeyword;
-	}
-
-	/**
-	 * searchUseYn attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getSearchUseYn() {
-		return searchUseYn;
-	}
-
-	/**
-	 * searchUseYn attribute 값을 설정한다.
-	 * @param searchUseYn String
-	 */
-	public void setSearchUseYn(String searchUseYn) {
-		this.searchUseYn = searchUseYn;
-	}
-
-	/**
-	 * pageIndex attribute 를 리턴한다.
-	 * @return int
-	 */
-	public int getPageIndex() {
-		return pageIndex;
-	}
-
-	/**
-	 * pageIndex attribute 값을 설정한다.
-	 * @param pageIndex int
-	 */
-	public void setPageIndex(int pageIndex) {
-		this.pageIndex = pageIndex;
-	}
-
-	/**
-	 * pageUnit attribute 를 리턴한다.
-	 * @return int
-	 */
-	public int getPageUnit() {
-		return pageUnit;
-	}
-
-	/**
-	 * pageUnit attribute 값을 설정한다.
-	 * @param pageUnit int
-	 */
-	public void setPageUnit(int pageUnit) {
-		this.pageUnit = pageUnit;
-	}
-
-	/**
-	 * pageSize attribute 를 리턴한다.
-	 * @return int
-	 */
-	public int getPageSize() {
-		return pageSize;
-	}
-
-	/**
-	 * pageSize attribute 값을 설정한다.
-	 * @param pageSize int
-	 */
-	public void setPageSize(int pageSize) {
-		this.pageSize = pageSize;
-	}
-
-	/**
-	 * firstIndex attribute 를 리턴한다.
-	 * @return int
-	 */
-	public int getFirstIndex() {
-		return firstIndex;
-	}
-
-	/**
-	 * firstIndex attribute 값을 설정한다.
-	 * @param firstIndex int
-	 */
-	public void setFirstIndex(int firstIndex) {
-		this.firstIndex = firstIndex;
-	}
-
-	/**
-	 * lastIndex attribute 를 리턴한다.
-	 * @return int
-	 */
-	public int getLastIndex() {
-		return lastIndex;
-	}
-
-	/**
-	 * lastIndex attribute 값을 설정한다.
-	 * @param lastIndex int
-	 */
-	public void setLastIndex(int lastIndex) {
-		this.lastIndex = lastIndex;
-	}
-
-	/**
-	 * recordCountPerPage attribute 를 리턴한다.
-	 * @return int
-	 */
-	public int getRecordCountPerPage() {
-		return recordCountPerPage;
-	}
-
-	/**
-	 * recordCountPerPage attribute 값을 설정한다.
-	 * @param recordCountPerPage int
-	 */
-	public void setRecordCountPerPage(int recordCountPerPage) {
-		this.recordCountPerPage = recordCountPerPage;
-	}
 
 }

--- a/src/main/java/egovframework/com/sym/ccm/ccc/service/CmmnClCodeVO.java
+++ b/src/main/java/egovframework/com/sym/ccm/ccc/service/CmmnClCodeVO.java
@@ -2,6 +2,9 @@ package egovframework.com.sym.ccm.ccc.service;
 
 import java.io.Serializable;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  *
  * 공통분류코드 VO 클래스
@@ -19,7 +22,9 @@ import java.io.Serializable;
  *
  * </pre>
  */
-public class  CmmnClCodeVO extends CmmnClCode implements Serializable {
+@Getter
+@Setter
+public class CmmnClCodeVO extends CmmnClCode implements Serializable {
 
 	private static final long serialVersionUID = 442842373959722378L;
 
@@ -49,150 +54,5 @@ public class  CmmnClCodeVO extends CmmnClCode implements Serializable {
 
     /** recordCountPerPage */
     private int recordCountPerPage = 10;
-
-	/**
-	 * searchCondition attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getSearchCondition() {
-		return searchCondition;
-	}
-
-	/**
-	 * searchCondition attribute 값을 설정한다.
-	 * @param searchCondition String
-	 */
-	public void setSearchCondition(String searchCondition) {
-		this.searchCondition = searchCondition;
-	}
-
-	/**
-	 * searchKeyword attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getSearchKeyword() {
-		return searchKeyword;
-	}
-
-	/**
-	 * searchKeyword attribute 값을 설정한다.
-	 * @param searchKeyword String
-	 */
-	public void setSearchKeyword(String searchKeyword) {
-		this.searchKeyword = searchKeyword;
-	}
-
-	/**
-	 * searchUseYn attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getSearchUseYn() {
-		return searchUseYn;
-	}
-
-	/**
-	 * searchUseYn attribute 값을 설정한다.
-	 * @param searchUseYn String
-	 */
-	public void setSearchUseYn(String searchUseYn) {
-		this.searchUseYn = searchUseYn;
-	}
-
-	/**
-	 * pageIndex attribute 를 리턴한다.
-	 * @return int
-	 */
-	public int getPageIndex() {
-		return pageIndex;
-	}
-
-	/**
-	 * pageIndex attribute 값을 설정한다.
-	 * @param pageIndex int
-	 */
-	public void setPageIndex(int pageIndex) {
-		this.pageIndex = pageIndex;
-	}
-
-	/**
-	 * pageUnit attribute 를 리턴한다.
-	 * @return int
-	 */
-	public int getPageUnit() {
-		return pageUnit;
-	}
-
-	/**
-	 * pageUnit attribute 값을 설정한다.
-	 * @param pageUnit int
-	 */
-	public void setPageUnit(int pageUnit) {
-		this.pageUnit = pageUnit;
-	}
-
-	/**
-	 * pageSize attribute 를 리턴한다.
-	 * @return int
-	 */
-	public int getPageSize() {
-		return pageSize;
-	}
-
-	/**
-	 * pageSize attribute 값을 설정한다.
-	 * @param pageSize int
-	 */
-	public void setPageSize(int pageSize) {
-		this.pageSize = pageSize;
-	}
-
-	/**
-	 * firstIndex attribute 를 리턴한다.
-	 * @return int
-	 */
-	public int getFirstIndex() {
-		return firstIndex;
-	}
-
-	/**
-	 * firstIndex attribute 값을 설정한다.
-	 * @param firstIndex int
-	 */
-	public void setFirstIndex(int firstIndex) {
-		this.firstIndex = firstIndex;
-	}
-
-	/**
-	 * lastIndex attribute 를 리턴한다.
-	 * @return int
-	 */
-	public int getLastIndex() {
-		return lastIndex;
-	}
-
-	/**
-	 * lastIndex attribute 값을 설정한다.
-	 * @param lastIndex int
-	 */
-	public void setLastIndex(int lastIndex) {
-		this.lastIndex = lastIndex;
-	}
-
-	/**
-	 * recordCountPerPage attribute 를 리턴한다.
-	 * @return int
-	 */
-	public int getRecordCountPerPage() {
-		return recordCountPerPage;
-	}
-
-	/**
-	 * recordCountPerPage attribute 값을 설정한다.
-	 * @param recordCountPerPage int
-	 */
-	public void setRecordCountPerPage(int recordCountPerPage) {
-		this.recordCountPerPage = recordCountPerPage;
-	}
-
 
 }

--- a/src/main/java/egovframework/com/sym/ccm/cde/service/CmmnDetailCodeVO.java
+++ b/src/main/java/egovframework/com/sym/ccm/cde/service/CmmnDetailCodeVO.java
@@ -3,6 +3,8 @@ package egovframework.com.sym.ccm.cde.service;
 import java.io.Serializable;
 
 import egovframework.com.cmm.service.CmmnDetailCode;
+import lombok.Getter;
+import lombok.Setter;
 
 /**
 *
@@ -21,8 +23,9 @@ import egovframework.com.cmm.service.CmmnDetailCode;
 *
 * </pre>
 */
-
-public class CmmnDetailCodeVO extends CmmnDetailCode implements Serializable{
+@Getter
+@Setter
+public class CmmnDetailCodeVO extends CmmnDetailCode implements Serializable {
 
 	private static final long serialVersionUID = 9137280036724974467L;
 
@@ -53,147 +56,4 @@ public class CmmnDetailCodeVO extends CmmnDetailCode implements Serializable{
     /** recordCountPerPage */
     private int recordCountPerPage = 10;
 
-	/**
-	 * searchCondition attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getSearchCondition() {
-		return searchCondition;
-	}
-
-	/**
-	 * searchCondition attribute 값을 설정한다.
-	 * @param searchCondition String
-	 */
-	public void setSearchCondition(String searchCondition) {
-		this.searchCondition = searchCondition;
-	}
-
-	/**
-	 * searchKeyword attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getSearchKeyword() {
-		return searchKeyword;
-	}
-
-	/**
-	 * searchKeyword attribute 값을 설정한다.
-	 * @param searchKeyword String
-	 */
-	public void setSearchKeyword(String searchKeyword) {
-		this.searchKeyword = searchKeyword;
-	}
-
-	/**
-	 * searchUseYn attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getSearchUseYn() {
-		return searchUseYn;
-	}
-
-	/**
-	 * searchUseYn attribute 값을 설정한다.
-	 * @param searchUseYn String
-	 */
-	public void setSearchUseYn(String searchUseYn) {
-		this.searchUseYn = searchUseYn;
-	}
-
-	/**
-	 * pageIndex attribute 를 리턴한다.
-	 * @return int
-	 */
-	public int getPageIndex() {
-		return pageIndex;
-	}
-
-	/**
-	 * pageIndex attribute 값을 설정한다.
-	 * @param pageIndex int
-	 */
-	public void setPageIndex(int pageIndex) {
-		this.pageIndex = pageIndex;
-	}
-
-	/**
-	 * pageUnit attribute 를 리턴한다.
-	 * @return int
-	 */
-	public int getPageUnit() {
-		return pageUnit;
-	}
-
-	/**
-	 * pageUnit attribute 값을 설정한다.
-	 * @param pageUnit int
-	 */
-	public void setPageUnit(int pageUnit) {
-		this.pageUnit = pageUnit;
-	}
-
-	/**
-	 * pageSize attribute 를 리턴한다.
-	 * @return int
-	 */
-	public int getPageSize() {
-		return pageSize;
-	}
-
-	/**
-	 * pageSize attribute 값을 설정한다.
-	 * @param pageSize int
-	 */
-	public void setPageSize(int pageSize) {
-		this.pageSize = pageSize;
-	}
-
-	/**
-	 * firstIndex attribute 를 리턴한다.
-	 * @return int
-	 */
-	public int getFirstIndex() {
-		return firstIndex;
-	}
-
-	/**
-	 * firstIndex attribute 값을 설정한다.
-	 * @param firstIndex int
-	 */
-	public void setFirstIndex(int firstIndex) {
-		this.firstIndex = firstIndex;
-	}
-
-	/**
-	 * lastIndex attribute 를 리턴한다.
-	 * @return int
-	 */
-	public int getLastIndex() {
-		return lastIndex;
-	}
-
-	/**
-	 * lastIndex attribute 값을 설정한다.
-	 * @param lastIndex int
-	 */
-	public void setLastIndex(int lastIndex) {
-		this.lastIndex = lastIndex;
-	}
-
-	/**
-	 * recordCountPerPage attribute 를 리턴한다.
-	 * @return int
-	 */
-	public int getRecordCountPerPage() {
-		return recordCountPerPage;
-	}
-
-	/**
-	 * recordCountPerPage attribute 값을 설정한다.
-	 * @param recordCountPerPage int
-	 */
-	public void setRecordCountPerPage(int recordCountPerPage) {
-		this.recordCountPerPage = recordCountPerPage;
-	}
 }

--- a/src/main/java/egovframework/com/sym/ccm/icr/service/InsttCodeRecptnVO.java
+++ b/src/main/java/egovframework/com/sym/ccm/icr/service/InsttCodeRecptnVO.java
@@ -2,6 +2,9 @@ package egovframework.com.sym.ccm.icr.service;
 
 import java.io.Serializable;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  *
  * 기관코드 VO 클래스
@@ -20,6 +23,8 @@ import java.io.Serializable;
  * Copyright (C) 2009 by MOPAS  All rights reserved.
  * </pre>
  */
+@Getter
+@Setter
 public class InsttCodeRecptnVO extends InsttCodeRecptn implements Serializable {
 
 	private static final long serialVersionUID = -1775265891182170426L;
@@ -50,150 +55,5 @@ public class InsttCodeRecptnVO extends InsttCodeRecptn implements Serializable {
 
     /** recordCountPerPage */
     private int recordCountPerPage = 10;
-
-	/**
-	 * searchCondition attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getSearchCondition() {
-		return searchCondition;
-	}
-
-	/**
-	 * searchCondition attribute 값을 설정한다.
-	 * @param searchCondition String
-	 */
-	public void setSearchCondition(String searchCondition) {
-		this.searchCondition = searchCondition;
-	}
-
-	/**
-	 * searchKeyword attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getSearchKeyword() {
-		return searchKeyword;
-	}
-
-	/**
-	 * searchKeyword attribute 값을 설정한다.
-	 * @param searchKeyword String
-	 */
-	public void setSearchKeyword(String searchKeyword) {
-		this.searchKeyword = searchKeyword;
-	}
-
-	/**
-	 * searchUseYn attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getSearchUseYn() {
-		return searchUseYn;
-	}
-
-	/**
-	 * searchUseYn attribute 값을 설정한다.
-	 * @param searchUseYn String
-	 */
-	public void setSearchUseYn(String searchUseYn) {
-		this.searchUseYn = searchUseYn;
-	}
-
-	/**
-	 * pageIndex attribute 를 리턴한다.
-	 * @return int
-	 */
-	public int getPageIndex() {
-		return pageIndex;
-	}
-
-	/**
-	 * pageIndex attribute 값을 설정한다.
-	 * @param pageIndex int
-	 */
-	public void setPageIndex(int pageIndex) {
-		this.pageIndex = pageIndex;
-	}
-
-	/**
-	 * pageUnit attribute 를 리턴한다.
-	 * @return int
-	 */
-	public int getPageUnit() {
-		return pageUnit;
-	}
-
-	/**
-	 * pageUnit attribute 값을 설정한다.
-	 * @param pageUnit int
-	 */
-	public void setPageUnit(int pageUnit) {
-		this.pageUnit = pageUnit;
-	}
-
-	/**
-	 * pageSize attribute 를 리턴한다.
-	 * @return int
-	 */
-	public int getPageSize() {
-		return pageSize;
-	}
-
-	/**
-	 * pageSize attribute 값을 설정한다.
-	 * @param pageSize int
-	 */
-	public void setPageSize(int pageSize) {
-		this.pageSize = pageSize;
-	}
-
-	/**
-	 * firstIndex attribute 를 리턴한다.
-	 * @return int
-	 */
-	public int getFirstIndex() {
-		return firstIndex;
-	}
-
-	/**
-	 * firstIndex attribute 값을 설정한다.
-	 * @param firstIndex int
-	 */
-	public void setFirstIndex(int firstIndex) {
-		this.firstIndex = firstIndex;
-	}
-
-	/**
-	 * lastIndex attribute 를 리턴한다.
-	 * @return int
-	 */
-	public int getLastIndex() {
-		return lastIndex;
-	}
-
-	/**
-	 * lastIndex attribute 값을 설정한다.
-	 * @param lastIndex int
-	 */
-	public void setLastIndex(int lastIndex) {
-		this.lastIndex = lastIndex;
-	}
-
-	/**
-	 * recordCountPerPage attribute 를 리턴한다.
-	 * @return int
-	 */
-	public int getRecordCountPerPage() {
-		return recordCountPerPage;
-	}
-
-	/**
-	 * recordCountPerPage attribute 값을 설정한다.
-	 * @param recordCountPerPage int
-	 */
-	public void setRecordCountPerPage(int recordCountPerPage) {
-		this.recordCountPerPage = recordCountPerPage;
-	}
-
 
 }

--- a/src/main/java/egovframework/com/sym/ccm/zip/service/ZipVO.java
+++ b/src/main/java/egovframework/com/sym/ccm/zip/service/ZipVO.java
@@ -2,6 +2,9 @@ package egovframework.com.sym.ccm.zip.service;
 
 import java.io.Serializable;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  *
  * 우편번호 VO 클래스
@@ -20,6 +23,8 @@ import java.io.Serializable;
  *
  * </pre>
  */
+@Getter
+@Setter
 public class ZipVO extends Zip implements Serializable {
 
 	private static final long serialVersionUID = -1884618301732456348L;
@@ -56,178 +61,5 @@ public class ZipVO extends Zip implements Serializable {
 
     /** recordCountPerPage */
     private int recordCountPerPage = 10;
-
-	/**
-	 * searchList attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getSearchList() {
-		return searchList;
-	}
-
-	/**
-	 * searchList attribute 값을 설정한다.
-	 * @param searchList String
-	 */
-	public void setSearchList(String searchList) {
-		this.searchList = searchList;
-	}
-
-	/**
-	 * searchCondition attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getsearchCondition() {
-		return searchCondition;
-	}
-
-	/**
-	 * searchCondition attribute 값을 설정한다.
-	 * @param searchCondition String
-	 */
-	public void setsearchCondition(String searchCondition) {
-		this.searchCondition = searchCondition;
-	}
-
-	public String getSearchCondition2() {
-		return searchCondition2;
-	}
-
-	/**
-	 * searchCondition attribute 값을 설정한다.
-	 * @param searchCondition String
-	 */
-	public void setSearchCondition2(String searchCondition2) {
-		this.searchCondition2 = searchCondition2;
-	}
-
-	/**
-	 * searchKeyword attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getSearchKeyword() {
-		return searchKeyword;
-	}
-
-	/**
-	 * searchKeyword attribute 값을 설정한다.
-	 * @param searchKeyword String
-	 */
-	public void setSearchKeyword(String searchKeyword) {
-		this.searchKeyword = searchKeyword;
-	}
-
-	/**
-	 * searchUseYn attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getSearchUseYn() {
-		return searchUseYn;
-	}
-
-	/**
-	 * searchUseYn attribute 값을 설정한다.
-	 * @param searchUseYn String
-	 */
-	public void setSearchUseYn(String searchUseYn) {
-		this.searchUseYn = searchUseYn;
-	}
-
-	/**
-	 * pageIndex attribute 를 리턴한다.
-	 * @return int
-	 */
-	public int getPageIndex() {
-		return pageIndex;
-	}
-
-	/**
-	 * pageIndex attribute 값을 설정한다.
-	 * @param pageIndex int
-	 */
-	public void setPageIndex(int pageIndex) {
-		this.pageIndex = pageIndex;
-	}
-
-	/**
-	 * pageUnit attribute 를 리턴한다.
-	 * @return int
-	 */
-	public int getPageUnit() {
-		return pageUnit;
-	}
-
-	/**
-	 * pageUnit attribute 값을 설정한다.
-	 * @param pageUnit int
-	 */
-	public void setPageUnit(int pageUnit) {
-		this.pageUnit = pageUnit;
-	}
-
-	/**
-	 * pageSize attribute 를 리턴한다.
-	 * @return int
-	 */
-	public int getPageSize() {
-		return pageSize;
-	}
-
-	/**
-	 * pageSize attribute 값을 설정한다.
-	 * @param pageSize int
-	 */
-	public void setPageSize(int pageSize) {
-		this.pageSize = pageSize;
-	}
-
-	/**
-	 * firstIndex attribute 를 리턴한다.
-	 * @return int
-	 */
-	public int getFirstIndex() {
-		return firstIndex;
-	}
-
-	/**
-	 * firstIndex attribute 값을 설정한다.
-	 * @param firstIndex int
-	 */
-	public void setFirstIndex(int firstIndex) {
-		this.firstIndex = firstIndex;
-	}
-
-	/**
-	 * lastIndex attribute 를 리턴한다.
-	 * @return int
-	 */
-	public int getLastIndex() {
-		return lastIndex;
-	}
-
-	/**
-	 * lastIndex attribute 값을 설정한다.
-	 * @param lastIndex int
-	 */
-	public void setLastIndex(int lastIndex) {
-		this.lastIndex = lastIndex;
-	}
-
-	/**
-	 * recordCountPerPage attribute 를 리턴한다.
-	 * @return int
-	 */
-	public int getRecordCountPerPage() {
-		return recordCountPerPage;
-	}
-
-	/**
-	 * recordCountPerPage attribute 값을 설정한다.
-	 * @param recordCountPerPage int
-	 */
-	public void setRecordCountPerPage(int recordCountPerPage) {
-		this.recordCountPerPage = recordCountPerPage;
-	}
-
 
 }


### PR DESCRIPTION
sym/ccm 모듈의 VO 7개에 Lombok `@Getter`/`@Setter`를 적용하고 수동 getter/setter를 제거했습니다.

## 변경 대상

| VO 클래스 | 패키지 |
|-----------|--------|
| AdministCodeRecptnVO | sym/ccm/acr/service |
| AdministCodeVO | sym/ccm/adc/service |
| CmmnCodeVO | sym/ccm/cca/service |
| CmmnClCodeVO | sym/ccm/ccc/service |
| CmmnDetailCodeVO | sym/ccm/cde/service |
| InsttCodeRecptnVO | sym/ccm/icr/service |
| ZipVO | sym/ccm/zip/service |

## 변경 사유

각 VO는 단순 필드 접근만 제공하는 getter/setter를 반복적으로 선언하고 있었습니다. 별도의 비즈니스 로직이 없어 Lombok으로 안전하게 대체할 수 있습니다.

## 변경 내용

- 각 VO 클래스에 `@Getter`/`@Setter` 추가 및 `lombok.Getter`, `lombok.Setter` import 추가
- 수동 getter/setter 메서드(9~11개) 제거
- ZipVO의 비표준 메서드명 `getsearchCondition`/`setsearchCondition` → 표준 `getSearchCondition`/`setSearchCondition`으로 통일 (해당 메서드를 직접 호출하는 코드 없음을 확인)

## 영향 범위

- 기존 getter/setter와 동일한 시그니처를 Lombok이 생성하므로 호출 코드 변경 없음
- MyBatis XML 매퍼는 필드명 직접 참조(`searchCondition` 등) — 영향 없음
- Lombok 의존성(`org.projectlombok:lombok`)은 이미 pom.xml에 포함되어 있음

## 체크리스트

- [x] 단일 주제만 다룸 (다른 변경 없음)
- [x] 기존 동작에 영향 없음
- [x] mvn -DskipTests compile — sym/ccm 관련 신규 에러 없음 확인
