### PR TITLE
[refactor][공통컴포넌트] 공통상세코드(sym/ccm/cde) XML 매퍼 @EgovMapper 인터페이스 방식으로 전환

### DIFF
--- a/src/main/java/egovframework/com/sym/ccm/cde/service/impl/CmmnDetailCodeManageDAO.java
+++ b/src/main/java/egovframework/com/sym/ccm/cde/service/impl/CmmnDetailCodeManageDAO.java
@@ -2,15 +2,14 @@ package egovframework.com.sym.ccm.cde.service.impl;
 
 import java.util.List;
 
-import org.springframework.stereotype.Repository;
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
 
 import egovframework.com.cmm.service.CmmnDetailCode;
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.sym.ccm.cde.service.CmmnDetailCodeVO;
 
 /**
 *
-* 공통상세코드에 대한 데이터 접근 클래스를 정의한다
+* 공통상세코드에 대한 데이터 접근 인터페이스를 정의한다
 * @author 공통서비스 개발팀 이중호
 * @since 2009.04.01
 * @version 1.0
@@ -22,69 +21,55 @@ import egovframework.com.sym.ccm.cde.service.CmmnDetailCodeVO;
 *   수정일      수정자           수정내용
 *  -------    --------    ---------------------------
 *   2009.04.01  이중호          최초 생성
+*   2026.05.28  dasomel        @EgovMapper 인터페이스 방식으로 전환
 *
 * </pre>
 */
 
-@Repository("CmmnDetailCodeManageDAO")
-public class CmmnDetailCodeManageDAO extends EgovComAbstractDAO {
+@EgovMapper("CmmnDetailCodeManageDAO")
+public interface CmmnDetailCodeManageDAO {
 
     /**
 	 * 공통상세코드 총 개수를 조회한다.
      * @param searchVO
      * @return int(공통상세코드 총 개수)
      */
-    public int selectCmmnDetailCodeListTotCnt(CmmnDetailCodeVO searchVO) throws Exception {
-        return (Integer)selectOne("CmmnDetailCodeManage.selectCmmnDetailCodeListTotCnt", searchVO);
-    }
-    
+    int selectCmmnDetailCodeListTotCnt(CmmnDetailCodeVO searchVO) throws Exception;
+
     /**
 	 * 공통상세코드 목록을 조회한다.
      * @param searchVO
      * @return List(공통상세코드 목록)
      * @throws Exception
      */
-    public List<CmmnDetailCodeVO> selectCmmnDetailCodeList(CmmnDetailCodeVO searchVO) throws Exception {
-        return selectList("CmmnDetailCodeManage.selectCmmnDetailCodeList", searchVO);
-    }
+    List<CmmnDetailCodeVO> selectCmmnDetailCodeList(CmmnDetailCodeVO searchVO) throws Exception;
 
 	/**
 	 * 공통상세코드 상세항목을 조회한다.
 	 * @param cmmnDetailCodeVO
-	 * @return CmmnDetailCodeVO(공통상세코드)
+	 * @return CmmnDetailCode(공통상세코드)
 	 */
-	public CmmnDetailCode selectCmmnDetailCodeDetail(CmmnDetailCodeVO cmmnDetailCodeVO) throws Exception{
-		return (CmmnDetailCode) selectOne("CmmnDetailCodeManage.selectCmmnDetailCodeDetail", cmmnDetailCodeVO);
-	}
-	
+	CmmnDetailCode selectCmmnDetailCodeDetail(CmmnDetailCodeVO cmmnDetailCodeVO) throws Exception;
+
 	/**
 	 * 공통상세코드를 삭제한다.
 	 * @param cmmnDetailCodeVO
 	 * @throws Exception
 	 */
-	public void deleteCmmnDetailCode(CmmnDetailCodeVO cmmnDetailCodeVO) throws Exception{
-		delete("CmmnDetailCodeManage.deleteCmmnDetailCode", cmmnDetailCodeVO);
-		
-	}
+	void deleteCmmnDetailCode(CmmnDetailCodeVO cmmnDetailCodeVO) throws Exception;
 
 	/**
 	 * 공통상세코드를 등록한다.
 	 * @param cmmnDetailCodeVO
 	 * @throws Exception
 	 */
-	public void insertCmmnDetailCode(CmmnDetailCodeVO cmmnDetailCodeVO) throws Exception{
-		insert("CmmnDetailCodeManage.insertCmmnDetailCode", cmmnDetailCodeVO);
-		
-	}
+	void insertCmmnDetailCode(CmmnDetailCodeVO cmmnDetailCodeVO) throws Exception;
 
 	/**
 	 * 공통상세코드를 수정한다.
 	 * @param cmmnDetailCodeVO
 	 * @throws Exception
 	 */
-	public void updateCmmnDetailCode(CmmnDetailCodeVO cmmnDetailCodeVO) throws Exception{
-		insert("CmmnDetailCodeManage.updateCmmnDetailCode", cmmnDetailCodeVO);
-		
-	}
-    
+	void updateCmmnDetailCode(CmmnDetailCodeVO cmmnDetailCodeVO) throws Exception;
+
 }

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/cde/EgovCmmnDetailCodeManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/cde/EgovCmmnDetailCodeManage_SQL_altibase.xml
@@ -5,7 +5,7 @@
 --><!--Converted at: Wed May 11 15:50:36 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmnDetailCodeManage">
+<mapper namespace="egovframework.com.sym.ccm.cde.service.impl.CmmnDetailCodeManageDAO">
 
 	<select id="selectCmmnDetailCodeList" parameterType="egovframework.com.sym.ccm.cde.service.CmmnDetailCodeVO" resultType="egovframework.com.sym.ccm.cde.service.CmmnDetailCodeVO">
 		

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/cde/EgovCmmnDetailCodeManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/cde/EgovCmmnDetailCodeManage_SQL_cubrid.xml
@@ -5,7 +5,7 @@
 --><!--Converted at: Wed May 11 15:50:36 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmnDetailCodeManage">
+<mapper namespace="egovframework.com.sym.ccm.cde.service.impl.CmmnDetailCodeManageDAO">
 
 
 	<select id="selectCmmnDetailCodeList" parameterType="egovframework.com.sym.ccm.cde.service.CmmnDetailCodeVO" resultType="egovframework.com.sym.ccm.cde.service.CmmnDetailCodeVO">

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/cde/EgovCmmnDetailCodeManage_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/cde/EgovCmmnDetailCodeManage_SQL_goldilocks.xml
@@ -5,7 +5,7 @@
 --><!--Converted at: Wed May 11 15:50:36 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmnDetailCodeManage">
+<mapper namespace="egovframework.com.sym.ccm.cde.service.impl.CmmnDetailCodeManageDAO">
 
 	<select id="selectCmmnDetailCodeList" parameterType="egovframework.com.sym.ccm.cde.service.CmmnDetailCodeVO" resultType="egovframework.com.sym.ccm.cde.service.CmmnDetailCodeVO">
 		

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/cde/EgovCmmnDetailCodeManage_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/cde/EgovCmmnDetailCodeManage_SQL_maria.xml
@@ -5,7 +5,7 @@
 --><!--Converted at: Wed May 11 15:50:37 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmnDetailCodeManage">
+<mapper namespace="egovframework.com.sym.ccm.cde.service.impl.CmmnDetailCodeManageDAO">
 
 	<select id="selectCmmnDetailCodeList" parameterType="egovframework.com.sym.ccm.cde.service.CmmnDetailCodeVO"  resultType="egovframework.com.sym.ccm.cde.service.CmmnDetailCodeVO">
 		

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/cde/EgovCmmnDetailCodeManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/cde/EgovCmmnDetailCodeManage_SQL_mysql.xml
@@ -5,7 +5,7 @@
 --><!--Converted at: Wed May 11 15:50:37 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmnDetailCodeManage">
+<mapper namespace="egovframework.com.sym.ccm.cde.service.impl.CmmnDetailCodeManageDAO">
 
 	<select id="selectCmmnDetailCodeList" parameterType="egovframework.com.sym.ccm.cde.service.CmmnDetailCodeVO"  resultType="egovframework.com.sym.ccm.cde.service.CmmnDetailCodeVO">
 		

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/cde/EgovCmmnDetailCodeManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/cde/EgovCmmnDetailCodeManage_SQL_oracle.xml
@@ -5,7 +5,7 @@
 --><!--Converted at: Wed May 11 15:50:37 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmnDetailCodeManage">
+<mapper namespace="egovframework.com.sym.ccm.cde.service.impl.CmmnDetailCodeManageDAO">
 
 	<select id="selectCmmnDetailCodeList" parameterType="egovframework.com.sym.ccm.cde.service.CmmnDetailCodeVO" resultType="egovframework.com.sym.ccm.cde.service.CmmnDetailCodeVO">
 		

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/cde/EgovCmmnDetailCodeManage_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/cde/EgovCmmnDetailCodeManage_SQL_postgres.xml
@@ -5,7 +5,7 @@
 --><!--Converted at: Wed May 11 15:50:37 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmnDetailCodeManage">
+<mapper namespace="egovframework.com.sym.ccm.cde.service.impl.CmmnDetailCodeManageDAO">
 
 	<select id="selectCmmnDetailCodeList" parameterType="egovframework.com.sym.ccm.cde.service.CmmnDetailCodeVO"  resultType="egovframework.com.sym.ccm.cde.service.CmmnDetailCodeVO">
 		

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/cde/EgovCmmnDetailCodeManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/cde/EgovCmmnDetailCodeManage_SQL_tibero.xml
@@ -5,7 +5,7 @@
 --><!--Converted at: Wed May 11 15:50:37 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmnDetailCodeManage">
+<mapper namespace="egovframework.com.sym.ccm.cde.service.impl.CmmnDetailCodeManageDAO">
 
 	<select id="selectCmmnDetailCodeList" parameterType="egovframework.com.sym.ccm.cde.service.CmmnDetailCodeVO" resultType="egovframework.com.sym.ccm.cde.service.CmmnDetailCodeVO">
 		

--- a/src/main/resources/egovframework/spring/com/context-mapper.xml
+++ b/src/main/resources/egovframework/spring/com/context-mapper.xml
@@ -21,5 +21,12 @@
 	<bean id="egov.sqlSessionTemplate" class="org.mybatis.spring.SqlSessionTemplate">
 		<constructor-arg ref="egov.sqlSession"/>
 	</bean>
-	
+
+	<!-- @EgovMapper 어노테이션이 붙은 인터페이스를 자동으로 스캔하여 빈으로 등록 -->
+	<bean class="org.mybatis.spring.mapper.MapperScannerConfigurer">
+		<property name="basePackage" value="egovframework.com"/>
+		<property name="annotationClass" value="org.egovframe.rte.psl.dataaccess.mapper.EgovMapper"/>
+		<property name="sqlSessionFactoryBeanName" value="egov.sqlSession"/>
+	</bean>
+
 </beans>


### PR DESCRIPTION
공통상세코드 관리(sym/ccm/cde) 컴포넌트의 데이터 접근 계층을 eGovFrame 5.x에서 권장하는 `@EgovMapper` 인터페이스 방식으로 전환한다.

### 변경 내용

- `CmmnDetailCodeManageDAO`: `EgovComAbstractDAO` 상속 클래스 → `@EgovMapper` 인터페이스로 변경
- `EgovCmmnDetailCodeManage_SQL_*.xml` (8개): mapper `namespace`를 단순명(`CmmnDetailCodeManage`)에서 인터페이스 FQN(`egovframework.com.sym.ccm.cde.service.impl.CmmnDetailCodeManageDAO`)으로 변경
- `context-mapper.xml`: `MapperScannerConfigurer` 빈 추가 — `@EgovMapper` 어노테이션이 붙은 인터페이스를 자동 스캔

### 영향 범위

`EgovCcmCmmnDetailCodeManageServiceImpl`의 `@Resource(name="CmmnDetailCodeManageDAO")` 주입은 변경 없이 동작한다. XML 매퍼의 SQL 자체는 수정하지 않았으므로 기존 동작에 영향 없다.

---

- [ ] 단일 주제만 다룸 (다른 변경 없음)
- [ ] 기존 동작에 영향 없음
- [ ] 빌드 확인 (cde 패키지 컴파일 오류 없음)
