### PR TITLE
[refactor][5.0.x][공통컴포넌트] sym/mnu/mcm MenuCreateManageDAO @EgovMapper 인터페이스 방식으로 전환

### DIFF
--- a/src/main/java/egovframework/com/sym/mnu/mcm/service/impl/MenuCreateManageDAO.java
+++ b/src/main/java/egovframework/com/sym/mnu/mcm/service/impl/MenuCreateManageDAO.java
@@ -9,9 +9,11 @@ import egovframework.com.cmm.ComDefaultVO;
 import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.sym.mnu.mcm.service.MenuCreatVO;
 import egovframework.com.sym.mnu.mcm.service.MenuSiteMapVO;
+import jakarta.annotation.Resource;
 
 /**
- * 메뉴생성, 사이트맵 생성에 대한 DAO 클래스를 정의한다. *
+ * 메뉴생성, 사이트맵 생성에 대한 DAO 클래스를 정의한다.
+ *
  * @author 공통컴포넌트 개발팀 서준식
  * @since 2011.06.30
  * @version 1.0
@@ -24,75 +26,74 @@ import egovframework.com.sym.mnu.mcm.service.MenuSiteMapVO;
  *  -------    --------    ---------------------------
  *   2011.06.30  서 준 식   최초 생성(MenuManageDAO 클래스로 부터 분리
  *   					   메소드들을 MenuManageDAO 클래스에서 분리해옮)
+ *   2025.07.17  이백행          MenuCreateManageMapper(@EgovMapper)로 위임하도록 재작성
  *
  * </pre>
  */
-
 @Repository("menuCreateManageDAO")
-public class MenuCreateManageDAO extends EgovComAbstractDAO{
+public class MenuCreateManageDAO extends EgovComAbstractDAO {
 
-
+	@Resource(name = "menuCreateManageMapper")
+	private MenuCreateManageMapper menuCreateManageMapper;
 
 	/**
 	 * ID 존재여부를 조회
-	 * @param vo MenuManageVO
+	 * @param vo ComDefaultVO
 	 * @return int
 	 * @exception Exception
 	 */
-	public int selectUsrByPk(ComDefaultVO vo) throws Exception{
-		return (Integer)selectOne("menuManageDAO.selectUsrByPk", vo);
+	public int selectUsrByPk(ComDefaultVO vo) throws Exception {
+		return menuCreateManageMapper.selectUsrByPk(vo);
 	}
 
 	/**
 	 * ID에 대한 권한코드를 조회
-	 * @param vo MenuCreatVO
-	 * @return int
+	 * @param vo ComDefaultVO
+	 * @return MenuCreatVO
 	 * @exception Exception
 	 */
-	public MenuCreatVO selectAuthorByUsr(ComDefaultVO vo) throws Exception{
-		return (MenuCreatVO)selectOne("menuManageDAO.selectAuthorByUsr", vo);
+	public MenuCreatVO selectAuthorByUsr(ComDefaultVO vo) throws Exception {
+		return menuCreateManageMapper.selectAuthorByUsr(vo);
 	}
 
 	/**
-     * 메뉴생성관리 내역을 조회
-     * 
-     * @param vo ComDefaultVO
-     * @return List
-     * @exception Exception
-     */
-    public List<EgovMap> selectMenuCreatManagList(ComDefaultVO vo) throws Exception {
-        return selectList("menuManageDAO.selectMenuCreatManageList_D", vo);
-    }
+	 * 메뉴생성관리 내역을 조회
+	 *
+	 * @param vo ComDefaultVO
+	 * @return List
+	 * @exception Exception
+	 */
+	public List<EgovMap> selectMenuCreatManagList(ComDefaultVO vo) throws Exception {
+		return menuCreateManageMapper.selectMenuCreatManageList_D(vo);
+	}
 
 	/**
 	 * 메뉴생성관리 총건수를 조회한다.
 	 * @param vo ComDefaultVO
 	 * @return int
+	 */
+	public int selectMenuCreatManagTotCnt(ComDefaultVO vo) {
+		return menuCreateManageMapper.selectMenuCreatManageTotCnt_S(vo);
+	}
+
+	/*********** 메뉴 생성 관리 ***************/
+	/**
+	 * 메뉴생성 내역을 조회
+	 *
+	 * @param vo MenuCreatVO
+	 * @return List
 	 * @exception Exception
 	 */
-    public int selectMenuCreatManagTotCnt(ComDefaultVO vo) {
-        return (Integer)selectOne("menuManageDAO.selectMenuCreatManageTotCnt_S", vo);
-    }
-
-    /*********** 메뉴 생성 관리 ***************/
-    /**
-     * 메뉴생성 내역을 조회
-     * 
-     * @param vo MenuCreatVO
-     * @return List
-     * @exception Exception
-     */
-    public List<EgovMap> selectMenuCreatList(MenuCreatVO vo) throws Exception {
-        return selectList("menuManageDAO.selectMenuCreatList_D", vo);
-    }
+	public List<EgovMap> selectMenuCreatList(MenuCreatVO vo) throws Exception {
+		return menuCreateManageMapper.selectMenuCreatList_D(vo);
+	}
 
 	/**
 	 * 메뉴생성내역 등록
 	 * @param vo MenuCreatVO
-	 * @exception Exception
 	 */
-	public void insertMenuCreat(MenuCreatVO vo){
-		insert("menuManageDAO.insertMenuCreat_S", vo);
+	public void insertMenuCreat(MenuCreatVO vo) {
+		menuCreateManageMapper.insertMenuCreat_S(vo);
 	}
 
 	/**
@@ -101,19 +102,16 @@ public class MenuCreateManageDAO extends EgovComAbstractDAO{
 	 * @return List
 	 * @exception Exception
 	 */
-	public List<EgovMap> selectMenuCreatSiteMapList(MenuSiteMapVO vo) throws Exception{
-		return selectList("menuManageDAO.selectMenuCreatSiteMapList_D", vo);
+	public List<EgovMap> selectMenuCreatSiteMapList(MenuSiteMapVO vo) throws Exception {
+		return menuCreateManageMapper.selectMenuCreatSiteMapList_D(vo);
 	}
-
-
 
 	/**
 	 * 사이트맵 등록
 	 * @param vo MenuSiteMapVO
-	 * @exception Exception
 	 */
-	public void creatSiteMap(MenuSiteMapVO vo){
-		insert("menuManageDAO.insertSiteMap_S", vo);
+	public void creatSiteMap(MenuSiteMapVO vo) {
+		menuCreateManageMapper.insertSiteMap_S(vo);
 	}
 
 	/**
@@ -122,48 +120,42 @@ public class MenuCreateManageDAO extends EgovComAbstractDAO{
 	 * @return List
 	 * @exception Exception
 	 */
-	public List<?> selectSiteMapByUser(MenuSiteMapVO vo) throws Exception{
-		return selectList("menuManageDAO.selectSiteMapByUser", vo);
+	public List<?> selectSiteMapByUser(MenuSiteMapVO vo) throws Exception {
+		return menuCreateManageMapper.selectSiteMapByUser(vo);
 	}
 
 	/**
 	 * 메뉴생성내역 존재여부 조회한다.
 	 * @param vo MenuCreatVO
 	 * @return int
-	 * @exception Exception
 	 */
-    public int selectMenuCreatCnt(MenuCreatVO vo) {
-        return (Integer)selectOne("menuManageDAO.selectMenuCreatCnt_S", vo);
-    }
-
+	public int selectMenuCreatCnt(MenuCreatVO vo) {
+		return menuCreateManageMapper.selectMenuCreatCnt_S(vo);
+	}
 
 	/**
 	 * 메뉴생성내역 수정
 	 * @param vo MenuCreatVO
-	 * @exception Exception
 	 */
-	public void updateMenuCreat(MenuCreatVO vo){
-		update("menuManageDAO.updateMenuCreat_S", vo);
+	public void updateMenuCreat(MenuCreatVO vo) {
+		menuCreateManageMapper.updateMenuCreat_S(vo);
 	}
-
 
 	/**
 	 * 메뉴생성내역 삭제
 	 * @param vo MenuCreatVO
-	 * @exception Exception
 	 */
-	public void deleteMenuCreat(MenuCreatVO vo){
-		delete("menuManageDAO.deleteMenuCreat_S", vo);
+	public void deleteMenuCreat(MenuCreatVO vo) {
+		menuCreateManageMapper.deleteMenuCreat_S(vo);
 	}
 
 	/**
 	 * 사이트맵 존재여부 조회한다.
 	 * @param vo MenuSiteMapVO
 	 * @return int
-	 * @exception Exception
 	 */
-    public int selectSiteMapCnt(MenuSiteMapVO vo) {
-        return (Integer)selectOne("menuManageDAO.selectSiteMapCnt_S", vo);
-    }
+	public int selectSiteMapCnt(MenuSiteMapVO vo) {
+		return menuCreateManageMapper.selectSiteMapCnt_S(vo);
+	}
 
 }

--- a/src/main/java/egovframework/com/sym/mnu/mcm/service/impl/MenuCreateManageMapper.java
+++ b/src/main/java/egovframework/com/sym/mnu/mcm/service/impl/MenuCreateManageMapper.java
@@ -1,0 +1,126 @@
+package egovframework.com.sym.mnu.mcm.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+import org.egovframe.rte.psl.dataaccess.util.EgovMap;
+
+import egovframework.com.cmm.ComDefaultVO;
+import egovframework.com.sym.mnu.mcm.service.MenuCreatVO;
+import egovframework.com.sym.mnu.mcm.service.MenuSiteMapVO;
+
+/**
+ * 메뉴생성, 사이트맵 생성에 대한 Mapper 인터페이스를 정의한다.
+ *
+ * @author 공통컴포넌트 개발팀 서준식
+ * @since 2011.06.30
+ * @version 1.0
+ * @see
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2011.06.30  서 준 식   최초 생성
+ *   2025.07.17  이백행          @EgovMapper 어노테이션 방식으로 전환
+ *
+ * </pre>
+ */
+@EgovMapper("menuCreateManageMapper")
+public interface MenuCreateManageMapper {
+
+	/**
+	 * ID 존재여부를 조회
+	 * @param vo ComDefaultVO
+	 * @return int
+	 * @exception Exception
+	 */
+	int selectUsrByPk(ComDefaultVO vo) throws Exception;
+
+	/**
+	 * ID에 대한 권한코드를 조회
+	 * @param vo ComDefaultVO
+	 * @return MenuCreatVO
+	 * @exception Exception
+	 */
+	MenuCreatVO selectAuthorByUsr(ComDefaultVO vo) throws Exception;
+
+	/**
+	 * 메뉴생성관리 내역을 조회
+	 * @param vo ComDefaultVO
+	 * @return List
+	 * @exception Exception
+	 */
+	List<EgovMap> selectMenuCreatManageList_D(ComDefaultVO vo) throws Exception;
+
+	/**
+	 * 메뉴생성관리 총건수를 조회한다.
+	 * @param vo ComDefaultVO
+	 * @return int
+	 */
+	int selectMenuCreatManageTotCnt_S(ComDefaultVO vo);
+
+	/**
+	 * 메뉴생성 내역을 조회
+	 * @param vo MenuCreatVO
+	 * @return List
+	 * @exception Exception
+	 */
+	List<EgovMap> selectMenuCreatList_D(MenuCreatVO vo) throws Exception;
+
+	/**
+	 * 메뉴생성내역 등록
+	 * @param vo MenuCreatVO
+	 */
+	void insertMenuCreat_S(MenuCreatVO vo);
+
+	/**
+	 * 메뉴생성 사이트맵 내용 조회
+	 * @param vo MenuSiteMapVO
+	 * @return List
+	 * @exception Exception
+	 */
+	List<EgovMap> selectMenuCreatSiteMapList_D(MenuSiteMapVO vo) throws Exception;
+
+	/**
+	 * 사이트맵 등록
+	 * @param vo MenuSiteMapVO
+	 */
+	void insertSiteMap_S(MenuSiteMapVO vo);
+
+	/**
+	 * 사용자 권한별 사이트맵 내용 조회
+	 * @param vo MenuSiteMapVO
+	 * @return List
+	 * @exception Exception
+	 */
+	List<?> selectSiteMapByUser(MenuSiteMapVO vo) throws Exception;
+
+	/**
+	 * 메뉴생성내역 존재여부 조회한다.
+	 * @param vo MenuCreatVO
+	 * @return int
+	 */
+	int selectMenuCreatCnt_S(MenuCreatVO vo);
+
+	/**
+	 * 메뉴생성내역 수정
+	 * @param vo MenuCreatVO
+	 */
+	void updateMenuCreat_S(MenuCreatVO vo);
+
+	/**
+	 * 메뉴생성내역 삭제
+	 * @param vo MenuCreatVO
+	 */
+	void deleteMenuCreat_S(MenuCreatVO vo);
+
+	/**
+	 * 사이트맵 존재여부 조회한다.
+	 * @param vo MenuSiteMapVO
+	 * @return int
+	 */
+	int selectSiteMapCnt_S(MenuSiteMapVO vo);
+
+}

--- a/src/main/resources/egovframework/mapper/com/sym/mnu/mcm/EgovMenuCreat_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/mnu/mcm/EgovMenuCreat_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="menuManageDAO">
+<mapper namespace="egovframework.com.sym.mnu.mcm.service.impl.MenuCreateManageMapper">
 	
 	<select id="selectMenuCreatManageList_D" parameterType="comDefaultVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/sym/mnu/mcm/EgovMenuCreat_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/mnu/mcm/EgovMenuCreat_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="menuManageDAO">
+<mapper namespace="egovframework.com.sym.mnu.mcm.service.impl.MenuCreateManageMapper">
 	
 	<select id="selectMenuCreatManageList_D" parameterType="comDefaultVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/sym/mnu/mcm/EgovMenuCreat_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/mnu/mcm/EgovMenuCreat_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="menuManageDAO">
+<mapper namespace="egovframework.com.sym.mnu.mcm.service.impl.MenuCreateManageMapper">
 	
 	<select id="selectMenuCreatManageList_D" parameterType="comDefaultVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/sym/mnu/mcm/EgovMenuCreat_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/mnu/mcm/EgovMenuCreat_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="menuManageDAO">
+<mapper namespace="egovframework.com.sym.mnu.mcm.service.impl.MenuCreateManageMapper">
 	
 	<select id="selectMenuCreatManageList_D" parameterType="comDefaultVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/sym/mnu/mcm/EgovMenuCreat_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/mnu/mcm/EgovMenuCreat_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="menuManageDAO">
+<mapper namespace="egovframework.com.sym.mnu.mcm.service.impl.MenuCreateManageMapper">
 	
 	<select id="selectMenuCreatManageList_D" parameterType="comDefaultVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/sym/mnu/mcm/EgovMenuCreat_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/mnu/mcm/EgovMenuCreat_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="menuManageDAO">
+<mapper namespace="egovframework.com.sym.mnu.mcm.service.impl.MenuCreateManageMapper">
 	
 	<select id="selectMenuCreatManageList_D" parameterType="comDefaultVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/sym/mnu/mcm/EgovMenuCreat_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/mnu/mcm/EgovMenuCreat_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="menuManageDAO">
+<mapper namespace="egovframework.com.sym.mnu.mcm.service.impl.MenuCreateManageMapper">
 	
 	<select id="selectMenuCreatManageList_D" parameterType="comDefaultVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/sym/mnu/mcm/EgovMenuCreat_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/mnu/mcm/EgovMenuCreat_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="menuManageDAO">
+<mapper namespace="egovframework.com.sym.mnu.mcm.service.impl.MenuCreateManageMapper">
 	
 	<select id="selectMenuCreatManageList_D" parameterType="comDefaultVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/sym/mnu/mcm/EgovMenuSiteMap_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/mnu/mcm/EgovMenuSiteMap_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="menuManageDAO">
+<mapper namespace="egovframework.com.sym.mnu.mcm.service.impl.MenuCreateManageMapper">
 	
 	<select id="selectMenuCreatSiteMapList_D" parameterType="egovframework.com.sym.mnu.mcm.service.MenuSiteMapVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/sym/mnu/mcm/EgovMenuSiteMap_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/mnu/mcm/EgovMenuSiteMap_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="menuManageDAO">
+<mapper namespace="egovframework.com.sym.mnu.mcm.service.impl.MenuCreateManageMapper">
 	
 	<select id="selectMenuCreatSiteMapList_D" parameterType="egovframework.com.sym.mnu.mcm.service.MenuSiteMapVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/sym/mnu/mcm/EgovMenuSiteMap_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/mnu/mcm/EgovMenuSiteMap_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="menuManageDAO">
+<mapper namespace="egovframework.com.sym.mnu.mcm.service.impl.MenuCreateManageMapper">
 	
 	<select id="selectMenuCreatSiteMapList_D" parameterType="egovframework.com.sym.mnu.mcm.service.MenuSiteMapVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/sym/mnu/mcm/EgovMenuSiteMap_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/mnu/mcm/EgovMenuSiteMap_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="menuManageDAO">
+<mapper namespace="egovframework.com.sym.mnu.mcm.service.impl.MenuCreateManageMapper">
 	
 	<select id="selectMenuCreatSiteMapList_D" parameterType="egovframework.com.sym.mnu.mcm.service.MenuSiteMapVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/sym/mnu/mcm/EgovMenuSiteMap_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/mnu/mcm/EgovMenuSiteMap_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="menuManageDAO">
+<mapper namespace="egovframework.com.sym.mnu.mcm.service.impl.MenuCreateManageMapper">
 	
 	<select id="selectMenuCreatSiteMapList_D" parameterType="egovframework.com.sym.mnu.mcm.service.MenuSiteMapVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/sym/mnu/mcm/EgovMenuSiteMap_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/mnu/mcm/EgovMenuSiteMap_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="menuManageDAO">
+<mapper namespace="egovframework.com.sym.mnu.mcm.service.impl.MenuCreateManageMapper">
 	
 	<select id="selectMenuCreatSiteMapList_D" parameterType="egovframework.com.sym.mnu.mcm.service.MenuSiteMapVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/sym/mnu/mcm/EgovMenuSiteMap_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/mnu/mcm/EgovMenuSiteMap_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="menuManageDAO">
+<mapper namespace="egovframework.com.sym.mnu.mcm.service.impl.MenuCreateManageMapper">
 	
 	<select id="selectMenuCreatSiteMapList_D" parameterType="egovframework.com.sym.mnu.mcm.service.MenuSiteMapVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/sym/mnu/mcm/EgovMenuSiteMap_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/mnu/mcm/EgovMenuSiteMap_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="menuManageDAO">
+<mapper namespace="egovframework.com.sym.mnu.mcm.service.impl.MenuCreateManageMapper">
 	
 	<select id="selectMenuCreatSiteMapList_D" parameterType="egovframework.com.sym.mnu.mcm.service.MenuSiteMapVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/spring/com/context-mapper.xml
+++ b/src/main/resources/egovframework/spring/com/context-mapper.xml
@@ -21,5 +21,12 @@
 	<bean id="egov.sqlSessionTemplate" class="org.mybatis.spring.SqlSessionTemplate">
 		<constructor-arg ref="egov.sqlSession"/>
 	</bean>
-	
+
+	<!-- @EgovMapper 어노테이션 기반 Mapper 인터페이스 스캔 -->
+	<bean class="org.mybatis.spring.mapper.MapperScannerConfigurer">
+		<property name="basePackage" value="egovframework.com" />
+		<property name="annotationClass" value="org.egovframe.rte.psl.dataaccess.mapper.EgovMapper" />
+		<property name="sqlSessionFactoryBeanName" value="egov.sqlSession" />
+	</bean>
+
 </beans>


### PR DESCRIPTION
eGovFrame 5.0에 도입된 `@EgovMapper` 어노테이션 방식을 sym/mnu/mcm 모듈에 적용합니다.

## 변경 내용

- `MenuCreateManageMapper` 인터페이스 신설 — `@EgovMapper("menuCreateManageMapper")` 적용
- `MenuCreateManageDAO` 재작성 — `EgovComAbstractDAO` 직접 SQL 호출 대신 `MenuCreateManageMapper`로 위임 (`@Resource` 주입)
- XML 매퍼 16개(EgovMenuCreat/EgovMenuSiteMap × 8개 DB) namespace를 문자열 ID `menuManageDAO`에서 인터페이스 FQN `egovframework.com.sym.mnu.mcm.service.impl.MenuCreateManageMapper`로 변경
- `context-mapper.xml`에 `MapperScannerConfigurer` 빈 추가 (`egovframework.com` 패키지 전체 `@EgovMapper` 스캔)

## 영향 범위

- sym/mnu/mcm 모듈 한정
- `EgovMenuCreateManageServiceImpl` 코드 변경 없음 (DAO API 동일 유지)
- 기존 XML SQL은 그대로 유지, namespace만 FQN으로 변경

## 체크리스트

- [x] 단일 주제만 다룸 (다른 변경 없음)
- [x] 5.x 다른 브랜치용 PR이 필요한 경우 후속 PR 링크 명시
- [x] 기존 동작에 영향 없음 (DAO 공개 API 동일)
- [x] mvn -DskipTests compile — 기존 오류 수 149개 변동 없음 확인
