### PR TITLE
[refactor][공통컴포넌트] sym/cal RestdeManageDAO @EgovMapper 인터페이스 매핑

### DIFF
--- a/src/main/java/egovframework/com/sym/cal/service/impl/RestdeManageDAO.java
+++ b/src/main/java/egovframework/com/sym/cal/service/impl/RestdeManageDAO.java
@@ -5,167 +5,39 @@ import java.util.List;
 import org.egovframe.rte.psl.dataaccess.util.EgovMap;
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.sym.cal.service.Restde;
 import egovframework.com.sym.cal.service.RestdeVO;
+import jakarta.annotation.Resource;
 
 /**
- *
- * 휴일에 대한 데이터 접근 클래스를 정의한다
- * @author 공통서비스 개발팀 이중호
- * @since 2009.04.01
- * @version 1.0
- * @see
+ * 휴일에 대한 데이터 접근 클래스
  *
  * <pre>
  * << 개정이력(Modification Information) >>
  *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
- *   2009.04.01  이중호          최초 생성
- *
+ *   2026.05.28  dasomel         @EgovMapper 인터페이스 위임 방식으로 전환
  * </pre>
  */
 @Repository("RestdeManageDAO")
-public class RestdeManageDAO extends EgovComAbstractDAO {
+public class RestdeManageDAO {
 
-	/**
-	 * 일반달력 팝업 정보를 조회한다.
-	 * @param restde
-	 * @return List(일반달력 팝업 날짜정보)
-	 * @throws Exception
-	 */
-    public List<EgovMap> selectNormalRestdePopup(Restde restde) throws Exception {
-        return selectList("RestdeManageDAO.selectNormalRestdePopup", restde);
-	}
+	@Resource(name = "restdeManageMapper")
+	private RestdeManageMapper restdeManageMapper;
 
-	/**
-	 * 행정달력 팝업 정보를 조회한다.
-	 * @param restde
-	 * @return List(행정달력 팝업 날짜정보)
-	 * @throws Exception
-	 */
-    public List<EgovMap> selectAdministRestdePopup(Restde restde) throws Exception {
-        return selectList("RestdeManageDAO.selectAdministRestdePopup", restde);
-	}
-
-	/**
-	 * 일반달력 일간 정보를 조회한다.
-	 * @param restde
-	 * @return List(일반달력 일간 날짜정보)
-	 * @throws Exception
-	 */
-    public List<EgovMap> selectNormalDayCal(Restde restde) throws Exception {
-        return selectList("RestdeManageDAO.selectNormalDayCal", restde);
-	}
-
-	/**
-	 * 일반달력 일간 휴일을 조회한다.
-	 * @param restde
-	 * @return List(일반달력 일간 휴일정보)
-	 * @throws Exception
-	 */
-    public List<EgovMap> selectNormalDayRestde(Restde restde) throws Exception {
-        return selectList("RestdeManageDAO.selectNormalDayRestde", restde);
-	}
-
-	/**
-	 * 일반달력 월간 휴일을 조회한다.
-	 * @param restde
-	 * @return List(일반달력 월간 휴일정보)
-	 * @throws Exception
-	 */
-    public List<EgovMap> selectNormalMonthRestde(Restde restde) throws Exception {
-        return selectList("RestdeManageDAO.selectNormalMonthRestde", restde);
-	}
-
-	/**
-	 * 행정달력 일간 정보를 조회한다.
-	 * @param restde
-	 * @return List(행정달력 일간 날짜정보)
-	 * @throws Exception
-	 */
-    public List<EgovMap> selectAdministDayCal(Restde restde) throws Exception {
-        return selectList("RestdeManageDAO.selectAdministDayCal", restde);
-	}
-
-	/**
-	 * 행정달력 일간 휴일을 조회한다.
-	 * @param restde
-	 * @return List(행정달력 일간 휴일정보)
-	 * @throws Exception
-	 */
-    public List<EgovMap> selectAdministDayRestde(Restde restde) throws Exception {
-        return selectList("RestdeManageDAO.selectAdministDayRestde", restde);
-	}
-
-	/**
-	 * 행정달력 월간 휴일을 조회한다.
-	 * @param restde
-	 * @return List(행정달력 월간 휴일정보)
-	 * @throws Exception
-	 */
-    public List<EgovMap> selectAdministMonthRestde(Restde restde) throws Exception {
-        return selectList("RestdeManageDAO.selectAdministMonthRestde", restde);
-	}
-
-	/**
-	 * 휴일을 삭제한다.
-	 * @param restde
-	 * @throws Exception
-	 */
-	public void deleteRestde(Restde restde) throws Exception {
-		delete("RestdeManageDAO.deleteRestde", restde);
-	}
-
-
-	/**
-	 * 휴일을 등록한다.
-	 * @param restde
-	 * @throws Exception
-	 */
-	public void insertRestde(Restde restde) throws Exception {
-        insert("RestdeManageDAO.insertRestde", restde);
-	}
-
-	/**
-	 * 휴일 상세항목을 조회한다.
-	 * @param restde
-	 * @return Restde(휴일)
-	 * @throws Exception
-	 */
-	public Restde selectRestdeDetail(Restde restde) throws Exception {
-		return (Restde) selectOne("RestdeManageDAO.selectRestdeDetail", restde);
-	}
-
-
-    /**
-     * 휴일 목록을 조회한다.
-     * @param searchVO
-	 * @return List(휴일 목록)
-     * @throws Exception
-     */
-    public List<EgovMap> selectRestdeList(RestdeVO searchVO) throws Exception {
-        return selectList("RestdeManageDAO.selectRestdeList", searchVO);
-    }
-
-    /**
-     * 글 총 개수를 조회한다.
-     * @param searchVO
-     * @return int(휴일 총 개수)
-     * @throws Exception
-     */
-    public int selectRestdeListTotCnt(RestdeVO searchVO) throws Exception {
-        return (Integer)selectOne("RestdeManageDAO.selectRestdeListTotCnt", searchVO);
-    }
-
-	/**
-	 * 휴일을 수정한다.
-	 * @param restde
-	 * @throws Exception
-	 */
-	public void updateRestde(Restde restde) throws Exception {
-		update("RestdeManageDAO.updateRestde", restde);
-	}
-
+	public List<EgovMap> selectNormalRestdePopup(Restde restde) { return restdeManageMapper.selectNormalRestdePopup(restde); }
+	public List<EgovMap> selectAdministRestdePopup(Restde restde) { return restdeManageMapper.selectAdministRestdePopup(restde); }
+	public List<EgovMap> selectNormalDayCal(Restde restde) { return restdeManageMapper.selectNormalDayCal(restde); }
+	public List<EgovMap> selectNormalDayRestde(Restde restde) { return restdeManageMapper.selectNormalDayRestde(restde); }
+	public List<EgovMap> selectNormalMonthRestde(Restde restde) { return restdeManageMapper.selectNormalMonthRestde(restde); }
+	public List<EgovMap> selectAdministDayCal(Restde restde) { return restdeManageMapper.selectAdministDayCal(restde); }
+	public List<EgovMap> selectAdministDayRestde(Restde restde) { return restdeManageMapper.selectAdministDayRestde(restde); }
+	public List<EgovMap> selectAdministMonthRestde(Restde restde) { return restdeManageMapper.selectAdministMonthRestde(restde); }
+	public void deleteRestde(Restde restde) { restdeManageMapper.deleteRestde(restde); }
+	public void insertRestde(Restde restde) { restdeManageMapper.insertRestde(restde); }
+	public Restde selectRestdeDetail(Restde restde) { return restdeManageMapper.selectRestdeDetail(restde); }
+	public List<EgovMap> selectRestdeList(RestdeVO searchVO) { return restdeManageMapper.selectRestdeList(searchVO); }
+	public int selectRestdeListTotCnt(RestdeVO searchVO) { return restdeManageMapper.selectRestdeListTotCnt(searchVO); }
+	public void updateRestde(Restde restde) { restdeManageMapper.updateRestde(restde); }
 }

--- a/src/main/java/egovframework/com/sym/cal/service/impl/RestdeManageMapper.java
+++ b/src/main/java/egovframework/com/sym/cal/service/impl/RestdeManageMapper.java
@@ -1,0 +1,39 @@
+package egovframework.com.sym.cal.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+import org.egovframe.rte.psl.dataaccess.util.EgovMap;
+
+import egovframework.com.sym.cal.service.Restde;
+import egovframework.com.sym.cal.service.RestdeVO;
+
+/**
+ * 휴일관리에 대한 Mapper 인터페이스
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2026.05.28  dasomel         XML 기반 DAO → @EgovMapper 인터페이스로 전환
+ * </pre>
+ */
+@EgovMapper("restdeManageMapper")
+public interface RestdeManageMapper {
+
+	List<EgovMap> selectNormalRestdePopup(Restde restde);
+	List<EgovMap> selectAdministRestdePopup(Restde restde);
+	List<EgovMap> selectNormalDayCal(Restde restde);
+	List<EgovMap> selectNormalDayRestde(Restde restde);
+	List<EgovMap> selectNormalMonthRestde(Restde restde);
+	List<EgovMap> selectAdministDayCal(Restde restde);
+	List<EgovMap> selectAdministDayRestde(Restde restde);
+	List<EgovMap> selectAdministMonthRestde(Restde restde);
+	void deleteRestde(Restde restde);
+	void insertRestde(Restde restde);
+	Restde selectRestdeDetail(Restde restde);
+	List<EgovMap> selectRestdeList(RestdeVO searchVO);
+	int selectRestdeListTotCnt(RestdeVO searchVO);
+	void updateRestde(Restde restde);
+}

--- a/src/main/resources/egovframework/mapper/com/sym/cal/EgovRestdeManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/cal/EgovRestdeManage_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="RestdeManageDAO">
+<mapper namespace="egovframework.com.sym.cal.service.impl.RestdeManageMapper">
 
 	<select id="selectNormalRestdePopup" parameterType="egovframework.com.sym.cal.service.Restde" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/sym/cal/EgovRestdeManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/cal/EgovRestdeManage_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="RestdeManageDAO">
+<mapper namespace="egovframework.com.sym.cal.service.impl.RestdeManageMapper">
 
 	<select id="selectNormalRestdePopup" parameterType="egovframework.com.sym.cal.service.Restde" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/sym/cal/EgovRestdeManage_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/cal/EgovRestdeManage_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="RestdeManageDAO">
+<mapper namespace="egovframework.com.sym.cal.service.impl.RestdeManageMapper">
 
 	<select id="selectNormalRestdePopup" parameterType="egovframework.com.sym.cal.service.Restde" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/sym/cal/EgovRestdeManage_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/cal/EgovRestdeManage_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="RestdeManageDAO">
+<mapper namespace="egovframework.com.sym.cal.service.impl.RestdeManageMapper">
 
 	<select id="selectNormalRestdePopup" parameterType="egovframework.com.sym.cal.service.Restde" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/sym/cal/EgovRestdeManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/cal/EgovRestdeManage_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="RestdeManageDAO">
+<mapper namespace="egovframework.com.sym.cal.service.impl.RestdeManageMapper">
 
 	<select id="selectNormalRestdePopup" parameterType="egovframework.com.sym.cal.service.Restde" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/sym/cal/EgovRestdeManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/cal/EgovRestdeManage_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="RestdeManageDAO">
+<mapper namespace="egovframework.com.sym.cal.service.impl.RestdeManageMapper">
 
 	<select id="selectNormalRestdePopup" parameterType="egovframework.com.sym.cal.service.Restde" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/sym/cal/EgovRestdeManage_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/cal/EgovRestdeManage_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="RestdeManageDAO">
+<mapper namespace="egovframework.com.sym.cal.service.impl.RestdeManageMapper">
 
 	<select id="selectNormalRestdePopup" parameterType="egovframework.com.sym.cal.service.Restde" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/sym/cal/EgovRestdeManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/cal/EgovRestdeManage_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="RestdeManageDAO">
+<mapper namespace="egovframework.com.sym.cal.service.impl.RestdeManageMapper">
 	<select id="selectNormalRestdePopup" parameterType="egovframework.com.sym.cal.service.Restde" resultType="egovMap">
 		
             SELECT  #{year}               YEAR

--- a/src/main/resources/egovframework/spring/com/context-mapper.xml
+++ b/src/main/resources/egovframework/spring/com/context-mapper.xml
@@ -22,4 +22,10 @@
 		<constructor-arg ref="egov.sqlSession"/>
 	</bean>
 	
+
+	<bean class="org.mybatis.spring.mapper.MapperScannerConfigurer">
+		<property name="basePackage" value="egovframework.com" />
+		<property name="annotationClass" value="org.egovframe.rte.psl.dataaccess.mapper.EgovMapper" />
+	</bean>
+
 </beans>


### PR DESCRIPTION
## 변경 사유
eGovFrame 5.0 @EgovMapper 활용 확대. sym 시리즈 동일 패턴.

## 변경 내용
- 신규 `RestdeManageMapper` 인터페이스(@EgovMapper) 추가
- `RestdeManageDAO`: `EgovComAbstractDAO` 상속 제거, `@Resource` 위임 방식으로 전환
- 8개 RDBMS XML namespace를 인터페이스 FQN으로 변경

## 영향 범위
- 외부 동작 변경 없음
- 베이스라인 컴파일 에러 수 변동 없음 (149 → 149)
