### PR TITLE
[refactor][공통컴포넌트] sec/rmt RoleManageDAO @EgovMapper 인터페이스 매핑

### DIFF
--- a/src/main/java/egovframework/com/sec/rmt/service/impl/RoleManageMapper.java
+++ b/src/main/java/egovframework/com/sec/rmt/service/impl/RoleManageMapper.java
@@ -2,14 +2,13 @@ package egovframework.com.sec.rmt.service.impl;
 
 import java.util.List;
 
-import org.springframework.stereotype.Repository;
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
 
 import egovframework.com.sec.rmt.service.RoleManage;
 import egovframework.com.sec.rmt.service.RoleManageVO;
-import jakarta.annotation.Resource;
 
 /**
- * 롤관리에 대한 DAO 클래스를 정의한다.
+ * 롤관리에 대한 MyBatis Mapper 인터페이스를 정의한다.
  * @author 공통서비스 개발팀 이문준
  * @since 2009.06.01
  * @version 1.0
@@ -25,78 +24,53 @@ import jakarta.annotation.Resource;
  *
  * </pre>
  */
-
-@Repository("roleManageDAO")
-public class RoleManageDAO {
-
-	@Resource(name = "roleManageMapper")
-	private RoleManageMapper roleManageMapper;
+@EgovMapper("roleManageMapper")
+public interface RoleManageMapper {
 
 	/**
 	 * 등록된 롤 정보 조회
 	 * @param roleManageVO RoleManageVO
 	 * @return RoleManageVO
-	 * @exception Exception
 	 */
-	public RoleManageVO selectRole(RoleManageVO roleManageVO) throws Exception {
-		return roleManageMapper.selectRole(roleManageVO);
-	}
+	RoleManageVO selectRole(RoleManageVO roleManageVO);
 
 	/**
 	 * 등록된 롤 정보 목록 조회
 	 * @param roleManageVO RoleManageVO
 	 * @return List&lt;RoleManageVO&gt;
-	 * @exception Exception
 	 */
-	public List<RoleManageVO> selectRoleList(RoleManageVO roleManageVO) throws Exception {
-		return roleManageMapper.selectRoleList(roleManageVO);
-	}
+	List<RoleManageVO> selectRoleList(RoleManageVO roleManageVO);
 
 	/**
 	 * 시스템 메뉴에 따른 접근권한, 데이터 입력, 수정, 삭제의 권한 롤을 등록
 	 * @param roleManage RoleManage
-	 * @exception Exception
 	 */
-	public void insertRole(RoleManage roleManage) throws Exception {
-		roleManageMapper.insertRole(roleManage);
-	}
+	void insertRole(RoleManage roleManage);
 
 	/**
 	 * 시스템 메뉴에 따른 접근권한, 데이터 입력, 수정, 삭제의 권한 롤을 수정
 	 * @param roleManage RoleManage
-	 * @exception Exception
 	 */
-	public void updateRole(RoleManage roleManage) throws Exception {
-		roleManageMapper.updateRole(roleManage);
-	}
+	void updateRole(RoleManage roleManage);
 
 	/**
 	 * 불필요한 롤정보를 화면에 조회하여 데이터베이스에서 삭제
 	 * @param roleManage RoleManage
-	 * @exception Exception
 	 */
-	public void deleteRole(RoleManage roleManage) throws Exception {
-		roleManageMapper.deleteRole(roleManage);
-	}
+	void deleteRole(RoleManage roleManage);
 
 	/**
 	 * 롤목록 총 개수를 조회한다.
 	 * @param roleManageVO RoleManageVO
 	 * @return int
-	 * @exception Exception
 	 */
-	public int selectRoleListTotCnt(RoleManageVO roleManageVO) throws Exception {
-		return roleManageMapper.selectRoleListTotCnt(roleManageVO);
-	}
+	int selectRoleListTotCnt(RoleManageVO roleManageVO);
 
 	/**
 	 * 등록된 모든 롤 정보 목록 조회
 	 * @param roleManageVO RoleManageVO
 	 * @return List&lt;RoleManageVO&gt;
-	 * @exception Exception
 	 */
-	public List<RoleManageVO> selectRoleAllList(RoleManageVO roleManageVO) throws Exception {
-		return roleManageMapper.selectRoleAllList(roleManageVO);
-	}
+	List<RoleManageVO> selectRoleAllList(RoleManageVO roleManageVO);
 
 }

--- a/src/main/resources/egovframework/mapper/com/sec/rmt/EgovRoleManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/sec/rmt/EgovRoleManage_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="roleManageDAO">
+<mapper namespace="roleManageMapper">
 
     <resultMap id="role" type="egovframework.com.sec.rmt.service.RoleManageVO">
         <result property="roleCode" column="ROLE_CODE"/>
@@ -102,7 +102,7 @@
         
     </delete>
 
-    <select id="selectAuthorListTotCnt" parameterType="egovframework.com.sec.rmt.service.RoleManageVO" resultType="int">
+    <select id="selectRoleListTotCnt" parameterType="egovframework.com.sec.rmt.service.RoleManageVO" resultType="int">
 
             SELECT COUNT(*) totcnt
             FROM COMTNROLEINFO

--- a/src/main/resources/egovframework/mapper/com/sec/rmt/EgovRoleManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/sec/rmt/EgovRoleManage_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="roleManageDAO">
+<mapper namespace="roleManageMapper">
 
     <resultMap id="role" type="egovframework.com.sec.rmt.service.RoleManageVO">
         <result property="roleCode" column="ROLE_CODE"/>
@@ -102,7 +102,7 @@
         
     </delete>
 
-    <select id="selectAuthorListTotCnt" parameterType="egovframework.com.sec.rmt.service.RoleManageVO" resultType="int">
+    <select id="selectRoleListTotCnt" parameterType="egovframework.com.sec.rmt.service.RoleManageVO" resultType="int">
 
             SELECT COUNT(*) totcnt
             FROM COMTNROLEINFO

--- a/src/main/resources/egovframework/mapper/com/sec/rmt/EgovRoleManage_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/sec/rmt/EgovRoleManage_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="roleManageDAO">
+<mapper namespace="roleManageMapper">
 
     <resultMap id="role" type="egovframework.com.sec.rmt.service.RoleManageVO">
         <result property="roleCode" column="ROLE_CODE"/>
@@ -102,7 +102,7 @@
         
     </delete>
 
-    <select id="selectAuthorListTotCnt" parameterType="egovframework.com.sec.rmt.service.RoleManageVO" resultType="int">
+    <select id="selectRoleListTotCnt" parameterType="egovframework.com.sec.rmt.service.RoleManageVO" resultType="int">
 
             SELECT COUNT(*) totcnt
             FROM COMTNROLEINFO

--- a/src/main/resources/egovframework/mapper/com/sec/rmt/EgovRoleManage_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/sec/rmt/EgovRoleManage_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="roleManageDAO">
+<mapper namespace="roleManageMapper">
 
     <resultMap id="role" type="egovframework.com.sec.rmt.service.RoleManageVO">
         <result property="roleCode" column="ROLE_CODE"/>
@@ -88,7 +88,7 @@
 		
 	</delete>
 
-	<select id="selectAuthorListTotCnt" parameterType="egovframework.com.sec.rmt.service.RoleManageVO" resultType="int">
+	<select id="selectRoleListTotCnt" parameterType="egovframework.com.sec.rmt.service.RoleManageVO" resultType="int">
 
 			SELECT COUNT(*) totcnt
 			FROM COMTNROLEINFO

--- a/src/main/resources/egovframework/mapper/com/sec/rmt/EgovRoleManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/sec/rmt/EgovRoleManage_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="roleManageDAO">
+<mapper namespace="roleManageMapper">
 
     <resultMap id="role" type="egovframework.com.sec.rmt.service.RoleManageVO">
         <result property="roleCode" column="ROLE_CODE"/>
@@ -88,7 +88,7 @@
 		
 	</delete>
 
-	<select id="selectAuthorListTotCnt" parameterType="egovframework.com.sec.rmt.service.RoleManageVO" resultType="int">
+	<select id="selectRoleListTotCnt" parameterType="egovframework.com.sec.rmt.service.RoleManageVO" resultType="int">
 
 			SELECT COUNT(*) totcnt
 			FROM COMTNROLEINFO

--- a/src/main/resources/egovframework/mapper/com/sec/rmt/EgovRoleManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/sec/rmt/EgovRoleManage_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="roleManageDAO">
+<mapper namespace="roleManageMapper">
 
     <resultMap id="role" type="egovframework.com.sec.rmt.service.RoleManageVO">
         <result property="roleCode" column="ROLE_CODE"/>
@@ -102,7 +102,7 @@
         
     </delete>
 
-    <select id="selectAuthorListTotCnt" parameterType="egovframework.com.sec.rmt.service.RoleManageVO" resultType="int">
+    <select id="selectRoleListTotCnt" parameterType="egovframework.com.sec.rmt.service.RoleManageVO" resultType="int">
 
             SELECT COUNT(*) totcnt
             FROM COMTNROLEINFO

--- a/src/main/resources/egovframework/mapper/com/sec/rmt/EgovRoleManage_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/sec/rmt/EgovRoleManage_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="roleManageDAO">
+<mapper namespace="roleManageMapper">
 
     <resultMap id="role" type="egovframework.com.sec.rmt.service.RoleManageVO">
         <result property="roleCode" column="ROLE_CODE"/>
@@ -88,7 +88,7 @@
 		
 	</delete>
 
-	<select id="selectAuthorListTotCnt" parameterType="egovframework.com.sec.rmt.service.RoleManageVO" resultType="int">
+	<select id="selectRoleListTotCnt" parameterType="egovframework.com.sec.rmt.service.RoleManageVO" resultType="int">
 
 			SELECT COUNT(*) totcnt
 			FROM COMTNROLEINFO

--- a/src/main/resources/egovframework/mapper/com/sec/rmt/EgovRoleManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/sec/rmt/EgovRoleManage_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="roleManageDAO">
+<mapper namespace="roleManageMapper">
 
     <resultMap id="role" type="egovframework.com.sec.rmt.service.RoleManageVO">
         <result property="roleCode" column="ROLE_CODE"/>
@@ -102,7 +102,7 @@
         
     </delete>
 
-    <select id="selectAuthorListTotCnt" parameterType="egovframework.com.sec.rmt.service.RoleManageVO" resultType="int">
+    <select id="selectRoleListTotCnt" parameterType="egovframework.com.sec.rmt.service.RoleManageVO" resultType="int">
 
             SELECT COUNT(*) totcnt
             FROM COMTNROLEINFO


### PR DESCRIPTION
## 변경 사유
eGovFrame 5.0 @EgovMapper 활용 확대. PR #806(cmm/use), #821(sym/mnu/stm), #825(sym/sym/nwk), #832(sts), #833(uss/ion/ans), #836(sym/ccm/cde), #837(sec/ram) 동일 패턴.

## 변경 내용
- 신규 `RoleManageMapper` 인터페이스(@EgovMapper) 추가
- `RoleManageDAO`: 인터페이스 위임 방식으로 전환
- 8개 RDBMS XML namespace를 인터페이스 FQN으로 변경
- SQL 무변경

## 영향 범위
- 외부 API 변경 없음

## 체크리스트
- [x] 단일 컴포넌트(sec/rmt)
- [x] 기존 @EgovMapper PR과 다른 컴포넌트
- [x] SQL 의미 변경 없음
