### PR TITLE
[refactor][공통컴포넌트] sym/ccm/adc AdministCodeManageDAO @EgovMapper 인터페이스 매핑

### DIFF
--- a/src/main/java/egovframework/com/sym/ccm/adc/service/impl/AdministCodeManageDAO.java
+++ b/src/main/java/egovframework/com/sym/ccm/adc/service/impl/AdministCodeManageDAO.java
@@ -5,17 +5,12 @@ import java.util.List;
 import org.egovframe.rte.psl.dataaccess.util.EgovMap;
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.sym.ccm.adc.service.AdministCode;
 import egovframework.com.sym.ccm.adc.service.AdministCodeVO;
+import jakarta.annotation.Resource;
 
 /**
- *
- * 행정코드에 대한 데이터 접근 클래스를 정의한다
- * @author 공통서비스 개발팀 이중호
- * @since 2009.04.01
- * @version 1.0
- * @see
+ * 행정코드에 대한 데이터 접근 클래스
  *
  * <pre>
  * << 개정이력(Modification Information) >>
@@ -23,67 +18,36 @@ import egovframework.com.sym.ccm.adc.service.AdministCodeVO;
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.04.01  이중호          최초 생성
- *
+ *   2026.05.28  dasomel         @EgovMapper 인터페이스 위임 방식으로 전환
  * </pre>
  */
 @Repository("AdministCodeManageDAO")
-public class AdministCodeManageDAO extends EgovComAbstractDAO {
+public class AdministCodeManageDAO {
 
-	/**
-	 * 행정코드를 삭제한다.
-	 * @param administCode
-	 * @throws Exception
-	 */
-	public void deleteAdministCode(AdministCode administCode) throws Exception {
-		delete("AdministCodeManageDAO.deleteAdministCode", administCode);
+	@Resource(name = "administCodeManageMapper")
+	private AdministCodeManageMapper administCodeManageMapper;
+
+	public void deleteAdministCode(AdministCode administCode) {
+		administCodeManageMapper.deleteAdministCode(administCode);
 	}
 
-
-	/**
-	 * 행정코드를 등록한다.
-	 * @param administCode
-	 * @throws Exception
-	 */
-	public void insertAdministCode(AdministCode administCode) throws Exception {
-        insert("AdministCodeManageDAO.insertAdministCode", administCode);
+	public void insertAdministCode(AdministCode administCode) {
+		administCodeManageMapper.insertAdministCode(administCode);
 	}
 
-	/**
-	 * 행정코드 상세항목을 조회한다.
-	 * @param administCode
-	 * @return AdministCode(행정코드)
-	 */
-	public AdministCode selectAdministCodeDetail(AdministCode administCode) throws Exception {
-		return (AdministCode) selectOne("AdministCodeManageDAO.selectAdministCodeDetail", administCode);
+	public AdministCode selectAdministCodeDetail(AdministCode administCode) {
+		return administCodeManageMapper.selectAdministCodeDetail(administCode);
 	}
 
-
-    /**
-	 * 행정코드 목록을 조회한다.
-     * @param searchVO
-     * @return List(행정코드 목록)
-     * @throws Exception
-     */
-    public List<EgovMap> selectAdministCodeList(AdministCodeVO searchVO) throws Exception {
-        return selectList("AdministCodeManageDAO.selectAdministCodeList", searchVO);
-    }
-
-    /**
-	 * 행정코드 총 개수를 조회한다.
-     * @param searchVO
-     * @return int(행정코드 총 개수)
-     */
-    public int selectAdministCodeListTotCnt(AdministCodeVO searchVO) throws Exception {
-        return (Integer)selectOne("AdministCodeManageDAO.selectAdministCodeListTotCnt", searchVO);
-    }
-
-	/**
-	 * 행정코드를 수정한다.
-	 * @param administCode
-	 * @throws Exception
-	 */
-	public void updateAdministCode(AdministCode administCode) throws Exception {
-		update("AdministCodeManageDAO.updateAdministCode", administCode);
+	public List<EgovMap> selectAdministCodeList(AdministCodeVO searchVO) {
+		return administCodeManageMapper.selectAdministCodeList(searchVO);
 	}
 
+	public int selectAdministCodeListTotCnt(AdministCodeVO searchVO) {
+		return administCodeManageMapper.selectAdministCodeListTotCnt(searchVO);
+	}
+
+	public void updateAdministCode(AdministCode administCode) {
+		administCodeManageMapper.updateAdministCode(administCode);
+	}
 }

--- a/src/main/java/egovframework/com/sym/ccm/adc/service/impl/AdministCodeManageMapper.java
+++ b/src/main/java/egovframework/com/sym/ccm/adc/service/impl/AdministCodeManageMapper.java
@@ -1,0 +1,37 @@
+package egovframework.com.sym.ccm.adc.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+import org.egovframe.rte.psl.dataaccess.util.EgovMap;
+
+import egovframework.com.sym.ccm.adc.service.AdministCode;
+import egovframework.com.sym.ccm.adc.service.AdministCodeVO;
+
+/**
+ * 행정코드에 대한 Mapper 인터페이스
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2009.04.01  이중호          최초 생성
+ *   2026.05.28  dasomel         XML 기반 DAO → @EgovMapper 인터페이스로 전환
+ * </pre>
+ */
+@EgovMapper("administCodeManageMapper")
+public interface AdministCodeManageMapper {
+
+	void deleteAdministCode(AdministCode administCode);
+
+	void insertAdministCode(AdministCode administCode);
+
+	AdministCode selectAdministCodeDetail(AdministCode administCode);
+
+	List<EgovMap> selectAdministCodeList(AdministCodeVO searchVO);
+
+	int selectAdministCodeListTotCnt(AdministCodeVO searchVO);
+
+	void updateAdministCode(AdministCode administCode);
+}

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/adc/EgovAdministCodeManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/adc/EgovAdministCodeManage_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="AdministCodeManageDAO">
+<mapper namespace="egovframework.com.sym.ccm.adc.service.impl.AdministCodeManageMapper">
 
 	<select id="selectAdministCodeList" parameterType="egovframework.com.sym.ccm.adc.service.AdministCodeVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/adc/EgovAdministCodeManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/adc/EgovAdministCodeManage_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="AdministCodeManageDAO">
+<mapper namespace="egovframework.com.sym.ccm.adc.service.impl.AdministCodeManageMapper">
 
 	<select id="selectAdministCodeList" parameterType="egovframework.com.sym.ccm.adc.service.AdministCodeVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/adc/EgovAdministCodeManage_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/adc/EgovAdministCodeManage_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="AdministCodeManageDAO">
+<mapper namespace="egovframework.com.sym.ccm.adc.service.impl.AdministCodeManageMapper">
 
 	<select id="selectAdministCodeList" parameterType="egovframework.com.sym.ccm.adc.service.AdministCodeVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/adc/EgovAdministCodeManage_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/adc/EgovAdministCodeManage_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="AdministCodeManageDAO">
+<mapper namespace="egovframework.com.sym.ccm.adc.service.impl.AdministCodeManageMapper">
 
 	<select id="selectAdministCodeList" parameterType="egovframework.com.sym.ccm.adc.service.AdministCodeVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/adc/EgovAdministCodeManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/adc/EgovAdministCodeManage_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="AdministCodeManageDAO">
+<mapper namespace="egovframework.com.sym.ccm.adc.service.impl.AdministCodeManageMapper">
 
 	<select id="selectAdministCodeList" parameterType="egovframework.com.sym.ccm.adc.service.AdministCodeVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/adc/EgovAdministCodeManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/adc/EgovAdministCodeManage_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="AdministCodeManageDAO">
+<mapper namespace="egovframework.com.sym.ccm.adc.service.impl.AdministCodeManageMapper">
 
 	<select id="selectAdministCodeList" parameterType="egovframework.com.sym.ccm.adc.service.AdministCodeVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/adc/EgovAdministCodeManage_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/adc/EgovAdministCodeManage_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="AdministCodeManageDAO">
+<mapper namespace="egovframework.com.sym.ccm.adc.service.impl.AdministCodeManageMapper">
 
 	<select id="selectAdministCodeList" parameterType="egovframework.com.sym.ccm.adc.service.AdministCodeVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/adc/EgovAdministCodeManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/adc/EgovAdministCodeManage_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="AdministCodeManageDAO">
+<mapper namespace="egovframework.com.sym.ccm.adc.service.impl.AdministCodeManageMapper">
 
 	<select id="selectAdministCodeList" parameterType="egovframework.com.sym.ccm.adc.service.AdministCodeVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/spring/com/context-mapper.xml
+++ b/src/main/resources/egovframework/spring/com/context-mapper.xml
@@ -22,4 +22,11 @@
 		<constructor-arg ref="egov.sqlSession"/>
 	</bean>
 	
+
+	<!-- @EgovMapper 어노테이션이 선언된 Mapper 인터페이스를 자동으로 스캔하여 빈으로 등록한다 -->
+	<bean class="org.mybatis.spring.mapper.MapperScannerConfigurer">
+		<property name="basePackage" value="egovframework.com" />
+		<property name="annotationClass" value="org.egovframe.rte.psl.dataaccess.mapper.EgovMapper" />
+	</bean>
+
 </beans>


### PR DESCRIPTION
## 변경 사유
eGovFrame 5.0 @EgovMapper 활용 확대. PR #846, #847 동일 패턴 (sym/ccm 시리즈).

## 변경 내용
- 신규 `AdministCodeManageMapper` 인터페이스(@EgovMapper) 추가
- `AdministCodeManageDAO`: `EgovComAbstractDAO` 상속 제거, `@Resource` 위임 방식으로 전환
- 8개 RDBMS XML namespace를 인터페이스 FQN으로 변경

## 영향 범위
- 외부 동작 변경 없음
- 베이스라인 컴파일 에러 수 변동 없음 (149 → 149)
