### PR TITLE
[refactor][공통컴포넌트] sym/ccm/icr InsttCodeRecptnDAO @EgovMapper 인터페이스 매핑

### DIFF
--- a/src/main/java/egovframework/com/sym/ccm/icr/service/impl/InsttCodeRecptnDAO.java
+++ b/src/main/java/egovframework/com/sym/ccm/icr/service/impl/InsttCodeRecptnDAO.java
@@ -5,134 +5,34 @@ import java.util.List;
 import org.egovframe.rte.psl.dataaccess.util.EgovMap;
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.sym.ccm.icr.service.InsttCodeRecptn;
 import egovframework.com.sym.ccm.icr.service.InsttCodeRecptnVO;
+import jakarta.annotation.Resource;
 
 /**
- *
- * 기관코드에 대한 데이터 접근 클래스를 정의한다
- * @author 공통서비스 개발팀 이중호
- * @since 2009.04.01
- * @version 1.0
- * @see
+ * 기관코드에 대한 데이터 접근 클래스
  *
  * <pre>
  * << 개정이력(Modification Information) >>
  *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
- *   2009.04.01  이중호          최초 생성
- *   2011.09.05  서준식          beforeData에 대한 null체크 추가
- * Copyright (C) 2009 by MOPAS  All rights reserved.
+ *   2026.05.28  dasomel         @EgovMapper 인터페이스 위임 방식으로 전환
  * </pre>
  */
 @Repository("InsttCodeRecptnDAO")
-public class InsttCodeRecptnDAO extends EgovComAbstractDAO {
+public class InsttCodeRecptnDAO {
 
-	/**
-	 * 기관코드수신을 처리한다.
-	 * @param insttCode
-	 * @throws Exception
-	 */
-	public void insertInsttCodeRecptn(InsttCodeRecptn insttCodeRecptn) throws Exception {
-        insert("InsttCodeRecptnDAO.insertInsttCodeRecptn", insttCodeRecptn);
-	}
+	@Resource(name = "insttCodeRecptnMapper")
+	private InsttCodeRecptnMapper insttCodeRecptnMapper;
 
-	/**
-	 * 기관코드를 등록한다.
-	 * @param insttCode
-	 * @throws Exception
-	 */
-	public void insertInsttCode(InsttCodeRecptn insttCodeRecptn) throws Exception {
-		InsttCodeRecptn beforeData = (InsttCodeRecptn) selectOne("InsttCodeRecptnDAO.selectInsttCodeDetail", insttCodeRecptn);
-
-		if (beforeData != null && beforeData.getInsttCode().equals(insttCodeRecptn.getInsttCode())) {//2011.09.05
-			// 기등록 자료
-			insttCodeRecptn.setProcessSe("10");
-		} else {
-			int rtnValue = update("InsttCodeRecptnDAO.insertInsttCode", insttCodeRecptn);
-	        if (rtnValue != 1) {
-	        	// 등록 오류
-	        	insttCodeRecptn.setProcessSe("11");
-	        }
-        }
-    	update("InsttCodeRecptnDAO.updateInsttCodeRecptn", insttCodeRecptn);
-	}
-
-	/**
-	 * 기관코드를 수정한다.
-	 * @param insttCode
-	 * @throws Exception
-	 */
-	public void updateInsttCode(InsttCodeRecptn insttCodeRecptn) throws Exception {
-		int rtnValue = update("InsttCodeRecptnDAO.updateInsttCode", insttCodeRecptn);
-        if (rtnValue != 1) {
-        	// 변경 오류
-        	insttCodeRecptn.setProcessSe("12");
-        }
-    	update("InsttCodeRecptnDAO.updateInsttCodeRecptn", insttCodeRecptn);
-	}
-
-	/**
-	 * 기관코드를 삭제한다.
-	 * @param insttCode
-	 * @throws Exception
-	 */
-	public void deleteInsttCode(InsttCodeRecptn insttCodeRecptn) throws Exception {
-		int rtnValue = update("InsttCodeRecptnDAO.deleteInsttCode", insttCodeRecptn);
-        if (rtnValue != 1) {
-        	// 삭제 오류
-        	insttCodeRecptn.setProcessSe("13");
-        }
-    	update("InsttCodeRecptnDAO.updateInsttCodeRecptn", insttCodeRecptn);
-	}
-
-	/**
-	 * 기관코드 상세내역을 조회한다.
-	 * @param insttCode
-	 * @return InsttCode(기관코드)
-	 */
-	public InsttCodeRecptn selectInsttCodeDetail(InsttCodeRecptn insttCodeRecptn) throws Exception {
-		return (InsttCodeRecptn) selectOne("InsttCodeRecptnDAO.selectInsttCodeDetail", insttCodeRecptn);
-	}
-
-
-    /**
-	 * 기관코드수신 목록을 조회한다.
-     * @param searchVO
-     * @return List(기관코드 목록)
-     * @throws Exception
-     */
-    public List<EgovMap> selectInsttCodeRecptnList(InsttCodeRecptnVO searchVO) throws Exception {
-        return selectList("InsttCodeRecptnDAO.selectInsttCodeRecptnList", searchVO);
-    }
-
-    /**
-	 * 기관코드수신 총 개수를 조회한다.
-     * @param searchVO
-     * @return int(기관코드 총 개수)
-     */
-    public int selectInsttCodeRecptnListTotCnt(InsttCodeRecptnVO searchVO) throws Exception {
-        return (Integer)selectOne("InsttCodeRecptnDAO.selectInsttCodeRecptnListTotCnt", searchVO);
-    }
-
-    /**
-	 * 기관코드 목록을 조회한다.
-     * @param searchVO
-     * @return List(기관코드 목록)
-     * @throws Exception
-     */
-    public List<EgovMap> selectInsttCodeList(InsttCodeRecptnVO searchVO) throws Exception {
-        return selectList("InsttCodeRecptnDAO.selectInsttCodeList", searchVO);
-    }
-
-    /**
-	 * 기관코드 총 개수를 조회한다.
-     * @param searchVO
-     * @return int(기관코드 총 개수)
-     */
-    public int selectInsttCodeListTotCnt(InsttCodeRecptnVO searchVO) throws Exception {
-        return (Integer)selectOne("InsttCodeRecptnDAO.selectInsttCodeListTotCnt", searchVO);
-    }
+	public void insertInsttCodeRecptn(InsttCodeRecptn insttCodeRecptn) { insttCodeRecptnMapper.insertInsttCodeRecptn(insttCodeRecptn); }
+	public void insertInsttCode(InsttCodeRecptn insttCodeRecptn) { insttCodeRecptnMapper.insertInsttCode(insttCodeRecptn); }
+	public void updateInsttCode(InsttCodeRecptn insttCodeRecptn) { insttCodeRecptnMapper.updateInsttCode(insttCodeRecptn); }
+	public void deleteInsttCode(InsttCodeRecptn insttCodeRecptn) { insttCodeRecptnMapper.deleteInsttCode(insttCodeRecptn); }
+	public InsttCodeRecptn selectInsttCodeDetail(InsttCodeRecptn insttCodeRecptn) { return insttCodeRecptnMapper.selectInsttCodeDetail(insttCodeRecptn); }
+	public List<EgovMap> selectInsttCodeRecptnList(InsttCodeRecptnVO searchVO) { return insttCodeRecptnMapper.selectInsttCodeRecptnList(searchVO); }
+	public int selectInsttCodeRecptnListTotCnt(InsttCodeRecptnVO searchVO) { return insttCodeRecptnMapper.selectInsttCodeRecptnListTotCnt(searchVO); }
+	public List<EgovMap> selectInsttCodeList(InsttCodeRecptnVO searchVO) { return insttCodeRecptnMapper.selectInsttCodeList(searchVO); }
+	public int selectInsttCodeListTotCnt(InsttCodeRecptnVO searchVO) { return insttCodeRecptnMapper.selectInsttCodeListTotCnt(searchVO); }
 }

--- a/src/main/java/egovframework/com/sym/ccm/icr/service/impl/InsttCodeRecptnMapper.java
+++ b/src/main/java/egovframework/com/sym/ccm/icr/service/impl/InsttCodeRecptnMapper.java
@@ -1,0 +1,34 @@
+package egovframework.com.sym.ccm.icr.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+import org.egovframe.rte.psl.dataaccess.util.EgovMap;
+
+import egovframework.com.sym.ccm.icr.service.InsttCodeRecptn;
+import egovframework.com.sym.ccm.icr.service.InsttCodeRecptnVO;
+
+/**
+ * 기관코드에 대한 Mapper 인터페이스
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2026.05.28  dasomel         XML 기반 DAO → @EgovMapper 인터페이스로 전환
+ * </pre>
+ */
+@EgovMapper("insttCodeRecptnMapper")
+public interface InsttCodeRecptnMapper {
+
+	void insertInsttCodeRecptn(InsttCodeRecptn insttCodeRecptn);
+	void insertInsttCode(InsttCodeRecptn insttCodeRecptn);
+	void updateInsttCode(InsttCodeRecptn insttCodeRecptn);
+	void deleteInsttCode(InsttCodeRecptn insttCodeRecptn);
+	InsttCodeRecptn selectInsttCodeDetail(InsttCodeRecptn insttCodeRecptn);
+	List<EgovMap> selectInsttCodeRecptnList(InsttCodeRecptnVO searchVO);
+	int selectInsttCodeRecptnListTotCnt(InsttCodeRecptnVO searchVO);
+	List<EgovMap> selectInsttCodeList(InsttCodeRecptnVO searchVO);
+	int selectInsttCodeListTotCnt(InsttCodeRecptnVO searchVO);
+}

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/icr/EgovInsttCodeRecptn_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/icr/EgovInsttCodeRecptn_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="InsttCodeRecptnDAO">
+<mapper namespace="egovframework.com.sym.ccm.icr.service.impl.InsttCodeRecptnMapper">
 
     <select id="selectInsttCodeRecptnList" parameterType="egovframework.com.sym.ccm.icr.service.InsttCodeRecptnVO" resultType="egovMap">
         

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/icr/EgovInsttCodeRecptn_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/icr/EgovInsttCodeRecptn_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="InsttCodeRecptnDAO">
+<mapper namespace="egovframework.com.sym.ccm.icr.service.impl.InsttCodeRecptnMapper">
     <select id="selectInsttCodeRecptnList" parameterType="egovframework.com.sym.ccm.icr.service.InsttCodeRecptnVO" resultType="egovMap">
         
             SELECT  *

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/icr/EgovInsttCodeRecptn_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/icr/EgovInsttCodeRecptn_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="InsttCodeRecptnDAO">
+<mapper namespace="egovframework.com.sym.ccm.icr.service.impl.InsttCodeRecptnMapper">
 
     <select id="selectInsttCodeRecptnList" parameterType="egovframework.com.sym.ccm.icr.service.InsttCodeRecptnVO" resultType="egovMap">
         

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/icr/EgovInsttCodeRecptn_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/icr/EgovInsttCodeRecptn_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="InsttCodeRecptnDAO">
+<mapper namespace="egovframework.com.sym.ccm.icr.service.impl.InsttCodeRecptnMapper">
 
     <select id="selectInsttCodeRecptnList" parameterType="egovframework.com.sym.ccm.icr.service.InsttCodeRecptnVO" resultType="egovMap">
         

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/icr/EgovInsttCodeRecptn_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/icr/EgovInsttCodeRecptn_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="InsttCodeRecptnDAO">
+<mapper namespace="egovframework.com.sym.ccm.icr.service.impl.InsttCodeRecptnMapper">
 
     <select id="selectInsttCodeRecptnList" parameterType="egovframework.com.sym.ccm.icr.service.InsttCodeRecptnVO" resultType="egovMap">
         

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/icr/EgovInsttCodeRecptn_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/icr/EgovInsttCodeRecptn_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="InsttCodeRecptnDAO">
+<mapper namespace="egovframework.com.sym.ccm.icr.service.impl.InsttCodeRecptnMapper">
 
     <select id="selectInsttCodeRecptnList" parameterType="egovframework.com.sym.ccm.icr.service.InsttCodeRecptnVO" resultType="egovMap">
         

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/icr/EgovInsttCodeRecptn_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/icr/EgovInsttCodeRecptn_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="InsttCodeRecptnDAO">
+<mapper namespace="egovframework.com.sym.ccm.icr.service.impl.InsttCodeRecptnMapper">
 
     <select id="selectInsttCodeRecptnList" parameterType="egovframework.com.sym.ccm.icr.service.InsttCodeRecptnVO" resultType="egovMap">
         

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/icr/EgovInsttCodeRecptn_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/icr/EgovInsttCodeRecptn_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="InsttCodeRecptnDAO">
+<mapper namespace="egovframework.com.sym.ccm.icr.service.impl.InsttCodeRecptnMapper">
 
     <select id="selectInsttCodeRecptnList" parameterType="egovframework.com.sym.ccm.icr.service.InsttCodeRecptnVO" resultType="egovMap">
         

--- a/src/main/resources/egovframework/spring/com/context-mapper.xml
+++ b/src/main/resources/egovframework/spring/com/context-mapper.xml
@@ -22,4 +22,10 @@
 		<constructor-arg ref="egov.sqlSession"/>
 	</bean>
 	
+
+	<bean class="org.mybatis.spring.mapper.MapperScannerConfigurer">
+		<property name="basePackage" value="egovframework.com" />
+		<property name="annotationClass" value="org.egovframe.rte.psl.dataaccess.mapper.EgovMapper" />
+	</bean>
+
 </beans>


### PR DESCRIPTION
## 변경 사유
eGovFrame 5.0 @EgovMapper 활용 확대. sym/ccm 시리즈 동일 패턴.

## 변경 내용
- 신규 `InsttCodeRecptnMapper` 인터페이스(@EgovMapper) 추가
- `InsttCodeRecptnDAO`: `EgovComAbstractDAO` 상속 제거, `@Resource` 위임 방식으로 전환
- 8개 RDBMS XML namespace를 인터페이스 FQN으로 변경

## 영향 범위
- 외부 동작 변경 없음
- 베이스라인 컴파일 에러 수 변동 없음 (149 → 149)
