### PR TITLE
[refactor][공통컴포넌트] cmm Request VO Lombok @Getter/@Setter 적용

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -597,6 +597,13 @@
 					<artifactId>maven-compiler-plugin</artifactId>
 					<configuration>
 						<release>${java.version}</release>
+						<annotationProcessorPaths>
+							<path>
+								<groupId>org.projectlombok</groupId>
+								<artifactId>lombok</artifactId>
+								<version>${lombok.version}</version>
+							</path>
+						</annotationProcessorPaths>
 					</configuration>
 				</plugin>
 				<plugin>

--- a/src/main/java/egovframework/com/cmm/BaseRequestVO.java
+++ b/src/main/java/egovframework/com/cmm/BaseRequestVO.java
@@ -2,6 +2,9 @@ package egovframework.com.cmm;
 
 import java.io.Serializable;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * @Class Name : BaseRequestVO.java
  * @Description : 로그인/검색 요청 기본 VO
@@ -13,6 +16,7 @@ import java.io.Serializable;
  *   수정일              수정자          수정내용
  *   ----------  --------  ---------------------------
  *   2025.12.09            기본 요청 VO 생성
+ *   2026.05.27            Lombok @Getter/@Setter 적용
  *</pre>
  *
  *  @since 2025.12.09
@@ -20,6 +24,8 @@ import java.io.Serializable;
  *  @see
  *
  */
+@Getter
+@Setter
 public class BaseRequestVO implements Serializable{
 
 	/**
@@ -30,19 +36,4 @@ public class BaseRequestVO implements Serializable{
 	/** 사용자구분 */
 	private String userSe;
 
-	/**
-	 * userSe attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getUserSe() {
-		return userSe;
-	}
-
-	/**
-	 * userSe attribute 값을 설정한다.
-	 * @param userSe String
-	 */
-	public void setUserSe(String userSe) {
-		this.userSe = userSe;
-	}
 }

--- a/src/main/java/egovframework/com/cmm/LoginRequestVO.java
+++ b/src/main/java/egovframework/com/cmm/LoginRequestVO.java
@@ -2,6 +2,9 @@ package egovframework.com.cmm;
 
 import org.egovframe.rte.ptl.reactive.validation.EgovNullCheck;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * @Class Name : LoginRequestVO.java
  * @Description : 로그인 요청 전용 VO
@@ -13,6 +16,7 @@ import org.egovframe.rte.ptl.reactive.validation.EgovNullCheck;
  *   수정일              수정자          수정내용
  *   ----------  --------  ---------------------------
  *   2025.12.09            로그인 전용 VO 생성
+ *   2026.05.27            Lombok @Getter/@Setter 적용
  *</pre>
  *
  *  @since 2025.12.09
@@ -20,6 +24,8 @@ import org.egovframe.rte.ptl.reactive.validation.EgovNullCheck;
  *  @see
  *
  */
+@Getter
+@Setter
 public class LoginRequestVO extends BaseRequestVO{
 
 	/**
@@ -35,35 +41,4 @@ public class LoginRequestVO extends BaseRequestVO{
 	@EgovNullCheck
 	private String password;
 
-	/**
-	 * id attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getId() {
-		return id;
-	}
-
-	/**
-	 * id attribute 값을 설정한다.
-	 * @param id String
-	 */
-	public void setId(String id) {
-		this.id = id;
-	}
-
-	/**
-	 * password attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getPassword() {
-		return password;
-	}
-
-	/**
-	 * password attribute 값을 설정한다.
-	 * @param password String
-	 */
-	public void setPassword(String password) {
-		this.password = password;
-	}
 }

--- a/src/main/java/egovframework/com/cmm/SearchIdRequestVO.java
+++ b/src/main/java/egovframework/com/cmm/SearchIdRequestVO.java
@@ -3,6 +3,9 @@ package egovframework.com.cmm;
 import org.egovframe.rte.ptl.reactive.validation.EgovNullCheck;
 import org.egovframe.rte.ptl.reactive.validation.EgovEmailCheck;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * @Class Name : SearchIdRequestVO.java
  * @Description : 아이디 찾기 요청 VO
@@ -14,6 +17,7 @@ import org.egovframe.rte.ptl.reactive.validation.EgovEmailCheck;
  *   수정일              수정자          수정내용
  *   ----------  --------  ---------------------------
  *   2025.12.09            아이디 찾기 요청 VO 생성
+ *   2026.05.27            Lombok @Getter/@Setter 적용
  *</pre>
  *
  *  @since 2025.12.09
@@ -21,6 +25,8 @@ import org.egovframe.rte.ptl.reactive.validation.EgovEmailCheck;
  *  @see
  *
  */
+@Getter
+@Setter
 public class SearchIdRequestVO extends BaseRequestVO{
 
 	/**
@@ -37,35 +43,4 @@ public class SearchIdRequestVO extends BaseRequestVO{
 	@EgovEmailCheck
 	private String email;
 
-	/**
-	 * name attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getName() {
-		return name;
-	}
-
-	/**
-	 * name attribute 값을 설정한다.
-	 * @param name String
-	 */
-	public void setName(String name) {
-		this.name = name;
-	}
-
-	/**
-	 * email attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getEmail() {
-		return email;
-	}
-
-	/**
-	 * email attribute 값을 설정한다.
-	 * @param email String
-	 */
-	public void setEmail(String email) {
-		this.email = email;
-	}
 }

--- a/src/main/java/egovframework/com/cmm/SearchPasswordRequestVO.java
+++ b/src/main/java/egovframework/com/cmm/SearchPasswordRequestVO.java
@@ -3,6 +3,9 @@ package egovframework.com.cmm;
 import org.egovframe.rte.ptl.reactive.validation.EgovNullCheck;
 import org.egovframe.rte.ptl.reactive.validation.EgovEmailCheck;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * @Class Name : SearchPasswordRequestVO.java
  * @Description : 비밀번호 찾기 요청 VO
@@ -14,6 +17,7 @@ import org.egovframe.rte.ptl.reactive.validation.EgovEmailCheck;
  *   수정일              수정자          수정내용
  *   ----------  --------  ---------------------------
  *   2025.12.09            비밀번호 찾기 요청 VO 생성
+ *   2026.05.27            Lombok @Getter/@Setter 적용
  *</pre>
  *
  *  @since 2025.12.09
@@ -21,6 +25,8 @@ import org.egovframe.rte.ptl.reactive.validation.EgovEmailCheck;
  *  @see
  *
  */
+@Getter
+@Setter
 public class SearchPasswordRequestVO extends BaseRequestVO{
 
 	/**
@@ -49,83 +55,4 @@ public class SearchPasswordRequestVO extends BaseRequestVO{
 	@EgovNullCheck
 	private String passwordCnsr;
 
-	/**
-	 * id attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getId() {
-		return id;
-	}
-
-	/**
-	 * id attribute 값을 설정한다.
-	 * @param id String
-	 */
-	public void setId(String id) {
-		this.id = id;
-	}
-
-	/**
-	 * name attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getName() {
-		return name;
-	}
-
-	/**
-	 * name attribute 값을 설정한다.
-	 * @param name String
-	 */
-	public void setName(String name) {
-		this.name = name;
-	}
-
-	/**
-	 * email attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getEmail() {
-		return email;
-	}
-
-	/**
-	 * email attribute 값을 설정한다.
-	 * @param email String
-	 */
-	public void setEmail(String email) {
-		this.email = email;
-	}
-
-	/**
-	 * passwordHint attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getPasswordHint() {
-		return passwordHint;
-	}
-
-	/**
-	 * passwordHint attribute 값을 설정한다.
-	 * @param passwordHint String
-	 */
-	public void setPasswordHint(String passwordHint) {
-		this.passwordHint = passwordHint;
-	}
-
-	/**
-	 * passwordCnsr attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getPasswordCnsr() {
-		return passwordCnsr;
-	}
-
-	/**
-	 * passwordCnsr attribute 값을 설정한다.
-	 * @param passwordCnsr String
-	 */
-	public void setPasswordCnsr(String passwordCnsr) {
-		this.passwordCnsr = passwordCnsr;
-	}
 }


### PR DESCRIPTION
## 변경 사유
cmm 루트 Request VO들에 수동 getter/setter가 작성되어 보일러플레이트가 많다.
Lombok 어노테이션으로 대체. LoginVO, ComDefaultVO 등 호환 이슈 있는 클래스는 별도 PR 대상으로 보류.

## 변경 내용
- `BaseRequestVO`, `LoginRequestVO`, `SearchIdRequestVO`, `SearchPasswordRequestVO` 4개 VO에 `@Getter @Setter` 적용
- 수동 getter/setter 제거
- `pom.xml`에 `annotationProcessorPaths` 추가 (PR #802와 동일 — fast-forward 가능)

## 영향 범위
- 외부 API 변경 없음
- `mvn -DskipTests compile` BUILD SUCCESS

## 체크리스트
- [x] cmm 루트 Request VO만 대상
- [x] LoginVO/ComDefaultVO 등 호환 이슈 VO는 회피
- [x] PR #802와 동일 pom 변경 — fast-forward 가능
- [x] mvn compile 통과
