### PR TITLE
[refactor][5.0.x][공통컴포넌트] sym/mnu/bmm BkmkMenuManageDAO @EgovMapper 인터페이스 방식 전환

### DIFF
--- a/src/main/java/egovframework/com/sym/mnu/bmm/service/impl/BkmkMenuManageDAO.java
+++ b/src/main/java/egovframework/com/sym/mnu/bmm/service/impl/BkmkMenuManageDAO.java
@@ -4,11 +4,10 @@ import java.util.List;
 
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.sym.mnu.bmm.service.BkmkMenuManage;
 import egovframework.com.sym.mnu.bmm.service.BkmkMenuManageVO;
 import egovframework.com.sym.mnu.mpm.service.MenuManageVO;
-
+import jakarta.annotation.Resource;
 
 /**
  * @Class Name : BkmkMenuManageDAO.java
@@ -18,118 +17,116 @@ import egovframework.com.sym.mnu.mpm.service.MenuManageVO;
  *    수정일       수정자         수정내용
  *    -------        -------     -------------------
  *    2009. 9. 25.     윤성록
+ *    2025. 5. 28.               BkmkMenuManageMapper(@EgovMapper) 위임 방식으로 전환
  *
  * @author 공통 컴포넌트 개발팀 윤성록
  * @since 2009. 9. 25.
- * @version
+ * @version 1.0
  * @see
  *
  */
 @Repository("bkmkMenuManageDAO")
-public class BkmkMenuManageDAO extends EgovComAbstractDAO{
+public class BkmkMenuManageDAO {
+
+    @Resource(name = "bkmkMenuManageMapper")
+    private BkmkMenuManageMapper bkmkMenuManageMapper;
 
     /**
      * 바로가기메뉴관리 정보를 삭제한다.
      *
-     * @param BkmkMenuManage
-     * @return
+     * @param bkmkMenuManage
      * @throws Exception
      */
     public void deleteBkmkMenuManage(BkmkMenuManage bkmkMenuManage) throws Exception {
-        delete("BkmkMenuManageDAO.deleteBkmkMenuManage", bkmkMenuManage);
+        bkmkMenuManageMapper.deleteBkmkMenuManage(bkmkMenuManage);
     }
 
     /**
      * 바로가기메뉴관리 정보를 등록한다.
      *
-     * @param BkmkMenuManage
-     * @return
+     * @param bkmkMenuManage
      * @throws Exception
      */
     public void insertBkmkMenuManage(BkmkMenuManage bkmkMenuManage) throws Exception {
-        insert("BkmkMenuManageDAO.insertBkmkMenuManage", bkmkMenuManage);
+        bkmkMenuManageMapper.insertBkmkMenuManage(bkmkMenuManage);
     }
 
     /**
      * 바로가기메뉴관리 정보를 조회한다.
      *
-     * @param BkmkMenuManageVO
-     * @return
+     * @param bkmkMenuManageVO
+     * @return BkmkMenuManageVO
      * @throws Exception
      */
-    public BkmkMenuManageVO selectBkmkMenuManageResult(BkmkMenuManageVO bkmkMenuManageVO)
-            throws Exception {
-        BkmkMenuManageVO vo = new BkmkMenuManageVO();
-        vo = (BkmkMenuManageVO)selectOne("BkmkMenuManageDAO.selectBkmkMenuManage", bkmkMenuManageVO);
-        return vo;
+    public BkmkMenuManageVO selectBkmkMenuManageResult(BkmkMenuManageVO bkmkMenuManageVO) throws Exception {
+        return bkmkMenuManageMapper.selectBkmkMenuManage(bkmkMenuManageVO);
     }
 
     /**
      * 조건에 맞는 바로가기메뉴관리 정보 목록을 조회한다.
      *
-     * @param BkmkMenuManageVO
-     * @return
+     * @param bkmkMenuManageVO
+     * @return List<BkmkMenuManageVO>
      * @throws Exception
      */
-	public List<BkmkMenuManageVO> selectBkmkMenuManageList(BkmkMenuManageVO bkmkMenuManageVO)
-            throws Exception {
-        return selectList("BkmkMenuManageDAO.selectBkmkMenuManageList", bkmkMenuManageVO);
+    public List<BkmkMenuManageVO> selectBkmkMenuManageList(BkmkMenuManageVO bkmkMenuManageVO) throws Exception {
+        return bkmkMenuManageMapper.selectBkmkMenuManageList(bkmkMenuManageVO);
     }
 
     /**
      * 조건에 맞는 바로가기메뉴관리 정보 목록의 건수를 조회한다.
      *
-     * @param BkmkMenuManageVO
-     * @return
+     * @param bkmkMenuManageVO
+     * @return int
      * @throws Exception
      */
     public int selectBkmkMenuManageListCnt(BkmkMenuManageVO bkmkMenuManageVO) throws Exception {
-        return (Integer)selectOne("BkmkMenuManageDAO.selectBkmkMenuManageListCnt", bkmkMenuManageVO);
+        return bkmkMenuManageMapper.selectBkmkMenuManageListCnt(bkmkMenuManageVO);
     }
 
     /**
-     * 등록할  메뉴정보 목록을 조회한다.
+     * 등록할 메뉴정보 목록을 조회한다.
      *
-     * @param BkmkMenuManageVO
-     * @return
+     * @param bkmkMenuManageVO
+     * @return List<BkmkMenuManageVO>
      * @throws Exception
      */
-	public List<BkmkMenuManageVO> selectBkmkMenuList(BkmkMenuManageVO bkmkMenuManageVO)
-            throws Exception {
-        return selectList("BkmkMenuManageDAO.selectBkmkMenuList", bkmkMenuManageVO);
+    public List<BkmkMenuManageVO> selectBkmkMenuList(BkmkMenuManageVO bkmkMenuManageVO) throws Exception {
+        return bkmkMenuManageMapper.selectBkmkMenuList(bkmkMenuManageVO);
     }
 
     /**
-     * 등록할  메뉴정보 목록의 건수를 조회한다.
+     * 등록할 메뉴정보 목록의 건수를 조회한다.
      *
-     * @param BkmkMenuManageVO
-     * @return
+     * @param bkmkMenuManageVO
+     * @return int
      * @throws Exception
      */
     public int selectBkmkMenuListCnt(BkmkMenuManageVO bkmkMenuManageVO) throws Exception {
-        return (Integer)selectOne("BkmkMenuManageDAO.selectBkmkMenuListCnt", bkmkMenuManageVO);
+        return bkmkMenuManageMapper.selectBkmkMenuListCnt(bkmkMenuManageVO);
     }
 
     /**
      * 미리보기를 할 바로가기메뉴관리의 목록을 조회한다.
      *
-     * @param BkmkMenuManageVO
-     * @return
+     * @param bkmkMenuManageVO
+     * @return List<MenuManageVO>
      * @throws Exception
      */
     public List<MenuManageVO> selectBkmkPreview(BkmkMenuManageVO bkmkMenuManageVO) throws Exception {
-        return selectList("BkmkMenuManageDAO.selectBkmkPreview", bkmkMenuManageVO);
+        return bkmkMenuManageMapper.selectBkmkPreview(bkmkMenuManageVO);
     }
 
     /**
      * 선택된 메뉴의 URL 을 조회한다.
      *
      * @param bkmkMenuManage
-     * @return
+     * @return String
      * @throws Exception
      */
     public String selectUrl(BkmkMenuManage bkmkMenuManage) throws Exception {
-        return (String)selectOne("BkmkMenuManageDAO.selectUrl", bkmkMenuManage);
+        return bkmkMenuManageMapper.selectUrl(bkmkMenuManage);
     }
+
 }
 

--- a/src/main/java/egovframework/com/sym/mnu/bmm/service/impl/BkmkMenuManageMapper.java
+++ b/src/main/java/egovframework/com/sym/mnu/bmm/service/impl/BkmkMenuManageMapper.java
@@ -1,0 +1,108 @@
+package egovframework.com.sym.mnu.bmm.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.sym.mnu.bmm.service.BkmkMenuManage;
+import egovframework.com.sym.mnu.bmm.service.BkmkMenuManageVO;
+import egovframework.com.sym.mnu.mpm.service.MenuManageVO;
+
+/**
+ * @Class Name : BkmkMenuManageMapper.java
+ * @Description : 바로가기메뉴관리 MyBatis Mapper 인터페이스
+ * @Modification Information
+ *
+ *    수정일       수정자         수정내용
+ *    -------    -------    -------------------
+ *    2025.05.28  최초 생성
+ *
+ * @author 공통 컴포넌트 개발팀
+ * @since 2025.05.28
+ * @version 1.0
+ * @see
+ *
+ */
+@EgovMapper("bkmkMenuManageMapper")
+public interface BkmkMenuManageMapper {
+
+    /**
+     * 바로가기메뉴관리 정보를 삭제한다.
+     *
+     * @param bkmkMenuManage
+     * @throws Exception
+     */
+    void deleteBkmkMenuManage(BkmkMenuManage bkmkMenuManage) throws Exception;
+
+    /**
+     * 바로가기메뉴관리 정보를 등록한다.
+     *
+     * @param bkmkMenuManage
+     * @throws Exception
+     */
+    void insertBkmkMenuManage(BkmkMenuManage bkmkMenuManage) throws Exception;
+
+    /**
+     * 바로가기메뉴관리 정보를 조회한다.
+     *
+     * @param bkmkMenuManageVO
+     * @return BkmkMenuManageVO
+     * @throws Exception
+     */
+    BkmkMenuManageVO selectBkmkMenuManage(BkmkMenuManageVO bkmkMenuManageVO) throws Exception;
+
+    /**
+     * 조건에 맞는 바로가기메뉴관리 정보 목록을 조회한다.
+     *
+     * @param bkmkMenuManageVO
+     * @return List<BkmkMenuManageVO>
+     * @throws Exception
+     */
+    List<BkmkMenuManageVO> selectBkmkMenuManageList(BkmkMenuManageVO bkmkMenuManageVO) throws Exception;
+
+    /**
+     * 조건에 맞는 바로가기메뉴관리 정보 목록의 건수를 조회한다.
+     *
+     * @param bkmkMenuManageVO
+     * @return int
+     * @throws Exception
+     */
+    int selectBkmkMenuManageListCnt(BkmkMenuManageVO bkmkMenuManageVO) throws Exception;
+
+    /**
+     * 등록할 메뉴정보 목록을 조회한다.
+     *
+     * @param bkmkMenuManageVO
+     * @return List<BkmkMenuManageVO>
+     * @throws Exception
+     */
+    List<BkmkMenuManageVO> selectBkmkMenuList(BkmkMenuManageVO bkmkMenuManageVO) throws Exception;
+
+    /**
+     * 등록할 메뉴정보 목록의 건수를 조회한다.
+     *
+     * @param bkmkMenuManageVO
+     * @return int
+     * @throws Exception
+     */
+    int selectBkmkMenuListCnt(BkmkMenuManageVO bkmkMenuManageVO) throws Exception;
+
+    /**
+     * 미리보기를 할 바로가기메뉴관리의 목록을 조회한다.
+     *
+     * @param bkmkMenuManageVO
+     * @return List<MenuManageVO>
+     * @throws Exception
+     */
+    List<MenuManageVO> selectBkmkPreview(BkmkMenuManageVO bkmkMenuManageVO) throws Exception;
+
+    /**
+     * 선택된 메뉴의 URL 을 조회한다.
+     *
+     * @param bkmkMenuManage
+     * @return String
+     * @throws Exception
+     */
+    String selectUrl(BkmkMenuManage bkmkMenuManage) throws Exception;
+
+}

--- a/src/main/resources/egovframework/mapper/com/sym/mnu/bmm/EgovBkmkMenuManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/mnu/bmm/EgovBkmkMenuManage_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BkmkMenuManageDAO">
+<mapper namespace="egovframework.com.sym.mnu.bmm.service.impl.BkmkMenuManageMapper">
     
     <resultMap id="BkmkInfs" type="egovframework.com.sym.mnu.bmm.service.BkmkMenuManageVO">
 		<result property="menuId" column="MENU_ID"/>

--- a/src/main/resources/egovframework/mapper/com/sym/mnu/bmm/EgovBkmkMenuManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/mnu/bmm/EgovBkmkMenuManage_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BkmkMenuManageDAO">
+<mapper namespace="egovframework.com.sym.mnu.bmm.service.impl.BkmkMenuManageMapper">
     
     <resultMap id="BkmkInfs" type="egovframework.com.sym.mnu.bmm.service.BkmkMenuManageVO">
 		<result property="menuId" column="MENU_ID"/>

--- a/src/main/resources/egovframework/mapper/com/sym/mnu/bmm/EgovBkmkMenuManage_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/mnu/bmm/EgovBkmkMenuManage_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BkmkMenuManageDAO">
+<mapper namespace="egovframework.com.sym.mnu.bmm.service.impl.BkmkMenuManageMapper">
     
     <resultMap id="BkmkInfs" type="egovframework.com.sym.mnu.bmm.service.BkmkMenuManageVO">
 		<result property="menuId" column="MENU_ID"/>

--- a/src/main/resources/egovframework/mapper/com/sym/mnu/bmm/EgovBkmkMenuManage_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/mnu/bmm/EgovBkmkMenuManage_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BkmkMenuManageDAO">
+<mapper namespace="egovframework.com.sym.mnu.bmm.service.impl.BkmkMenuManageMapper">
     
     <resultMap id="BkmkInfs" type="egovframework.com.sym.mnu.bmm.service.BkmkMenuManageVO">
 		<result property="menuId" column="MENU_ID"/>

--- a/src/main/resources/egovframework/mapper/com/sym/mnu/bmm/EgovBkmkMenuManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/mnu/bmm/EgovBkmkMenuManage_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BkmkMenuManageDAO">
+<mapper namespace="egovframework.com.sym.mnu.bmm.service.impl.BkmkMenuManageMapper">
     
     <resultMap id="BkmkInfs" type="egovframework.com.sym.mnu.bmm.service.BkmkMenuManageVO">
 		<result property="menuId" column="MENU_ID"/>

--- a/src/main/resources/egovframework/mapper/com/sym/mnu/bmm/EgovBkmkMenuManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/mnu/bmm/EgovBkmkMenuManage_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BkmkMenuManageDAO">
+<mapper namespace="egovframework.com.sym.mnu.bmm.service.impl.BkmkMenuManageMapper">
     
     <resultMap id="BkmkInfs" type="egovframework.com.sym.mnu.bmm.service.BkmkMenuManageVO">
 		<result property="menuId" column="MENU_ID"/>

--- a/src/main/resources/egovframework/mapper/com/sym/mnu/bmm/EgovBkmkMenuManage_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/mnu/bmm/EgovBkmkMenuManage_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BkmkMenuManageDAO">
+<mapper namespace="egovframework.com.sym.mnu.bmm.service.impl.BkmkMenuManageMapper">
     
     <resultMap id="BkmkInfs" type="egovframework.com.sym.mnu.bmm.service.BkmkMenuManageVO">
 		<result property="menuId" column="MENU_ID"/>

--- a/src/main/resources/egovframework/mapper/com/sym/mnu/bmm/EgovBkmkMenuManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/mnu/bmm/EgovBkmkMenuManage_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BkmkMenuManageDAO">
+<mapper namespace="egovframework.com.sym.mnu.bmm.service.impl.BkmkMenuManageMapper">
     
     <resultMap id="BkmkInfs" type="egovframework.com.sym.mnu.bmm.service.BkmkMenuManageVO">
 		<result property="menuId" column="MENU_ID"/>

--- a/src/main/resources/egovframework/spring/com/context-mapper.xml
+++ b/src/main/resources/egovframework/spring/com/context-mapper.xml
@@ -21,5 +21,12 @@
 	<bean id="egov.sqlSessionTemplate" class="org.mybatis.spring.SqlSessionTemplate">
 		<constructor-arg ref="egov.sqlSession"/>
 	</bean>
-	
+
+	<!-- @EgovMapper 인터페이스 스캔 -->
+	<bean class="org.mybatis.spring.mapper.MapperScannerConfigurer">
+		<property name="basePackage" value="egovframework.com" />
+		<property name="annotationClass" value="org.egovframe.rte.psl.dataaccess.mapper.EgovMapper" />
+		<property name="sqlSessionFactoryBeanName" value="egov.sqlSession" />
+	</bean>
+
 </beans>


### PR DESCRIPTION
eGovFrame 5.x에서 도입된 `@EgovMapper` 어노테이션 방식을 sym/mnu/bmm 모듈에 적용한다.
기존 `EgovComAbstractDAO` 상속 방식을 MyBatis 매퍼 인터페이스 방식으로 전환하여
스프링 빈 주입과 쿼리 매핑을 명시적으로 관리할 수 있게 한다.

변경 파일:
- `BkmkMenuManageMapper.java` 신설: `@EgovMapper` 어노테이션 적용 MyBatis 인터페이스
- `BkmkMenuManageDAO.java`: `EgovComAbstractDAO` 상속 제거, `BkmkMenuManageMapper` 위임 방식으로 재작성
- XML 매퍼 8종(altibase/cubrid/goldilocks/maria/mysql/oracle/postgres/tibero): `namespace`를 `BkmkMenuManageMapper` FQN으로 변경
- `context-mapper.xml`: `MapperScannerConfigurer` 빈 추가 (`egovframework.com` 패키지 대상 `@EgovMapper` 스캔)

- [ ] 단일 주제만 다룸 (다른 변경 없음)
- [ ] 5.x 다른 브랜치용 PR이 필요한 경우 후속 PR 링크 명시
- [ ] 의존성 추가가 필요한 경우 선행 PR 링크 명시
- [ ] 기존 동작에 영향 없음 (DAO 공개 API 시그니처 유지, ServiceImpl 무변경)
- [ ] 컴파일 통과 확인 (기존 pre-existing 오류 외 신규 오류 없음)
