### PR TITLE
[refactor][공통컴포넌트] sym/ccm/cca CmmnCodeManageDAO @EgovMapper 인터페이스 매핑

### DIFF
--- a/src/main/java/egovframework/com/sym/ccm/cca/service/impl/CmmnCodeManageDAO.java
+++ b/src/main/java/egovframework/com/sym/ccm/cca/service/impl/CmmnCodeManageDAO.java
@@ -4,84 +4,49 @@ import java.util.List;
 
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.sym.ccm.cca.service.CmmnCode;
 import egovframework.com.sym.ccm.cca.service.CmmnCodeVO;
+import jakarta.annotation.Resource;
 
 /**
-*
-* 공통코드에 대한 데이터 접근 클래스를 정의한다
-* @author 공통서비스 개발팀 이중호
-* @since 2009.04.01
-* @version 1.0
-* @see
-*
-* <pre>
-* << 개정이력(Modification Information) >>
-*
-*   수정일      수정자           수정내용
-*  -------    --------    ---------------------------
-*   2009.04.01  이중호          최초 생성
-*
-* </pre>
-*/
-
+ * 공통코드에 대한 데이터 접근 클래스
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2009.04.01  이중호          최초 생성
+ *   2026.05.28  dasomel         @EgovMapper 인터페이스 위임 방식으로 전환
+ * </pre>
+ */
 @Repository("CmmnCodeManageDAO")
-public class CmmnCodeManageDAO extends    EgovComAbstractDAO {
+public class CmmnCodeManageDAO {
 
-   /**
-	 * 공통코드 총 개수를 조회한다.
-     * @param searchVO
-     * @return int(공통코드 총 개수)
-     */
-	public int selectCmmnCodeListTotCnt(CmmnCodeVO searchVO) throws Exception{
-		return (Integer)selectOne("CmmnCodeManage.selectCmmnCodeListTotCnt", searchVO);
+	@Resource(name = "cmmnCodeManageMapper")
+	private CmmnCodeManageMapper cmmnCodeManageMapper;
+
+	public int selectCmmnCodeListTotCnt(CmmnCodeVO searchVO) {
+		return cmmnCodeManageMapper.selectCmmnCodeListTotCnt(searchVO);
 	}
 
-   /**
-	 * 공통코드 목록을 조회한다.
-     * @param searchVO
-     * @return List(공통코드 목록)
-     * @throws Exception
-     */
-	public List<CmmnCodeVO> selectCmmnCodeList(CmmnCodeVO searchVO) throws Exception{
-		 return selectList("CmmnCodeManage.selectCmmnCodeList", searchVO);
+	public List<CmmnCodeVO> selectCmmnCodeList(CmmnCodeVO searchVO) {
+		return cmmnCodeManageMapper.selectCmmnCodeList(searchVO);
 	}
 
-	/**
-	 * 공통코드 상세항목을 조회한다.
-	 * @param cmmnCode
-	 * @return CmmnCode(공통코드)
-	 */
-	public CmmnCodeVO selectCmmnCodeDetail(CmmnCodeVO cmmnCodeVO) throws Exception{
-		return selectOne("CmmnCodeManage.selectCmmnCodeDetail", cmmnCodeVO);
-}
-
-	/**
-	 * 공통코드를 수정한다.
-	 * @param cmmnCode
-	 * @throws Exception
-	 */
-	public void updateCmmnCode(CmmnCode cmmnCode) throws Exception{
-		update("CmmnCodeManage.updateCmmnCode", cmmnCode);
+	public CmmnCodeVO selectCmmnCodeDetail(CmmnCodeVO cmmnCodeVO) {
+		return cmmnCodeManageMapper.selectCmmnCodeDetail(cmmnCodeVO);
 	}
 
-	/**
-	 * 공통코드를 등록한다.
-	 * @param cmmnCode
-	 * @throws Exception
-	 */
-	public void insertCmmnCode(CmmnCode cmmnCode) throws Exception{
-		insert("CmmnCodeManage.insertCmmnCode", cmmnCode);
+	public void updateCmmnCode(CmmnCode cmmnCode) {
+		cmmnCodeManageMapper.updateCmmnCode(cmmnCode);
 	}
 
-	/**
-	 * 공통코드를 삭제한다.
-	 * @param cmmnCode
-	 * @throws Exception
-	 */
+	public void insertCmmnCode(CmmnCode cmmnCode) {
+		cmmnCodeManageMapper.insertCmmnCode(cmmnCode);
+	}
+
 	public void deleteCmmnCode(CmmnCode cmmnCode) {
-		delete("CmmnCodeManage.deleteCmmnCode", cmmnCode);
+		cmmnCodeManageMapper.deleteCmmnCode(cmmnCode);
 	}
-
 }

--- a/src/main/java/egovframework/com/sym/ccm/cca/service/impl/CmmnCodeManageMapper.java
+++ b/src/main/java/egovframework/com/sym/ccm/cca/service/impl/CmmnCodeManageMapper.java
@@ -1,0 +1,36 @@
+package egovframework.com.sym.ccm.cca.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.sym.ccm.cca.service.CmmnCode;
+import egovframework.com.sym.ccm.cca.service.CmmnCodeVO;
+
+/**
+ * 공통코드에 대한 Mapper 인터페이스
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2009.04.01  이중호          최초 생성
+ *   2026.05.28  dasomel         XML 기반 DAO → @EgovMapper 인터페이스로 전환
+ * </pre>
+ */
+@EgovMapper("cmmnCodeManageMapper")
+public interface CmmnCodeManageMapper {
+
+	int selectCmmnCodeListTotCnt(CmmnCodeVO searchVO);
+
+	List<CmmnCodeVO> selectCmmnCodeList(CmmnCodeVO searchVO);
+
+	CmmnCodeVO selectCmmnCodeDetail(CmmnCodeVO cmmnCodeVO);
+
+	void updateCmmnCode(CmmnCode cmmnCode);
+
+	void insertCmmnCode(CmmnCode cmmnCode);
+
+	void deleteCmmnCode(CmmnCode cmmnCode);
+}

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/cca/EgovCmmnCodeManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/cca/EgovCmmnCodeManage_SQL_altibase.xml
@@ -5,7 +5,7 @@
 --><!--Converted at: Wed May 11 15:50:35 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmnCodeManage">
+<mapper namespace="egovframework.com.sym.ccm.cca.service.impl.CmmnCodeManageMapper">
 
 	<select id="selectCmmnCodeList" parameterType="egovframework.com.sym.ccm.cca.service.CmmnCodeVO" resultType="egovframework.com.sym.ccm.cca.service.CmmnCodeVO">
 		<![CDATA[

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/cca/EgovCmmnCodeManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/cca/EgovCmmnCodeManage_SQL_cubrid.xml
@@ -5,7 +5,7 @@
 --><!--Converted at: Wed May 11 15:50:35 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmnCodeManage">
+<mapper namespace="egovframework.com.sym.ccm.cca.service.impl.CmmnCodeManageMapper">
 
 	<select id="selectCmmnCodeList" parameterType="egovframework.com.sym.ccm.cca.service.CmmnCodeVO" resultType="egovframework.com.sym.ccm.cca.service.CmmnCodeVO">
 		

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/cca/EgovCmmnCodeManage_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/cca/EgovCmmnCodeManage_SQL_goldilocks.xml
@@ -5,7 +5,7 @@
 --><!--Converted at: Wed May 11 15:50:35 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmnCodeManage">
+<mapper namespace="egovframework.com.sym.ccm.cca.service.impl.CmmnCodeManageMapper">
 
 	<select id="selectCmmnCodeList" parameterType="egovframework.com.sym.ccm.cca.service.CmmnCodeVO" resultType="egovframework.com.sym.ccm.cca.service.CmmnCodeVO">
 		<![CDATA[

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/cca/EgovCmmnCodeManage_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/cca/EgovCmmnCodeManage_SQL_maria.xml
@@ -5,7 +5,7 @@
 --><!--Converted at: Wed May 11 15:50:35 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmnCodeManage">
+<mapper namespace="egovframework.com.sym.ccm.cca.service.impl.CmmnCodeManageMapper">
 
 	<select id="selectCmmnCodeList" parameterType="egovframework.com.sym.ccm.cca.service.CmmnCodeVO" resultType="egovframework.com.sym.ccm.cca.service.CmmnCodeVO">
 		<![CDATA[

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/cca/EgovCmmnCodeManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/cca/EgovCmmnCodeManage_SQL_mysql.xml
@@ -5,7 +5,7 @@
 --><!--Converted at: Wed May 11 15:50:35 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmnCodeManage">
+<mapper namespace="egovframework.com.sym.ccm.cca.service.impl.CmmnCodeManageMapper">
 
 	<select id="selectCmmnCodeList" parameterType="egovframework.com.sym.ccm.cca.service.CmmnCodeVO" resultType="egovframework.com.sym.ccm.cca.service.CmmnCodeVO">
 		<![CDATA[

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/cca/EgovCmmnCodeManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/cca/EgovCmmnCodeManage_SQL_oracle.xml
@@ -5,7 +5,7 @@
 --><!--Converted at: Wed May 11 15:50:35 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmnCodeManage">
+<mapper namespace="egovframework.com.sym.ccm.cca.service.impl.CmmnCodeManageMapper">
 
 	<select id="selectCmmnCodeList" parameterType="egovframework.com.sym.ccm.cca.service.CmmnCodeVO" resultType="egovframework.com.sym.ccm.cca.service.CmmnCodeVO">
 		

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/cca/EgovCmmnCodeManage_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/cca/EgovCmmnCodeManage_SQL_postgres.xml
@@ -5,7 +5,7 @@
 --><!--Converted at: Wed May 11 15:50:35 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmnCodeManage">
+<mapper namespace="egovframework.com.sym.ccm.cca.service.impl.CmmnCodeManageMapper">
 
 	<select id="selectCmmnCodeList" parameterType="egovframework.com.sym.ccm.cca.service.CmmnCodeVO" resultType="egovframework.com.sym.ccm.cca.service.CmmnCodeVO">
 		<![CDATA[

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/cca/EgovCmmnCodeManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/cca/EgovCmmnCodeManage_SQL_tibero.xml
@@ -5,7 +5,7 @@
 --><!--Converted at: Wed May 11 15:50:35 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmnCodeManage">
+<mapper namespace="egovframework.com.sym.ccm.cca.service.impl.CmmnCodeManageMapper">
 
 	<select id="selectCmmnCodeList" parameterType="egovframework.com.sym.ccm.cca.service.CmmnCodeVO" resultType="egovframework.com.sym.ccm.cca.service.CmmnCodeVO">
 		

--- a/src/main/resources/egovframework/spring/com/context-mapper.xml
+++ b/src/main/resources/egovframework/spring/com/context-mapper.xml
@@ -22,4 +22,11 @@
 		<constructor-arg ref="egov.sqlSession"/>
 	</bean>
 	
+
+	<!-- @EgovMapper 어노테이션이 선언된 Mapper 인터페이스를 자동으로 스캔하여 빈으로 등록한다 -->
+	<bean class="org.mybatis.spring.mapper.MapperScannerConfigurer">
+		<property name="basePackage" value="egovframework.com" />
+		<property name="annotationClass" value="org.egovframe.rte.psl.dataaccess.mapper.EgovMapper" />
+	</bean>
+
 </beans>


### PR DESCRIPTION
## 변경 사유
eGovFrame 5.0 @EgovMapper 활용 확대. PR #806/#821/#825/#832/#833/#836~#845 동일 패턴.

## 변경 내용
- 신규 `CmmnCodeManageMapper` 인터페이스(@EgovMapper) 추가
- `CmmnCodeManageDAO`: `EgovComAbstractDAO` 상속 제거, `@Resource` 위임 방식으로 전환
- 8개 RDBMS XML namespace를 인터페이스 FQN으로 변경
- `context-mapper.xml`에 `MapperScannerConfigurer` 추가

## 영향 범위
- 외부 동작 변경 없음
- 베이스라인 컴파일 에러 수 변동 없음 (149 → 149)
