### PR TITLE
[refactor] sym/log/clg LoginLogDAO @EgovMapper 인터페이스 방식으로 전환

### DIFF
--- a/src/main/java/egovframework/com/sym/log/clg/service/impl/LoginLogDAO.java
+++ b/src/main/java/egovframework/com/sym/log/clg/service/impl/LoginLogDAO.java
@@ -2,20 +2,20 @@ package egovframework.com.sym.log.clg.service.impl;
 
 import java.util.List;
 
-import org.springframework.stereotype.Repository;
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.sym.log.clg.service.LoginLog;
 
 /**
  * @Class Name : LoginLogDAO.java
- * @Description : 시스템 로그 관리를 위한 데이터 접근 클래스
+ * @Description : 시스템 로그 관리를 위한 데이터 접근 인터페이스
  * @Modification Information
  *
  *    수정일       수정자         수정내용
  *    -------       -------     -------------------
  *    2009. 3. 11.  이삼섭       최초생성
  *    2011. 7. 01.  이기하       패키지 분리(sym.log -> sym.log.clg)
+ *    2026. 5. 28.  dasomel      @EgovMapper 인터페이스 방식으로 전환
  *
  * @author 공통 서비스 개발팀 이삼섭
  * @since 2009. 3. 11.
@@ -23,52 +23,38 @@ import egovframework.com.sym.log.clg.service.LoginLog;
  * @see
  *
  */
-@Repository("loginLogDAO")
-public class LoginLogDAO extends EgovComAbstractDAO {
+@EgovMapper("loginLogDAO")
+public interface LoginLogDAO {
 
 	/**
 	 * 접속로그를 기록한다.
 	 *
-	 * @param LoginLog
-	 * @return
-	 * @throws Exception
+	 * @param loginLog
 	 */
-	public void logInsertLoginLog(LoginLog loginLog) throws Exception{
-		insert("LoginLog.logInsertLoginLog", loginLog);
-	}
+	void logInsertLoginLog(LoginLog loginLog);
 
 	/**
 	 * 접속로그 상세보기를 조회한다.
 	 *
 	 * @param loginLog
 	 * @return loginLog
-	 * @throws Exception
 	 */
-	public LoginLog selectLoginLog(LoginLog loginLog) throws Exception{
-
-		return (LoginLog) selectOne("LoginLog.selectLoginLog", loginLog);
-	}
+	LoginLog selectLoginLog(LoginLog loginLog);
 
 	/**
-	 * 접속로그를 목록을 조회한다.
+	 * 접속로그 목록을 조회한다.
 	 *
 	 * @param loginLog
-	 * @return
-	 * @throws Exception
+	 * @return List
 	 */
-	public List<LoginLog> selectLoginLogInf(LoginLog loginLog) throws Exception{
-		return selectList("LoginLog.selectLoginLogInf", loginLog);
-	}
+	List<LoginLog> selectLoginLogInf(LoginLog loginLog);
 
 	/**
 	 * 접속로그 목록의 숫자를 조회한다.
+	 *
 	 * @param loginLog
-	 * @return
-	 * @throws Exception
+	 * @return int
 	 */
-	public int selectLoginLogInfCnt(LoginLog loginLog) throws Exception{
-
-		return (Integer)selectOne("LoginLog.selectLoginLogInfCnt", loginLog);
-	}
+	int selectLoginLogInfCnt(LoginLog loginLog);
 
 }

--- a/src/main/resources/egovframework/mapper/com/sym/log/clg/EgovLoginLog_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/log/clg/EgovLoginLog_SQL_altibase.xml
@@ -5,7 +5,7 @@
   -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="LoginLog">
+<mapper namespace="egovframework.com.sym.log.clg.service.impl.LoginLogDAO">
 
 	<!-- 로그인로그 맵 -->
 	<resultMap id="LoginLogVO" type="egovframework.com.sym.log.clg.service.LoginLog">

--- a/src/main/resources/egovframework/mapper/com/sym/log/clg/EgovLoginLog_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/log/clg/EgovLoginLog_SQL_cubrid.xml
@@ -5,7 +5,7 @@
   -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="LoginLog">
+<mapper namespace="egovframework.com.sym.log.clg.service.impl.LoginLogDAO">
 
 	<!-- 로그인로그 맵 -->
 	<resultMap id="LoginLogVO" type="egovframework.com.sym.log.clg.service.LoginLog">

--- a/src/main/resources/egovframework/mapper/com/sym/log/clg/EgovLoginLog_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/log/clg/EgovLoginLog_SQL_goldilocks.xml
@@ -5,7 +5,7 @@
   -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="LoginLog">
+<mapper namespace="egovframework.com.sym.log.clg.service.impl.LoginLogDAO">
 
 	<!-- 로그인로그 맵 -->
 	<resultMap id="LoginLogVO" type="egovframework.com.sym.log.clg.service.LoginLog">

--- a/src/main/resources/egovframework/mapper/com/sym/log/clg/EgovLoginLog_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/log/clg/EgovLoginLog_SQL_maria.xml
@@ -5,7 +5,7 @@
   -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="LoginLog">
+<mapper namespace="egovframework.com.sym.log.clg.service.impl.LoginLogDAO">
 
 	<!-- 로그인로그 맵 -->
 	<resultMap id="LoginLogVO" type="egovframework.com.sym.log.clg.service.LoginLog">

--- a/src/main/resources/egovframework/mapper/com/sym/log/clg/EgovLoginLog_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/log/clg/EgovLoginLog_SQL_mysql.xml
@@ -5,7 +5,7 @@
   -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="LoginLog">
+<mapper namespace="egovframework.com.sym.log.clg.service.impl.LoginLogDAO">
 
 	<!-- 로그인로그 맵 -->
 	<resultMap id="LoginLogVO" type="egovframework.com.sym.log.clg.service.LoginLog">

--- a/src/main/resources/egovframework/mapper/com/sym/log/clg/EgovLoginLog_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/log/clg/EgovLoginLog_SQL_oracle.xml
@@ -5,7 +5,7 @@
   -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="LoginLog">
+<mapper namespace="egovframework.com.sym.log.clg.service.impl.LoginLogDAO">
 	<!-- 로그인로그 맵 -->
 	<resultMap id="LoginLogVO" type="egovframework.com.sym.log.clg.service.LoginLog">
 		<result property="logId" column="LOG_ID"/>

--- a/src/main/resources/egovframework/mapper/com/sym/log/clg/EgovLoginLog_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/log/clg/EgovLoginLog_SQL_postgres.xml
@@ -5,7 +5,7 @@
   -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="LoginLog">
+<mapper namespace="egovframework.com.sym.log.clg.service.impl.LoginLogDAO">
 
 	<!-- 로그인로그 맵 -->
 	<resultMap id="LoginLogVO" type="egovframework.com.sym.log.clg.service.LoginLog">

--- a/src/main/resources/egovframework/mapper/com/sym/log/clg/EgovLoginLog_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/log/clg/EgovLoginLog_SQL_tibero.xml
@@ -5,7 +5,7 @@
   -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="LoginLog">
+<mapper namespace="egovframework.com.sym.log.clg.service.impl.LoginLogDAO">
 
 	<!-- 로그인로그 맵 -->
 	<resultMap id="LoginLogVO" type="egovframework.com.sym.log.clg.service.LoginLog">

--- a/src/main/resources/egovframework/spring/com/context-mapper.xml
+++ b/src/main/resources/egovframework/spring/com/context-mapper.xml
@@ -21,5 +21,12 @@
 	<bean id="egov.sqlSessionTemplate" class="org.mybatis.spring.SqlSessionTemplate">
 		<constructor-arg ref="egov.sqlSession"/>
 	</bean>
-	
+
+	<!-- @EgovMapper 어노테이션이 붙은 인터페이스를 자동으로 스캔하여 빈으로 등록 -->
+	<bean class="org.mybatis.spring.mapper.MapperScannerConfigurer">
+		<property name="basePackage" value="egovframework.com"/>
+		<property name="annotationClass" value="org.egovframe.rte.psl.dataaccess.mapper.EgovMapper"/>
+		<property name="sqlSessionFactoryBeanName" value="egov.sqlSession"/>
+	</bean>
+
 </beans>


### PR DESCRIPTION
sym/log/clg 모듈의 LoginLogDAO를 eGovFrame 5.0에서 도입된 @EgovMapper 어노테이션 인터페이스 방식으로 전환합니다.

**변경 내용**

- `LoginLogDAO`: `EgovComAbstractDAO` 상속 클래스 → `@EgovMapper` 어노테이션 인터페이스로 전환
- `EgovLoginLog_SQL_*.xml` (altibase/cubrid/goldilocks/maria/mysql/oracle/postgres/tibero): mapper namespace를 단순 문자열(`LoginLog`)에서 인터페이스 FQCN(`egovframework.com.sym.log.clg.service.impl.LoginLogDAO`)으로 변경
- `context-mapper.xml`: `MapperScannerConfigurer` 빈 등록 추가 — `@EgovMapper` 어노테이션 기반 자동 스캔 설정

**영향 범위**

- `EgovLoginLogServiceImpl`에서 `LoginLogDAO` 주입 방식(`@Resource(name="loginLogDAO")`) 유지, 변경 없음
- 기존 동작에 영향 없음 (동일 SQL, 동일 빈 이름)

---

- [ ] 단일 주제만 다룸 (다른 변경 없음)
- [ ] 기존 동작에 영향 없음
- [ ] 5.x 다른 브랜치용 PR 필요 시 후속 PR 예정
