### PR TITLE
[refactor][공통컴포넌트] 기념일관리 XML 매퍼 @EgovMapper 인터페이스 방식으로 전환

### DIFF
--- a/src/main/java/egovframework/com/uss/ion/ans/service/impl/AnnvrsryManageDAO.java
+++ b/src/main/java/egovframework/com/uss/ion/ans/service/impl/AnnvrsryManageDAO.java
@@ -2,15 +2,14 @@ package egovframework.com.uss.ion.ans.service.impl;
 
 import java.util.List;
 
-import org.springframework.stereotype.Repository;
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.uss.ion.ans.service.AnnvrsryManage;
 import egovframework.com.uss.ion.ans.service.AnnvrsryManageVO;
 
 /**
  * 개요
- * - 기념일관리에 대한 DAO 클래스를 정의한다.
+ * - 기념일관리에 대한 DAO 인터페이스를 정의한다.
  *
  * 상세내용
  * - 기념일관리에 대한 등록, 수정, 삭제, 조회, 반영확인 기능을 제공한다.
@@ -18,89 +17,78 @@ import egovframework.com.uss.ion.ans.service.AnnvrsryManageVO;
  * @author 이용
  * @version 1.0
  * @created 06-15-2010 오후 2:08:56
+ *
+ * <pre>
+ *  == 개정이력(Modification Information) ==
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2010.06.15  이용           최초 생성
+ *   2026.05.27  dasomel        @EgovMapper 인터페이스 방식으로 전환
+ *
+ * </pre>
  */
-
-@Repository("annvrsryManageDAO")
-public class AnnvrsryManageDAO extends EgovComAbstractDAO {
+@EgovMapper("annvrsryManageDAO")
+public interface AnnvrsryManageDAO {
 
 	/**
 	 * 기념일관리정보를 관리하기 위해 등록된 기념일관리 목록을 조회한다.
 	 * @param annvrsryManageVO - 기념일관리 VO
 	 * @return List - 기념일관리 목록
-	 */	
-	public List<AnnvrsryManageVO> selectAnnvrsryManageList(AnnvrsryManageVO annvrsryManageVO) throws Exception {
-		return selectList("annvrsryManageDAO.selectAnnvrsryManageList", annvrsryManageVO);
-	}
+	 */
+	List<AnnvrsryManageVO> selectAnnvrsryManageList(AnnvrsryManageVO annvrsryManageVO);
 
-    /**
+	/**
 	 * 기념일관리목록 총 개수를 조회한다.
 	 * @param annvrsryManageVO - 기념일관리 VO
 	 * @return int
-	 * @exception Exception
 	 */
-    public int selectAnnvrsryManageListTotCnt(AnnvrsryManageVO annvrsryManageVO) throws Exception {
-        return (Integer)selectOne("annvrsryManageDAO.selectAnnvrsryManageListTotCnt", annvrsryManageVO);
-    }
+	int selectAnnvrsryManageListTotCnt(AnnvrsryManageVO annvrsryManageVO);
 
 	/**
 	 * 등록된 기념일관리의 상세정보를 조회한다.
 	 * @param annvrsryManageVO - 기념일관리 VO
 	 * @return AnnvrsryManageVO - 기념일관리 VO
 	 */
-	public AnnvrsryManageVO selectAnnvrsryManage(AnnvrsryManageVO annvrsryManageVO)  throws Exception {
-		return (AnnvrsryManageVO) selectOne("annvrsryManageDAO.selectAnnvrsryManage", annvrsryManageVO);
-	}
+	AnnvrsryManageVO selectAnnvrsryManage(AnnvrsryManageVO annvrsryManageVO);
 
 	/**
 	 * 기념일관리정보를 신규로 등록한다.
 	 * @param annvrsryManage - 기념일관리 model
 	 */
-	public void insertAnnvrsryManage(AnnvrsryManage annvrsryManage) throws Exception {
-		insert("annvrsryManageDAO.insertAnnvrsryManage", annvrsryManage);
-	}
+	void insertAnnvrsryManage(AnnvrsryManage annvrsryManage);
 
 	/**
 	 * 기 등록된 기념일관리정보를 수정한다.
 	 * @param annvrsryManage - 기념일관리 model
 	 */
-	public void updateAnnvrsryManage(AnnvrsryManage annvrsryManage) throws Exception {
-		update("annvrsryManageDAO.updateAnnvrsryManage", annvrsryManage);
-	}
+	void updateAnnvrsryManage(AnnvrsryManage annvrsryManage);
 
 	/**
 	 * 기 등록된 기념일관리정보를 삭제한다.
 	 * @param annvrsryManage - 기념일관리 model
 	 */
-	public void deleteAnnvrsryManage(AnnvrsryManage annvrsryManage) throws Exception {
-        delete("annvrsryManageDAO.deleteAnnvrsryManage",annvrsryManage);
-	}
+	void deleteAnnvrsryManage(AnnvrsryManage annvrsryManage);
 
 	/**
 	 * 등록된 기념일관리의 상세정보를 조회한다.
 	 * @param annvrsryManageVO - 기념일관리 VO
-	 * @return AnnvrsryManageVO - 기념일관리 VO
-	 */	
-	public List<AnnvrsryManageVO> selectAnnvrsryGdcc(AnnvrsryManageVO annvrsryManageVO)  throws Exception {
-		return selectList("annvrsryManageDAO.selectAnnvrsryGdcc", annvrsryManageVO);
-	}
+	 * @return List - 기념일관리 목록
+	 */
+	List<AnnvrsryManageVO> selectAnnvrsryGdcc(AnnvrsryManageVO annvrsryManageVO);
 
-    /**
+	/**
 	 * 기념일관리 등록시 중복여부를 조회한다.
-	 * @param annvrsryManage - 기념일관리 VO
+	 * @param annvrsryManage - 기념일관리 model
 	 * @return int
-	 * @exception Exception
 	 */
-    public int selectAnnvrsryManageDplctAt(AnnvrsryManage annvrsryManage) throws Exception {
-        return (Integer)selectOne("annvrsryManageDAO.selectAnnvrsryManageDplctAt", annvrsryManage);
-    }
+	int selectAnnvrsryManageDplctAt(AnnvrsryManage annvrsryManage);
 
 	/**
 	 * 등록된 기념일관리의 상세정보를 조회한다.
 	 * @param annvrsryManageVO - 기념일관리 VO
 	 * @return AnnvrsryManageVO - 기념일관리 VO
 	 */
-	public AnnvrsryManageVO selectAnnvrsryManageBnde(AnnvrsryManageVO annvrsryManageVO)  throws Exception {
-		return (AnnvrsryManageVO) selectOne("annvrsryManageDAO.selectAnnvrsryManageBnde", annvrsryManageVO);
-	}
+	AnnvrsryManageVO selectAnnvrsryManageBnde(AnnvrsryManageVO annvrsryManageVO);
 
 }

--- a/src/main/resources/egovframework/mapper/com/uss/ion/ans/EgovAnnvrsryManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/ans/EgovAnnvrsryManage_SQL_altibase.xml
@@ -12,7 +12,7 @@
  --><!--Converted at: Wed May 11 15:51:01 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="annvrsryManageDAO">
+<mapper namespace="egovframework.com.uss.ion.ans.service.impl.AnnvrsryManageDAO">
 
     <resultMap id="annvrsryManage" type="egovframework.com.uss.ion.ans.service.AnnvrsryManageVO">
         <result property="usid" column="USER_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/ans/EgovAnnvrsryManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/ans/EgovAnnvrsryManage_SQL_cubrid.xml
@@ -12,7 +12,7 @@
  --><!--Converted at: Wed May 11 15:51:01 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="annvrsryManageDAO">
+<mapper namespace="egovframework.com.uss.ion.ans.service.impl.AnnvrsryManageDAO">
 
     <resultMap id="annvrsryManage" type="egovframework.com.uss.ion.ans.service.AnnvrsryManageVO">
         <result property="usid" column="USER_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/ans/EgovAnnvrsryManage_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/ans/EgovAnnvrsryManage_SQL_goldilocks.xml
@@ -12,7 +12,7 @@
  --><!--Converted at: Wed May 11 15:51:01 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="annvrsryManageDAO">
+<mapper namespace="egovframework.com.uss.ion.ans.service.impl.AnnvrsryManageDAO">
 
     <resultMap id="annvrsryManage" type="egovframework.com.uss.ion.ans.service.AnnvrsryManageVO">
         <result property="usid" column="USER_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/ans/EgovAnnvrsryManage_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/ans/EgovAnnvrsryManage_SQL_maria.xml
@@ -12,7 +12,7 @@
  --><!--Converted at: Wed May 11 15:51:01 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="annvrsryManageDAO">
+<mapper namespace="egovframework.com.uss.ion.ans.service.impl.AnnvrsryManageDAO">
 
     <resultMap id="annvrsryManage" type="egovframework.com.uss.ion.ans.service.AnnvrsryManageVO">
         <result property="usid" column="USER_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/ans/EgovAnnvrsryManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/ans/EgovAnnvrsryManage_SQL_mysql.xml
@@ -12,7 +12,7 @@
  --><!--Converted at: Wed May 11 15:51:01 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="annvrsryManageDAO">
+<mapper namespace="egovframework.com.uss.ion.ans.service.impl.AnnvrsryManageDAO">
 
     <resultMap id="annvrsryManage" type="egovframework.com.uss.ion.ans.service.AnnvrsryManageVO">
         <result property="usid" column="USER_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/ans/EgovAnnvrsryManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/ans/EgovAnnvrsryManage_SQL_oracle.xml
@@ -12,7 +12,7 @@
  --><!--Converted at: Wed May 11 15:51:01 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="annvrsryManageDAO">
+<mapper namespace="egovframework.com.uss.ion.ans.service.impl.AnnvrsryManageDAO">
 
     <resultMap id="annvrsryManage" type="egovframework.com.uss.ion.ans.service.AnnvrsryManageVO">
         <result property="usid" column="USER_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/ans/EgovAnnvrsryManage_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/ans/EgovAnnvrsryManage_SQL_postgres.xml
@@ -12,7 +12,7 @@
  --><!--Converted at: Wed May 11 15:51:01 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="annvrsryManageDAO">
+<mapper namespace="egovframework.com.uss.ion.ans.service.impl.AnnvrsryManageDAO">
 
     <resultMap id="annvrsryManage" type="egovframework.com.uss.ion.ans.service.AnnvrsryManageVO">
         <result property="usid" column="USER_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/ans/EgovAnnvrsryManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/ans/EgovAnnvrsryManage_SQL_tibero.xml
@@ -12,7 +12,7 @@
  --><!--Converted at: Wed May 11 15:51:02 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="annvrsryManageDAO">
+<mapper namespace="egovframework.com.uss.ion.ans.service.impl.AnnvrsryManageDAO">
 
     <resultMap id="annvrsryManage" type="egovframework.com.uss.ion.ans.service.AnnvrsryManageVO">
         <result property="usid" column="USER_ID"/>

--- a/src/main/resources/egovframework/spring/com/context-mapper.xml
+++ b/src/main/resources/egovframework/spring/com/context-mapper.xml
@@ -21,5 +21,12 @@
 	<bean id="egov.sqlSessionTemplate" class="org.mybatis.spring.SqlSessionTemplate">
 		<constructor-arg ref="egov.sqlSession"/>
 	</bean>
-	
+
+	<!-- @EgovMapper 어노테이션이 붙은 인터페이스를 자동으로 스캔하여 빈으로 등록 -->
+	<bean class="org.mybatis.spring.mapper.MapperScannerConfigurer">
+		<property name="basePackage" value="egovframework.com"/>
+		<property name="annotationClass" value="org.egovframe.rte.psl.dataaccess.mapper.EgovMapper"/>
+		<property name="sqlSessionFactoryBeanName" value="egov.sqlSession"/>
+	</bean>
+
 </beans>


### PR DESCRIPTION
### 변경 사유

eGovFrame 5.0에서 도입된 `@EgovMapper` 어노테이션 방식을 기념일관리(uss/ion/ans) 컴포넌트에 적용한다.
기존 `EgovComAbstractDAO` 상속 클래스 방식은 sqlSession을 직접 다루는 레거시 패턴으로,
인터페이스 기반 `@EgovMapper` 방식이 더 명확하고 유지보수성이 높다.

### 변경 내용

**대상 컴포넌트**: `uss/ion/ans` — 기념일관리 (AnnvrsryManageDAO, SQL 8개)

1. `AnnvrsryManageDAO.java`: `@Repository` 클래스 → `@EgovMapper` 인터페이스로 전환
   - `EgovComAbstractDAO` 상속 제거
   - `selectList(...)`, `selectOne(...)`, `insert(...)` 등 직접 호출 제거, 메서드 시그니처만 선언
   - `throws Exception` 제거 (인터페이스 방식에서 불필요)
2. `EgovAnnvrsryManage_SQL_*.xml` (8개 DB): `namespace="annvrsryManageDAO"` → `namespace="egovframework.com.uss.ion.ans.service.impl.AnnvrsryManageDAO"` (인터페이스 FQN)
   - SQL 내용 변경 없음
   - DB별 XML 유지 (altibase/goldilocks/cubrid/maria/mysql/oracle/postgres/tibero)
3. `context-mapper.xml`: `MapperScannerConfigurer` 빈 추가
   - `basePackage=egovframework.com`, `annotationClass=EgovMapper`
   - PR #806(cmm/use), PR #821(sym/mnu/stm), PR #825(sym/sym/nwk)와 동일 설정

### 영향 범위

- `EgovAnnvrsryManageServiceImpl`의 `@Resource(name="annvrsryManageDAO")` 주입 구조는 변경 없음
- SQL 내용 변경 없음 — 기존 동작 동일
- 다른 컴포넌트에 영향 없음

### 체크리스트

- [x] 단일 주제만 다룸 (uss/ion/ans 기념일관리만 변경)
- [x] PR #806(cmm/use) 선행 PR과 동일 패턴 적용, context-mapper.xml은 fast-forward 가능
- [x] 의존성 추가 없음 (egovframe-runtime에 이미 포함된 EgovMapper 사용)
- [x] 기존 동작에 영향 없음 (SQL 변경 없음, 빈 이름 동일)
- [x] mvn compile: 기준선(149 errors in 5.0.x) 대비 변동 없음
