### PR TITLE
[refactor][공통컴포넌트] sec/drm·rgm·ram 모듈 VO Lombok @Getter/@Setter 적용

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -597,6 +597,7 @@
 					<artifactId>maven-compiler-plugin</artifactId>
 					<configuration>
 						<release>${java.version}</release>
+						<proc>full</proc>
 					</configuration>
 				</plugin>
 				<plugin>

--- a/src/main/java/egovframework/com/sec/drm/service/DeptAuthor.java
+++ b/src/main/java/egovframework/com/sec/drm/service/DeptAuthor.java
@@ -3,6 +3,9 @@ package egovframework.com.sec.drm.service;
 import egovframework.com.cmm.ComDefaultVO;
 import egovframework.com.sec.rgm.service.AuthorGroup;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * 부서권한에 대한 model 클래스를 정의한다.
  * @author 공통서비스 개발팀 이문준
@@ -12,14 +15,15 @@ import egovframework.com.sec.rgm.service.AuthorGroup;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.03.20  이문준          최초 생성
  *
  * </pre>
  */
-
+@Getter
+@Setter
 public class DeptAuthor extends ComDefaultVO {
 	/**
 	 * serialVersionUID
@@ -28,7 +32,7 @@ public class DeptAuthor extends ComDefaultVO {
 	/**
 	 * 권한그룹관리
 	 */
-	private AuthorGroup authorGroup;	
+	private AuthorGroup authorGroup;
 	/**
 	 * 설정대상 사용자 ID
 	 */
@@ -40,14 +44,14 @@ public class DeptAuthor extends ComDefaultVO {
 	/**
 	 * 설정대상 그룹 ID
 	 */
-	private String groupId;	
+	private String groupId;
 	/**
 	 * 설정대상 사용자 유형 코드
 	 */
 	private String mberTyCode;
 	/**
 	 * 설정대상 사용자 유형 명
-	 */	
+	 */
 	private String mberTyNm;
 	/**
 	 * 권한코드
@@ -61,133 +65,5 @@ public class DeptAuthor extends ComDefaultVO {
 	 * Uniq ID
 	 */
 	private String uniqId;
-	
-	/**
-	 * authorGroup attribute 를 리턴한다.
-	 * @return AuthorGroup
-	 */
-	public AuthorGroup getAuthorGroup() {
-		return authorGroup;
-	}
-	/**
-	 * authorGroup attribute 값을 설정한다.
-	 * @param authorGroup AuthorGroup 
-	 */
-	public void setAuthorGroup(AuthorGroup authorGroup) {
-		this.authorGroup = authorGroup;
-	}
-	/**
-	 * userId attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getUserId() {
-		return userId;
-	}
-	/**
-	 * userId attribute 값을 설정한다.
-	 * @param userId String 
-	 */
-	public void setUserId(String userId) {
-		this.userId = userId;
-	}
-	/**
-	 * userNm attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getUserNm() {
-		return userNm;
-	}
-	/**
-	 * userNm attribute 값을 설정한다.
-	 * @param userNm String 
-	 */
-	public void setUserNm(String userNm) {
-		this.userNm = userNm;
-	}
-	/**
-	 * groupId attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getGroupId() {
-		return groupId;
-	}
-	/**
-	 * groupId attribute 값을 설정한다.
-	 * @param groupId String 
-	 */
-	public void setGroupId(String groupId) {
-		this.groupId = groupId;
-	}
-	/**
-	 * mberTyCode attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getMberTyCode() {
-		return mberTyCode;
-	}
-	/**
-	 * mberTyCode attribute 값을 설정한다.
-	 * @param mberTyCode String 
-	 */
-	public void setMberTyCode(String mberTyCode) {
-		this.mberTyCode = mberTyCode;
-	}
-	/**
-	 * mberTyNm attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getMberTyNm() {
-		return mberTyNm;
-	}
-	/**
-	 * mberTyNm attribute 값을 설정한다.
-	 * @param mberTyNm String 
-	 */
-	public void setMberTyNm(String mberTyNm) {
-		this.mberTyNm = mberTyNm;
-	}
-	/**
-	 * authorCode attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getAuthorCode() {
-		return authorCode;
-	}
-	/**
-	 * authorCode attribute 값을 설정한다.
-	 * @param authorCode String 
-	 */
-	public void setAuthorCode(String authorCode) {
-		this.authorCode = authorCode;
-	}
-	/**
-	 * regYn attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getRegYn() {
-		return regYn;
-	}
-	/**
-	 * regYn attribute 값을 설정한다.
-	 * @param regYn String 
-	 */
-	public void setRegYn(String regYn) {
-		this.regYn = regYn;
-	}
-	/**
-	 * uniqId attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getUniqId() {
-		return uniqId;
-	}
-	/**
-	 * uniqId attribute 값을 설정한다.
-	 * @param uniqId String 
-	 */
-	public void setUniqId(String uniqId) {
-		this.uniqId = uniqId;
-	}	
-	
 
 }

--- a/src/main/java/egovframework/com/sec/drm/service/DeptAuthorVO.java
+++ b/src/main/java/egovframework/com/sec/drm/service/DeptAuthorVO.java
@@ -2,6 +2,8 @@ package egovframework.com.sec.drm.service;
 
 import java.util.List;
 
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * 부서권한에 대한 Vo 클래스를 정의한다.
@@ -12,14 +14,15 @@ import java.util.List;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.03.20  이문준          최초 생성
  *
  * </pre>
  */
-
+@Getter
+@Setter
 public class DeptAuthorVO extends DeptAuthor {
 	/**
 	 * serialVersionUID
@@ -32,7 +35,7 @@ public class DeptAuthorVO extends DeptAuthor {
 	/**
 	 * 부서목록
 	 */
-	List <DeptAuthorVO> deptList;	
+	List <DeptAuthorVO> deptList;
 	/**
 	 * 부서코드
 	 */
@@ -41,62 +44,5 @@ public class DeptAuthorVO extends DeptAuthor {
 	 * 부서 명
 	 */
 	private String deptNm;
-	
-	/**
-	 * deptAuthorList attribute 를 리턴한다.
-	 * @return List<DeptAuthorVO>
-	 */
-	public List<DeptAuthorVO> getDeptAuthorList() {
-		return deptAuthorList;
-	}
-	/**
-	 * deptAuthorList attribute 값을 설정한다.
-	 * @param deptAuthorList List<DeptAuthorVO> 
-	 */
-	public void setDeptAuthorList(List<DeptAuthorVO> deptAuthorList) {
-		this.deptAuthorList = deptAuthorList;
-	}
-	/**
-	 * deptList attribute 를 리턴한다.
-	 * @return List<DeptAuthorVO>
-	 */
-	public List<DeptAuthorVO> getDeptList() {
-		return deptList;
-	}
-	/**
-	 * deptList attribute 값을 설정한다.
-	 * @param deptList List<DeptAuthorVO> 
-	 */
-	public void setDeptList(List<DeptAuthorVO> deptList) {
-		this.deptList = deptList;
-	}
-	/**
-	 * deptCode attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getDeptCode() {
-		return deptCode;
-	}
-	/**
-	 * deptCode attribute 값을 설정한다.
-	 * @param deptCode String 
-	 */
-	public void setDeptCode(String deptCode) {
-		this.deptCode = deptCode;
-	}
-	/**
-	 * deptNm attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getDeptNm() {
-		return deptNm;
-	}
-	/**
-	 * deptNm attribute 값을 설정한다.
-	 * @param deptNm String 
-	 */
-	public void setDeptNm(String deptNm) {
-		this.deptNm = deptNm;
-	}
-	
+
 }

--- a/src/main/java/egovframework/com/sec/ram/service/AuthorManage.java
+++ b/src/main/java/egovframework/com/sec/ram/service/AuthorManage.java
@@ -5,6 +5,9 @@ import egovframework.com.cmm.ComDefaultVO;
 import org.egovframe.rte.ptl.reactive.validation.EgovNullCheck;
 import jakarta.validation.constraints.Size;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * 권한관리에 대한 model 클래스를 정의한다.
  * @author 공통서비스 개발팀 이문준
@@ -14,14 +17,15 @@ import jakarta.validation.constraints.Size;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.03.20  이문준          최초 생성
  *   2024.10.29	LeeBaekHaeng	시큐어코딩 일련번호 PK 파라미터 암복호화
  * </pre>
  */
-
+@Getter
+@Setter
 public class AuthorManage extends ComDefaultVO {
 
 	/**
@@ -30,7 +34,7 @@ public class AuthorManage extends ComDefaultVO {
 	private static final long serialVersionUID = 1L;
 	/**
 	 * 권한관리
-	 */	
+	 */
 	private AuthorManage authorManage;
 	/**
 	 * 권한코드
@@ -57,89 +61,5 @@ public class AuthorManage extends ComDefaultVO {
 	@EgovNullCheck
 	@Size(max=60)
 	private String authorNm;
-	
-	/**
-	 * authorManage attribute 를 리턴한다.
-	 * @return AuthorManage
-	 */
-	public AuthorManage getAuthorManage() {
-		return authorManage;
-	}
-	/**
-	 * authorManage attribute 값을 설정한다.
-	 * @param authorManage AuthorManage 
-	 */
-	public void setAuthorManage(AuthorManage authorManage) {
-		this.authorManage = authorManage;
-	}
-	/**
-	 * authorCode attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getAuthorCode() {
-		return authorCode;
-	}
-	/**
-	 * authorCode attribute 값을 설정한다.
-	 * @param authorCode String 
-	 */
-	public void setAuthorCode(String authorCode) {
-		this.authorCode = authorCode;
-	}
-
-	public String getAuthorCodeEncrypt() {
-		return authorCodeEncrypt;
-	}
-
-	public void setAuthorCodeEncrypt(String authorCodeEncrypt) {
-		this.authorCodeEncrypt = authorCodeEncrypt;
-	}
-
-	/**
-	 * authorCreatDe attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getAuthorCreatDe() {
-		return authorCreatDe;
-	}
-	/**
-	 * authorCreatDe attribute 값을 설정한다.
-	 * @param authorCreatDe String 
-	 */
-	public void setAuthorCreatDe(String authorCreatDe) {
-		this.authorCreatDe = authorCreatDe;
-	}
-	/**
-	 * authorDc attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getAuthorDc() {
-		return authorDc;
-	}
-	/**
-	 * authorDc attribute 값을 설정한다.
-	 * @param authorDc String 
-	 */
-	public void setAuthorDc(String authorDc) {
-		this.authorDc = authorDc;
-	}
-	/**
-	 * authorNm attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getAuthorNm() {
-		return authorNm;
-	}
-	/**
-	 * authorNm attribute 값을 설정한다.
-	 * @param authorNm String 
-	 */
-	public void setAuthorNm(String authorNm) {
-		this.authorNm = authorNm;
-	}
-	
-
-
-	
 
 }

--- a/src/main/java/egovframework/com/sec/ram/service/AuthorManageVO.java
+++ b/src/main/java/egovframework/com/sec/ram/service/AuthorManageVO.java
@@ -2,6 +2,9 @@ package egovframework.com.sec.ram.service;
 
 import java.util.List;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * 권한관리에 대한 Vo 클래스를 정의한다.
  * @author 공통서비스 개발팀 이문준
@@ -11,37 +14,19 @@ import java.util.List;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.03.20  이문준          최초 생성
  *
  * </pre>
  */
-
+@Getter
+@Setter
 public class AuthorManageVO extends AuthorManage {
 
 	private static final long serialVersionUID = 1L;
 
 	List <AuthorManageVO> authorManageList;
-
-
-	/**
-	 * authorManageList attribute 를 리턴한다.
-	 * @return List<AuthorManageVO>
-	 */
-	public List<AuthorManageVO> getAuthorManageList() {
-		return authorManageList;
-	}
-
-	/**
-	 * authorManageList attribute 값을 설정한다.
-	 * @param authorManageList List<AuthorManageVO> 
-	 */
-	public void setAuthorManageList(List<AuthorManageVO> authorManageList) {
-		this.authorManageList = authorManageList;
-	}
-
-
 
 }

--- a/src/main/java/egovframework/com/sec/ram/service/AuthorRoleManage.java
+++ b/src/main/java/egovframework/com/sec/ram/service/AuthorRoleManage.java
@@ -2,6 +2,9 @@ package egovframework.com.sec.ram.service;
 
 import egovframework.com.cmm.ComDefaultVO;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * 권한별 롤 관리에 대한 model 클래스를 정의한다.
  * @author 공통서비스 개발팀 이문준
@@ -11,14 +14,15 @@ import egovframework.com.cmm.ComDefaultVO;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.03.20  이문준          최초 생성
  *
  * </pre>
  */
-
+@Getter
+@Setter
 public class AuthorRoleManage extends ComDefaultVO {
 
 	/**
@@ -27,7 +31,7 @@ public class AuthorRoleManage extends ComDefaultVO {
 	private static final long serialVersionUID = 1L;
 	/**
 	 * 권한 롤 관리
-	 */	
+	 */
 	private AuthorRoleManage authorRole;
 	/**
 	 * 권한코드
@@ -40,171 +44,30 @@ public class AuthorRoleManage extends ComDefaultVO {
 	/**
 	 * 롤명
 	 */
-	private String roleNm;	
+	private String roleNm;
 	/**
 	 * 롤 패턴
 	 */
-	private String rolePtn;	
+	private String rolePtn;
 	/**
 	 * 롤 설명
 	 */
-	private String roleDc;	
+	private String roleDc;
 	/**
 	 * 롤 타입
 	 */
-	private String roleTyp;	
+	private String roleTyp;
 	/**
 	 * 롤 순서정렬
 	 */
-	private String roleSort;	
+	private String roleSort;
 	/**
 	 * 롤 등록여부
 	 */
-	private String regYn;	
+	private String regYn;
 	/**
 	 * 등록일자
 	 */
 	private String creatDt;
-	/**
-	 * authorRole attribute 를 리턴한다.
-	 * @return AuthorRoleManage
-	 */
-	public AuthorRoleManage getAuthorRole() {
-		return authorRole;
-	}
-	/**
-	 * authorRole attribute 값을 설정한다.
-	 * @param authorRole AuthorRoleManage 
-	 */
-	public void setAuthorRole(AuthorRoleManage authorRole) {
-		this.authorRole = authorRole;
-	}
-	/**
-	 * authorCode attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getAuthorCode() {
-		return authorCode;
-	}
-	/**
-	 * authorCode attribute 값을 설정한다.
-	 * @param authorCode String 
-	 */
-	public void setAuthorCode(String authorCode) {
-		this.authorCode = authorCode;
-	}
-	/**
-	 * roleCode attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getRoleCode() {
-		return roleCode;
-	}
-	/**
-	 * roleCode attribute 값을 설정한다.
-	 * @param roleCode String 
-	 */
-	public void setRoleCode(String roleCode) {
-		this.roleCode = roleCode;
-	}
-	/**
-	 * roleNm attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getRoleNm() {
-		return roleNm;
-	}
-	/**
-	 * roleNm attribute 값을 설정한다.
-	 * @param roleNm String 
-	 */
-	public void setRoleNm(String roleNm) {
-		this.roleNm = roleNm;
-	}
-	/**
-	 * rolePtn attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getRolePtn() {
-		return rolePtn;
-	}
-	/**
-	 * rolePtn attribute 값을 설정한다.
-	 * @param rolePtn String 
-	 */
-	public void setRolePtn(String rolePtn) {
-		this.rolePtn = rolePtn;
-	}
-	/**
-	 * roleDc attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getRoleDc() {
-		return roleDc;
-	}
-	/**
-	 * roleDc attribute 값을 설정한다.
-	 * @param roleDc String 
-	 */
-	public void setRoleDc(String roleDc) {
-		this.roleDc = roleDc;
-	}
-	/**
-	 * roleTyp attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getRoleTyp() {
-		return roleTyp;
-	}
-	/**
-	 * roleTyp attribute 값을 설정한다.
-	 * @param roleTyp String 
-	 */
-	public void setRoleTyp(String roleTyp) {
-		this.roleTyp = roleTyp;
-	}
-	/**
-	 * roleSort attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getRoleSort() {
-		return roleSort;
-	}
-	/**
-	 * roleSort attribute 값을 설정한다.
-	 * @param roleSort String 
-	 */
-	public void setRoleSort(String roleSort) {
-		this.roleSort = roleSort;
-	}
-	/**
-	 * regYn attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getRegYn() {
-		return regYn;
-	}
-	/**
-	 * regYn attribute 값을 설정한다.
-	 * @param regYn String 
-	 */
-	public void setRegYn(String regYn) {
-		this.regYn = regYn;
-	}
-	/**
-	 * creatDt attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getCreatDt() {
-		return creatDt;
-	}
-	/**
-	 * creatDt attribute 값을 설정한다.
-	 * @param creatDt String 
-	 */
-	public void setCreatDt(String creatDt) {
-		this.creatDt = creatDt;
-	}
-	
-	
+
 }

--- a/src/main/java/egovframework/com/sec/ram/service/AuthorRoleManageVO.java
+++ b/src/main/java/egovframework/com/sec/ram/service/AuthorRoleManageVO.java
@@ -2,6 +2,9 @@ package egovframework.com.sec.ram.service;
 
 import java.util.List;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * 권한별 롤 관리에 대한 Vo 클래스를 정의한다.
  * @author 공통서비스 개발팀 이문준
@@ -11,36 +14,19 @@ import java.util.List;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.03.20  이문준          최초 생성
  *
  * </pre>
  */
-
+@Getter
+@Setter
 public class AuthorRoleManageVO extends AuthorRoleManage {
 
 	private static final long serialVersionUID = 1L;
 
 	List <AuthorRoleManageVO> authorRoleList;
-	
-	/**
-	 * authorRoleList attribute 를 리턴한다.
-	 * @return List<AuthorRoleManageVO>
-	 */
-	public List<AuthorRoleManageVO> getAuthorRoleList() {
-		return authorRoleList;
-	}
-
-	/**
-	 * authorRoleList attribute 값을 설정한다.
-	 * @param authorRoleList List<AuthorRoleManageVO> 
-	 */
-	public void setAuthorRoleList(List<AuthorRoleManageVO> authorRoleList) {
-		this.authorRoleList = authorRoleList;
-	}
-
-
 
 }

--- a/src/main/java/egovframework/com/sec/rgm/service/AuthorGroup.java
+++ b/src/main/java/egovframework/com/sec/rgm/service/AuthorGroup.java
@@ -2,6 +2,8 @@ package egovframework.com.sec.rgm.service;
 
 import egovframework.com.cmm.ComDefaultVO;
 
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * 권한그룹에 대한 model 클래스를 정의한다.
@@ -12,14 +14,15 @@ import egovframework.com.cmm.ComDefaultVO;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.03.20  이문준          최초 생성
  *
  * </pre>
  */
-
+@Getter
+@Setter
 public class AuthorGroup extends ComDefaultVO {
 	/**
 	 * serialVersionUID
@@ -28,7 +31,7 @@ public class AuthorGroup extends ComDefaultVO {
 	/**
 	 * 권한그룹관리
 	 */
-	private AuthorGroup authorGroup;	
+	private AuthorGroup authorGroup;
 	/**
 	 * 설정대상 사용자 ID
 	 */
@@ -40,14 +43,14 @@ public class AuthorGroup extends ComDefaultVO {
 	/**
 	 * 설정대상 그룹 ID
 	 */
-	private String groupId;	
+	private String groupId;
 	/**
 	 * 설정대상 사용자 유형 코드
 	 */
 	private String mberTyCode;
 	/**
 	 * 설정대상 사용자 유형 명
-	 */	
+	 */
 	private String mberTyNm;
 	/**
 	 * 권한코드
@@ -61,135 +64,5 @@ public class AuthorGroup extends ComDefaultVO {
 	 * Uniq ID
 	 */
 	private String uniqId;
-	
-	/**
-	 * authorGroup attribute 를 리턴한다.
-	 * @return AuthorGroup
-	 */
-	public AuthorGroup getAuthorGroup() {
-		return authorGroup;
-	}
-	/**
-	 * authorGroup attribute 값을 설정한다.
-	 * @param authorGroup AuthorGroup 
-	 */
-	public void setAuthorGroup(AuthorGroup authorGroup) {
-		this.authorGroup = authorGroup;
-	}
-	/**
-	 * userId attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getUserId() {
-		return userId;
-	}
-	/**
-	 * userId attribute 값을 설정한다.
-	 * @param userId String 
-	 */
-	public void setUserId(String userId) {
-		this.userId = userId;
-	}
-	/**
-	 * userNm attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getUserNm() {
-		return userNm;
-	}
-	/**
-	 * userNm attribute 값을 설정한다.
-	 * @param userNm String 
-	 */
-	public void setUserNm(String userNm) {
-		this.userNm = userNm;
-	}
-	/**
-	 * groupId attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getGroupId() {
-		return groupId;
-	}
-	/**
-	 * groupId attribute 값을 설정한다.
-	 * @param groupId String 
-	 */
-	public void setGroupId(String groupId) {
-		this.groupId = groupId;
-	}
-	/**
-	 * mberTyCode attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getMberTyCode() {
-		return mberTyCode;
-	}
-	/**
-	 * mberTyCode attribute 값을 설정한다.
-	 * @param mberTyCode String 
-	 */
-	public void setMberTyCode(String mberTyCode) {
-		this.mberTyCode = mberTyCode;
-	}
-	/**
-	 * mberTyNm attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getMberTyNm() {
-		return mberTyNm;
-	}
-	/**
-	 * mberTyNm attribute 값을 설정한다.
-	 * @param mberTyNm String 
-	 */
-	public void setMberTyNm(String mberTyNm) {
-		this.mberTyNm = mberTyNm;
-	}
-	/**
-	 * authorCode attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getAuthorCode() {
-		return authorCode;
-	}
-	/**
-	 * authorCode attribute 값을 설정한다.
-	 * @param authorCode String 
-	 */
-	public void setAuthorCode(String authorCode) {
-		this.authorCode = authorCode;
-	}
-	/**
-	 * regYn attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getRegYn() {
-		return regYn;
-	}
-	/**
-	 * regYn attribute 값을 설정한다.
-	 * @param regYn String 
-	 */
-	public void setRegYn(String regYn) {
-		this.regYn = regYn;
-	}
-	/**
-	 * uniqId attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getUniqId() {
-		return uniqId;
-	}
-	/**
-	 * uniqId attribute 값을 설정한다.
-	 * @param uniqId String 
-	 */
-	public void setUniqId(String uniqId) {
-		this.uniqId = uniqId;
-	}
-	
 
-	
-	
 }

--- a/src/main/java/egovframework/com/sec/rgm/service/AuthorGroupVO.java
+++ b/src/main/java/egovframework/com/sec/rgm/service/AuthorGroupVO.java
@@ -2,6 +2,9 @@ package egovframework.com.sec.rgm.service;
 
 import java.util.List;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * 권한그룹에 대한 Vo 클래스를 정의한다.
  * @author 공통서비스 개발팀 이문준
@@ -11,34 +14,19 @@ import java.util.List;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.03.20  이문준          최초 생성
  *
  * </pre>
  */
-
+@Getter
+@Setter
 public class AuthorGroupVO extends AuthorGroup {
 
 	private static final long serialVersionUID = 1L;
 
 	List <AuthorGroupVO> authorGroupList;
-
-	/**
-	 * authorGroupList attribute 를 리턴한다.
-	 * @return List<AuthorGroupVO>
-	 */
-	public List<AuthorGroupVO> getAuthorGroupList() {
-		return authorGroupList;
-	}
-	/**
-	 * authorGroupList attribute 값을 설정한다.
-	 * @param authorGroupList List<AuthorGroupVO> 
-	 */
-	public void setAuthorGroupList(List<AuthorGroupVO> authorGroupList) {
-		this.authorGroupList = authorGroupList;
-	}
-	
 
 }


### PR DESCRIPTION
## 변경 사유

sec/drm, sec/rgm, sec/ram 패키지 내 도메인 클래스에 수작업으로 작성된 getter/setter 메서드가
코드량을 불필요하게 늘리고 있어 Lombok 어노테이션으로 대체하여 가독성과 유지보수성을 개선했다.

## 변경 내용

| 파일 | 제거된 메서드 수 |
|------|----------------|
| `sec/drm/service/DeptAuthor.java` | getter 9 + setter 9 = 18 |
| `sec/drm/service/DeptAuthorVO.java` | getter 4 + setter 4 = 8 |
| `sec/rgm/service/AuthorGroup.java` | getter 9 + setter 9 = 18 |
| `sec/rgm/service/AuthorGroupVO.java` | getter 1 + setter 1 = 2 |
| `sec/ram/service/AuthorManage.java` | getter 5 + setter 5 = 10 |
| `sec/ram/service/AuthorManageVO.java` | getter 1 + setter 1 = 2 |
| `sec/ram/service/AuthorRoleManage.java` | getter 10 + setter 10 = 20 |
| `sec/ram/service/AuthorRoleManageVO.java` | getter 1 + setter 1 = 2 |

- 클래스 레벨 `@Getter` + `@Setter` 적용, 기존 javadoc 주석 보존
- `pom.xml` maven-compiler-plugin에 `<proc>full</proc>` 추가 (Lombok annotation processing 활성화)

## 테스트

- `mvn -DskipTests compile` 빌드 성공 확인

## 체크리스트

- [x] 단일 주제만 다룸 (다른 변경 없음)
- [x] 기존 동작에 영향 없음 (getter/setter 시그니처 동일)
- [x] 빌드 통과 확인
