### PR TITLE
[refactor][5.0.x][공통컴포넌트] sym/prm ProgrmManageDAO @EgovMapper 인터페이스 전환

### DIFF
--- a/src/main/java/egovframework/com/sym/prm/service/impl/ProgrmManageDAO.java
+++ b/src/main/java/egovframework/com/sym/prm/service/impl/ProgrmManageDAO.java
@@ -5,9 +5,10 @@ import java.util.List;
 import org.springframework.stereotype.Repository;
 
 import egovframework.com.cmm.ComDefaultVO;
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.sym.prm.service.ProgrmManageDtlVO;
 import egovframework.com.sym.prm.service.ProgrmManageVO;
+import jakarta.annotation.Resource;
+
 /**
  * 프로그램 목록관리및 프로그램변경관리에 대한 DAO 클래스를 정의한다.
  * @author 개발환경 개발팀 이용
@@ -24,78 +25,75 @@ import egovframework.com.sym.prm.service.ProgrmManageVO;
  *
  * </pre>
  */
-
 @Repository("progrmManageDAO")
-public class ProgrmManageDAO extends EgovComAbstractDAO {
+public class ProgrmManageDAO {
+
+	@Resource(name = "progrmManageDAO")
+	private ProgrmManageMapper progrmManageMapper;
 
 	/**
      * 프로그램 목록을 조회
-     * 
+     *
      * @param vo ComDefaultVO
      * @return List
      * @exception Exception
      */
     public List<ProgrmManageVO> selectProgrmList(ComDefaultVO vo) throws Exception {
-        return selectList("progrmManageDAO.selectProgrmList_D", vo);
+        return progrmManageMapper.selectProgrmList_D(vo);
     }
 
     /**
 	 * 프로그램목록 총건수를 조회한다.
 	 * @param vo ComDefaultVO
 	 * @return int
-	 * @exception Exception
 	 */
     public int selectProgrmListTotCnt(ComDefaultVO vo) {
-        return (Integer)selectOne("progrmManageDAO.selectProgrmListTotCnt_S", vo);
+        return progrmManageMapper.selectProgrmListTotCnt_S(vo);
     }
 
 	/**
 	 * 프로그램 기본정보를 조회
-	 * @param vo ComDefaultVO
+	 * @param vo ProgrmManageVO
 	 * @return ProgrmManageVO
 	 * @exception Exception
 	 */
-	public ProgrmManageVO selectProgrm(ProgrmManageVO vo)throws Exception{
-		return (ProgrmManageVO)selectOne("progrmManageDAO.selectProgrm_D", vo);
+	public ProgrmManageVO selectProgrm(ProgrmManageVO vo) throws Exception {
+		return progrmManageMapper.selectProgrm_D(vo);
 	}
 
 	/**
 	 * 프로그램 기본정보 및 URL을 등록
 	 * @param vo ProgrmManageVO
-	 * @exception Exception
 	 */
-	public void insertProgrm(ProgrmManageVO vo){
-		insert("progrmManageDAO.insertProgrm_S", vo);
+	public void insertProgrm(ProgrmManageVO vo) {
+		progrmManageMapper.insertProgrm_S(vo);
 	}
 
 	/**
 	 * 프로그램 기본정보 및 URL을 수정
 	 * @param vo ProgrmManageVO
-	 * @exception Exception
 	 */
-	public void updateProgrm(ProgrmManageVO vo){
-		update("progrmManageDAO.updateProgrm_S", vo);
+	public void updateProgrm(ProgrmManageVO vo) {
+		progrmManageMapper.updateProgrm_S(vo);
 	}
 
 	/**
 	 * 프로그램 기본정보 및 URL을 삭제
 	 * @param vo ProgrmManageVO
-	 * @exception Exception
 	 */
-	public void deleteProgrm(ProgrmManageVO vo){
-		delete("progrmManageDAO.deleteProgrm_S", vo);
+	public void deleteProgrm(ProgrmManageVO vo) {
+		progrmManageMapper.deleteProgrm_S(vo);
 	}
 
 	/**
 	 * 프로그램 파일 존재여부를 조회
-	 * @param vo ProgrmManageVO
+	 * @param vo ComDefaultVO
 	 * @return int
 	 * @exception Exception
 	 */
-	public int selectProgrmNMTotCnt(ComDefaultVO vo) throws Exception{
-		return (Integer)selectOne("progrmManageDAO.selectProgrmNMTotCnt", vo);
+	public int selectProgrmNMTotCnt(ComDefaultVO vo) throws Exception {
+		return progrmManageMapper.selectProgrmNMTotCnt(vo);
 	}
-
 
 	/**
 	 * 프로그램변경요청 목록을 조회
@@ -103,19 +101,17 @@ public class ProgrmManageDAO extends EgovComAbstractDAO {
 	 * @return List
 	 * @exception Exception
 	 */
-
-	public List<ProgrmManageDtlVO> selectProgrmChangeRequstList(ComDefaultVO vo) throws Exception{
-		return selectList("progrmManageDAO.selectProgrmChangeRequstList_D", vo);
+	public List<ProgrmManageDtlVO> selectProgrmChangeRequstList(ComDefaultVO vo) throws Exception {
+		return progrmManageMapper.selectProgrmChangeRequstList_D(vo);
 	}
 
     /**
 	 * 프로그램변경요청 총건수를 조회한다.
 	 * @param vo ComDefaultVO
-	 * @return  int
-	 * @exception Exception
+	 * @return int
 	 */
     public int selectProgrmChangeRequstListTotCnt(ComDefaultVO vo) {
-        return (Integer)selectOne("progrmManageDAO.selectProgrmChangeRequstListTotCnt_S", vo);
+        return progrmManageMapper.selectProgrmChangeRequstListTotCnt_S(vo);
     }
 
 	/**
@@ -124,116 +120,102 @@ public class ProgrmManageDAO extends EgovComAbstractDAO {
 	 * @return ProgrmManageDtlVO
 	 * @exception Exception
 	 */
-	public ProgrmManageDtlVO selectProgrmChangeRequst(ProgrmManageDtlVO vo)throws Exception{
-		return (ProgrmManageDtlVO)selectOne("progrmManageDAO.selectProgrmChangeRequst_D", vo);
+	public ProgrmManageDtlVO selectProgrmChangeRequst(ProgrmManageDtlVO vo) throws Exception {
+		return progrmManageMapper.selectProgrmChangeRequst_D(vo);
 	}
 
 	/**
 	 * 프로그램변경요청을 등록
 	 * @param vo ProgrmManageDtlVO
-	 * @exception Exception
 	 */
-	public void insertProgrmChangeRequst(ProgrmManageDtlVO vo){
-		insert("progrmManageDAO.insertProgrmChangeRequst_S", vo);
+	public void insertProgrmChangeRequst(ProgrmManageDtlVO vo) {
+		progrmManageMapper.insertProgrmChangeRequst_S(vo);
 	}
 
 	/**
 	 * 프로그램변경요청을 수정
 	 * @param vo ProgrmManageDtlVO
-	 * @exception Exception
 	 */
-	public void updateProgrmChangeRequst(ProgrmManageDtlVO vo){
-		update("progrmManageDAO.updateProgrmChangeRequst_S", vo);
+	public void updateProgrmChangeRequst(ProgrmManageDtlVO vo) {
+		progrmManageMapper.updateProgrmChangeRequst_S(vo);
 	}
 
 	/**
 	 * 프로그램변경요청을 삭제
 	 * @param vo ProgrmManageDtlVO
-	 * @exception Exception
 	 */
-	public void deleteProgrmChangeRequst(ProgrmManageDtlVO vo){
-		delete("progrmManageDAO.deleteProgrmChangeRequst_S", vo);
+	public void deleteProgrmChangeRequst(ProgrmManageDtlVO vo) {
+		progrmManageMapper.deleteProgrmChangeRequst_S(vo);
 	}
 
 	/**
 	 * 프로그램변경요청 요청번호MAX 정보를 조회
 	 * @param vo ProgrmManageDtlVO
 	 * @return ProgrmManageDtlVO
-	 * @exception Exception
 	 */
-	public ProgrmManageDtlVO selectProgrmChangeRequstNo(ProgrmManageDtlVO vo){
-		return (ProgrmManageDtlVO)selectOne("progrmManageDAO.selectProgrmChangeRequstNo_D", vo);
+	public ProgrmManageDtlVO selectProgrmChangeRequstNo(ProgrmManageDtlVO vo) {
+		return progrmManageMapper.selectProgrmChangeRequstNo_D(vo);
 	}
 
 	/**
-	 * 프로그램변경요청 목록을 조회
+	 * 프로그램변경요청처리 목록을 조회
 	 * @param vo ComDefaultVO
 	 * @return List
 	 * @exception Exception
 	 */
-	public List<?> selectChangeRequstProcessList(ComDefaultVO vo) throws Exception{
-		return selectList("progrmManageDAO.selectChangeRequstProcessList_D", vo);
+	public List<?> selectChangeRequstProcessList(ComDefaultVO vo) throws Exception {
+		return progrmManageMapper.selectChangeRequstProcessList_D(vo);
 	}
 
     /**
-	 * 프로그램변경요청 총건수를 조회한다.
+	 * 프로그램변경요청처리 총건수를 조회한다.
 	 * @param vo ComDefaultVO
 	 * @return int
-	 * @exception Exception
 	 */
     public int selectChangeRequstListProcessTotCnt(ComDefaultVO vo) {
-        return (Integer)selectOne("progrmManageDAO.selectChangeRequstProcessListTotCnt_S", vo);
+        return progrmManageMapper.selectChangeRequstProcessListTotCnt_S(vo);
     }
 
 	/**
 	 * 프로그램변경요청 처리 수정
 	 * @param vo ProgrmManageDtlVO
-	 * @exception Exception
 	 */
-	public void updateProgrmChangeRequstProcess(ProgrmManageDtlVO vo){
-		update("progrmManageDAO.updateProgrmChangeRequstProcess_S", vo);
+	public void updateProgrmChangeRequstProcess(ProgrmManageDtlVO vo) {
+		progrmManageMapper.updateProgrmChangeRequstProcess_S(vo);
 	}
-
 
 	/**
 	 * 프로그램목록 전체삭제 초기화
 	 * @return boolean
-	 * @exception Exception
 	 */
-	public boolean deleteAllProgrm(){
-		ProgrmManageVO vo = new ProgrmManageVO();
-		update("progrmManageDAO.deleteAllProgrm", vo);
+	public boolean deleteAllProgrm() {
+		progrmManageMapper.deleteAllProgrm(new ProgrmManageVO());
 		return true;
 	}
 
 	/**
 	 * 프로그램변경내역 전체삭제 초기화
 	 * @return boolean
-	 * @exception Exception
 	 */
-	public boolean deleteAllProgrmDtls(){
-		ProgrmManageDtlVO vo = new ProgrmManageDtlVO();
-		update("progrmManageDAO.deleteAllProgrmDtls", vo);
+	public boolean deleteAllProgrmDtls() {
+		progrmManageMapper.deleteAllProgrmDtls(new ProgrmManageDtlVO());
 		return true;
 	}
 
     /**
 	 * 프로그램목록 데이타 존재여부 조회한다.
 	 * @return int
-	 * @exception Exception
 	 */
     public int selectProgrmListTotCnt() {
-    	ProgrmManageVO vo = new ProgrmManageVO();
-        return (Integer)selectOne("progrmManageDAO.selectProgrmListTotCnt", vo);
+        return progrmManageMapper.selectProgrmListTotCnt(new ProgrmManageVO());
     }
 
 	/**
 	 * 프로그램변경요청자 Email 정보를 조회
 	 * @param vo ProgrmManageDtlVO
 	 * @return ProgrmManageDtlVO
-	 * @exception Exception
 	 */
-	public ProgrmManageDtlVO selectRqesterEmail(ProgrmManageDtlVO vo){
-		return (ProgrmManageDtlVO)selectOne("progrmManageDAO.selectRqesterEmail", vo);
+	public ProgrmManageDtlVO selectRqesterEmail(ProgrmManageDtlVO vo) {
+		return progrmManageMapper.selectRqesterEmail(vo);
 	}
 }

--- a/src/main/java/egovframework/com/sym/prm/service/impl/ProgrmManageMapper.java
+++ b/src/main/java/egovframework/com/sym/prm/service/impl/ProgrmManageMapper.java
@@ -1,0 +1,173 @@
+package egovframework.com.sym.prm.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.cmm.ComDefaultVO;
+import egovframework.com.sym.prm.service.ProgrmManageDtlVO;
+import egovframework.com.sym.prm.service.ProgrmManageVO;
+
+/**
+ * 프로그램 목록관리 및 프로그램변경관리에 대한 MyBatis 매퍼 인터페이스를 정의한다.
+ * @author 개발환경 개발팀 이용
+ * @since 2009.06.01
+ * @version 1.0
+ * @see
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2009.03.20  이  용          최초 생성
+ *
+ * </pre>
+ */
+@EgovMapper("progrmManageDAO")
+public interface ProgrmManageMapper {
+
+	/**
+	 * 프로그램 목록을 조회
+	 * @param vo ComDefaultVO
+	 * @return List
+	 * @exception Exception
+	 */
+	List<ProgrmManageVO> selectProgrmList_D(ComDefaultVO vo) throws Exception;
+
+	/**
+	 * 프로그램목록 총건수를 조회한다.
+	 * @param vo ComDefaultVO
+	 * @return int
+	 */
+	int selectProgrmListTotCnt_S(ComDefaultVO vo);
+
+	/**
+	 * 프로그램 기본정보를 조회
+	 * @param vo ProgrmManageVO
+	 * @return ProgrmManageVO
+	 * @exception Exception
+	 */
+	ProgrmManageVO selectProgrm_D(ProgrmManageVO vo) throws Exception;
+
+	/**
+	 * 프로그램 기본정보 및 URL을 등록
+	 * @param vo ProgrmManageVO
+	 */
+	void insertProgrm_S(ProgrmManageVO vo);
+
+	/**
+	 * 프로그램 기본정보 및 URL을 수정
+	 * @param vo ProgrmManageVO
+	 */
+	void updateProgrm_S(ProgrmManageVO vo);
+
+	/**
+	 * 프로그램 기본정보 및 URL을 삭제
+	 * @param vo ProgrmManageVO
+	 */
+	void deleteProgrm_S(ProgrmManageVO vo);
+
+	/**
+	 * 프로그램 파일 존재여부를 조회
+	 * @param vo ComDefaultVO
+	 * @return int
+	 * @exception Exception
+	 */
+	int selectProgrmNMTotCnt(ComDefaultVO vo) throws Exception;
+
+	/**
+	 * 프로그램변경요청 목록을 조회
+	 * @param vo ComDefaultVO
+	 * @return List
+	 * @exception Exception
+	 */
+	List<ProgrmManageDtlVO> selectProgrmChangeRequstList_D(ComDefaultVO vo) throws Exception;
+
+	/**
+	 * 프로그램변경요청 총건수를 조회한다.
+	 * @param vo ComDefaultVO
+	 * @return int
+	 */
+	int selectProgrmChangeRequstListTotCnt_S(ComDefaultVO vo);
+
+	/**
+	 * 프로그램변경요청 정보를 조회
+	 * @param vo ProgrmManageDtlVO
+	 * @return ProgrmManageDtlVO
+	 * @exception Exception
+	 */
+	ProgrmManageDtlVO selectProgrmChangeRequst_D(ProgrmManageDtlVO vo) throws Exception;
+
+	/**
+	 * 프로그램변경요청을 등록
+	 * @param vo ProgrmManageDtlVO
+	 */
+	void insertProgrmChangeRequst_S(ProgrmManageDtlVO vo);
+
+	/**
+	 * 프로그램변경요청을 수정
+	 * @param vo ProgrmManageDtlVO
+	 */
+	void updateProgrmChangeRequst_S(ProgrmManageDtlVO vo);
+
+	/**
+	 * 프로그램변경요청을 삭제
+	 * @param vo ProgrmManageDtlVO
+	 */
+	void deleteProgrmChangeRequst_S(ProgrmManageDtlVO vo);
+
+	/**
+	 * 프로그램변경요청 요청번호MAX 정보를 조회
+	 * @param vo ProgrmManageDtlVO
+	 * @return ProgrmManageDtlVO
+	 */
+	ProgrmManageDtlVO selectProgrmChangeRequstNo_D(ProgrmManageDtlVO vo);
+
+	/**
+	 * 프로그램변경요청처리 목록을 조회
+	 * @param vo ComDefaultVO
+	 * @return List
+	 * @exception Exception
+	 */
+	List<?> selectChangeRequstProcessList_D(ComDefaultVO vo) throws Exception;
+
+	/**
+	 * 프로그램변경요청처리 총건수를 조회한다.
+	 * @param vo ComDefaultVO
+	 * @return int
+	 */
+	int selectChangeRequstProcessListTotCnt_S(ComDefaultVO vo);
+
+	/**
+	 * 프로그램변경요청처리를 수정
+	 * @param vo ProgrmManageDtlVO
+	 */
+	void updateProgrmChangeRequstProcess_S(ProgrmManageDtlVO vo);
+
+	/**
+	 * 프로그램목록 전체삭제 초기화
+	 * @param vo ProgrmManageVO
+	 */
+	void deleteAllProgrm(ProgrmManageVO vo);
+
+	/**
+	 * 프로그램변경내역 전체삭제 초기화
+	 * @param vo ProgrmManageDtlVO
+	 */
+	void deleteAllProgrmDtls(ProgrmManageDtlVO vo);
+
+	/**
+	 * 프로그램목록 데이타 존재여부 조회한다.
+	 * @param vo ProgrmManageVO
+	 * @return int
+	 */
+	int selectProgrmListTotCnt(ProgrmManageVO vo);
+
+	/**
+	 * 프로그램변경요청자 Email 정보를 조회
+	 * @param vo ProgrmManageDtlVO
+	 * @return ProgrmManageDtlVO
+	 */
+	ProgrmManageDtlVO selectRqesterEmail(ProgrmManageDtlVO vo);
+}

--- a/src/main/resources/egovframework/mapper/com/sym/prm/EgovProgrmManageDtl_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/prm/EgovProgrmManageDtl_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="progrmManageDAO">
+<mapper namespace="egovframework.com.sym.prm.service.impl.ProgrmManageMapper">
 
     <!-- 프로그램 변경요청  --> 
 	<resultMap id="progrmManageDtl" type="egovframework.com.sym.prm.service.ProgrmManageDtlVO">

--- a/src/main/resources/egovframework/mapper/com/sym/prm/EgovProgrmManageDtl_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/prm/EgovProgrmManageDtl_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="progrmManageDAO">
+<mapper namespace="egovframework.com.sym.prm.service.impl.ProgrmManageMapper">
 
     <!-- 프로그램 변경요청  --> 
 	<resultMap id="progrmManageDtl" type="egovframework.com.sym.prm.service.ProgrmManageDtlVO">

--- a/src/main/resources/egovframework/mapper/com/sym/prm/EgovProgrmManageDtl_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/prm/EgovProgrmManageDtl_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="progrmManageDAO">
+<mapper namespace="egovframework.com.sym.prm.service.impl.ProgrmManageMapper">
 
     <!-- 프로그램 변경요청  --> 
 	<resultMap id="progrmManageDtl" type="egovframework.com.sym.prm.service.ProgrmManageDtlVO">

--- a/src/main/resources/egovframework/mapper/com/sym/prm/EgovProgrmManageDtl_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/prm/EgovProgrmManageDtl_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="progrmManageDAO">
+<mapper namespace="egovframework.com.sym.prm.service.impl.ProgrmManageMapper">
 
     <!-- 프로그램 변경요청  --> 
 	<resultMap id="progrmManageDtl" type="egovframework.com.sym.prm.service.ProgrmManageDtlVO">

--- a/src/main/resources/egovframework/mapper/com/sym/prm/EgovProgrmManageDtl_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/prm/EgovProgrmManageDtl_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="progrmManageDAO">
+<mapper namespace="egovframework.com.sym.prm.service.impl.ProgrmManageMapper">
 
     <!-- 프로그램 변경요청  --> 
 	<resultMap id="progrmManageDtl" type="egovframework.com.sym.prm.service.ProgrmManageDtlVO">

--- a/src/main/resources/egovframework/mapper/com/sym/prm/EgovProgrmManageDtl_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/prm/EgovProgrmManageDtl_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="progrmManageDAO">
+<mapper namespace="egovframework.com.sym.prm.service.impl.ProgrmManageMapper">
 
     <!-- 프로그램 변경요청  --> 
 	<resultMap id="progrmManageDtl" type="egovframework.com.sym.prm.service.ProgrmManageDtlVO">

--- a/src/main/resources/egovframework/mapper/com/sym/prm/EgovProgrmManageDtl_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/prm/EgovProgrmManageDtl_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="progrmManageDAO">
+<mapper namespace="egovframework.com.sym.prm.service.impl.ProgrmManageMapper">
 
     <!-- 프로그램 변경요청  --> 
 	<resultMap id="progrmManageDtl" type="egovframework.com.sym.prm.service.ProgrmManageDtlVO">

--- a/src/main/resources/egovframework/mapper/com/sym/prm/EgovProgrmManageDtl_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/prm/EgovProgrmManageDtl_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="progrmManageDAO">
+<mapper namespace="egovframework.com.sym.prm.service.impl.ProgrmManageMapper">
 
     <!-- 프로그램 변경요청  --> 
 	<resultMap id="progrmManageDtl" type="egovframework.com.sym.prm.service.ProgrmManageDtlVO">

--- a/src/main/resources/egovframework/mapper/com/sym/prm/EgovProgrmManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/prm/EgovProgrmManage_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="progrmManageDAO">
+<mapper namespace="egovframework.com.sym.prm.service.impl.ProgrmManageMapper">
  
     <!-- 프로그램목록 관리 -->
 	<resultMap id="progrmManage" type="egovframework.com.sym.prm.service.ProgrmManageVO">

--- a/src/main/resources/egovframework/mapper/com/sym/prm/EgovProgrmManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/prm/EgovProgrmManage_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="progrmManageDAO">
+<mapper namespace="egovframework.com.sym.prm.service.impl.ProgrmManageMapper">
 
     <!-- 프로그램목록 관리 -->
 	<resultMap id="progrmManage" type="egovframework.com.sym.prm.service.ProgrmManageVO">

--- a/src/main/resources/egovframework/mapper/com/sym/prm/EgovProgrmManage_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/prm/EgovProgrmManage_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="progrmManageDAO">
+<mapper namespace="egovframework.com.sym.prm.service.impl.ProgrmManageMapper">
  
     <!-- 프로그램목록 관리 -->
 	<resultMap id="progrmManage" type="egovframework.com.sym.prm.service.ProgrmManageVO">

--- a/src/main/resources/egovframework/mapper/com/sym/prm/EgovProgrmManage_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/prm/EgovProgrmManage_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="progrmManageDAO">
+<mapper namespace="egovframework.com.sym.prm.service.impl.ProgrmManageMapper">
 
     <!-- 프로그램목록 관리 -->
 	<resultMap id="progrmManage" type="egovframework.com.sym.prm.service.ProgrmManageVO">
@@ -91,7 +91,7 @@
 		                                
 	</delete> 
 
-	<delete id="progrmManageDAO.deleteAllProgrm">
+	<delete id="deleteAllProgrm">
 		                          
 			DELETE FROM COMTNPROGRMLIST              
 		                                

--- a/src/main/resources/egovframework/mapper/com/sym/prm/EgovProgrmManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/prm/EgovProgrmManage_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="progrmManageDAO">
+<mapper namespace="egovframework.com.sym.prm.service.impl.ProgrmManageMapper">
 
     <!-- 프로그램목록 관리 -->
 	<resultMap id="progrmManage" type="egovframework.com.sym.prm.service.ProgrmManageVO">
@@ -91,7 +91,7 @@
 		                                
 	</delete> 
 
-	<delete id="progrmManageDAO.deleteAllProgrm">
+	<delete id="deleteAllProgrm">
 		                          
 			DELETE FROM COMTNPROGRMLIST              
 		                                

--- a/src/main/resources/egovframework/mapper/com/sym/prm/EgovProgrmManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/prm/EgovProgrmManage_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="progrmManageDAO">
+<mapper namespace="egovframework.com.sym.prm.service.impl.ProgrmManageMapper">
 
     <!-- 프로그램목록 관리 -->
 	<resultMap id="progrmManage" type="egovframework.com.sym.prm.service.ProgrmManageVO">

--- a/src/main/resources/egovframework/mapper/com/sym/prm/EgovProgrmManage_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/prm/EgovProgrmManage_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="progrmManageDAO">
+<mapper namespace="egovframework.com.sym.prm.service.impl.ProgrmManageMapper">
 
     <!-- 프로그램목록 관리 -->
 	<resultMap id="progrmManage" type="egovframework.com.sym.prm.service.ProgrmManageVO">
@@ -91,7 +91,7 @@
 		                                
 	</delete> 
 
-	<delete id="progrmManageDAO.deleteAllProgrm">
+	<delete id="deleteAllProgrm">
 		                          
 			DELETE FROM COMTNPROGRMLIST              
 		                                

--- a/src/main/resources/egovframework/mapper/com/sym/prm/EgovProgrmManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/prm/EgovProgrmManage_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="progrmManageDAO">
+<mapper namespace="egovframework.com.sym.prm.service.impl.ProgrmManageMapper">
 	
     <!-- 프로그램목록 관리 -->
 	<resultMap id="progrmManage" type="egovframework.com.sym.prm.service.ProgrmManageVO">

--- a/src/main/resources/egovframework/spring/com/context-mapper.xml
+++ b/src/main/resources/egovframework/spring/com/context-mapper.xml
@@ -21,5 +21,12 @@
 	<bean id="egov.sqlSessionTemplate" class="org.mybatis.spring.SqlSessionTemplate">
 		<constructor-arg ref="egov.sqlSession"/>
 	</bean>
-	
+
+	<!-- @EgovMapper 인터페이스 자동 스캔 -->
+	<bean class="org.mybatis.spring.mapper.MapperScannerConfigurer">
+		<property name="basePackage" value="egovframework.com" />
+		<property name="annotationClass" value="org.egovframe.rte.psl.dataaccess.mapper.EgovMapper" />
+		<property name="sqlSessionFactoryBeanName" value="egov.sqlSession" />
+	</bean>
+
 </beans>


### PR DESCRIPTION
EgovFrame 5.0에서 도입된 `@EgovMapper` 어노테이션 방식으로 `sym/prm` 모듈의 MyBatis 연동을 전환한다.

## 변경 내용

- `ProgrmManageMapper` 인터페이스 신설 — `@EgovMapper("progrmManageDAO")` 적용
- `ProgrmManageDAO`가 `EgovComAbstractDAO` 상속 대신 `ProgrmManageMapper`에 위임하도록 재작성 (기존 메서드 시그니처 유지)
- `EgovProgrmManage_SQL_*.xml`, `EgovProgrmManageDtl_SQL_*.xml` (16개) `namespace`를 인터페이스 FQN으로 변경
- `deleteAllProgrm` 구문 ID에서 구 네임스페이스 접두어(`progrmManageDAO.`) 제거
- `context-mapper.xml`에 `MapperScannerConfigurer` 등록 (`basePackage: egovframework.com`)

## 영향 범위

- `EgovProgrmManageServiceImpl`의 public API 변경 없음
- 기존 동작 그대로 유지 (XML SQL 내용 변경 없음, 메서드 시그니처 동일)

## 체크리스트

- [x] 단일 주제만 다룸 (다른 변경 없음)
- [x] 5.x 다른 브랜치용 PR이 필요한 경우 후속 PR 링크 명시 — 5.1.x, 5.2.x 대상 후속 PR 예정
- [x] 기존 동작에 영향 없음
- [x] `mvn -DskipTests compile` 통과 확인 (기존 149개 사전 오류 수 변동 없음)
