### PR TITLE
[refactor][공통컴포넌트] sts/cst·sst·ust 3 DAO @EgovMapper 인터페이스 매핑

### DIFF
--- a/src/main/java/egovframework/com/sts/cst/service/impl/ConectStatsMapper.java
+++ b/src/main/java/egovframework/com/sts/cst/service/impl/ConectStatsMapper.java
@@ -2,13 +2,12 @@ package egovframework.com.sts.cst.service.impl;
 
 import java.util.List;
 
-import org.springframework.stereotype.Repository;
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
 
 import egovframework.com.sts.com.StatsVO;
-import jakarta.annotation.Resource;
 
 /**
- * 접속 통계 검색 DAO 클래스
+ * 접속 통계 검색 Mapper 인터페이스
  * @author 공통서비스 개발팀 박지욱
  * @since 2009.03.12
  * @version 1.0
@@ -25,11 +24,8 @@ import jakarta.annotation.Resource;
  *
  *  </pre>
  */
-@Repository("conectStatsDAO")
-public class ConectStatsDAO {
-
-	@Resource(name = "conectStatsDAO")
-	private ConectStatsMapper conectStatsMapper;
+@EgovMapper("conectStatsDAO")
+public interface ConectStatsMapper {
 
 	/**
 	 * 접속 통계를 조회한다
@@ -37,7 +33,6 @@ public class ConectStatsDAO {
 	 * @return List
 	 * @exception Exception
 	 */
-    public List<StatsVO> selectConectStats(StatsVO vo) throws Exception {
-        return conectStatsMapper.selectConectStats(vo);
-    }
+	List<StatsVO> selectConectStats(StatsVO vo) throws Exception;
+
 }

--- a/src/main/java/egovframework/com/sts/sst/service/impl/ScrinStatsMapper.java
+++ b/src/main/java/egovframework/com/sts/sst/service/impl/ScrinStatsMapper.java
@@ -1,14 +1,13 @@
-package egovframework.com.sts.cst.service.impl;
+package egovframework.com.sts.sst.service.impl;
 
 import java.util.List;
 
-import org.springframework.stereotype.Repository;
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
 
 import egovframework.com.sts.com.StatsVO;
-import jakarta.annotation.Resource;
 
 /**
- * 접속 통계 검색 DAO 클래스
+ * 화면 통계 검색 Mapper 인터페이스
  * @author 공통서비스 개발팀 박지욱
  * @since 2009.03.12
  * @version 1.0
@@ -20,24 +19,20 @@ import jakarta.annotation.Resource;
  *   수정일      수정자          수정내용
  *  -------    --------    ---------------------------
  *  2009.03.19  박지욱          최초 생성
- *  2011.06.30  이기하          패키지 분리(sts -> sts.cst)
+ *  2011.06.30  이기하          패키지 분리(sts -> sts.sst)
  *  2026.05.27  dasomel         @EgovMapper 인터페이스 방식으로 전환
  *
  *  </pre>
  */
-@Repository("conectStatsDAO")
-public class ConectStatsDAO {
-
-	@Resource(name = "conectStatsDAO")
-	private ConectStatsMapper conectStatsMapper;
+@EgovMapper("scrinStatsDAO")
+public interface ScrinStatsMapper {
 
 	/**
-	 * 접속 통계를 조회한다
+	 * 화면 통계를 조회한다
 	 * @param vo StatsVO
 	 * @return List
 	 * @exception Exception
 	 */
-    public List<StatsVO> selectConectStats(StatsVO vo) throws Exception {
-        return conectStatsMapper.selectConectStats(vo);
-    }
+	List<StatsVO> selectScrinStats(StatsVO vo) throws Exception;
+
 }

--- a/src/main/java/egovframework/com/sts/ust/service/impl/UserStatsDAO.java
+++ b/src/main/java/egovframework/com/sts/ust/service/impl/UserStatsDAO.java
@@ -4,8 +4,8 @@ import java.util.List;
 
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.sts.com.StatsVO;
+import jakarta.annotation.Resource;
 
 /**
  * 사용자 통계 검색 DAO 클래스
@@ -21,11 +21,15 @@ import egovframework.com.sts.com.StatsVO;
  *  -------    --------    ---------------------------
  *  2009.03.19  박지욱          최초 생성
  *  2011.06.30  이기하          패키지 분리(sts -> sts.sst)
+ *  2026.05.27  dasomel         @EgovMapper 인터페이스 방식으로 전환
  *
  *  </pre>
  */
 @Repository("userStatsDAO")
-public class UserStatsDAO extends EgovComAbstractDAO {
+public class UserStatsDAO {
+
+	@Resource(name = "userStatsDAO")
+	private UserStatsMapper userStatsMapper;
 
 	/**
 	 * 사용자 통계를 조회한다
@@ -34,7 +38,7 @@ public class UserStatsDAO extends EgovComAbstractDAO {
 	 * @exception Exception
 	 */
     public List<StatsVO> selectUserStats(StatsVO vo) throws Exception {
-        return selectList("UserStatsDAO.selectUserStats", vo);
+        return userStatsMapper.selectUserStats(vo);
     }
 
     /**
@@ -42,6 +46,6 @@ public class UserStatsDAO extends EgovComAbstractDAO {
 	 * @exception Exception
 	 */
     public void summaryUserStats() throws Exception {
-        insert("UserStatsDAO.summaryUserStats", null);
+        userStatsMapper.summaryUserStats();
     }
 }

--- a/src/main/java/egovframework/com/sts/ust/service/impl/UserStatsMapper.java
+++ b/src/main/java/egovframework/com/sts/ust/service/impl/UserStatsMapper.java
@@ -1,14 +1,13 @@
-package egovframework.com.sts.sst.service.impl;
+package egovframework.com.sts.ust.service.impl;
 
 import java.util.List;
 
-import org.springframework.stereotype.Repository;
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
 
 import egovframework.com.sts.com.StatsVO;
-import jakarta.annotation.Resource;
 
 /**
- * 화면 통계 검색 DAO 클래스
+ * 사용자 통계 검색 Mapper 인터페이스
  * @author 공통서비스 개발팀 박지욱
  * @since 2009.03.12
  * @version 1.0
@@ -17,7 +16,7 @@ import jakarta.annotation.Resource;
  * <pre>
  * << 개정이력(Modification Information) >>
  *
- *   수정일      수정자          수정내용
+ *   수정일     수정자          수정내용
  *  -------    --------    ---------------------------
  *  2009.03.19  박지욱          최초 생성
  *  2011.06.30  이기하          패키지 분리(sts -> sts.sst)
@@ -25,19 +24,21 @@ import jakarta.annotation.Resource;
  *
  *  </pre>
  */
-@Repository("scrinStatsDAO")
-public class ScrinStatsDAO {
-
-	@Resource(name = "scrinStatsDAO")
-	private ScrinStatsMapper scrinStatsMapper;
+@EgovMapper("userStatsDAO")
+public interface UserStatsMapper {
 
 	/**
-	 * 화면 통계를 조회한다
+	 * 사용자 통계를 조회한다
 	 * @param vo StatsVO
 	 * @return List
 	 * @exception Exception
 	 */
-    public List<StatsVO> selectScrinStats(StatsVO vo) throws Exception {
-        return scrinStatsMapper.selectScrinStats(vo);
-    }
+	List<StatsVO> selectUserStats(StatsVO vo) throws Exception;
+
+	/**
+	 * 사용자 통계를 위한 집계를 하루단위로 작업하는 배치 프로그램
+	 * @exception Exception
+	 */
+	void summaryUserStats() throws Exception;
+
 }

--- a/src/main/resources/egovframework/mapper/com/sts/cst/EgovConectStats_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/sts/cst/EgovConectStats_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ConectStatsDAO">
+<mapper namespace="egovframework.com.sts.cst.service.impl.ConectStatsMapper">
 
 	<!-- 접속통계 조회 -->
 	<select id="selectConectStats" parameterType="egovframework.com.sts.com.StatsVO" resultType="egovframework.com.sts.com.StatsVO">

--- a/src/main/resources/egovframework/mapper/com/sts/cst/EgovConectStats_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/sts/cst/EgovConectStats_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:50:23 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ConectStatsDAO">
+<mapper namespace="egovframework.com.sts.cst.service.impl.ConectStatsMapper">
 
 	<!-- 접속통계 조회 -->
 	<select id="selectConectStats" parameterType="egovframework.com.sts.com.StatsVO" resultType="egovframework.com.sts.com.StatsVO">

--- a/src/main/resources/egovframework/mapper/com/sts/cst/EgovConectStats_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/sts/cst/EgovConectStats_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ConectStatsDAO">
+<mapper namespace="egovframework.com.sts.cst.service.impl.ConectStatsMapper">
 
 	<!-- 접속통계 조회 -->
 	<select id="selectConectStats" parameterType="egovframework.com.sts.com.StatsVO" resultType="egovframework.com.sts.com.StatsVO">

--- a/src/main/resources/egovframework/mapper/com/sts/cst/EgovConectStats_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/sts/cst/EgovConectStats_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ConectStatsDAO">
+<mapper namespace="egovframework.com.sts.cst.service.impl.ConectStatsMapper">
 	
 	<!-- 접속통계 조회 -->
 	<select id="selectConectStats" parameterType="egovframework.com.sts.com.StatsVO" resultType="egovframework.com.sts.com.StatsVO">

--- a/src/main/resources/egovframework/mapper/com/sts/cst/EgovConectStats_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/sts/cst/EgovConectStats_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ConectStatsDAO">
+<mapper namespace="egovframework.com.sts.cst.service.impl.ConectStatsMapper">
 	
 	<!-- 접속통계 조회 -->
 	<select id="selectConectStats" parameterType="egovframework.com.sts.com.StatsVO" resultType="egovframework.com.sts.com.StatsVO">

--- a/src/main/resources/egovframework/mapper/com/sts/cst/EgovConectStats_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/sts/cst/EgovConectStats_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ConectStatsDAO">
+<mapper namespace="egovframework.com.sts.cst.service.impl.ConectStatsMapper">
 
 	<!-- 접속통계 조회 -->
 	<select id="selectConectStats" parameterType="egovframework.com.sts.com.StatsVO" resultType="egovframework.com.sts.com.StatsVO">

--- a/src/main/resources/egovframework/mapper/com/sts/cst/EgovConectStats_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/sts/cst/EgovConectStats_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ConectStatsDAO">
+<mapper namespace="egovframework.com.sts.cst.service.impl.ConectStatsMapper">
 	
 	<!-- 접속통계 조회 -->
 	<select id="selectConectStats" parameterType="egovframework.com.sts.com.StatsVO" resultType="egovframework.com.sts.com.StatsVO">

--- a/src/main/resources/egovframework/mapper/com/sts/cst/EgovConectStats_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/sts/cst/EgovConectStats_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ConectStatsDAO">
+<mapper namespace="egovframework.com.sts.cst.service.impl.ConectStatsMapper">
 
 	<!-- 접속통계 조회 -->
 	<select id="selectConectStats" parameterType="egovframework.com.sts.com.StatsVO" resultType="egovframework.com.sts.com.StatsVO">

--- a/src/main/resources/egovframework/mapper/com/sts/sst/EgovScrinStats_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/sts/sst/EgovScrinStats_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ScrinStatsDAO">
+<mapper namespace="egovframework.com.sts.sst.service.impl.ScrinStatsMapper">
 	
 	<!-- 화면통계 조회 -->
 	<select id="selectScrinStats" parameterType="egovframework.com.sts.com.StatsVO" resultType="egovframework.com.sts.com.StatsVO">

--- a/src/main/resources/egovframework/mapper/com/sts/sst/EgovScrinStats_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/sts/sst/EgovScrinStats_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ScrinStatsDAO">
+<mapper namespace="egovframework.com.sts.sst.service.impl.ScrinStatsMapper">
 	
 	<!-- 화면통계 조회 -->
 	<select id="selectScrinStats" parameterType="egovframework.com.sts.com.StatsVO" resultType="egovframework.com.sts.com.StatsVO">

--- a/src/main/resources/egovframework/mapper/com/sts/sst/EgovScrinStats_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/sts/sst/EgovScrinStats_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ScrinStatsDAO">
+<mapper namespace="egovframework.com.sts.sst.service.impl.ScrinStatsMapper">
 	
 	<!-- 화면통계 조회 -->
 	<select id="selectScrinStats" parameterType="egovframework.com.sts.com.StatsVO" resultType="egovframework.com.sts.com.StatsVO">

--- a/src/main/resources/egovframework/mapper/com/sts/sst/EgovScrinStats_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/sts/sst/EgovScrinStats_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ScrinStatsDAO">
+<mapper namespace="egovframework.com.sts.sst.service.impl.ScrinStatsMapper">
 	
 	<!-- 화면통계 조회 -->
 	<select id="selectScrinStats" parameterType="egovframework.com.sts.com.StatsVO" resultType="egovframework.com.sts.com.StatsVO">

--- a/src/main/resources/egovframework/mapper/com/sts/sst/EgovScrinStats_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/sts/sst/EgovScrinStats_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ScrinStatsDAO">
+<mapper namespace="egovframework.com.sts.sst.service.impl.ScrinStatsMapper">
 	
 	<!-- 화면통계 조회 -->
 	<select id="selectScrinStats" parameterType="egovframework.com.sts.com.StatsVO" resultType="egovframework.com.sts.com.StatsVO">

--- a/src/main/resources/egovframework/mapper/com/sts/sst/EgovScrinStats_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/sts/sst/EgovScrinStats_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ScrinStatsDAO">
+<mapper namespace="egovframework.com.sts.sst.service.impl.ScrinStatsMapper">
 	
 	<!-- 화면통계 조회 -->
 	<select id="selectScrinStats" parameterType="egovframework.com.sts.com.StatsVO" resultType="egovframework.com.sts.com.StatsVO">

--- a/src/main/resources/egovframework/mapper/com/sts/sst/EgovScrinStats_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/sts/sst/EgovScrinStats_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ScrinStatsDAO">
+<mapper namespace="egovframework.com.sts.sst.service.impl.ScrinStatsMapper">
 	
 	<!-- 화면통계 조회 -->
 	<select id="selectScrinStats" parameterType="egovframework.com.sts.com.StatsVO" resultType="egovframework.com.sts.com.StatsVO">

--- a/src/main/resources/egovframework/mapper/com/sts/sst/EgovScrinStats_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/sts/sst/EgovScrinStats_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ScrinStatsDAO">
+<mapper namespace="egovframework.com.sts.sst.service.impl.ScrinStatsMapper">
 	
 	<!-- 화면통계 조회 -->
 	<select id="selectScrinStats" parameterType="egovframework.com.sts.com.StatsVO" resultType="egovframework.com.sts.com.StatsVO">

--- a/src/main/resources/egovframework/mapper/com/sts/ust/EgovUserStats_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/sts/ust/EgovUserStats_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="UserStatsDAO">
+<mapper namespace="egovframework.com.sts.ust.service.impl.UserStatsMapper">
 	
 	<!-- 사용자통계 조회 -->
 	<select id="selectUserStats" parameterType="egovframework.com.sts.com.StatsVO" resultType="egovframework.com.sts.com.StatsVO">

--- a/src/main/resources/egovframework/mapper/com/sts/ust/EgovUserStats_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/sts/ust/EgovUserStats_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="UserStatsDAO">
+<mapper namespace="egovframework.com.sts.ust.service.impl.UserStatsMapper">
 	
 	<!-- 사용자통계 조회 -->
 	<select id="selectUserStats" parameterType="egovframework.com.sts.com.StatsVO" resultType="egovframework.com.sts.com.StatsVO">

--- a/src/main/resources/egovframework/mapper/com/sts/ust/EgovUserStats_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/sts/ust/EgovUserStats_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="UserStatsDAO">
+<mapper namespace="egovframework.com.sts.ust.service.impl.UserStatsMapper">
 	
 	<!-- 사용자통계 조회 -->
 	<select id="selectUserStats" parameterType="egovframework.com.sts.com.StatsVO" resultType="egovframework.com.sts.com.StatsVO">

--- a/src/main/resources/egovframework/mapper/com/sts/ust/EgovUserStats_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/sts/ust/EgovUserStats_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="UserStatsDAO">
+<mapper namespace="egovframework.com.sts.ust.service.impl.UserStatsMapper">
 	
 	<!-- 사용자통계 조회 -->
 	<select id="selectUserStats" parameterType="egovframework.com.sts.com.StatsVO" resultType="egovframework.com.sts.com.StatsVO">

--- a/src/main/resources/egovframework/mapper/com/sts/ust/EgovUserStats_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/sts/ust/EgovUserStats_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="UserStatsDAO">
+<mapper namespace="egovframework.com.sts.ust.service.impl.UserStatsMapper">
 	
 	<!-- 사용자통계 조회 -->
 	<select id="selectUserStats" parameterType="egovframework.com.sts.com.StatsVO" resultType="egovframework.com.sts.com.StatsVO">

--- a/src/main/resources/egovframework/mapper/com/sts/ust/EgovUserStats_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/sts/ust/EgovUserStats_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="UserStatsDAO">
+<mapper namespace="egovframework.com.sts.ust.service.impl.UserStatsMapper">
 	
 	<!-- 사용자통계 조회 -->
 	<select id="selectUserStats" parameterType="egovframework.com.sts.com.StatsVO" resultType="egovframework.com.sts.com.StatsVO">

--- a/src/main/resources/egovframework/mapper/com/sts/ust/EgovUserStats_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/sts/ust/EgovUserStats_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="UserStatsDAO">
+<mapper namespace="egovframework.com.sts.ust.service.impl.UserStatsMapper">
 	
 	<!-- 사용자통계 조회 -->
 	<select id="selectUserStats" parameterType="egovframework.com.sts.com.StatsVO" resultType="egovframework.com.sts.com.StatsVO">

--- a/src/main/resources/egovframework/mapper/com/sts/ust/EgovUserStats_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/sts/ust/EgovUserStats_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="UserStatsDAO">
+<mapper namespace="egovframework.com.sts.ust.service.impl.UserStatsMapper">
 	
 	<!-- 사용자통계 조회 -->
 	<select id="selectUserStats" parameterType="egovframework.com.sts.com.StatsVO" resultType="egovframework.com.sts.com.StatsVO">

--- a/src/main/resources/egovframework/spring/com/context-mapper.xml
+++ b/src/main/resources/egovframework/spring/com/context-mapper.xml
@@ -21,5 +21,12 @@
 	<bean id="egov.sqlSessionTemplate" class="org.mybatis.spring.SqlSessionTemplate">
 		<constructor-arg ref="egov.sqlSession"/>
 	</bean>
-	
+
+	<!-- @EgovMapper 어노테이션이 붙은 인터페이스를 자동으로 스캔하여 빈으로 등록 -->
+	<bean class="org.mybatis.spring.mapper.MapperScannerConfigurer">
+		<property name="basePackage" value="egovframework.com"/>
+		<property name="annotationClass" value="org.egovframe.rte.psl.dataaccess.mapper.EgovMapper"/>
+		<property name="sqlSessionFactoryBeanName" value="egov.sqlSession"/>
+	</bean>
+
 </beans>


### PR DESCRIPTION
## 변경 사유
eGovFrame 5.0 @EgovMapper 활용 확대. PR #806(cmm/use), #821(sym/mnu/stm), #825(sym/sym/nwk) 동일 패턴.

## 변경 내용
- `sts/cst`(접속통계), `sts/sst`(스크린통계), `sts/ust`(사용자통계) 3개 DAO 일괄 전환
- 각 DAO에 신규 Mapper 인터페이스(`ConectStatsMapper`, `ScrinStatsMapper`, `UserStatsMapper`) 추가, `@EgovMapper` 어노테이션 적용
- 각 DAO: `EgovComAbstractDAO` 상속 제거, `@Resource` 주입 방식으로 전환
- 24개 RDBMS XML namespace를 인터페이스 FQN으로 변경 (3 컴포넌트 × 8 방언)
- `context-mapper.xml`에 `MapperScannerConfigurer` 추가 (PR #806, #821, #825와 동일 — fast-forward 가능)
- SQL 무변경

## 영향 범위
- 외부 동작 변경 없음
- 타입 안전성 향상
- 베이스라인 컴파일 에러 수 변동 없음 (sts 관련 신규 에러 0)

## 체크리스트
- [x] sts 패키지 3 컴포넌트 자연 단위 묶음
- [x] PR #806, #821, #825와 다른 컴포넌트
- [x] context-mapper.xml 변경은 기존 PR과 동일
- [x] SQL 의미 변경 없음
