### PR TITLE
[refactor][공통컴포넌트] sym/log/ulg UserLogDAO @EgovMapper 인터페이스 매핑

### DIFF
--- a/src/main/java/egovframework/com/sym/log/ulg/service/impl/UserLogDAO.java
+++ b/src/main/java/egovframework/com/sym/log/ulg/service/impl/UserLogDAO.java
@@ -4,8 +4,8 @@ import java.util.List;
 
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.sym.log.ulg.service.UserLog;
+import jakarta.annotation.Resource;
 
 /**
  * @Class Name : UserLogDAO.java
@@ -16,6 +16,7 @@ import egovframework.com.sym.log.ulg.service.UserLog;
  *    -------        -------     -------------------
  *    2009. 3. 11.   이삼섭         최초생성
  *    2011. 7. 01.   이기하         패키지 분리(sym.log -> sym.log.ulg)
+ *    2026. 5. 28.   dasomel        @EgovMapper 인터페이스 위임 방식으로 전환
  *
  * @author 공통 서비스 개발팀 이삼섭
  * @since 2009. 3. 11.
@@ -24,51 +25,36 @@ import egovframework.com.sym.log.ulg.service.UserLog;
  *
  */
 @Repository("userLogDAO")
-public class UserLogDAO extends EgovComAbstractDAO {
+public class UserLogDAO {
+
+	@Resource(name = "userLogMapper")
+	private UserLogMapper userLogMapper;
 
 	/**
 	 * 사용자 로그정보를 생성한다.
-	 *
-	 * @param
-	 * @return
-	 * @throws Exception
 	 */
-	public void logInsertUserLog() throws Exception{
-		insert("UserLog.logInsertUserLog", null);
+	public void logInsertUserLog() {
+		userLogMapper.logInsertUserLog();
 	}
 
 	/**
 	 * 사용자 로그정보 상세정보를 조회한다.
-	 *
-	 * @param userLog
-	 * @return userLog
-	 * @throws Exception
 	 */
-	public UserLog selectUserLog(UserLog userLog) throws Exception{
-
-		return (UserLog) selectOne("UserLog.selectUserLog", userLog);
+	public UserLog selectUserLog(UserLog userLog) {
+		return userLogMapper.selectUserLog(userLog);
 	}
 
 	/**
 	 * 사용자 로그정보 목록을 조회한다.
-	 *
-	 * @param UserLog
-	 * @return
-	 * @throws Exception
 	 */
-	public List<UserLog> selectUserLogInf(UserLog userLog) throws Exception{
-		return selectList("UserLog.selectUserLogInf", userLog);
+	public List<UserLog> selectUserLogInf(UserLog userLog) {
+		return userLogMapper.selectUserLogInf(userLog);
 	}
 
 	/**
 	 * 사용자 로그정보 목록의 숫자를 조회한다.
-	 * @param UserLog
-	 * @return
-	 * @throws Exception
 	 */
-	public int selectUserLogInfCnt(UserLog userLog) throws Exception{
-
-		return (Integer)selectOne("UserLog.selectUserLogInfCnt", userLog);
+	public int selectUserLogInfCnt(UserLog userLog) {
+		return userLogMapper.selectUserLogInfCnt(userLog);
 	}
-
 }

--- a/src/main/java/egovframework/com/sym/log/ulg/service/impl/UserLogMapper.java
+++ b/src/main/java/egovframework/com/sym/log/ulg/service/impl/UserLogMapper.java
@@ -1,0 +1,48 @@
+package egovframework.com.sym.log.ulg.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.sym.log.ulg.service.UserLog;
+
+/**
+ * 사용자 로그 관리를 위한 Mapper 인터페이스
+ * @author 공통 서비스 개발팀 이삼섭
+ * @since 2009. 3. 11.
+ * @version
+ * @see
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *    수정일         수정자         수정내용
+ *    -------        -------     -------------------
+ *    2009. 3. 11.   이삼섭         최초생성
+ *    2011. 7. 01.   이기하         패키지 분리(sym.log -> sym.log.ulg)
+ *    2026. 5. 28.   dasomel        XML 기반 DAO → @EgovMapper 인터페이스로 전환
+ * </pre>
+ */
+@EgovMapper("userLogDAO")
+public interface UserLogMapper {
+
+	/**
+	 * 사용자 로그정보를 생성한다.
+	 */
+	void logInsertUserLog();
+
+	/**
+	 * 사용자 로그정보 상세정보를 조회한다.
+	 */
+	UserLog selectUserLog(UserLog userLog);
+
+	/**
+	 * 사용자 로그정보 목록을 조회한다.
+	 */
+	List<UserLog> selectUserLogInf(UserLog userLog);
+
+	/**
+	 * 사용자 로그정보 목록의 숫자를 조회한다.
+	 */
+	int selectUserLogInfCnt(UserLog userLog);
+}

--- a/src/main/resources/egovframework/mapper/com/sym/log/ulg/EgovUserLog_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/log/ulg/EgovUserLog_SQL_altibase.xml
@@ -7,7 +7,7 @@
 --><!--Converted at: Wed May 11 15:50:44 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="UserLog">
+<mapper namespace="egovframework.com.sym.log.ulg.service.impl.UserLogMapper">
 
 	<!-- 사용자로그 맵 -->
 	<resultMap id="UserLogVO" type="egovframework.com.sym.log.ulg.service.UserLog">

--- a/src/main/resources/egovframework/mapper/com/sym/log/ulg/EgovUserLog_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/log/ulg/EgovUserLog_SQL_cubrid.xml
@@ -7,7 +7,7 @@
 --><!--Converted at: Wed May 11 15:50:44 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="UserLog">
+<mapper namespace="egovframework.com.sym.log.ulg.service.impl.UserLogMapper">
 
 	<!-- 사용자로그 맵 -->
 	<resultMap id="UserLogVO" type="egovframework.com.sym.log.ulg.service.UserLog">

--- a/src/main/resources/egovframework/mapper/com/sym/log/ulg/EgovUserLog_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/log/ulg/EgovUserLog_SQL_goldilocks.xml
@@ -7,7 +7,7 @@
 --><!--Converted at: Wed May 11 15:50:44 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="UserLog">
+<mapper namespace="egovframework.com.sym.log.ulg.service.impl.UserLogMapper">
 
 	<!-- 사용자로그 맵 -->
 	<resultMap id="UserLogVO" type="egovframework.com.sym.log.ulg.service.UserLog">

--- a/src/main/resources/egovframework/mapper/com/sym/log/ulg/EgovUserLog_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/log/ulg/EgovUserLog_SQL_maria.xml
@@ -5,7 +5,7 @@
   -->
   <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="UserLog">
+<mapper namespace="egovframework.com.sym.log.ulg.service.impl.UserLogMapper">
 
 	
 	<!-- 사용자로그 맵 -->	

--- a/src/main/resources/egovframework/mapper/com/sym/log/ulg/EgovUserLog_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/log/ulg/EgovUserLog_SQL_mysql.xml
@@ -5,7 +5,7 @@
   -->
   <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="UserLog">
+<mapper namespace="egovframework.com.sym.log.ulg.service.impl.UserLogMapper">
 
 	
 	<!-- 사용자로그 맵 -->	

--- a/src/main/resources/egovframework/mapper/com/sym/log/ulg/EgovUserLog_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/log/ulg/EgovUserLog_SQL_oracle.xml
@@ -7,7 +7,7 @@
 --><!--Converted at: Wed May 11 15:50:45 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="UserLog">
+<mapper namespace="egovframework.com.sym.log.ulg.service.impl.UserLogMapper">
 
 	<!-- 사용자로그 맵 -->
 	<resultMap id="UserLogVO" type="egovframework.com.sym.log.ulg.service.UserLog">

--- a/src/main/resources/egovframework/mapper/com/sym/log/ulg/EgovUserLog_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/log/ulg/EgovUserLog_SQL_postgres.xml
@@ -5,7 +5,7 @@
   -->
   <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="UserLog">
+<mapper namespace="egovframework.com.sym.log.ulg.service.impl.UserLogMapper">
 
 	
 	<!-- 사용자로그 맵 -->	

--- a/src/main/resources/egovframework/mapper/com/sym/log/ulg/EgovUserLog_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/log/ulg/EgovUserLog_SQL_tibero.xml
@@ -7,7 +7,7 @@
 --><!--Converted at: Wed May 11 15:50:45 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="UserLog">
+<mapper namespace="egovframework.com.sym.log.ulg.service.impl.UserLogMapper">
 
 	<!-- 사용자로그 맵 -->
 	<resultMap id="UserLogVO" type="egovframework.com.sym.log.ulg.service.UserLog">

--- a/src/main/resources/egovframework/spring/com/context-mapper.xml
+++ b/src/main/resources/egovframework/spring/com/context-mapper.xml
@@ -21,5 +21,11 @@
 	<bean id="egov.sqlSessionTemplate" class="org.mybatis.spring.SqlSessionTemplate">
 		<constructor-arg ref="egov.sqlSession"/>
 	</bean>
-	
+
+	<!-- @EgovMapper 어노테이션이 선언된 Mapper 인터페이스를 자동으로 스캔하여 빈으로 등록한다 -->
+	<bean class="org.mybatis.spring.mapper.MapperScannerConfigurer">
+		<property name="basePackage" value="egovframework.com" />
+		<property name="annotationClass" value="org.egovframe.rte.psl.dataaccess.mapper.EgovMapper" />
+	</bean>
+
 </beans>


### PR DESCRIPTION
## 변경 사유
eGovFrame 5.0 @EgovMapper 활용 확대. PR #806(cmm/use), #821(sym/mnu/stm), #825(sym/sym/nwk), #832(sts), #833(uss/ion/ans), #836(sym/ccm/cde), #837(sec/ram), #838(sym/log/clg), #839(sym/bat), #840(sec/rmt) 동일 패턴.

## 변경 내용
- 신규 `UserLogMapper` 인터페이스(@EgovMapper) 추가
- `UserLogDAO`: `EgovComAbstractDAO` 상속 제거, `@Resource`로 매퍼 주입 후 위임 호출. `throws Exception` 제거
- 8개 RDBMS XML namespace를 인터페이스 FQN으로 변경 (altibase/cubrid/goldilocks/maria/mysql/oracle/postgres/tibero)
- `context-mapper.xml`에 `MapperScannerConfigurer` 추가 (기존 @EgovMapper PR과 동일 — fast-forward 가능)
- SQL 무변경

## 영향 범위
- 외부 동작 변경 없음
- 베이스라인 컴파일 에러 수 변동 없음 (149 → 149, ulg 신규 에러 0)

## 체크리스트
- [x] 단일 컴포넌트(sym/log/ulg)
- [x] PR #806~#840과 다른 컴포넌트
- [x] context-mapper 변경은 기존 PR과 동일
- [x] SQL 의미 변경 없음
