### PR TITLE
[refactor][5.0.x][공통컴포넌트] sym/bat 모듈 @EgovMapper 인터페이스 추가

### DIFF
--- a/src/main/java/egovframework/com/sym/bat/service/impl/BatchOpertDao.java
+++ b/src/main/java/egovframework/com/sym/bat/service/impl/BatchOpertDao.java
@@ -33,7 +33,7 @@ public class BatchOpertDao extends EgovComAbstractDAO {
 	 * @exception Exception Exception
 	 */
 	public void deleteBatchOpert(BatchOpert batchOpert) throws Exception {
-		delete("BatchOpertDao.deleteBatchOpert", batchOpert);
+		delete("egovframework.com.sym.bat.service.impl.mapper.BatchOpertMapper.deleteBatchOpert", batchOpert);
 	}
 
 	/**
@@ -43,7 +43,7 @@ public class BatchOpertDao extends EgovComAbstractDAO {
 	 * @exception Exception Exception
 	 */
 	public void insertBatchOpert(BatchOpert batchOpert) throws Exception {
-		insert("BatchOpertDao.insertBatchOpert", batchOpert);
+		insert("egovframework.com.sym.bat.service.impl.mapper.BatchOpertMapper.insertBatchOpert", batchOpert);
 	}
 
 	/**
@@ -54,7 +54,7 @@ public class BatchOpertDao extends EgovComAbstractDAO {
 	 * @exception Exception Exception
 	 */
 	public BatchOpert selectBatchOpert(BatchOpert batchOpert) throws Exception {
-		return selectOne("BatchOpertDao.selectBatchOpert", batchOpert);
+		return selectOne("egovframework.com.sym.bat.service.impl.mapper.BatchOpertMapper.selectBatchOpert", batchOpert);
 	}
 
 	/**
@@ -65,7 +65,7 @@ public class BatchOpertDao extends EgovComAbstractDAO {
 	 * @exception Exception Exception
 	 */
 	public List<BatchOpert> selectBatchOpertList(BatchOpert searchVO) throws Exception {
-		return selectList("BatchOpertDao.selectBatchOpertList", searchVO);
+		return selectList("egovframework.com.sym.bat.service.impl.mapper.BatchOpertMapper.selectBatchOpertList", searchVO);
 	}
 
 	/**
@@ -76,7 +76,7 @@ public class BatchOpertDao extends EgovComAbstractDAO {
 	 * @exception Exception Exception
 	 */
 	public int selectBatchOpertListCnt(BatchOpert searchVO) throws Exception {
-		return (Integer) selectOne("BatchOpertDao.selectBatchOpertListCnt", searchVO);
+		return (Integer) selectOne("egovframework.com.sym.bat.service.impl.mapper.BatchOpertMapper.selectBatchOpertListCnt", searchVO);
 	}
 
 	/**
@@ -86,7 +86,7 @@ public class BatchOpertDao extends EgovComAbstractDAO {
 	 * @exception Exception Exception
 	 */
 	public void updateBatchOpert(BatchOpert batchOpert) throws Exception {
-		update("BatchOpertDao.updateBatchOpert", batchOpert);
+		update("egovframework.com.sym.bat.service.impl.mapper.BatchOpertMapper.updateBatchOpert", batchOpert);
 	}
 
 }

--- a/src/main/java/egovframework/com/sym/bat/service/impl/BatchResultDao.java
+++ b/src/main/java/egovframework/com/sym/bat/service/impl/BatchResultDao.java
@@ -33,7 +33,7 @@ public class BatchResultDao extends EgovComAbstractDAO {
 	 * @exception Exception Exception
 	 */
 	public void deleteBatchResult(BatchResult batchResult) throws Exception {
-		delete("BatchResultDao.deleteBatchResult", batchResult);
+		delete("egovframework.com.sym.bat.service.impl.mapper.BatchResultMapper.deleteBatchResult", batchResult);
 	}
 
 	/**
@@ -43,7 +43,7 @@ public class BatchResultDao extends EgovComAbstractDAO {
 	 * @exception Exception Exception
 	 */
 	public void insertBatchResult(BatchResult batchResult) throws Exception {
-		insert("BatchResultDao.insertBatchResult", batchResult);
+		insert("egovframework.com.sym.bat.service.impl.mapper.BatchResultMapper.insertBatchResult", batchResult);
 	}
 
 	/**
@@ -54,7 +54,7 @@ public class BatchResultDao extends EgovComAbstractDAO {
 	 * @exception Exception Exception
 	 */
 	public BatchResult selectBatchResult(BatchResult batchResult) throws Exception {
-		return (BatchResult) selectOne("BatchResultDao.selectBatchResult", batchResult);
+		return (BatchResult) selectOne("egovframework.com.sym.bat.service.impl.mapper.BatchResultMapper.selectBatchResult", batchResult);
 	}
 
 	/**
@@ -65,7 +65,7 @@ public class BatchResultDao extends EgovComAbstractDAO {
 	 * @exception Exception Exception
 	 */
 	public List<BatchResult> selectBatchResultList(BatchResult searchVO) throws Exception {
-		return selectList("BatchResultDao.selectBatchResultList", searchVO);
+		return selectList("egovframework.com.sym.bat.service.impl.mapper.BatchResultMapper.selectBatchResultList", searchVO);
 	}
 
 	/**
@@ -76,7 +76,7 @@ public class BatchResultDao extends EgovComAbstractDAO {
 	 * @exception Exception Exception
 	 */
 	public int selectBatchResultListCnt(BatchResult searchVO) throws Exception {
-		return (Integer) selectOne("BatchResultDao.selectBatchResultListCnt", searchVO);
+		return (Integer) selectOne("egovframework.com.sym.bat.service.impl.mapper.BatchResultMapper.selectBatchResultListCnt", searchVO);
 	}
 
 	/**
@@ -86,7 +86,7 @@ public class BatchResultDao extends EgovComAbstractDAO {
 	 * @exception Exception Exception
 	 */
 	public void updateBatchResult(BatchResult batchResult) throws Exception {
-		update("BatchResultDao.updateBatchResult", batchResult);
+		update("egovframework.com.sym.bat.service.impl.mapper.BatchResultMapper.updateBatchResult", batchResult);
 	}
 
 }

--- a/src/main/java/egovframework/com/sym/bat/service/impl/mapper/BatchOpertMapper.java
+++ b/src/main/java/egovframework/com/sym/bat/service/impl/mapper/BatchOpertMapper.java
@@ -1,0 +1,73 @@
+package egovframework.com.sym.bat.service.impl.mapper;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.sym.bat.service.BatchOpert;
+
+/**
+ * 배치작업관리에 대한 Mapper 인터페이스를 정의한다.
+ *
+ * @author 김진만
+ * @since 2010.06.17
+ * @version 2.0
+ * @see
+ * <pre>
+ * == 개정이력(Modification Information) ==
+ *
+ *   수정일       수정자           수정내용
+ *  -------     --------    ---------------------------
+ *  2010.06.17   김진만     최초 생성
+ *  2025.05.28              @EgovMapper 인터페이스 방식으로 추가
+ * </pre>
+ */
+@EgovMapper("batchOpertMapper")
+public interface BatchOpertMapper {
+
+	/**
+	 * 배치작업을 삭제한다.
+	 *
+	 * @param batchOpert 삭제할 배치작업 VO
+	 */
+	void deleteBatchOpert(BatchOpert batchOpert);
+
+	/**
+	 * 배치작업을 등록한다.
+	 *
+	 * @param batchOpert 저장할 배치작업 VO
+	 */
+	void insertBatchOpert(BatchOpert batchOpert);
+
+	/**
+	 * 배치작업정보를 상세조회 한다.
+	 *
+	 * @param batchOpert 조회할 KEY가 있는 배치작업 VO
+	 * @return 배치작업정보
+	 */
+	BatchOpert selectBatchOpert(BatchOpert batchOpert);
+
+	/**
+	 * 배치작업정보 목록을 조회한다.
+	 *
+	 * @param searchVO 조회조건이 저장된 VO
+	 * @return 배치작업목록
+	 */
+	List<BatchOpert> selectBatchOpertList(BatchOpert searchVO);
+
+	/**
+	 * 배치작업 목록 전체 건수를 조회한다.
+	 *
+	 * @param searchVO 조회할 정보가 담긴 VO
+	 * @return 목록건수
+	 */
+	int selectBatchOpertListCnt(BatchOpert searchVO);
+
+	/**
+	 * 배치작업정보를 수정한다.
+	 *
+	 * @param batchOpert 수정대상 배치작업 VO
+	 */
+	void updateBatchOpert(BatchOpert batchOpert);
+
+}

--- a/src/main/java/egovframework/com/sym/bat/service/impl/mapper/BatchResultMapper.java
+++ b/src/main/java/egovframework/com/sym/bat/service/impl/mapper/BatchResultMapper.java
@@ -1,0 +1,73 @@
+package egovframework.com.sym.bat.service.impl.mapper;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.sym.bat.service.BatchResult;
+
+/**
+ * 배치결과관리에 대한 Mapper 인터페이스를 정의한다.
+ *
+ * @author 김진만
+ * @since 2010.06.17
+ * @version 2.0
+ * @see
+ * <pre>
+ * == 개정이력(Modification Information) ==
+ *
+ *   수정일       수정자           수정내용
+ *  -------     --------    ---------------------------
+ *  2010.06.17   김진만     최초 생성
+ *  2025.05.28              @EgovMapper 인터페이스 방식으로 추가
+ * </pre>
+ */
+@EgovMapper("batchResultMapper")
+public interface BatchResultMapper {
+
+	/**
+	 * 배치결과를 삭제한다.
+	 *
+	 * @param batchResult 삭제할 배치결과 VO
+	 */
+	void deleteBatchResult(BatchResult batchResult);
+
+	/**
+	 * 배치결과를 등록한다.
+	 *
+	 * @param batchResult 저장할 배치결과 VO
+	 */
+	void insertBatchResult(BatchResult batchResult);
+
+	/**
+	 * 배치결과정보를 상세조회 한다.
+	 *
+	 * @param batchResult 조회할 KEY가 있는 배치결과 VO
+	 * @return 배치결과정보
+	 */
+	BatchResult selectBatchResult(BatchResult batchResult);
+
+	/**
+	 * 배치결과정보 목록을 조회한다.
+	 *
+	 * @param searchVO 조회조건이 저장된 VO
+	 * @return 배치결과목록
+	 */
+	List<BatchResult> selectBatchResultList(BatchResult searchVO);
+
+	/**
+	 * 배치결과 목록 전체 건수를 조회한다.
+	 *
+	 * @param searchVO 조회할 정보가 담긴 VO
+	 * @return 목록건수
+	 */
+	int selectBatchResultListCnt(BatchResult searchVO);
+
+	/**
+	 * 배치결과정보를 수정한다.
+	 *
+	 * @param batchResult 수정대상 배치결과 VO
+	 */
+	void updateBatchResult(BatchResult batchResult);
+
+}

--- a/src/main/resources/egovframework/mapper/com/sym/bat/EgovBatchOpert_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/bat/EgovBatchOpert_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BatchOpertDao">
+<mapper namespace="egovframework.com.sym.bat.service.impl.mapper.BatchOpertMapper">
 
     <resultMap id="batchOpertResult" type="egovframework.com.sym.bat.service.BatchOpert">
         <result property="batchOpertId" column="BATCH_OPERT_ID"/>

--- a/src/main/resources/egovframework/mapper/com/sym/bat/EgovBatchOpert_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/bat/EgovBatchOpert_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BatchOpertDao">
+<mapper namespace="egovframework.com.sym.bat.service.impl.mapper.BatchOpertMapper">
     <resultMap id="batchOpertResult" type="egovframework.com.sym.bat.service.BatchOpert">
         <result property="batchOpertId" column="BATCH_OPERT_ID"/>
         <result property="batchOpertNm" column="BATCH_OPERT_NM"/>

--- a/src/main/resources/egovframework/mapper/com/sym/bat/EgovBatchOpert_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/bat/EgovBatchOpert_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BatchOpertDao">
+<mapper namespace="egovframework.com.sym.bat.service.impl.mapper.BatchOpertMapper">
 
     <resultMap id="batchOpertResult" type="egovframework.com.sym.bat.service.BatchOpert">
         <result property="batchOpertId" column="BATCH_OPERT_ID"/>

--- a/src/main/resources/egovframework/mapper/com/sym/bat/EgovBatchOpert_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/bat/EgovBatchOpert_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BatchOpertDao">
+<mapper namespace="egovframework.com.sym.bat.service.impl.mapper.BatchOpertMapper">
     <resultMap id="batchOpertResult" type="egovframework.com.sym.bat.service.BatchOpert">
         <result property="batchOpertId" column="BATCH_OPERT_ID"/>
         <result property="batchOpertNm" column="BATCH_OPERT_NM"/>

--- a/src/main/resources/egovframework/mapper/com/sym/bat/EgovBatchOpert_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/bat/EgovBatchOpert_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BatchOpertDao">
+<mapper namespace="egovframework.com.sym.bat.service.impl.mapper.BatchOpertMapper">
     <resultMap id="batchOpertResult" type="egovframework.com.sym.bat.service.BatchOpert">
         <result property="batchOpertId" column="BATCH_OPERT_ID"/>
         <result property="batchOpertNm" column="BATCH_OPERT_NM"/>

--- a/src/main/resources/egovframework/mapper/com/sym/bat/EgovBatchOpert_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/bat/EgovBatchOpert_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BatchOpertDao">
+<mapper namespace="egovframework.com.sym.bat.service.impl.mapper.BatchOpertMapper">
     <resultMap id="batchOpertResult" type="egovframework.com.sym.bat.service.BatchOpert">
         <result property="batchOpertId" column="BATCH_OPERT_ID"/>
         <result property="batchOpertNm" column="BATCH_OPERT_NM"/>

--- a/src/main/resources/egovframework/mapper/com/sym/bat/EgovBatchOpert_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/bat/EgovBatchOpert_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BatchOpertDao">
+<mapper namespace="egovframework.com.sym.bat.service.impl.mapper.BatchOpertMapper">
     <resultMap id="batchOpertResult" type="egovframework.com.sym.bat.service.BatchOpert">
         <result property="batchOpertId" column="BATCH_OPERT_ID"/>
         <result property="batchOpertNm" column="BATCH_OPERT_NM"/>

--- a/src/main/resources/egovframework/mapper/com/sym/bat/EgovBatchOpert_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/bat/EgovBatchOpert_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BatchOpertDao">
+<mapper namespace="egovframework.com.sym.bat.service.impl.mapper.BatchOpertMapper">
     <resultMap id="batchOpertResult" type="egovframework.com.sym.bat.service.BatchOpert">
         <result property="batchOpertId" column="BATCH_OPERT_ID"/>
         <result property="batchOpertNm" column="BATCH_OPERT_NM"/>

--- a/src/main/resources/egovframework/mapper/com/sym/bat/EgovBatchResult_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/bat/EgovBatchResult_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BatchResultDao">
+<mapper namespace="egovframework.com.sym.bat.service.impl.mapper.BatchResultMapper">
     <resultMap id="batchResultResult" type="egovframework.com.sym.bat.service.BatchResult">
         <result property="batchResultId" column="BATCH_RESULT_ID"/>
         <result property="batchSchdulId" column="BATCH_SCHDUL_ID"/>

--- a/src/main/resources/egovframework/mapper/com/sym/bat/EgovBatchResult_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/bat/EgovBatchResult_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BatchResultDao">
+<mapper namespace="egovframework.com.sym.bat.service.impl.mapper.BatchResultMapper">
     <resultMap id="batchResultResult" type="egovframework.com.sym.bat.service.BatchResult">
         <result property="batchResultId" column="BATCH_RESULT_ID"/>
         <result property="batchSchdulId" column="BATCH_SCHDUL_ID"/>

--- a/src/main/resources/egovframework/mapper/com/sym/bat/EgovBatchResult_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/bat/EgovBatchResult_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BatchResultDao">
+<mapper namespace="egovframework.com.sym.bat.service.impl.mapper.BatchResultMapper">
     <resultMap id="batchResultResult" type="egovframework.com.sym.bat.service.BatchResult">
         <result property="batchResultId" column="BATCH_RESULT_ID"/>
         <result property="batchSchdulId" column="BATCH_SCHDUL_ID"/>

--- a/src/main/resources/egovframework/mapper/com/sym/bat/EgovBatchResult_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/bat/EgovBatchResult_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BatchResultDao">
+<mapper namespace="egovframework.com.sym.bat.service.impl.mapper.BatchResultMapper">
     <resultMap id="batchResultResult" type="egovframework.com.sym.bat.service.BatchResult">
         <result property="batchResultId" column="BATCH_RESULT_ID"/>
         <result property="batchSchdulId" column="BATCH_SCHDUL_ID"/>

--- a/src/main/resources/egovframework/mapper/com/sym/bat/EgovBatchResult_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/bat/EgovBatchResult_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BatchResultDao">
+<mapper namespace="egovframework.com.sym.bat.service.impl.mapper.BatchResultMapper">
     <resultMap id="batchResultResult" type="egovframework.com.sym.bat.service.BatchResult">
         <result property="batchResultId" column="BATCH_RESULT_ID"/>
         <result property="batchSchdulId" column="BATCH_SCHDUL_ID"/>

--- a/src/main/resources/egovframework/mapper/com/sym/bat/EgovBatchResult_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/bat/EgovBatchResult_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BatchResultDao">
+<mapper namespace="egovframework.com.sym.bat.service.impl.mapper.BatchResultMapper">
     <resultMap id="batchResultResult" type="egovframework.com.sym.bat.service.BatchResult">
         <result property="batchResultId" column="BATCH_RESULT_ID"/>
         <result property="batchSchdulId" column="BATCH_SCHDUL_ID"/>

--- a/src/main/resources/egovframework/mapper/com/sym/bat/EgovBatchResult_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/bat/EgovBatchResult_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BatchResultDao">
+<mapper namespace="egovframework.com.sym.bat.service.impl.mapper.BatchResultMapper">
     <resultMap id="batchResultResult" type="egovframework.com.sym.bat.service.BatchResult">
         <result property="batchResultId" column="BATCH_RESULT_ID"/>
         <result property="batchSchdulId" column="BATCH_SCHDUL_ID"/>

--- a/src/main/resources/egovframework/mapper/com/sym/bat/EgovBatchResult_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/bat/EgovBatchResult_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BatchResultDao">
+<mapper namespace="egovframework.com.sym.bat.service.impl.mapper.BatchResultMapper">
     <resultMap id="batchResultResult" type="egovframework.com.sym.bat.service.BatchResult">
         <result property="batchResultId" column="BATCH_RESULT_ID"/>
         <result property="batchSchdulId" column="BATCH_SCHDUL_ID"/>


### PR DESCRIPTION
## 변경 사유

eGovFrame 5.0에서 도입된 `@EgovMapper` 어노테이션 방식을 sym/bat 모듈에 적용.
기존 `EgovComAbstractDAO` 상속 방식 외에 MyBatis Mapper 인터페이스 방식을 병행 지원하여
의존성 주입 유연성과 타입 안전성을 높임.

## 변경 내용

- `BatchResultMapper` 인터페이스 추가 (`@EgovMapper("batchResultMapper")`)
- `BatchOpertMapper` 인터페이스 추가 (`@EgovMapper("batchOpertMapper")`)
- 각 DB 방언별 XML mapper namespace를 인터페이스 FQCN으로 변경 (16개 파일)
  - 대상 방언: mysql, oracle, tibero, cubrid, altibase, goldilocks, maria, postgres
- 기존 `BatchResultDao`, `BatchOpertDao` DAO 클래스의 query ID 참조를 변경된 namespace에 맞게 수정 (하위 호환 유지)

## 영향 범위

- sym/bat 모듈 (배치작업관리, 배치결과관리)
- 기존 DAO 클래스는 유지되므로 현재 동작에 영향 없음

## 체크리스트

- [x] 단일 주제만 다룸 (다른 변경 없음)
- [x] 5.x 다른 브랜치용 PR이 필요한 경우 후속 PR 링크 명시 (5.1.x, 5.2.x 대응 예정)
- [x] 기존 동작에 영향 없음 (기존 DAO 클래스 유지)
- [x] 컴파일 통과 확인
