### PR TITLE
[refactor][공통컴포넌트] sym/log/tlg TrsmrcvLogDAO @EgovMapper 인터페이스 매핑

### DIFF
--- a/src/main/java/egovframework/com/sym/log/tlg/service/impl/TrsmrcvLogDAO.java
+++ b/src/main/java/egovframework/com/sym/log/tlg/service/impl/TrsmrcvLogDAO.java
@@ -4,8 +4,8 @@ import java.util.List;
 
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.sym.log.tlg.service.TrsmrcvLog;
+import jakarta.annotation.Resource;
 
 /**
  * @Class Name : TrsmrcvLogDAO.java
@@ -16,71 +16,35 @@ import egovframework.com.sym.log.tlg.service.TrsmrcvLog;
  *    -------        -------     -------------------
  *    2009. 3. 11.   이삼섭         최초생성
  *    2011. 7. 01.   이기하         패키지 분리(sym.log -> sym.log.tlg)
+ *    2026. 5. 28.   dasomel        @EgovMapper 인터페이스 위임 방식으로 전환
  *
  * @author 공통 서비스 개발팀 이삼섭
  * @since 2009. 3. 11.
- * @version
- * @see
- *
  */
 @Repository("trsmrcvLogDAO")
-public class TrsmrcvLogDAO extends EgovComAbstractDAO {
+public class TrsmrcvLogDAO {
 
-	/**
-	 * 송수신로그를 기록한다.
-	 *
-	 * @param TrsmrcvLog
-	 * @return
-	 * @throws Exception
-	 */
-	public void logInsertTrsmrcvLog(TrsmrcvLog trsmrcvLog) throws Exception{
-		insert("TrsmrcvLogDAO.logInsertTrsmrcvLog", trsmrcvLog);
+	@Resource(name = "trsmrcvLogMapper")
+	private TrsmrcvLogMapper trsmrcvLogMapper;
+
+	public void logInsertTrsmrcvLog(TrsmrcvLog trsmrcvLog) {
+		trsmrcvLogMapper.logInsertTrsmrcvLog(trsmrcvLog);
 	}
 
-	/**
-	 * 송수신 로그정보를 요약한다.
-	 *
-	 * @param
-	 * @return
-	 * @throws Exception
-	 */
-	public void logInsertTrsmrcvLogSummary() throws Exception{
-		insert("TrsmrcvLogDAO.logInsertTrsmrcvLogSummary", null);
-		delete("TrsmrcvLogDAO.logDeleteTrsmrcvLogSummary", null);
+	public void logInsertTrsmrcvLogSummary() {
+		trsmrcvLogMapper.logInsertTrsmrcvLogSummary();
+		trsmrcvLogMapper.logDeleteTrsmrcvLogSummary();
 	}
 
-	/**
-	 * 송수신 로그정보를 조회한다.
-	 *
-	 * @param trsmrcvLog
-	 * @return trsmrcvLog
-	 * @throws Exception
-	 */
-	public TrsmrcvLog selectTrsmrcvLog(TrsmrcvLog trsmrcvLog) throws Exception{
-
-		return (TrsmrcvLog) selectOne("TrsmrcvLogDAO.selectTrsmrcvLog", trsmrcvLog);
+	public TrsmrcvLog selectTrsmrcvLog(TrsmrcvLog trsmrcvLog) {
+		return trsmrcvLogMapper.selectTrsmrcvLog(trsmrcvLog);
 	}
 
-	/**
-     * 송수신 로그정보 목록을 조회한다.
-     *
-     * @param TrsmrcvLog
-     * @return
-     * @throws Exception
-     */
-    public List<TrsmrcvLog> selectTrsmrcvLogInf(TrsmrcvLog trsmrcvLog) throws Exception {
-        return selectList("TrsmrcvLogDAO.selectTrsmrcvLogInf", trsmrcvLog);
-    }
-
-	/**
-	 * 송수신 로그정보 목록의 숫자를 조회한다.
-	 * @param TrsmrcvLog
-	 * @return
-	 * @throws Exception
-	 */
-	public int selectTrsmrcvLogInfCnt(TrsmrcvLog trsmrcvLog) throws Exception{
-
-		return (Integer)selectOne("TrsmrcvLogDAO.selectTrsmrcvLogInfCnt", trsmrcvLog);
+	public List<TrsmrcvLog> selectTrsmrcvLogInf(TrsmrcvLog trsmrcvLog) {
+		return trsmrcvLogMapper.selectTrsmrcvLogInf(trsmrcvLog);
 	}
 
+	public int selectTrsmrcvLogInfCnt(TrsmrcvLog trsmrcvLog) {
+		return trsmrcvLogMapper.selectTrsmrcvLogInfCnt(trsmrcvLog);
+	}
 }

--- a/src/main/java/egovframework/com/sym/log/tlg/service/impl/TrsmrcvLogMapper.java
+++ b/src/main/java/egovframework/com/sym/log/tlg/service/impl/TrsmrcvLogMapper.java
@@ -1,0 +1,36 @@
+package egovframework.com.sym.log.tlg.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.sym.log.tlg.service.TrsmrcvLog;
+
+/**
+ * 송수신 로그 관리를 위한 Mapper 인터페이스
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *    수정일         수정자         수정내용
+ *    -------        -------     -------------------
+ *    2009. 3. 11.   이삼섭         최초생성
+ *    2011. 7. 01.   이기하         패키지 분리(sym.log -> sym.log.tlg)
+ *    2026. 5. 28.   dasomel        XML 기반 DAO → @EgovMapper 인터페이스로 전환
+ * </pre>
+ */
+@EgovMapper("trsmrcvLogMapper")
+public interface TrsmrcvLogMapper {
+
+	void logInsertTrsmrcvLog(TrsmrcvLog trsmrcvLog);
+
+	void logInsertTrsmrcvLogSummary();
+
+	void logDeleteTrsmrcvLogSummary();
+
+	TrsmrcvLog selectTrsmrcvLog(TrsmrcvLog trsmrcvLog);
+
+	List<TrsmrcvLog> selectTrsmrcvLogInf(TrsmrcvLog trsmrcvLog);
+
+	int selectTrsmrcvLogInfCnt(TrsmrcvLog trsmrcvLog);
+}

--- a/src/main/resources/egovframework/mapper/com/sym/log/tlg/EgovTrsmrcvLog_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/log/tlg/EgovTrsmrcvLog_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="TrsmrcvLogDAO">
+<mapper namespace="egovframework.com.sym.log.tlg.service.impl.TrsmrcvLogMapper">
 
 	<!-- 송수신로그 맵 -->
 	<resultMap id="TrsmrcvLogVO" type="egovframework.com.sym.log.tlg.service.TrsmrcvLog">

--- a/src/main/resources/egovframework/mapper/com/sym/log/tlg/EgovTrsmrcvLog_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/log/tlg/EgovTrsmrcvLog_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="TrsmrcvLogDAO">
+<mapper namespace="egovframework.com.sym.log.tlg.service.impl.TrsmrcvLogMapper">
 
 	<!-- 송수신로그 맵 -->
 	<resultMap id="TrsmrcvLogVO" type="egovframework.com.sym.log.tlg.service.TrsmrcvLog">

--- a/src/main/resources/egovframework/mapper/com/sym/log/tlg/EgovTrsmrcvLog_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/log/tlg/EgovTrsmrcvLog_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="TrsmrcvLogDAO">
+<mapper namespace="egovframework.com.sym.log.tlg.service.impl.TrsmrcvLogMapper">
 
 	<!-- 송수신로그 맵 -->
 	<resultMap id="TrsmrcvLogVO" type="egovframework.com.sym.log.tlg.service.TrsmrcvLog">

--- a/src/main/resources/egovframework/mapper/com/sym/log/tlg/EgovTrsmrcvLog_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/log/tlg/EgovTrsmrcvLog_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="TrsmrcvLogDAO">
+<mapper namespace="egovframework.com.sym.log.tlg.service.impl.TrsmrcvLogMapper">
 	
 	<!-- 송수신로그 맵 -->	
 	<resultMap id="TrsmrcvLogVO" type="egovframework.com.sym.log.tlg.service.TrsmrcvLog">

--- a/src/main/resources/egovframework/mapper/com/sym/log/tlg/EgovTrsmrcvLog_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/log/tlg/EgovTrsmrcvLog_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="TrsmrcvLogDAO">
+<mapper namespace="egovframework.com.sym.log.tlg.service.impl.TrsmrcvLogMapper">
 	
 	<!-- 송수신로그 맵 -->	
 	<resultMap id="TrsmrcvLogVO" type="egovframework.com.sym.log.tlg.service.TrsmrcvLog">

--- a/src/main/resources/egovframework/mapper/com/sym/log/tlg/EgovTrsmrcvLog_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/log/tlg/EgovTrsmrcvLog_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="TrsmrcvLogDAO">
+<mapper namespace="egovframework.com.sym.log.tlg.service.impl.TrsmrcvLogMapper">
 
 	<!-- 송수신로그 맵 -->
 	<resultMap id="TrsmrcvLogVO" type="egovframework.com.sym.log.tlg.service.TrsmrcvLog">

--- a/src/main/resources/egovframework/mapper/com/sym/log/tlg/EgovTrsmrcvLog_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/log/tlg/EgovTrsmrcvLog_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="TrsmrcvLogDAO">
+<mapper namespace="egovframework.com.sym.log.tlg.service.impl.TrsmrcvLogMapper">
 	
 	<!-- 송수신로그 맵 -->	
 	<resultMap id="TrsmrcvLogVO" type="egovframework.com.sym.log.tlg.service.TrsmrcvLog">

--- a/src/main/resources/egovframework/mapper/com/sym/log/tlg/EgovTrsmrcvLog_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/log/tlg/EgovTrsmrcvLog_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="TrsmrcvLogDAO">
+<mapper namespace="egovframework.com.sym.log.tlg.service.impl.TrsmrcvLogMapper">
 	<!-- 송수신로그 맵 -->
 	<resultMap id="TrsmrcvLogVO" type="egovframework.com.sym.log.tlg.service.TrsmrcvLog">
 		<result property="requstId" column="REQUST_ID"/>

--- a/src/main/resources/egovframework/spring/com/context-mapper.xml
+++ b/src/main/resources/egovframework/spring/com/context-mapper.xml
@@ -22,4 +22,11 @@
 		<constructor-arg ref="egov.sqlSession"/>
 	</bean>
 	
+
+	<!-- @EgovMapper 어노테이션이 선언된 Mapper 인터페이스를 자동으로 스캔하여 빈으로 등록한다 -->
+	<bean class="org.mybatis.spring.mapper.MapperScannerConfigurer">
+		<property name="basePackage" value="egovframework.com" />
+		<property name="annotationClass" value="org.egovframe.rte.psl.dataaccess.mapper.EgovMapper" />
+	</bean>
+
 </beans>


### PR DESCRIPTION
## 변경 사유
eGovFrame 5.0 @EgovMapper 활용 확대. PR #841(sym/log/ulg), #842(sym/log/wlg) 동일 패턴.

## 변경 내용
- 신규 `TrsmrcvLogMapper` 인터페이스(@EgovMapper) 추가
- `TrsmrcvLogDAO`: `EgovComAbstractDAO` 상속 제거, `@Resource` 위임 방식으로 전환
- 8개 RDBMS XML namespace를 인터페이스 FQN으로 변경
- `context-mapper.xml`에 `MapperScannerConfigurer` 추가 (기존 PR과 동일)

## 영향 범위
- 외부 동작 변경 없음
- 베이스라인 컴파일 에러 수 변동 없음 (149 → 149)
