### PR TITLE
[refactor][5.0.x][공통컴포넌트] sym/sym/srv ServerDAO @EgovMapper 인터페이스 방식으로 전환

### DIFF
--- a/src/main/java/egovframework/com/sym/sym/srv/service/impl/ServerMapper.java
+++ b/src/main/java/egovframework/com/sym/sym/srv/service/impl/ServerMapper.java
@@ -2,7 +2,7 @@ package egovframework.com.sym.sym.srv.service.impl;
 
 import java.util.List;
 
-import org.springframework.stereotype.Repository;
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
 
 import egovframework.com.sym.sym.srv.service.Server;
 import egovframework.com.sym.sym.srv.service.ServerEqpmn;
@@ -10,11 +10,10 @@ import egovframework.com.sym.sym.srv.service.ServerEqpmnRelate;
 import egovframework.com.sym.sym.srv.service.ServerEqpmnRelateVO;
 import egovframework.com.sym.sym.srv.service.ServerEqpmnVO;
 import egovframework.com.sym.sym.srv.service.ServerVO;
-import jakarta.annotation.Resource;
 
 /**
  * 개요
- * - 서버정보에 대한 DAO 클래스를 정의한다.
+ * - 서버정보에 대한 Mapper 인터페이스를 정의한다.
  *
  * 상세내용
  * - 서버정보에 대한 등록, 수정, 삭제, 조회 등의 기능을 제공한다.
@@ -23,173 +22,132 @@ import jakarta.annotation.Resource;
  * @version 1.0
  * @created 28-6-2010 오전 10:44:54
  */
-@Repository("serverDAO")
-public class ServerDAO {
-
-	@Resource(name = "serverMapper")
-	private ServerMapper serverMapper;
+@EgovMapper
+public interface ServerMapper {
 
 	/**
 	 * 서버장비를 관리하기 위해 등록된 서버장비목록을 조회한다.
 	 * @param serverEqpmnVO - 서버장비 Vo
 	 * @return List - 서버장비 목록
 	 */
-	public List<ServerEqpmnVO> selectServerEqpmnList(ServerEqpmnVO serverEqpmnVO) {
-		return serverMapper.selectServerEqpmnList(serverEqpmnVO);
-	}
+	List<ServerEqpmnVO> selectServerEqpmnList(ServerEqpmnVO serverEqpmnVO);
 
 	/**
 	 * 서버장비목록 총 개수를 조회한다.
 	 * @param serverEqpmnVO - 서버장비 Vo
 	 * @return int - 서버장비 카운트 수
 	 */
-	public int selectServerEqpmnListTotCnt(ServerEqpmnVO serverEqpmnVO) throws Exception {
-		return serverMapper.selectServerEqpmnListTotCnt(serverEqpmnVO);
-	}
+	int selectServerEqpmnListTotCnt(ServerEqpmnVO serverEqpmnVO) throws Exception;
 
 	/**
 	 * 등록된 서버장비의 상세정보를 조회한다.
 	 * @param serverEqpmnVO - 서버장비 Vo
 	 * @return serverEqpmnVO - 서버장비 Vo
 	 */
-	public ServerEqpmnVO selectServerEqpmn(ServerEqpmnVO serverEqpmnVO) throws Exception {
-		return serverMapper.selectServerEqpmn(serverEqpmnVO);
-	}
+	ServerEqpmnVO selectServerEqpmn(ServerEqpmnVO serverEqpmnVO) throws Exception;
 
 	/**
 	 * 서버장비정보를 신규로 등록한다.
 	 * @param serverEqpmn - 서버장비 model
 	 */
-	public void insertServerEqpmn(ServerEqpmn serverEqpmn) throws Exception {
-		serverMapper.insertServerEqpmn(serverEqpmn);
-	}
+	void insertServerEqpmn(ServerEqpmn serverEqpmn) throws Exception;
 
 	/**
 	 * 기 등록된 서버장비정보를 수정한다.
 	 * @param serverEqpmn - 서버장비 model
 	 */
-	public void updateServerEqpmn(ServerEqpmn serverEqpmn) throws Exception {
-		serverMapper.updateServerEqpmn(serverEqpmn);
-	}
+	void updateServerEqpmn(ServerEqpmn serverEqpmn) throws Exception;
 
 	/**
 	 * 기 등록된 서버장비정보를 삭제한다.
 	 * @param serverEqpmn - 서버장비 model
 	 */
-	public void deleteServerEqpmn(ServerEqpmn serverEqpmn) throws Exception {
-		serverMapper.deleteServerEqpmn(serverEqpmn);
-	}
+	void deleteServerEqpmn(ServerEqpmn serverEqpmn) throws Exception;
 
 	/**
 	 * 서버정보를 관리하기 위해 등록된 서버목록을 조회한다.
 	 * @param serverVO - 서버 Vo
 	 * @return List - 서버 목록
 	 */
-	public List<ServerVO> selectServerList(ServerVO serverVO) throws Exception {
-		return serverMapper.selectServerList(serverVO);
-	}
+	List<ServerVO> selectServerList(ServerVO serverVO) throws Exception;
 
 	/**
 	 * 서버목록 총 개수를 조회한다.
 	 * @param serverVO - 서버 Vo
 	 * @return int - 서버 카운트 수
 	 */
-	public int selectServerListTotCnt(ServerVO serverVO) throws Exception {
-		return serverMapper.selectServerListTotCnt(serverVO);
-	}
+	int selectServerListTotCnt(ServerVO serverVO) throws Exception;
 
 	/**
 	 * 등록된 서버의 상세정보를 조회한다.
 	 * @param serverVO - 서버 Vo
 	 * @return serverVO - 서버 Vo
 	 */
-	public ServerVO selectServer(ServerVO serverVO) throws Exception {
-		return serverMapper.selectServer(serverVO);
-	}
+	ServerVO selectServer(ServerVO serverVO) throws Exception;
 
 	/**
 	 * 서버에 등록된 서버장비목록을 조회한다.
 	 * @param serverVO - 서버 Vo
 	 * @return List - 서버장비 목록
 	 */
-	public List<ServerEqpmnVO> selectServerEqpmnRelateDetail(ServerVO serverVO) throws Exception {
-		return serverMapper.selectServerEqpmnRelateDetail(serverVO);
-	}
+	List<ServerEqpmnVO> selectServerEqpmnRelateDetail(ServerVO serverVO) throws Exception;
 
 	/**
 	 * 서버에 등록된 서버장비목록의 카운트를 조회한다.
 	 * @param serverVO - 서버 Vo
 	 * @return int - 서버에 등록된 서버장비 카운트 수
 	 */
-	public int selectServerEqpmnRelateDetailTotCnt(ServerVO serverVO) throws Exception {
-		return serverMapper.selectServerEqpmnRelateDetailTotCnt(serverVO);
-	}
+	int selectServerEqpmnRelateDetailTotCnt(ServerVO serverVO) throws Exception;
 
 	/**
 	 * 서버정보를 신규로 등록한다.
 	 * @param server - 서버 model
 	 */
-	public void insertServer(Server server) throws Exception {
-		serverMapper.insertServer(server);
-	}
+	void insertServer(Server server) throws Exception;
 
 	/**
 	 * 기 등록된 서버정보를 수정한다.
 	 * @param server - 서버 model
 	 */
-	public void updateServer(Server server) throws Exception {
-		serverMapper.updateServer(server);
-	}
+	void updateServer(Server server) throws Exception;
 
 	/**
 	 * 기 등록된 서버정보를 삭제한다.
 	 * @param server - 서버 model
 	 */
-	public void deleteServer(Server server) throws Exception {
-		serverMapper.deleteServer(server);
-	}
+	void deleteServer(Server server) throws Exception;
 
 	/**
 	 * 서버장비관계정보를 관리하기 위해 대상 서버장비목록을 조회한다.
 	 * @param serverEqpmnRelateVO - 서버장비관계 Vo
 	 * @return List - 서버장비 목록
 	 */
-	public List<ServerEqpmnRelateVO> selectServerEqpmnRelateList(ServerEqpmnRelateVO serverEqpmnRelateVO) throws Exception {
-		return serverMapper.selectServerEqpmnRelateList(serverEqpmnRelateVO);
-	}
+	List<ServerEqpmnRelateVO> selectServerEqpmnRelateList(ServerEqpmnRelateVO serverEqpmnRelateVO) throws Exception;
 
 	/**
 	 * 서버장비관계 대상 목록 총 개수를 조회한다.
 	 * @param serverEqpmnRelateVO - 서버장비관계 Vo
 	 * @return int - 서버장비관계 카운트 수
 	 */
-	public int selectServerEqpmnRelateListTotCnt(ServerEqpmnRelateVO serverEqpmnRelateVO) throws Exception {
-		return serverMapper.selectServerEqpmnRelateListTotCnt(serverEqpmnRelateVO);
-	}
+	int selectServerEqpmnRelateListTotCnt(ServerEqpmnRelateVO serverEqpmnRelateVO) throws Exception;
 
 	/**
 	 * 서버장비관계정보를 신규로 등록한다.
 	 * @param serverEqpmnRelate - 서버장비관계 model
 	 */
-	public void insertServerEqpmnRelate(ServerEqpmnRelate serverEqpmnRelate) throws Exception {
-		serverMapper.insertServerEqpmnRelate(serverEqpmnRelate);
-	}
+	void insertServerEqpmnRelate(ServerEqpmnRelate serverEqpmnRelate) throws Exception;
 
 	/**
 	 * 기 등록된 서버장비관계정보를 삭제한다.
 	 * @param serverEqpmnRelate - 서버장비관계 model
 	 */
-	public void deleteServerEqpmnRelate(ServerEqpmnRelate serverEqpmnRelate) throws Exception {
-		serverMapper.deleteServerEqpmnRelate(serverEqpmnRelate);
-	}
+	void deleteServerEqpmnRelate(ServerEqpmnRelate serverEqpmnRelate) throws Exception;
 
 	/**
 	 * 특정 서버장비를 참조하는 서버S/W 목록을 조회한다.
 	 * @param serverEqpmnId - 서버장비 ID
 	 * @return List - 해당 서버장비를 사용하는 서버S/W 목록
 	 */
-	public List<ServerVO> selectRelatedServersByEqpmnId(String serverEqpmnId) throws Exception {
-		return serverMapper.selectRelatedServersByEqpmnId(serverEqpmnId);
-	}
+	List<ServerVO> selectRelatedServersByEqpmnId(String serverEqpmnId) throws Exception;
 
 }

--- a/src/main/resources/egovframework/mapper/com/sym/sym/srv/EgovServer_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/sym/srv/EgovServer_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="serverDAO">
+<mapper namespace="egovframework.com.sym.sym.srv.service.impl.ServerMapper">
 
     <resultMap id="serverEqpmn" type="egovframework.com.sym.sym.srv.service.ServerEqpmnVO">
         <result property="serverEqpmnId" column="SERVER_EQPMN_ID"/>

--- a/src/main/resources/egovframework/mapper/com/sym/sym/srv/EgovServer_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/sym/srv/EgovServer_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="serverDAO">
+<mapper namespace="egovframework.com.sym.sym.srv.service.impl.ServerMapper">
 
     <resultMap id="serverEqpmn" type="egovframework.com.sym.sym.srv.service.ServerEqpmnVO">
         <result property="serverEqpmnId" column="SERVER_EQPMN_ID"/>

--- a/src/main/resources/egovframework/mapper/com/sym/sym/srv/EgovServer_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/sym/srv/EgovServer_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="serverDAO">
+<mapper namespace="egovframework.com.sym.sym.srv.service.impl.ServerMapper">
 
     <resultMap id="serverEqpmn" type="egovframework.com.sym.sym.srv.service.ServerEqpmnVO">
         <result property="serverEqpmnId" column="SERVER_EQPMN_ID"/>

--- a/src/main/resources/egovframework/mapper/com/sym/sym/srv/EgovServer_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/sym/srv/EgovServer_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="serverDAO">
+<mapper namespace="egovframework.com.sym.sym.srv.service.impl.ServerMapper">
 
     <resultMap id="serverEqpmn" type="egovframework.com.sym.sym.srv.service.ServerEqpmnVO">
         <result property="serverEqpmnId" column="SERVER_EQPMN_ID"/>

--- a/src/main/resources/egovframework/mapper/com/sym/sym/srv/EgovServer_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/sym/srv/EgovServer_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="serverDAO">
+<mapper namespace="egovframework.com.sym.sym.srv.service.impl.ServerMapper">
 
     <resultMap id="serverEqpmn" type="egovframework.com.sym.sym.srv.service.ServerEqpmnVO">
         <result property="serverEqpmnId" column="SERVER_EQPMN_ID"/>

--- a/src/main/resources/egovframework/mapper/com/sym/sym/srv/EgovServer_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/sym/srv/EgovServer_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="serverDAO">
+<mapper namespace="egovframework.com.sym.sym.srv.service.impl.ServerMapper">
 
     <resultMap id="serverEqpmn" type="egovframework.com.sym.sym.srv.service.ServerEqpmnVO">
         <result property="serverEqpmnId" column="SERVER_EQPMN_ID"/>

--- a/src/main/resources/egovframework/mapper/com/sym/sym/srv/EgovServer_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/sym/srv/EgovServer_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="serverDAO">
+<mapper namespace="egovframework.com.sym.sym.srv.service.impl.ServerMapper">
 
     <resultMap id="serverEqpmn" type="egovframework.com.sym.sym.srv.service.ServerEqpmnVO">
         <result property="serverEqpmnId" column="SERVER_EQPMN_ID"/>

--- a/src/main/resources/egovframework/mapper/com/sym/sym/srv/EgovServer_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/sym/srv/EgovServer_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="serverDAO">
+<mapper namespace="egovframework.com.sym.sym.srv.service.impl.ServerMapper">
 
     <resultMap id="serverEqpmn" type="egovframework.com.sym.sym.srv.service.ServerEqpmnVO">
         <result property="serverEqpmnId" column="SERVER_EQPMN_ID"/>

--- a/src/main/resources/egovframework/spring/com/context-mapper.xml
+++ b/src/main/resources/egovframework/spring/com/context-mapper.xml
@@ -21,5 +21,11 @@
 	<bean id="egov.sqlSessionTemplate" class="org.mybatis.spring.SqlSessionTemplate">
 		<constructor-arg ref="egov.sqlSession"/>
 	</bean>
-	
+
+	<!-- @EgovMapper 어노테이션 기반 Mapper 인터페이스 자동 등록 -->
+	<bean class="org.mybatis.spring.mapper.MapperScannerConfigurer">
+		<property name="basePackage" value="egovframework.com"/>
+		<property name="annotationClass" value="org.egovframe.rte.psl.dataaccess.mapper.EgovMapper"/>
+	</bean>
+
 </beans>


### PR DESCRIPTION
sym/sym/srv 모듈의 ServerDAO를 EgovComAbstractDAO 상속 방식에서 @EgovMapper 인터페이스 위임 방식으로 전환한다.

### 변경 내용

- `ServerMapper` 인터페이스 신설: `@EgovMapper` 어노테이션 적용, ServerDAO가 제공하던 모든 메서드 선언 포함
- `ServerDAO` 재작성: `EgovComAbstractDAO` 상속 제거, `@Resource(name="serverMapper")`로 주입받아 위임
- `EgovServer_SQL_*.xml` 8개(altibase/cubrid/goldilocks/maria/mysql/oracle/postgres/tibero): `namespace="serverDAO"` → `namespace="egovframework.com.sym.sym.srv.service.impl.ServerMapper"` 변경
- `context-mapper.xml`: `MapperScannerConfigurer` 빈 추가 — `@EgovMapper` 스캔 대상 패키지 `egovframework.com` 등록

### 영향 범위

`EgovServerServiceImpl`은 `ServerDAO` 인터페이스를 그대로 사용하므로 변경 없음. 기존 동작 동일하게 유지.

---

- [ ] 단일 주제만 다룸 (다른 변경 없음)
- [ ] 5.x 다른 브랜치용 PR이 필요한 경우 후속 PR 링크 명시
- [ ] 의존성 추가가 필요한 경우 선행 PR 링크 명시
- [ ] 기존 동작에 영향 없음 (또는 영향 범위 명시)
- [ ] 테스트 통과 확인
