### PR TITLE
[refactor][공통컴포넌트] sym/ccm/ccc CmmnClCodeManageDAO @EgovMapper 인터페이스 매핑

### DIFF
--- a/src/main/java/egovframework/com/sym/ccm/ccc/service/impl/CmmnClCodeManageDAO.java
+++ b/src/main/java/egovframework/com/sym/ccm/ccc/service/impl/CmmnClCodeManageDAO.java
@@ -6,88 +6,52 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.sym.ccm.ccc.service.CmmnClCode;
 import egovframework.com.sym.ccm.ccc.service.CmmnClCodeVO;
+import jakarta.annotation.Resource;
 
 /**
-*
-* 공통분류코드에 대한 데이터 접근 클래스를 정의한다
-* @author 공통서비스 개발팀 이중호
-* @since 2009.04.01
-* @version 1.0
-* @see
-*
-* <pre>
-* << 개정이력(Modification Information) >>
-*
-*   수정일      수정자           수정내용
-*  -------    --------    ---------------------------
-*   2009.04.01  이중호          최초 생성
-*
-* </pre>
-*/
+ * 공통분류코드에 대한 데이터 접근 클래스
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2009.04.01  이중호          최초 생성
+ *   2026.05.28  dasomel         @EgovMapper 인터페이스 위임 방식으로 전환
+ * </pre>
+ */
 @Repository("CmmnClCodeManageDAO")
-public class CmmnClCodeManageDAO extends EgovComAbstractDAO {
-	
+public class CmmnClCodeManageDAO {
+
 	private static final Logger LOGGER = LoggerFactory.getLogger(CmmnClCodeManageDAO.class);
-	
-	   /**
-		 * 공통분류코드 총 개수를 조회한다.
-	     * @param searchVO
-	     * @return int(공통분류코드 총 개수)
-	     */
-	    public int selectCmmnClCodeListTotCnt(CmmnClCodeVO searchVO) throws Exception {
-	        return (Integer)selectOne("CmmnClCodeManage.selectCmmnClCodeListTotCnt", searchVO);
-	    }
-	    
-	    /**
-		 * 공통분류코드 목록을 조회한다.
-	     * @param searchVO
-	     * @return List(공통분류코드 목록)
-	     * @throws Exception
-	     */
-	    public List<CmmnClCodeVO> selectCmmnClCodeList(CmmnClCodeVO searchVO) throws Exception {
-	        return selectList("CmmnClCodeManage.selectCmmnClCodeList", searchVO);
-	    }
-	    
-	    /**
-		 * 공통분류코드 상세항목을 조회한다.
-		 * @param cmmnClCode
-		 * @return CmmnClCode(공통분류코드)
-		 */
-		public CmmnClCode selectCmmnClCodeDetail(CmmnClCode cmmnClCode) throws Exception {
-			return (CmmnClCode)selectOne("CmmnClCodeManage.selectCmmnClCodeDetail", cmmnClCode);
-		}
-		
-		/**
-		 * 공통분류코드를 등록한다.
-		 * @param cmmnClCodeVO
-		 * @throws Exception
-		 */
-		public void insertCmmnClCode(CmmnClCodeVO cmmnClCodeVO) throws Exception{
-			LOGGER.info("TEST5 : 등록 DAO");
-			insert("CmmnClCodeManage.insertCmmnClCode", cmmnClCodeVO);
-		}
 
-		/**
-		 * 공통분류코드를 삭제한다.
-		 * @param cmmnClCodeVO
-		 * @throws Exception
-		 */
-		public void deleteCmmnClCode(CmmnClCodeVO cmmnClCodeVO) throws Exception {
-			delete("CmmnClCodeManage.deleteCmmnClCode", cmmnClCodeVO);
-			
-		}
-		
-		/**
-		 * 공통분류코드를 수정한다.
-		 * @param cmmnClCodeVO
-		 * @throws Exception
-		 */
-		public void updateCmmnClCode(CmmnClCodeVO cmmnClCodeVO) throws Exception{
-			update("CmmnClCodeManage.updateCmmnClCode", cmmnClCodeVO);
-			
-		}
+	@Resource(name = "cmmnClCodeManageMapper")
+	private CmmnClCodeManageMapper cmmnClCodeManageMapper;
 
+	public int selectCmmnClCodeListTotCnt(CmmnClCodeVO searchVO) {
+		return cmmnClCodeManageMapper.selectCmmnClCodeListTotCnt(searchVO);
+	}
+
+	public List<CmmnClCodeVO> selectCmmnClCodeList(CmmnClCodeVO searchVO) {
+		return cmmnClCodeManageMapper.selectCmmnClCodeList(searchVO);
+	}
+
+	public CmmnClCode selectCmmnClCodeDetail(CmmnClCode cmmnClCode) {
+		return cmmnClCodeManageMapper.selectCmmnClCodeDetail(cmmnClCode);
+	}
+
+	public void insertCmmnClCode(CmmnClCodeVO cmmnClCodeVO) {
+		LOGGER.info("TEST5 : 등록 DAO");
+		cmmnClCodeManageMapper.insertCmmnClCode(cmmnClCodeVO);
+	}
+
+	public void deleteCmmnClCode(CmmnClCodeVO cmmnClCodeVO) {
+		cmmnClCodeManageMapper.deleteCmmnClCode(cmmnClCodeVO);
+	}
+
+	public void updateCmmnClCode(CmmnClCodeVO cmmnClCodeVO) {
+		cmmnClCodeManageMapper.updateCmmnClCode(cmmnClCodeVO);
+	}
 }

--- a/src/main/java/egovframework/com/sym/ccm/ccc/service/impl/CmmnClCodeManageMapper.java
+++ b/src/main/java/egovframework/com/sym/ccm/ccc/service/impl/CmmnClCodeManageMapper.java
@@ -1,0 +1,36 @@
+package egovframework.com.sym.ccm.ccc.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.sym.ccm.ccc.service.CmmnClCode;
+import egovframework.com.sym.ccm.ccc.service.CmmnClCodeVO;
+
+/**
+ * 공통분류코드에 대한 Mapper 인터페이스
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2009.04.01  이중호          최초 생성
+ *   2026.05.28  dasomel         XML 기반 DAO → @EgovMapper 인터페이스로 전환
+ * </pre>
+ */
+@EgovMapper("cmmnClCodeManageMapper")
+public interface CmmnClCodeManageMapper {
+
+	int selectCmmnClCodeListTotCnt(CmmnClCodeVO searchVO);
+
+	List<CmmnClCodeVO> selectCmmnClCodeList(CmmnClCodeVO searchVO);
+
+	CmmnClCode selectCmmnClCodeDetail(CmmnClCode cmmnClCode);
+
+	void insertCmmnClCode(CmmnClCodeVO cmmnClCodeVO);
+
+	void deleteCmmnClCode(CmmnClCodeVO cmmnClCodeVO);
+
+	void updateCmmnClCode(CmmnClCodeVO cmmnClCodeVO);
+}

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/ccc/EgovCmmnClCodeManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/ccc/EgovCmmnClCodeManage_SQL_altibase.xml
@@ -5,7 +5,7 @@
 --><!--Converted at: Wed May 11 15:50:35 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmnClCodeManage">
+<mapper namespace="egovframework.com.sym.ccm.ccc.service.impl.CmmnClCodeManageMapper">
 
 	<select id="selectCmmnClCodeList" parameterType="egovframework.com.sym.ccm.ccc.service.CmmnClCodeVO" resultType="egovframework.com.sym.ccm.ccc.service.CmmnClCode">
 		

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/ccc/EgovCmmnClCodeManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/ccc/EgovCmmnClCodeManage_SQL_cubrid.xml
@@ -5,7 +5,7 @@
 --><!--Converted at: Wed May 11 15:50:36 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmnClCodeManage">
+<mapper namespace="egovframework.com.sym.ccm.ccc.service.impl.CmmnClCodeManageMapper">
 
 	<select id="selectCmmnClCodeList" parameterType="egovframework.com.sym.ccm.ccc.service.CmmnClCodeVO" resultType="egovframework.com.sym.ccm.ccc.service.CmmnClCode">
 		

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/ccc/EgovCmmnClCodeManage_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/ccc/EgovCmmnClCodeManage_SQL_goldilocks.xml
@@ -5,7 +5,7 @@
 --><!--Converted at: Wed May 11 15:50:35 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmnClCodeManage">
+<mapper namespace="egovframework.com.sym.ccm.ccc.service.impl.CmmnClCodeManageMapper">
 
 	<select id="selectCmmnClCodeList" parameterType="egovframework.com.sym.ccm.ccc.service.CmmnClCodeVO" resultType="egovframework.com.sym.ccm.ccc.service.CmmnClCode">
 		

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/ccc/EgovCmmnClCodeManage_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/ccc/EgovCmmnClCodeManage_SQL_maria.xml
@@ -5,7 +5,7 @@
 --><!--Converted at: Wed May 11 15:50:36 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmnClCodeManage">
+<mapper namespace="egovframework.com.sym.ccm.ccc.service.impl.CmmnClCodeManageMapper">
 
 	<select id="selectCmmnClCodeList" parameterType="egovframework.com.sym.ccm.ccc.service.CmmnClCodeVO" resultType="egovframework.com.sym.ccm.ccc.service.CmmnClCodeVO">
 		

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/ccc/EgovCmmnClCodeManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/ccc/EgovCmmnClCodeManage_SQL_mysql.xml
@@ -5,7 +5,7 @@
 --><!--Converted at: Wed May 11 15:50:36 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmnClCodeManage">
+<mapper namespace="egovframework.com.sym.ccm.ccc.service.impl.CmmnClCodeManageMapper">
 
 	<select id="selectCmmnClCodeList" parameterType="egovframework.com.sym.ccm.ccc.service.CmmnClCodeVO" resultType="egovframework.com.sym.ccm.ccc.service.CmmnClCodeVO">
 		

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/ccc/EgovCmmnClCodeManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/ccc/EgovCmmnClCodeManage_SQL_oracle.xml
@@ -5,7 +5,7 @@
 --><!--Converted at: Wed May 11 15:50:36 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmnClCodeManage">
+<mapper namespace="egovframework.com.sym.ccm.ccc.service.impl.CmmnClCodeManageMapper">
 
 	<select id="selectCmmnClCodeList" parameterType="egovframework.com.sym.ccm.ccc.service.CmmnClCodeVO" resultType="egovframework.com.sym.ccm.ccc.service.CmmnClCodeVO">
 		

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/ccc/EgovCmmnClCodeManage_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/ccc/EgovCmmnClCodeManage_SQL_postgres.xml
@@ -5,7 +5,7 @@
 --><!--Converted at: Wed May 11 15:50:36 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmnClCodeManage">
+<mapper namespace="egovframework.com.sym.ccm.ccc.service.impl.CmmnClCodeManageMapper">
 
 	<select id="selectCmmnClCodeList" parameterType="egovframework.com.sym.ccm.ccc.service.CmmnClCodeVO" resultType="egovframework.com.sym.ccm.ccc.service.CmmnClCodeVO">
 		

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/ccc/EgovCmmnClCodeManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/ccc/EgovCmmnClCodeManage_SQL_tibero.xml
@@ -5,7 +5,7 @@
 --><!--Converted at: Wed May 11 15:50:36 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmnClCodeManage">
+<mapper namespace="egovframework.com.sym.ccm.ccc.service.impl.CmmnClCodeManageMapper">
 
 	<select id="selectCmmnClCodeList" parameterType="egovframework.com.sym.ccm.ccc.service.CmmnClCodeVO" resultType="egovframework.com.sym.ccm.ccc.service.CmmnClCode">
 		

--- a/src/main/resources/egovframework/spring/com/context-mapper.xml
+++ b/src/main/resources/egovframework/spring/com/context-mapper.xml
@@ -22,4 +22,11 @@
 		<constructor-arg ref="egov.sqlSession"/>
 	</bean>
 	
+
+	<!-- @EgovMapper 어노테이션이 선언된 Mapper 인터페이스를 자동으로 스캔하여 빈으로 등록한다 -->
+	<bean class="org.mybatis.spring.mapper.MapperScannerConfigurer">
+		<property name="basePackage" value="egovframework.com" />
+		<property name="annotationClass" value="org.egovframe.rte.psl.dataaccess.mapper.EgovMapper" />
+	</bean>
+
 </beans>


### PR DESCRIPTION
## 변경 사유
eGovFrame 5.0 @EgovMapper 활용 확대. PR #846(sym/ccm/cca) 등 동일 패턴.

## 변경 내용
- 신규 `CmmnClCodeManageMapper` 인터페이스(@EgovMapper) 추가
- `CmmnClCodeManageDAO`: `EgovComAbstractDAO` 상속 제거, `@Resource` 위임 방식으로 전환
- 8개 RDBMS XML namespace를 인터페이스 FQN으로 변경
- `context-mapper.xml`에 `MapperScannerConfigurer` 추가

## 영향 범위
- 외부 동작 변경 없음
- 베이스라인 컴파일 에러 수 변동 없음 (149 → 149)
