### PR TITLE
[refactor][공통컴포넌트] sym/log/slg SysHistoryDAO @EgovMapper 인터페이스 매핑

### DIFF
--- a/src/main/java/egovframework/com/sym/log/slg/service/impl/SysHistoryDAO.java
+++ b/src/main/java/egovframework/com/sym/log/slg/service/impl/SysHistoryDAO.java
@@ -4,84 +4,49 @@ import java.util.List;
 
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.sym.log.slg.service.SysHistory;
 import egovframework.com.sym.log.slg.service.SysHistoryVO;
+import jakarta.annotation.Resource;
 
 /**
- * @Class Name : SysHistoryDAO.java
- * @Description : 시스템 이력정보를 관리하기 위한 데이터 처리 클래스
- * @Modification Information
+ * 시스템 이력정보를 관리하기 위한 데이터 처리 클래스
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
  *
  *    수정일       수정자         수정내용
  *    -------        -------     -------------------
- *    2009. 3. 9.   이삼섭
- *
- * @author 공통 서비스 개발팀 이삼섭
- * @since 2009. 3. 9.
- * @version
- * @see
- *
+ *    2009. 3. 9.   이삼섭         최초생성
+ *    2026. 5. 28.  dasomel       @EgovMapper 인터페이스 위임 방식으로 전환
+ * </pre>
  */
 @Repository("sysHistoryDAO")
-public class SysHistoryDAO extends EgovComAbstractDAO {
+public class SysHistoryDAO {
 
+	@Resource(name = "sysHistoryMapper")
+	private SysHistoryMapper sysHistoryMapper;
 
-	/**
-	 * 시스템 이력정보를 생성한다.
-	 * @param history - 시스템 이력정보가 담긴 모델 객체
-	 */
-	public int insertSysHistory(SysHistory history) throws Exception{
-		return insert("SysHistoryDAO.insertSysHistory", history);
+	public int insertSysHistory(SysHistory history) {
+		return sysHistoryMapper.insertSysHistory(history);
 	}
 
-
-	/**
-	 * 시스템 이력정보를 수정한다.
-	 * @param history - 시스템 이력정보가 담긴 모델 객체
-	 */
-	public void updateSysHistory(SysHistory history) throws Exception{
-		update("SysHistoryDAO.updateSysHistory", history);
+	public void updateSysHistory(SysHistory history) {
+		sysHistoryMapper.updateSysHistory(history);
 	}
 
-	/**
-	 * 시스템 이력정보를 삭제한다.
-	 * @param history - 시스템 이력정보가 담긴 모델 객체
-	 */
-	public void deleteSysHistory(SysHistory history) throws Exception{
-		delete("SysHistoryDAO.deleteSysHistory", history);
+	public void deleteSysHistory(SysHistory history) {
+		sysHistoryMapper.deleteSysHistory(history);
 	}
 
-
-	/**
-	 * 시스템 이력정보 목록을 조회한다.
-	 *
-	 * @param history - 시스템 이력정보가 담긴 모델 객체
-	 */
-	public List<SysHistoryVO> selectSysHistorList(SysHistoryVO historyVO) throws Exception{
-		return selectList("SysHistoryDAO.selectSysHistoryList", historyVO);
+	public List<SysHistoryVO> selectSysHistorList(SysHistoryVO historyVO) {
+		return sysHistoryMapper.selectSysHistoryList(historyVO);
 	}
 
-	/**
-	 * 시스템 이력정보 목록의 글 개수를 조회한다.
-	 * @param history
-	 * @return
-	 * @throws Exception
-	 */
-	public int selectSysHistortListCnt(SysHistoryVO historyVO) throws Exception{
-		return (Integer)selectOne("SysHistoryDAO.selectSysHistoryListCnt", historyVO);
+	public int selectSysHistortListCnt(SysHistoryVO historyVO) {
+		return sysHistoryMapper.selectSysHistoryListCnt(historyVO);
 	}
 
-	/**
-	 * 시스템 이력정보를 조회한다.
-	 *
-	 * @param history - 시스템 이력정보가 담긴 모델 객체
-	 */
-	public SysHistoryVO selectSysHistory(SysHistoryVO historyVO) throws Exception{
-
-		return (SysHistoryVO) selectOne("SysHistoryDAO.selectSysHistory", historyVO);
+	public SysHistoryVO selectSysHistory(SysHistoryVO historyVO) {
+		return sysHistoryMapper.selectSysHistory(historyVO);
 	}
-
-
-
 }

--- a/src/main/java/egovframework/com/sym/log/slg/service/impl/SysHistoryMapper.java
+++ b/src/main/java/egovframework/com/sym/log/slg/service/impl/SysHistoryMapper.java
@@ -1,0 +1,35 @@
+package egovframework.com.sym.log.slg.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.sym.log.slg.service.SysHistory;
+import egovframework.com.sym.log.slg.service.SysHistoryVO;
+
+/**
+ * 시스템 이력정보를 관리하기 위한 Mapper 인터페이스
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *    수정일         수정자         수정내용
+ *    -------        -------     -------------------
+ *    2026. 5. 28.   dasomel        XML 기반 DAO → @EgovMapper 인터페이스로 전환
+ * </pre>
+ */
+@EgovMapper("sysHistoryMapper")
+public interface SysHistoryMapper {
+
+	int insertSysHistory(SysHistory history);
+
+	void updateSysHistory(SysHistory history);
+
+	void deleteSysHistory(SysHistory history);
+
+	List<SysHistoryVO> selectSysHistoryList(SysHistoryVO historyVO);
+
+	int selectSysHistoryListCnt(SysHistoryVO historyVO);
+
+	SysHistoryVO selectSysHistory(SysHistoryVO historyVO);
+}

--- a/src/main/resources/egovframework/mapper/com/sym/log/slg/EgovSysHist_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/log/slg/EgovSysHist_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="SysHistoryDAO">
+<mapper namespace="egovframework.com.sym.log.slg.service.impl.SysHistoryMapper">
 
 	<resultMap id="historyVO" type="egovframework.com.sym.log.slg.service.SysHistoryVO">
 		<result property="histId" column="HIST_ID"/>

--- a/src/main/resources/egovframework/mapper/com/sym/log/slg/EgovSysHist_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/log/slg/EgovSysHist_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="SysHistoryDAO">
+<mapper namespace="egovframework.com.sym.log.slg.service.impl.SysHistoryMapper">
 
 	<resultMap id="historyVO" type="egovframework.com.sym.log.slg.service.SysHistoryVO">
 		<result property="histId" column="HIST_ID"/>

--- a/src/main/resources/egovframework/mapper/com/sym/log/slg/EgovSysHist_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/log/slg/EgovSysHist_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="SysHistoryDAO">
+<mapper namespace="egovframework.com.sym.log.slg.service.impl.SysHistoryMapper">
 
 	<resultMap id="historyVO" type="egovframework.com.sym.log.slg.service.SysHistoryVO">
 		<result property="histId" column="HIST_ID"/>

--- a/src/main/resources/egovframework/mapper/com/sym/log/slg/EgovSysHist_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/log/slg/EgovSysHist_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
  <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="SysHistoryDAO">
+<mapper namespace="egovframework.com.sym.log.slg.service.impl.SysHistoryMapper">
 	
 	<resultMap id="historyVO" type="egovframework.com.sym.log.slg.service.SysHistoryVO">
 		<result property="histId" column="HIST_ID"/>

--- a/src/main/resources/egovframework/mapper/com/sym/log/slg/EgovSysHist_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/log/slg/EgovSysHist_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
  <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="SysHistoryDAO">
+<mapper namespace="egovframework.com.sym.log.slg.service.impl.SysHistoryMapper">
 	
 	<resultMap id="historyVO" type="egovframework.com.sym.log.slg.service.SysHistoryVO">
 		<result property="histId" column="HIST_ID"/>

--- a/src/main/resources/egovframework/mapper/com/sym/log/slg/EgovSysHist_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/log/slg/EgovSysHist_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="SysHistoryDAO">
+<mapper namespace="egovframework.com.sym.log.slg.service.impl.SysHistoryMapper">
 	
 	<resultMap id="historyVO" type="egovframework.com.sym.log.slg.service.SysHistoryVO">
 		<result property="histId" column="HIST_ID"/>

--- a/src/main/resources/egovframework/mapper/com/sym/log/slg/EgovSysHist_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/log/slg/EgovSysHist_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
  <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="SysHistoryDAO">
+<mapper namespace="egovframework.com.sym.log.slg.service.impl.SysHistoryMapper">
 	
 	<resultMap id="historyVO" type="egovframework.com.sym.log.slg.service.SysHistoryVO">
 		<result property="histId" column="HIST_ID"/>

--- a/src/main/resources/egovframework/mapper/com/sym/log/slg/EgovSysHist_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/log/slg/EgovSysHist_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="SysHistoryDAO">
+<mapper namespace="egovframework.com.sym.log.slg.service.impl.SysHistoryMapper">
 
 	<resultMap id="historyVO" type="egovframework.com.sym.log.slg.service.SysHistoryVO">
 		<result property="histId" column="HIST_ID"/>

--- a/src/main/resources/egovframework/spring/com/context-mapper.xml
+++ b/src/main/resources/egovframework/spring/com/context-mapper.xml
@@ -22,4 +22,11 @@
 		<constructor-arg ref="egov.sqlSession"/>
 	</bean>
 	
+
+	<!-- @EgovMapper 어노테이션이 선언된 Mapper 인터페이스를 자동으로 스캔하여 빈으로 등록한다 -->
+	<bean class="org.mybatis.spring.mapper.MapperScannerConfigurer">
+		<property name="basePackage" value="egovframework.com" />
+		<property name="annotationClass" value="org.egovframe.rte.psl.dataaccess.mapper.EgovMapper" />
+	</bean>
+
 </beans>


### PR DESCRIPTION
## 변경 사유
eGovFrame 5.0 @EgovMapper 활용 확대. PR #841~#844 동일 패턴.

## 변경 내용
- 신규 `SysHistoryMapper` 인터페이스(@EgovMapper) 추가
- `SysHistoryDAO`: `EgovComAbstractDAO` 상속 제거, `@Resource` 위임 방식으로 전환
- 8개 RDBMS XML namespace를 인터페이스 FQN으로 변경
- `context-mapper.xml`에 `MapperScannerConfigurer` 추가

## 영향 범위
- 외부 동작 변경 없음
- 베이스라인 컴파일 에러 수 변동 없음 (149 → 149)
