### PR TITLE
[refactor][공통컴포넌트] 권한별롤관리 XML 매퍼 @EgovMapper 인터페이스 방식으로 전환

### DIFF
--- a/src/main/java/egovframework/com/sec/ram/service/impl/AuthorRoleManageDAO.java
+++ b/src/main/java/egovframework/com/sec/ram/service/impl/AuthorRoleManageDAO.java
@@ -2,14 +2,13 @@ package egovframework.com.sec.ram.service.impl;
 
 import java.util.List;
 
-import org.springframework.stereotype.Repository;
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.sec.ram.service.AuthorRoleManage;
 import egovframework.com.sec.ram.service.AuthorRoleManageVO;
 
 /**
- * 권한별 롤관리에 대한 DAO 클래스를 정의한다.
+ * 권한별 롤관리에 대한 DAO 인터페이스를 정의한다.
  * @author 공통서비스 개발팀 이문준
  * @since 2009.06.01
  * @version 1.0
@@ -17,54 +16,42 @@ import egovframework.com.sec.ram.service.AuthorRoleManageVO;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *  수정일               수정자               수정내용
  *  ----------   ---------   ---------------------------
  *  2009.03.11   이문준              최초 생성
  *  2021.02-09   신용호              updateAuthorRole 삭제
+ *  2026.05.28   dasomel             @EgovMapper 인터페이스 방식으로 전환
  *
  * </pre>
  */
-
-@Repository("authorRoleManageDAO")
-public class AuthorRoleManageDAO extends EgovComAbstractDAO {
+@EgovMapper("authorRoleManageDAO")
+public interface AuthorRoleManageDAO {
 
 	/**
 	 * 권한 롤 관계정보 목록 조회
 	 * @param authorRoleManageVO AuthorRoleManageVO
 	 * @return List<AuthorRoleManageVO>
-	 * @exception Exception
 	 */
-	public List<AuthorRoleManageVO> selectAuthorRoleList(AuthorRoleManageVO authorRoleManageVO) throws Exception {
-		return selectList("authorRoleManageDAO.selectAuthorRoleList", authorRoleManageVO);
-	}
-	
+	List<AuthorRoleManageVO> selectAuthorRoleList(AuthorRoleManageVO authorRoleManageVO);
+
 	/**
 	 * 권한 롤 관계정보를 화면에서 입력하여 입력항목의 정합성을 체크하고 데이터베이스에 저장
 	 * @param authorRoleManage AuthorRoleManage
-	 * @exception Exception
 	 */
-	public void insertAuthorRole(AuthorRoleManage authorRoleManage) throws Exception {
-		insert("authorRoleManageDAO.insertAuthorRole", authorRoleManage);
-	}
+	void insertAuthorRole(AuthorRoleManage authorRoleManage);
 
 	/**
 	 * 권한 롤 관계정보를 화면에 조회하여 데이터베이스에서 삭제
 	 * @param authorRoleManage AuthorRoleManage
-	 * @exception Exception
 	 */
-	public void deleteAuthorRole(AuthorRoleManage authorRoleManage) throws Exception {
-		delete("authorRoleManageDAO.deleteAuthorRole", authorRoleManage);
-	}
+	void deleteAuthorRole(AuthorRoleManage authorRoleManage);
 
-    /**
+	/**
 	 * 목록조회 카운트를 반환한다
 	 * @param authorRoleManageVO AuthorRoleManageVO
 	 * @return int
-	 * @exception Exception
 	 */
-	public int selectAuthorRoleListTotCnt(AuthorRoleManageVO authorRoleManageVO) throws Exception {
-		return (Integer)selectOne("authorRoleManageDAO.selectAuthorRoleListTotCnt", authorRoleManageVO);
-	}
+	int selectAuthorRoleListTotCnt(AuthorRoleManageVO authorRoleManageVO);
 
 }

--- a/src/main/resources/egovframework/mapper/com/sec/ram/EgovAuthorRoleManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/sec/ram/EgovAuthorRoleManage_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="authorRoleManageDAO">
+<mapper namespace="egovframework.com.sec.ram.service.impl.AuthorRoleManageDAO">
 
     <resultMap id="authorRole" type="egovframework.com.sec.ram.service.AuthorRoleManageVO">
         <result property="roleCode" column="ROLE_CODE"/>

--- a/src/main/resources/egovframework/mapper/com/sec/ram/EgovAuthorRoleManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/sec/ram/EgovAuthorRoleManage_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="authorRoleManageDAO">
+<mapper namespace="egovframework.com.sec.ram.service.impl.AuthorRoleManageDAO">
 
     <resultMap id="authorRole" type="egovframework.com.sec.ram.service.AuthorRoleManageVO">
         <result property="roleCode" column="ROLE_CODE"/>

--- a/src/main/resources/egovframework/mapper/com/sec/ram/EgovAuthorRoleManage_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/sec/ram/EgovAuthorRoleManage_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="authorRoleManageDAO">
+<mapper namespace="egovframework.com.sec.ram.service.impl.AuthorRoleManageDAO">
 
     <resultMap id="authorRole" type="egovframework.com.sec.ram.service.AuthorRoleManageVO">
         <result property="roleCode" column="ROLE_CODE"/>

--- a/src/main/resources/egovframework/mapper/com/sec/ram/EgovAuthorRoleManage_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/sec/ram/EgovAuthorRoleManage_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="authorRoleManageDAO">
+<mapper namespace="egovframework.com.sec.ram.service.impl.AuthorRoleManageDAO">
 
     <resultMap id="authorRole" type="egovframework.com.sec.ram.service.AuthorRoleManageVO">
         <result property="roleCode" column="ROLE_CODE"/>

--- a/src/main/resources/egovframework/mapper/com/sec/ram/EgovAuthorRoleManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/sec/ram/EgovAuthorRoleManage_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="authorRoleManageDAO">
+<mapper namespace="egovframework.com.sec.ram.service.impl.AuthorRoleManageDAO">
 
     <resultMap id="authorRole" type="egovframework.com.sec.ram.service.AuthorRoleManageVO">
         <result property="roleCode" column="ROLE_CODE"/>

--- a/src/main/resources/egovframework/mapper/com/sec/ram/EgovAuthorRoleManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/sec/ram/EgovAuthorRoleManage_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="authorRoleManageDAO">
+<mapper namespace="egovframework.com.sec.ram.service.impl.AuthorRoleManageDAO">
 
     <resultMap id="authorRole" type="egovframework.com.sec.ram.service.AuthorRoleManageVO">
         <result property="roleCode" column="ROLE_CODE"/>

--- a/src/main/resources/egovframework/mapper/com/sec/ram/EgovAuthorRoleManage_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/sec/ram/EgovAuthorRoleManage_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="authorRoleManageDAO">
+<mapper namespace="egovframework.com.sec.ram.service.impl.AuthorRoleManageDAO">
 
     <resultMap id="authorRole" type="egovframework.com.sec.ram.service.AuthorRoleManageVO">
         <result property="roleCode" column="ROLE_CODE"/>

--- a/src/main/resources/egovframework/mapper/com/sec/ram/EgovAuthorRoleManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/sec/ram/EgovAuthorRoleManage_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="authorRoleManageDAO">
+<mapper namespace="egovframework.com.sec.ram.service.impl.AuthorRoleManageDAO">
 
     <resultMap id="authorRole" type="egovframework.com.sec.ram.service.AuthorRoleManageVO">
         <result property="roleCode" column="ROLE_CODE"/>

--- a/src/main/resources/egovframework/spring/com/context-mapper.xml
+++ b/src/main/resources/egovframework/spring/com/context-mapper.xml
@@ -21,5 +21,12 @@
 	<bean id="egov.sqlSessionTemplate" class="org.mybatis.spring.SqlSessionTemplate">
 		<constructor-arg ref="egov.sqlSession"/>
 	</bean>
-	
+
+	<!-- @EgovMapper 어노테이션이 붙은 인터페이스를 자동으로 스캔하여 빈으로 등록 -->
+	<bean class="org.mybatis.spring.mapper.MapperScannerConfigurer">
+		<property name="basePackage" value="egovframework.com"/>
+		<property name="annotationClass" value="org.egovframe.rte.psl.dataaccess.mapper.EgovMapper"/>
+		<property name="sqlSessionFactoryBeanName" value="egov.sqlSession"/>
+	</bean>
+
 </beans>


### PR DESCRIPTION
## 변경 사유

eGovFrame 5.0에서 도입된 `@EgovMapper` 어노테이션 기반 인터페이스 매핑 방식을 권한별롤관리(sec/ram) 컴포넌트에 적용한다.

기존 `EgovComAbstractDAO`를 상속하는 클래스 방식은 MyBatis sqlSession을 직접 호출하는 레거시 패턴이다. 인터페이스 기반 `@EgovMapper` 방식으로 전환하면 MyBatis가 프록시 구현체를 자동으로 생성하여 보일러플레이트 코드를 제거하고 유지보수성을 높인다.

## 변경 내용

- `AuthorRoleManageDAO`: `@Repository` 클래스 → `@EgovMapper` 인터페이스로 전환
  - `EgovComAbstractDAO` 상속 제거
  - `selectList` / `selectOne` / `insert` / `delete` 직접 호출 제거
  - 메서드 시그니처 유지 (기존 ServiceImpl 호환)
- `EgovAuthorRoleManage_SQL_*.xml` (8개 DB 방언): `namespace`를 인터페이스 FQN으로 변경
  - SQL 내용 변경 없음
- `context-mapper.xml`: `MapperScannerConfigurer` 빈 추가
  - `@EgovMapper` 어노테이션이 붙은 인터페이스를 자동 스캔하여 빈 등록

## 영향 범위

`sec/ram` 패키지 한정. 기존 ServiceImpl(`EgovAuthorRoleManageServiceImpl`)의 코드 변경 없음.

## 체크리스트

- [x] 단일 주제만 다룸 (다른 변경 없음)
- [x] SQL 내용 변경 없음 (namespace만 FQN으로 변경)
- [x] 기존 ServiceImpl과 인터페이스 호환성 유지
- [x] 기존 동작에 영향 없음
