### PR TITLE
[refactor][공통컴포넌트] sym/log/plg PrivacyLogDAO @EgovMapper 인터페이스 매핑

### DIFF
--- a/src/main/java/egovframework/com/sym/log/plg/service/impl/PrivacyLogDAO.java
+++ b/src/main/java/egovframework/com/sym/log/plg/service/impl/PrivacyLogDAO.java
@@ -4,53 +4,39 @@ import java.util.List;
 
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.sym.log.plg.service.PrivacyLog;
+import jakarta.annotation.Resource;
 
+/**
+ * 개인정보조회 로그 관리를 위한 데이터 접근 클래스
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *    수정일         수정자         수정내용
+ *    -------        -------     -------------------
+ *    2026. 5. 28.   dasomel        @EgovMapper 인터페이스 위임 방식으로 전환
+ * </pre>
+ */
 @Repository("privacyLogDAO")
-public class PrivacyLogDAO extends EgovComAbstractDAO {
+public class PrivacyLogDAO {
 
-	/**
-	 * 개인정보조회 로그정보를 생성한다.
-	 *
-	 * @param
-	 * @return
-	 * @throws Exception
-	 */
-	public void insertPrivacyLog(PrivacyLog privacyLog) throws Exception{
-		insert("PrivacyLog.insertPrivacyLog", privacyLog);
+	@Resource(name = "privacyLogMapper")
+	private PrivacyLogMapper privacyLogMapper;
+
+	public void insertPrivacyLog(PrivacyLog privacyLog) {
+		privacyLogMapper.insertPrivacyLog(privacyLog);
 	}
 
-	/**
-	 * 개인정보조회 로그정보 목록을 조회한다.
-	 *
-	 * @param privacyLog
-	 * @return
-	 * @throws Exception
-	 */
-	public List<PrivacyLog> selectPrivacyLogList(PrivacyLog privacyLog) throws Exception{
-		return selectList("PrivacyLog.selectPrivacyLogList", privacyLog);
-	}
-	
-	/**
-	 * 개인정보조회 로그정보 목록의 숫자를 조회한다.
-	 * @param privacyLog
-	 * @return
-	 * @throws Exception
-	 */
-	public int selectPrivacyLogListCount(PrivacyLog privacyLog) throws Exception{
-		return (Integer)selectOne("PrivacyLog.selectPrivacyLogListCount", privacyLog);
+	public List<PrivacyLog> selectPrivacyLogList(PrivacyLog privacyLog) {
+		return privacyLogMapper.selectPrivacyLogList(privacyLog);
 	}
 
-	/**
-	 * 개인정보조회 로그정보 상세정보를 조회한다.
-	 *
-	 * @param privacyLog
-	 * @return privacyLog
-	 * @throws Exception
-	 */
-	public PrivacyLog selectPrivacyLog(PrivacyLog privacyLog) throws Exception{
-		return (PrivacyLog) selectOne("PrivacyLog.selectPrivacyLog", privacyLog);
+	public int selectPrivacyLogListCount(PrivacyLog privacyLog) {
+		return privacyLogMapper.selectPrivacyLogListCount(privacyLog);
 	}
 
+	public PrivacyLog selectPrivacyLog(PrivacyLog privacyLog) {
+		return privacyLogMapper.selectPrivacyLog(privacyLog);
+	}
 }

--- a/src/main/java/egovframework/com/sym/log/plg/service/impl/PrivacyLogMapper.java
+++ b/src/main/java/egovframework/com/sym/log/plg/service/impl/PrivacyLogMapper.java
@@ -1,0 +1,30 @@
+package egovframework.com.sym.log.plg.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.sym.log.plg.service.PrivacyLog;
+
+/**
+ * 개인정보조회 로그 관리를 위한 Mapper 인터페이스
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *    수정일         수정자         수정내용
+ *    -------        -------     -------------------
+ *    2026. 5. 28.   dasomel        XML 기반 DAO → @EgovMapper 인터페이스로 전환
+ * </pre>
+ */
+@EgovMapper("privacyLogMapper")
+public interface PrivacyLogMapper {
+
+	void insertPrivacyLog(PrivacyLog privacyLog);
+
+	List<PrivacyLog> selectPrivacyLogList(PrivacyLog privacyLog);
+
+	int selectPrivacyLogListCount(PrivacyLog privacyLog);
+
+	PrivacyLog selectPrivacyLog(PrivacyLog privacyLog);
+}

--- a/src/main/resources/egovframework/mapper/com/sym/log/plg/EgovPrivacyLog_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/log/plg/EgovPrivacyLog_SQL_altibase.xml
@@ -5,7 +5,7 @@
  -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="PrivacyLog">
+<mapper namespace="egovframework.com.sym.log.plg.service.impl.PrivacyLogMapper">
 
 	<!-- 개인정보조회 로그 result mapping -->	
 	<resultMap id="privacyLogMapping" type="egovframework.com.sym.log.plg.service.PrivacyLog">

--- a/src/main/resources/egovframework/mapper/com/sym/log/plg/EgovPrivacyLog_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/log/plg/EgovPrivacyLog_SQL_cubrid.xml
@@ -5,7 +5,7 @@
  -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="PrivacyLog">
+<mapper namespace="egovframework.com.sym.log.plg.service.impl.PrivacyLogMapper">
 
 	<!-- 개인정보조회 로그 result mapping -->	
 	<resultMap id="privacyLogMapping" type="egovframework.com.sym.log.plg.service.PrivacyLog">

--- a/src/main/resources/egovframework/mapper/com/sym/log/plg/EgovPrivacyLog_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/log/plg/EgovPrivacyLog_SQL_goldilocks.xml
@@ -5,7 +5,7 @@
  -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="PrivacyLog">
+<mapper namespace="egovframework.com.sym.log.plg.service.impl.PrivacyLogMapper">
 
 	<!-- 개인정보조회 로그 result mapping -->	
 	<resultMap id="privacyLogMapping" type="egovframework.com.sym.log.plg.service.PrivacyLog">

--- a/src/main/resources/egovframework/mapper/com/sym/log/plg/EgovPrivacyLog_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/log/plg/EgovPrivacyLog_SQL_maria.xml
@@ -5,7 +5,7 @@
   -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="PrivacyLog">
+<mapper namespace="egovframework.com.sym.log.plg.service.impl.PrivacyLogMapper">
 
 	<!-- 개인정보조회 로그 result mapping -->	
 	<resultMap id="privacyLogMapping" type="egovframework.com.sym.log.plg.service.PrivacyLog">

--- a/src/main/resources/egovframework/mapper/com/sym/log/plg/EgovPrivacyLog_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/log/plg/EgovPrivacyLog_SQL_mysql.xml
@@ -5,7 +5,7 @@
   -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="PrivacyLog">
+<mapper namespace="egovframework.com.sym.log.plg.service.impl.PrivacyLogMapper">
 
 	<!-- 개인정보조회 로그 result mapping -->	
 	<resultMap id="privacyLogMapping" type="egovframework.com.sym.log.plg.service.PrivacyLog">

--- a/src/main/resources/egovframework/mapper/com/sym/log/plg/EgovPrivacyLog_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/log/plg/EgovPrivacyLog_SQL_oracle.xml
@@ -5,7 +5,7 @@
   -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="PrivacyLog">
+<mapper namespace="egovframework.com.sym.log.plg.service.impl.PrivacyLogMapper">
 	
 	<!-- 개인정보조회 로그 result mapping -->	
 	<resultMap id="privacyLogMapping" type="egovframework.com.sym.log.plg.service.PrivacyLog">

--- a/src/main/resources/egovframework/mapper/com/sym/log/plg/EgovPrivacyLog_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/log/plg/EgovPrivacyLog_SQL_postgres.xml
@@ -5,7 +5,7 @@
   -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="PrivacyLog">
+<mapper namespace="egovframework.com.sym.log.plg.service.impl.PrivacyLogMapper">
 
 	<!-- 개인정보조회 로그 result mapping -->	
 	<resultMap id="privacyLogMapping" type="egovframework.com.sym.log.plg.service.PrivacyLog">

--- a/src/main/resources/egovframework/mapper/com/sym/log/plg/EgovPrivacyLog_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/log/plg/EgovPrivacyLog_SQL_tibero.xml
@@ -5,7 +5,7 @@
  -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="PrivacyLog">
+<mapper namespace="egovframework.com.sym.log.plg.service.impl.PrivacyLogMapper">
 	
 	<!-- 개인정보조회 로그 result mapping -->	
 	<resultMap id="privacyLogMapping" type="egovframework.com.sym.log.plg.service.PrivacyLog">

--- a/src/main/resources/egovframework/spring/com/context-mapper.xml
+++ b/src/main/resources/egovframework/spring/com/context-mapper.xml
@@ -22,4 +22,11 @@
 		<constructor-arg ref="egov.sqlSession"/>
 	</bean>
 	
+
+	<!-- @EgovMapper 어노테이션이 선언된 Mapper 인터페이스를 자동으로 스캔하여 빈으로 등록한다 -->
+	<bean class="org.mybatis.spring.mapper.MapperScannerConfigurer">
+		<property name="basePackage" value="egovframework.com" />
+		<property name="annotationClass" value="org.egovframe.rte.psl.dataaccess.mapper.EgovMapper" />
+	</bean>
+
 </beans>


### PR DESCRIPTION
## 변경 사유
eGovFrame 5.0 @EgovMapper 활용 확대. PR #841(ulg), #842(wlg), #843(tlg) 동일 패턴.

## 변경 내용
- 신규 `PrivacyLogMapper` 인터페이스(@EgovMapper) 추가
- `PrivacyLogDAO`: `EgovComAbstractDAO` 상속 제거, `@Resource` 위임 방식으로 전환
- 8개 RDBMS XML namespace를 인터페이스 FQN으로 변경
- `context-mapper.xml`에 `MapperScannerConfigurer` 추가 (기존 PR과 동일)

## 영향 범위
- 외부 동작 변경 없음
- 베이스라인 컴파일 에러 수 변동 없음 (149 → 149)
