### PR TITLE
[refactor][공통컴포넌트] cop/bbs 모듈 BlogVO·BlogUserVO Lombok @Getter/@Setter 적용

### DIFF
--- a/src/main/java/egovframework/com/cop/bbs/service/BlogUserVO.java
+++ b/src/main/java/egovframework/com/cop/bbs/service/BlogUserVO.java
@@ -4,6 +4,8 @@ import java.io.Serializable;
 
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * 블로그게시판 관리를 위한 VO 클래스
@@ -14,306 +16,61 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일            수정자           수정내용
  *  -----------   --------   ---------------------------
  *   2017.09.12  양희훈          최초 생성
  *
  * </pre>
  */
+@Getter
+@Setter
 @SuppressWarnings("serial")
 public class BlogUserVO extends BlogUser implements Serializable {
-    
+
     /** 검색시작일 */
     private String searchBgnDe = "";
-    
+
     /** 검색조건 */
     private String searchCnd = "";
-    
+
     /** 검색종료일 */
     private String searchEndDe = "";
-    
+
     /** 검색단어 */
     private String searchWrd = "";
-    
+
     /** 정렬순서(DESC,ASC) */
     private long sortOrdr = 0L;
-    
+
     /** 검색사용여부 */
     private String searchUseYn = "";
-    
+
     /** 현재페이지 */
     private int pageIndex = 1;
-    
+
     /** 페이지개수 */
     private int pageUnit = 10;
-    
+
     /** 페이지사이즈 */
     private int pageSize = 10;
-    
+
     /** 첫페이지 인덱스 */
     private int firstIndex = 1;
-    
+
     /** 마지막페이지 인덱스 */
     private int lastIndex = 1;
-    
+
     /** 페이지당 레코드 개수 */
     private int recordCountPerPage = 10;
-    
+
     /** 레코드 번호 */
     private int rowNo = 0;
-
-    /**
-     * searchBgnDe attribute를 리턴한다.
-     * 
-     * @return the searchBgnDe
-     */
-    public String getSearchBgnDe() {
-	return searchBgnDe;
-    }
-
-    /**
-     * searchBgnDe attribute 값을 설정한다.
-     * 
-     * @param searchBgnDe
-     *            the searchBgnDe to set
-     */
-    public void setSearchBgnDe(String searchBgnDe) {
-	this.searchBgnDe = searchBgnDe;
-    }
-
-    /**
-     * searchCnd attribute를 리턴한다.
-     * 
-     * @return the searchCnd
-     */
-    public String getSearchCnd() {
-	return searchCnd;
-    }
-
-    /**
-     * searchCnd attribute 값을 설정한다.
-     * 
-     * @param searchCnd
-     *            the searchCnd to set
-     */
-    public void setSearchCnd(String searchCnd) {
-	this.searchCnd = searchCnd;
-    }
-
-    /**
-     * searchEndDe attribute를 리턴한다.
-     * 
-     * @return the searchEndDe
-     */
-    public String getSearchEndDe() {
-	return searchEndDe;
-    }
-
-    /**
-     * searchEndDe attribute 값을 설정한다.
-     * 
-     * @param searchEndDe
-     *            the searchEndDe to set
-     */
-    public void setSearchEndDe(String searchEndDe) {
-	this.searchEndDe = searchEndDe;
-    }
-
-    /**
-     * searchWrd attribute를 리턴한다.
-     * 
-     * @return the searchWrd
-     */
-    public String getSearchWrd() {
-	return searchWrd;
-    }
-
-    /**
-     * searchWrd attribute 값을 설정한다.
-     * 
-     * @param searchWrd
-     *            the searchWrd to set
-     */
-    public void setSearchWrd(String searchWrd) {
-	this.searchWrd = searchWrd;
-    }
-
-    /**
-     * sortOrdr attribute를 리턴한다.
-     * 
-     * @return the sortOrdr
-     */
-    public long getSortOrdr() {
-	return sortOrdr;
-    }
-
-    /**
-     * sortOrdr attribute 값을 설정한다.
-     * 
-     * @param sortOrdr
-     *            the sortOrdr to set
-     */
-    public void setSortOrdr(long sortOrdr) {
-	this.sortOrdr = sortOrdr;
-    }
-
-    /**
-     * searchUseYn attribute를 리턴한다.
-     * 
-     * @return the searchUseYn
-     */
-    public String getSearchUseYn() {
-	return searchUseYn;
-    }
-
-    /**
-     * searchUseYn attribute 값을 설정한다.
-     * 
-     * @param searchUseYn
-     *            the searchUseYn to set
-     */
-    public void setSearchUseYn(String searchUseYn) {
-	this.searchUseYn = searchUseYn;
-    }
-
-    /**
-     * pageIndex attribute를 리턴한다.
-     * 
-     * @return the pageIndex
-     */
-    public int getPageIndex() {
-	return pageIndex;
-    }
-
-    /**
-     * pageIndex attribute 값을 설정한다.
-     * 
-     * @param pageIndex
-     *            the pageIndex to set
-     */
-    public void setPageIndex(int pageIndex) {
-	this.pageIndex = pageIndex;
-    }
-
-    /**
-     * pageUnit attribute를 리턴한다.
-     * 
-     * @return the pageUnit
-     */
-    public int getPageUnit() {
-	return pageUnit;
-    }
-
-    /**
-     * pageUnit attribute 값을 설정한다.
-     * 
-     * @param pageUnit
-     *            the pageUnit to set
-     */
-    public void setPageUnit(int pageUnit) {
-	this.pageUnit = pageUnit;
-    }
-
-    /**
-     * pageSize attribute를 리턴한다.
-     * 
-     * @return the pageSize
-     */
-    public int getPageSize() {
-	return pageSize;
-    }
-
-    /**
-     * pageSize attribute 값을 설정한다.
-     * 
-     * @param pageSize
-     *            the pageSize to set
-     */
-    public void setPageSize(int pageSize) {
-	this.pageSize = pageSize;
-    }
-
-    /**
-     * firstIndex attribute를 리턴한다.
-     * 
-     * @return the firstIndex
-     */
-    public int getFirstIndex() {
-	return firstIndex;
-    }
-
-    /**
-     * firstIndex attribute 값을 설정한다.
-     * 
-     * @param firstIndex
-     *            the firstIndex to set
-     */
-    public void setFirstIndex(int firstIndex) {
-	this.firstIndex = firstIndex;
-    }
-
-    /**
-     * lastIndex attribute를 리턴한다.
-     * 
-     * @return the lastIndex
-     */
-    public int getLastIndex() {
-	return lastIndex;
-    }
-
-    /**
-     * lastIndex attribute 값을 설정한다.
-     * 
-     * @param lastIndex
-     *            the lastIndex to set
-     */
-    public void setLastIndex(int lastIndex) {
-	this.lastIndex = lastIndex;
-    }
-
-    /**
-     * recordCountPerPage attribute를 리턴한다.
-     * 
-     * @return the recordCountPerPage
-     */
-    public int getRecordCountPerPage() {
-	return recordCountPerPage;
-    }
-
-    /**
-     * recordCountPerPage attribute 값을 설정한다.
-     * 
-     * @param recordCountPerPage
-     *            the recordCountPerPage to set
-     */
-    public void setRecordCountPerPage(int recordCountPerPage) {
-	this.recordCountPerPage = recordCountPerPage;
-    }
-
-    /**
-     * rowNo attribute를 리턴한다.
-     * 
-     * @return the rowNo
-     */
-    public int getRowNo() {
-	return rowNo;
-    }
-
-    /**
-     * rowNo attribute 값을 설정한다.
-     * 
-     * @param rowNo
-     *            the rowNo to set
-     */
-    public void setRowNo(int rowNo) {
-	this.rowNo = rowNo;
-    }
 
     /**
      * toString 메소드를 대치한다.
      */
     public String toString() {
-	return ToStringBuilder.reflectionToString(this);
+        return ToStringBuilder.reflectionToString(this);
     }
 }

--- a/src/main/java/egovframework/com/cop/bbs/service/BlogVO.java
+++ b/src/main/java/egovframework/com/cop/bbs/service/BlogVO.java
@@ -4,6 +4,9 @@ import java.io.Serializable;
 
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * 커뮤니티 관리를 위한 VO 클래스
  * @author 공통서비스개발팀 이삼섭
@@ -13,28 +16,30 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.4.2  이삼섭          최초 생성
  *
  * </pre>
  */
+@Getter
+@Setter
 @SuppressWarnings("serial")
 public class BlogVO extends Blog implements Serializable {
 
     /** 검색시작일 */
     private String searchBgnDe = "";
-    
+
     /** 검색조건 */
     private String searchCnd = "";
-    
+
     /** 검색종료일 */
     private String searchEndDe = "";
-    
+
     /** 검색단어 */
     private String searchWrd = "";
-    
+
     /** 정렬순서(DESC,ASC) */
     private long sortOrdr = 0L;
 
@@ -73,371 +78,16 @@ public class BlogVO extends Blog implements Serializable {
 
     /** 게시판 이름 */
     private String bbsNm = "";
-    
+
     /** 제공 URL */
     private String provdUrl = "";
-    
+
     private String blogId = "";
-    
-
-    /**
-     * searchBgnDe attribute를 리턴한다.
-     * 
-     * @return the searchBgnDe
-     */
-    public String getSearchBgnDe() {
-	return searchBgnDe;
-    }
-
-    /**
-     * searchBgnDe attribute 값을 설정한다.
-     * 
-     * @param searchBgnDe
-     *            the searchBgnDe to set
-     */
-    public void setSearchBgnDe(String searchBgnDe) {
-	this.searchBgnDe = searchBgnDe;
-    }
-
-    /**
-     * searchCnd attribute를 리턴한다.
-     * 
-     * @return the searchCnd
-     */
-    public String getSearchCnd() {
-	return searchCnd;
-    }
-
-    /**
-     * searchCnd attribute 값을 설정한다.
-     * 
-     * @param searchCnd
-     *            the searchCnd to set
-     */
-    public void setSearchCnd(String searchCnd) {
-	this.searchCnd = searchCnd;
-    }
-
-    /**
-     * searchEndDe attribute를 리턴한다.
-     * 
-     * @return the searchEndDe
-     */
-    public String getSearchEndDe() {
-	return searchEndDe;
-    }
-
-    /**
-     * searchEndDe attribute 값을 설정한다.
-     * 
-     * @param searchEndDe
-     *            the searchEndDe to set
-     */
-    public void setSearchEndDe(String searchEndDe) {
-	this.searchEndDe = searchEndDe;
-    }
-
-    /**
-     * searchWrd attribute를 리턴한다.
-     * 
-     * @return the searchWrd
-     */
-    public String getSearchWrd() {
-	return searchWrd;
-    }
-
-    /**
-     * searchWrd attribute 값을 설정한다.
-     * 
-     * @param searchWrd
-     *            the searchWrd to set
-     */
-    public void setSearchWrd(String searchWrd) {
-	this.searchWrd = searchWrd;
-    }
-
-    /**
-     * sortOrdr attribute를 리턴한다.
-     * 
-     * @return the sortOrdr
-     */
-    public long getSortOrdr() {
-	return sortOrdr;
-    }
-
-    /**
-     * sortOrdr attribute 값을 설정한다.
-     * 
-     * @param sortOrdr
-     *            the sortOrdr to set
-     */
-    public void setSortOrdr(long sortOrdr) {
-	this.sortOrdr = sortOrdr;
-    }
-
-    /**
-     * searchUseYn attribute를 리턴한다.
-     * 
-     * @return the searchUseYn
-     */
-    public String getSearchUseYn() {
-	return searchUseYn;
-    }
-
-    /**
-     * searchUseYn attribute 값을 설정한다.
-     * 
-     * @param searchUseYn
-     *            the searchUseYn to set
-     */
-    public void setSearchUseYn(String searchUseYn) {
-	this.searchUseYn = searchUseYn;
-    }
-
-    /**
-     * pageIndex attribute를 리턴한다.
-     * 
-     * @return the pageIndex
-     */
-    public int getPageIndex() {
-	return pageIndex;
-    }
-
-    /**
-     * pageIndex attribute 값을 설정한다.
-     * 
-     * @param pageIndex
-     *            the pageIndex to set
-     */
-    public void setPageIndex(int pageIndex) {
-	this.pageIndex = pageIndex;
-    }
-
-    /**
-     * pageUnit attribute를 리턴한다.
-     * 
-     * @return the pageUnit
-     */
-    public int getPageUnit() {
-	return pageUnit;
-    }
-
-    /**
-     * pageUnit attribute 값을 설정한다.
-     * 
-     * @param pageUnit
-     *            the pageUnit to set
-     */
-    public void setPageUnit(int pageUnit) {
-	this.pageUnit = pageUnit;
-    }
-
-    /**
-     * pageSize attribute를 리턴한다.
-     * 
-     * @return the pageSize
-     */
-    public int getPageSize() {
-	return pageSize;
-    }
-
-    /**
-     * pageSize attribute 값을 설정한다.
-     * 
-     * @param pageSize
-     *            the pageSize to set
-     */
-    public void setPageSize(int pageSize) {
-	this.pageSize = pageSize;
-    }
-
-    /**
-     * firstIndex attribute를 리턴한다.
-     * 
-     * @return the firstIndex
-     */
-    public int getFirstIndex() {
-	return firstIndex;
-    }
-
-    /**
-     * firstIndex attribute 값을 설정한다.
-     * 
-     * @param firstIndex
-     *            the firstIndex to set
-     */
-    public void setFirstIndex(int firstIndex) {
-	this.firstIndex = firstIndex;
-    }
-
-    /**
-     * lastIndex attribute를 리턴한다.
-     * 
-     * @return the lastIndex
-     */
-    public int getLastIndex() {
-	return lastIndex;
-    }
-
-    /**
-     * lastIndex attribute 값을 설정한다.
-     * 
-     * @param lastIndex
-     *            the lastIndex to set
-     */
-    public void setLastIndex(int lastIndex) {
-	this.lastIndex = lastIndex;
-    }
-
-    /**
-     * recordCountPerPage attribute를 리턴한다.
-     * 
-     * @return the recordCountPerPage
-     */
-    public int getRecordCountPerPage() {
-	return recordCountPerPage;
-    }
-
-    /**
-     * recordCountPerPage attribute 값을 설정한다.
-     * 
-     * @param recordCountPerPage
-     *            the recordCountPerPage to set
-     */
-    public void setRecordCountPerPage(int recordCountPerPage) {
-	this.recordCountPerPage = recordCountPerPage;
-    }
-
-    /**
-     * rowNo attribute를 리턴한다.
-     * 
-     * @return the rowNo
-     */
-    public int getRowNo() {
-	return rowNo;
-    }
-
-    /**
-     * rowNo attribute 값을 설정한다.
-     * 
-     * @param rowNo
-     *            the rowNo to set
-     */
-    public void setRowNo(int rowNo) {
-	this.rowNo = rowNo;
-    }
-
-    /**
-     * registSeCodeNm attribute를 리턴한다.
-     * 
-     * @return the registSeCodeNm
-     */
-    public String getRegistSeCodeNm() {
-	return registSeCodeNm;
-    }
-
-    /**
-     * registSeCodeNm attribute 값을 설정한다.
-     * 
-     * @param registSeCodeNm
-     *            the registSeCodeNm to set
-     */
-    public void setRegistSeCodeNm(String registSeCodeNm) {
-	this.registSeCodeNm = registSeCodeNm;
-    }
-
-    /**
-     * frstRegisterNm attribute를 리턴한다.
-     * 
-     * @return the frstRegisterNm
-     */
-    public String getFrstRegisterNm() {
-	return frstRegisterNm;
-    }
-
-    /**
-     * frstRegisterNm attribute 값을 설정한다.
-     * 
-     * @param frstRegisterNm
-     *            the frstRegisterNm to set
-     */
-    public void setFrstRegisterNm(String frstRegisterNm) {
-	this.frstRegisterNm = frstRegisterNm;
-    }
-
-    /**
-     * bbsId attribute를 리턴한다.
-     * 
-     * @return the bbsId
-     */
-    public String getBbsId() {
-	return bbsId;
-    }
-
-    /**
-     * bbsId attribute 값을 설정한다.
-     * 
-     * @param bbsId
-     *            the bbsId to set
-     */
-    public void setBbsId(String bbsId) {
-	this.bbsId = bbsId;
-    }
-
- 
-    public String getBlogId() {
-    	return blogId;
-        }
-
-        /**
-         * bbsId attribute 값을 설정한다.
-         * 
-         * @param bbsId
-         *            the bbsId to set
-         */
-        public void setBlogId(String blogId) {
-    	this.blogId = blogId;
-        }
-        
-    /**
-     * bbsNm attribute를 리턴한다.
-     * 
-     * @return the bbsNm
-     */
-    public String getBbsNm() {
-	return bbsNm;
-    }
-
-    /**
-     * bbsNm attribute 값을 설정한다.
-     * 
-     * @param bbsNm
-     *            the bbsNm to set
-     */
-    public void setBbsNm(String bbsNm) {
-	this.bbsNm = bbsNm;
-    }
-
-    /**
-     * provdUrl attribute를 리턴한다.
-     * @return the provdUrl
-     */
-    public String getProvdUrl() {
-        return provdUrl;
-    }
-
-    /**
-     * provdUrl attribute 값을 설정한다.
-     * @param provdUrl the provdUrl to set
-     */
-    public void setProvdUrl(String provdUrl) {
-        this.provdUrl = provdUrl;
-    }
 
     /**
      * toString 메소드를 대치한다.
      */
     public String toString() {
-	return ToStringBuilder.reflectionToString(this);
+        return ToStringBuilder.reflectionToString(this);
     }
 }


### PR DESCRIPTION
cop/bbs 모듈의 BlogVO, BlogUserVO에 Lombok @Getter/@Setter를 적용하여 보일러플레이트 getter/setter 코드를 제거합니다.

## 변경 내용

- `BlogVO`: 단순 위임 getter/setter 14쌍 제거, 클래스 레벨 @Getter/@Setter 추가
- `BlogUserVO`: 단순 위임 getter/setter 12쌍 제거, 클래스 레벨 @Getter/@Setter 추가

기존 커스텀 로직이 있는 BoardMasterVO(부모 클래스 중복 필드), BoardVO(null 가드 로직), SatisfactionVO(boolean 필드명 비표준) 는 적용 대상에서 제외하였습니다.

## 영향 범위

- Lombok은 pom.xml에 이미 `provided` scope로 선언되어 있습니다.
- getter/setter 시그니처 변경 없으므로 기존 호출부에 영향 없습니다.

## 확인 사항

- [ ] 단일 주제만 다룸 (다른 변경 없음)
- [ ] 의존성(Lombok)은 기존에 선언된 것 사용
- [ ] 기존 동작에 영향 없음
- [ ] 베이스라인 동일 에러 수 유지 확인 (기존 미빌드 파일 다수 존재, 본 변경으로 추가 에러 없음)
