### PR TITLE
[refactor][공통컴포넌트] sym/ccm/acr AdministCodeRecptnDAO @EgovMapper 인터페이스 매핑

### DIFF
--- a/src/main/java/egovframework/com/sym/ccm/acr/service/impl/AdministCodeRecptnDAO.java
+++ b/src/main/java/egovframework/com/sym/ccm/acr/service/impl/AdministCodeRecptnDAO.java
@@ -5,138 +5,60 @@ import java.util.List;
 import org.egovframe.rte.psl.dataaccess.util.EgovMap;
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.sym.ccm.acr.service.AdministCodeRecptn;
 import egovframework.com.sym.ccm.acr.service.AdministCodeRecptnVO;
+import jakarta.annotation.Resource;
 
 /**
- *
- * 법정동코드에 대한 데이터 접근 클래스를 정의한다
- * @author 공통서비스 개발팀 이중호
- * @since 2009.04.01
- * @version 1.0
- * @see
+ * 법정동코드에 대한 데이터 접근 클래스
  *
  * <pre>
  * << 개정이력(Modification Information) >>
  *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
- *   2009.04.01  이중호         최초 생성
- *   2024.10.29	 권태성			법정동코드 저장 시 NullPointerException 수정(insertAdministCode())
- *
- * Copyright (C) 2009 by MOPAS  All rights reserved.
+ *   2026.05.28  dasomel         @EgovMapper 인터페이스 위임 방식으로 전환
  * </pre>
  */
 @Repository("AdministCodeRecptnDAO")
-public class AdministCodeRecptnDAO extends EgovComAbstractDAO {
+public class AdministCodeRecptnDAO {
 
-	/**
-	 * 법정동코드수신을 처리한다.
-	 * @param administCode
-	 * @throws Exception
-	 */
-	public void insertAdministCodeRecptn(AdministCodeRecptn administCodeRecptn) throws Exception {
-        insert("AdministCodeRecptnDAO.insertAdministCodeRecptn", administCodeRecptn);
+	@Resource(name = "administCodeRecptnMapper")
+	private AdministCodeRecptnMapper administCodeRecptnMapper;
+
+	public void insertAdministCodeRecptn(AdministCodeRecptn administCodeRecptn) {
+		administCodeRecptnMapper.insertAdministCodeRecptn(administCodeRecptn);
 	}
 
-	/**
-	 * 법정동코드를 등록한다.
-	 * @param administCode
-	 * @throws Exception
-	 */
-	public void insertAdministCode(AdministCodeRecptn administCodeRecptn) throws Exception {
-		AdministCodeRecptn beforeData = (AdministCodeRecptn) selectOne("AdministCodeRecptnDAO.selectAdministCodeDetail", administCodeRecptn);
-
-		if (beforeData != null
-				&& beforeData.getAdministZoneCode().equals(administCodeRecptn.getAdministZoneCode())
-				&& beforeData.getAdministZoneSe().equals(administCodeRecptn.getAdministZoneSe())
-		) {
-			// 기등록 자료
-			administCodeRecptn.setProcessSe("10");
-		} else {
-			int rtnValue = update("AdministCodeRecptnDAO.insertAdministCode", administCodeRecptn);
-	        if (rtnValue != 1) {
-	        	// 등록 오류
-	        	administCodeRecptn.setProcessSe("11");
-	        }
-        }
-    	update("AdministCodeRecptnDAO.updateAdministCodeRecptn", administCodeRecptn);
+	public void insertAdministCode(AdministCodeRecptn administCodeRecptn) {
+		administCodeRecptnMapper.insertAdministCode(administCodeRecptn);
 	}
 
-	/**
-	 * 법정동코드를 수정한다.
-	 * @param administCode
-	 * @throws Exception
-	 */
-	public void updateAdministCode(AdministCodeRecptn administCodeRecptn) throws Exception {
-		int rtnValue = update("AdministCodeRecptnDAO.updateAdministCode", administCodeRecptn);
-        if (rtnValue != 1) {
-        	// 변경 오류
-        	administCodeRecptn.setProcessSe("12");
-        }
-    	update("AdministCodeRecptnDAO.updateAdministCodeRecptn", administCodeRecptn);
+	public void updateAdministCode(AdministCodeRecptn administCodeRecptn) {
+		administCodeRecptnMapper.updateAdministCode(administCodeRecptn);
 	}
 
-	/**
-	 * 법정동코드를 삭제한다.
-	 * @param administCode
-	 * @throws Exception
-	 */
-	public void deleteAdministCode(AdministCodeRecptn administCodeRecptn) throws Exception {
-		int rtnValue = update("AdministCodeRecptnDAO.deleteAdministCode", administCodeRecptn);
-        if (rtnValue != 1) {
-        	// 삭제 오류
-        	administCodeRecptn.setProcessSe("13");
-        }
-    	update("AdministCodeRecptnDAO.updateAdministCodeRecptn", administCodeRecptn);
+	public void deleteAdministCode(AdministCodeRecptn administCodeRecptn) {
+		administCodeRecptnMapper.deleteAdministCode(administCodeRecptn);
 	}
 
-	/**
-	 * 법정동코드 상세내역을 조회한다.
-	 * @param administCode
-	 * @return AdministCode(법정동코드)
-	 */
-	public AdministCodeRecptn selectAdministCodeDetail(AdministCodeRecptn administCodeRecptn) throws Exception {
-		return (AdministCodeRecptn) selectOne("AdministCodeRecptnDAO.selectAdministCodeDetail", administCodeRecptn);
+	public AdministCodeRecptn selectAdministCodeDetail(AdministCodeRecptn administCodeRecptn) {
+		return administCodeRecptnMapper.selectAdministCodeDetail(administCodeRecptn);
 	}
 
+	public List<EgovMap> selectAdministCodeRecptnList(AdministCodeRecptnVO searchVO) {
+		return administCodeRecptnMapper.selectAdministCodeRecptnList(searchVO);
+	}
 
-    /**
-	 * 법정동코드수신 목록을 조회한다.
-     * @param searchVO
-     * @return List(법정동코드 목록)
-     * @throws Exception
-     */
-    public List<EgovMap> selectAdministCodeRecptnList(AdministCodeRecptnVO searchVO) throws Exception {
-        return selectList("AdministCodeRecptnDAO.selectAdministCodeRecptnList", searchVO);
-    }
+	public int selectAdministCodeRecptnListTotCnt(AdministCodeRecptnVO searchVO) {
+		return administCodeRecptnMapper.selectAdministCodeRecptnListTotCnt(searchVO);
+	}
 
-    /**
-	 * 법정동코드수신 총 개수를 조회한다.
-     * @param searchVO
-     * @return int(법정동코드 총 개수)
-     */
-    public int selectAdministCodeRecptnListTotCnt(AdministCodeRecptnVO searchVO) throws Exception {
-        return (Integer)selectOne("AdministCodeRecptnDAO.selectAdministCodeRecptnListTotCnt", searchVO);
-    }
+	public List<EgovMap> selectAdministCodeList(AdministCodeRecptnVO searchVO) {
+		return administCodeRecptnMapper.selectAdministCodeList(searchVO);
+	}
 
-    /**
-	 * 법정동코드 목록을 조회한다.
-     * @param searchVO
-     * @return List(법정동코드 목록)
-     * @throws Exception
-     */
-    public List<EgovMap> selectAdministCodeList(AdministCodeRecptnVO searchVO) throws Exception {
-        return selectList("AdministCodeRecptnDAO.selectAdministCodeList", searchVO);
-    }
-
-    /**
-	 * 법정동코드 총 개수를 조회한다.
-     * @param searchVO
-     * @return int(법정동코드 총 개수)
-     */
-    public int selectAdministCodeListTotCnt(AdministCodeRecptnVO searchVO) throws Exception {
-        return (Integer)selectOne("AdministCodeRecptnDAO.selectAdministCodeListTotCnt", searchVO);
-    }
+	public int selectAdministCodeListTotCnt(AdministCodeRecptnVO searchVO) {
+		return administCodeRecptnMapper.selectAdministCodeListTotCnt(searchVO);
+	}
 }

--- a/src/main/java/egovframework/com/sym/ccm/acr/service/impl/AdministCodeRecptnMapper.java
+++ b/src/main/java/egovframework/com/sym/ccm/acr/service/impl/AdministCodeRecptnMapper.java
@@ -1,0 +1,42 @@
+package egovframework.com.sym.ccm.acr.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+import org.egovframe.rte.psl.dataaccess.util.EgovMap;
+
+import egovframework.com.sym.ccm.acr.service.AdministCodeRecptn;
+import egovframework.com.sym.ccm.acr.service.AdministCodeRecptnVO;
+
+/**
+ * 법정동코드에 대한 Mapper 인터페이스
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2026.05.28  dasomel         XML 기반 DAO → @EgovMapper 인터페이스로 전환
+ * </pre>
+ */
+@EgovMapper("administCodeRecptnMapper")
+public interface AdministCodeRecptnMapper {
+
+	void insertAdministCodeRecptn(AdministCodeRecptn administCodeRecptn);
+
+	void insertAdministCode(AdministCodeRecptn administCodeRecptn);
+
+	void updateAdministCode(AdministCodeRecptn administCodeRecptn);
+
+	void deleteAdministCode(AdministCodeRecptn administCodeRecptn);
+
+	AdministCodeRecptn selectAdministCodeDetail(AdministCodeRecptn administCodeRecptn);
+
+	List<EgovMap> selectAdministCodeRecptnList(AdministCodeRecptnVO searchVO);
+
+	int selectAdministCodeRecptnListTotCnt(AdministCodeRecptnVO searchVO);
+
+	List<EgovMap> selectAdministCodeList(AdministCodeRecptnVO searchVO);
+
+	int selectAdministCodeListTotCnt(AdministCodeRecptnVO searchVO);
+}

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/acr/EgovAdministCodeRecptn_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/acr/EgovAdministCodeRecptn_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="AdministCodeRecptnDAO">
+<mapper namespace="egovframework.com.sym.ccm.acr.service.impl.AdministCodeRecptnMapper">
 
     <select id="selectAdministCodeRecptnList" parameterType="egovframework.com.sym.ccm.acr.service.AdministCodeRecptnVO" resultType="egovMap">
         

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/acr/EgovAdministCodeRecptn_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/acr/EgovAdministCodeRecptn_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="AdministCodeRecptnDAO">
+<mapper namespace="egovframework.com.sym.ccm.acr.service.impl.AdministCodeRecptnMapper">
 
     <select id="selectAdministCodeRecptnList" parameterType="egovframework.com.sym.ccm.acr.service.AdministCodeRecptnVO" resultType="egovMap">
         

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/acr/EgovAdministCodeRecptn_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/acr/EgovAdministCodeRecptn_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="AdministCodeRecptnDAO">
+<mapper namespace="egovframework.com.sym.ccm.acr.service.impl.AdministCodeRecptnMapper">
 
     <select id="selectAdministCodeRecptnList" parameterType="egovframework.com.sym.ccm.acr.service.AdministCodeRecptnVO" resultType="egovMap">
         

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/acr/EgovAdministCodeRecptn_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/acr/EgovAdministCodeRecptn_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="AdministCodeRecptnDAO">
+<mapper namespace="egovframework.com.sym.ccm.acr.service.impl.AdministCodeRecptnMapper">
 
     <select id="selectAdministCodeRecptnList" parameterType="egovframework.com.sym.ccm.acr.service.AdministCodeRecptnVO" resultType="egovMap">
         

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/acr/EgovAdministCodeRecptn_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/acr/EgovAdministCodeRecptn_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="AdministCodeRecptnDAO">
+<mapper namespace="egovframework.com.sym.ccm.acr.service.impl.AdministCodeRecptnMapper">
 
     <select id="selectAdministCodeRecptnList" parameterType="egovframework.com.sym.ccm.acr.service.AdministCodeRecptnVO" resultType="egovMap">
         

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/acr/EgovAdministCodeRecptn_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/acr/EgovAdministCodeRecptn_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="AdministCodeRecptnDAO">
+<mapper namespace="egovframework.com.sym.ccm.acr.service.impl.AdministCodeRecptnMapper">
 
     <select id="selectAdministCodeRecptnList" parameterType="egovframework.com.sym.ccm.acr.service.AdministCodeRecptnVO" resultType="egovMap">
         

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/acr/EgovAdministCodeRecptn_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/acr/EgovAdministCodeRecptn_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="AdministCodeRecptnDAO">
+<mapper namespace="egovframework.com.sym.ccm.acr.service.impl.AdministCodeRecptnMapper">
 
     <select id="selectAdministCodeRecptnList" parameterType="egovframework.com.sym.ccm.acr.service.AdministCodeRecptnVO" resultType="egovMap">
         

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/acr/EgovAdministCodeRecptn_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/acr/EgovAdministCodeRecptn_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="AdministCodeRecptnDAO">
+<mapper namespace="egovframework.com.sym.ccm.acr.service.impl.AdministCodeRecptnMapper">
 
     <select id="selectAdministCodeRecptnList" parameterType="egovframework.com.sym.ccm.acr.service.AdministCodeRecptnVO" resultType="egovMap">
         

--- a/src/main/resources/egovframework/spring/com/context-mapper.xml
+++ b/src/main/resources/egovframework/spring/com/context-mapper.xml
@@ -22,4 +22,11 @@
 		<constructor-arg ref="egov.sqlSession"/>
 	</bean>
 	
+
+	<!-- @EgovMapper 어노테이션이 선언된 Mapper 인터페이스를 자동으로 스캔하여 빈으로 등록한다 -->
+	<bean class="org.mybatis.spring.mapper.MapperScannerConfigurer">
+		<property name="basePackage" value="egovframework.com" />
+		<property name="annotationClass" value="org.egovframe.rte.psl.dataaccess.mapper.EgovMapper" />
+	</bean>
+
 </beans>


### PR DESCRIPTION
## 변경 사유
eGovFrame 5.0 @EgovMapper 활용 확대. sym/ccm 시리즈 동일 패턴.

## 변경 내용
- 신규 `AdministCodeRecptnMapper` 인터페이스(@EgovMapper) 추가
- `AdministCodeRecptnDAO`: `EgovComAbstractDAO` 상속 제거, `@Resource` 위임 방식으로 전환
- 8개 RDBMS XML namespace를 인터페이스 FQN으로 변경

## 영향 범위
- 외부 동작 변경 없음
- 베이스라인 컴파일 에러 수 변동 없음 (149 → 149)
