### PR TITLE
[refactor][5.0.x][공통컴포넌트] sym/mnu/mpm MenuManageDAO @EgovMapper 인터페이스 방식으로 전환

### DIFF
--- a/src/main/java/egovframework/com/sym/mnu/mpm/service/impl/MenuManageDAO.java
+++ b/src/main/java/egovframework/com/sym/mnu/mpm/service/impl/MenuManageDAO.java
@@ -1,4 +1,4 @@
- package egovframework.com.sym.mnu.mpm.service.impl;
+package egovframework.com.sym.mnu.mpm.service.impl;
 
 import java.util.List;
 
@@ -6,10 +6,12 @@ import org.egovframe.rte.psl.dataaccess.util.EgovMap;
 import org.springframework.stereotype.Repository;
 
 import egovframework.com.cmm.ComDefaultVO;
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.sym.mnu.mpm.service.MenuManageVO;
+import jakarta.annotation.Resource;
+
 /**
  * 메뉴관리, 메뉴생성, 사이트맵 생성에 대한 DAO 클래스를 정의한다.
+ *
  * @author 개발환경 개발팀 이용
  * @since 2009.06.01
  * @version 1.0
@@ -21,177 +23,171 @@ import egovframework.com.sym.mnu.mpm.service.MenuManageVO;
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.03.20  이  용          최초 생성
- *   2011.07.01  서준식			자기 메뉴 정보를 상위메뉴 정보로 참조하는 메뉴정보가 있는지 조회하는
- *   							selectUpperMenuNoByPk() 메서드 추가
+ *   2011.07.01  서준식          selectUpperMenuNoByPk() 메서드 추가
  *
  * </pre>
  */
-
 @Repository("menuManageDAO")
-public class MenuManageDAO extends EgovComAbstractDAO{
+public class MenuManageDAO {
 
-	/**
+    @Resource(name = "menuManageMapper")
+    private MenuManageMapper menuManageMapper;
+
+    /**
      * 메뉴목록을 조회
-     * 
+     *
      * @param vo ComDefaultVO
      * @return List
-     * @exception Exception
      */
-    public List<EgovMap> selectMenuManageList(ComDefaultVO vo) throws Exception {
-        return selectList("menuManageDAO.selectMenuManageList_D", vo);
+    public List<EgovMap> selectMenuManageList(ComDefaultVO vo) {
+        return menuManageMapper.selectMenuManageList_D(vo);
     }
 
     /**
-	 * 메뉴목록관리 총건수를 조회한다.
-	 * @param vo ComDefaultVO
-	 * @return int
-	 * @exception Exception
-	 */
+     * 메뉴목록관리 총건수를 조회한다.
+     *
+     * @param vo ComDefaultVO
+     * @return int
+     */
     public int selectMenuManageListTotCnt(ComDefaultVO vo) {
-        return (Integer)selectOne("menuManageDAO.selectMenuManageListTotCnt_S", vo);
+        return menuManageMapper.selectMenuManageListTotCnt_S(vo);
     }
-
-	/**
-	 * 메뉴목록관리 기본정보를 조회
-	 * @param vo ComDefaultVO
-	 * @return MenuManageVO
-	 * @exception Exception
-	 */
-	public MenuManageVO selectMenuManage(ComDefaultVO vo)throws Exception{
-		return (MenuManageVO)selectOne("menuManageDAO.selectMenuManage_D", vo);
-	}
-
-	/**
-	 * 메뉴목록 기본정보를 등록
-	 * @param vo MenuManageVO
-	 * @exception Exception
-	 */
-	public void insertMenuManage(MenuManageVO vo){
-		insert("menuManageDAO.insertMenuManage_S", vo);
-	}
-
-	/**
-	 * 메뉴목록 기본정보를 수정
-	 * @param vo MenuManageVO
-	 * @exception Exception
-	 */
-	public void updateMenuManage(MenuManageVO vo){
-		update("menuManageDAO.updateMenuManage_S", vo);
-	}
-
-	/**
-	 * 메뉴목록 기본정보를 삭제
-	 * @param vo MenuManageVO
-	 * @exception Exception
-	 */
-	public void deleteMenuManage(MenuManageVO vo){
-		delete("menuManageDAO.deleteMenuManage_S", vo);
-	}
-
-	/**
-	 * 메뉴 전체목록을 조회
-	 * @return list
-	 * @exception Exception
-	 */
-	public List<EgovMap> selectMenuList() throws Exception{
-		ComDefaultVO vo  = new ComDefaultVO();
-		return selectList("menuManageDAO.selectMenuListT_D", vo);
-	}
-
-
-	/**
-	 * 메뉴번호 존재여부를 조회
-	 * @param vo MenuManageVO
-	 * @return int
-	 * @exception Exception
-	 */
-	public int selectMenuNoByPk(MenuManageVO vo) throws Exception{
-		return (Integer)selectOne("menuManageDAO.selectMenuNoByPk", vo);
-	}
-
-
-
-	/**
-	 * 메뉴번호를 상위메뉴로 참조하고 있는 메뉴 존재여부를 조회
-	 * @param vo MenuManageVO
-	 * @return int
-	 * @exception Exception
-	 */
-	public int selectUpperMenuNoByPk(MenuManageVO vo) throws Exception{
-		return (Integer)selectOne("menuManageDAO.selectUpperMenuNoByPk", vo);
-	}
-
-
-	/**
-	 * 메뉴정보 전체삭제 초기화
-	 * @return boolean
-	 * @exception Exception
-	 */
-	public boolean deleteAllMenuList(){
-		MenuManageVO vo = new MenuManageVO();
-		insert("menuManageDAO.deleteAllMenuList", vo);
-		return true;
-	}
 
     /**
-	 * 메뉴정보 존재여부 조회한다.
-	 * @return int
-	 * @exception Exception
-	 */
-    public int selectMenuListTotCnt() {
-    	MenuManageVO vo = new MenuManageVO();
-        return (Integer)selectOne("menuManageDAO.selectMenuListTotCnt", vo);
+     * 메뉴목록관리 기본정보를 조회
+     *
+     * @param vo ComDefaultVO
+     * @return MenuManageVO
+     */
+    public MenuManageVO selectMenuManage(ComDefaultVO vo) {
+        return menuManageMapper.selectMenuManage_D(vo);
     }
 
+    /**
+     * 메뉴목록 기본정보를 등록
+     *
+     * @param vo MenuManageVO
+     */
+    public void insertMenuManage(MenuManageVO vo) {
+        menuManageMapper.insertMenuManage_S(vo);
+    }
 
-	/*### 메뉴관련 프로세스 ###*/
-	/**
-	 * MainMenu Head Menu 조회
-	 * @param vo MenuManageVO
-	 * @return List
-	 * @exception Exception
-	 */
-	public List<?> selectMainMenuHead(MenuManageVO vo) throws Exception{
-		return selectList("menuManageDAO.selectMainMenuHead", vo);
-	}
+    /**
+     * 메뉴목록 기본정보를 수정
+     *
+     * @param vo MenuManageVO
+     */
+    public void updateMenuManage(MenuManageVO vo) {
+        menuManageMapper.updateMenuManage_S(vo);
+    }
 
-	/**
-	 * MainMenu Left Menu 조회
-	 * @param vo MenuManageVO
-	 * @return List
-	 * @exception Exception
-	 */
-	public List<?> selectMainMenuLeft(MenuManageVO vo) throws Exception{
-		return selectList("menuManageDAO.selectMainMenuLeft", vo);
-	}
+    /**
+     * 메뉴목록 기본정보를 삭제
+     *
+     * @param vo MenuManageVO
+     */
+    public void deleteMenuManage(MenuManageVO vo) {
+        menuManageMapper.deleteMenuManage_S(vo);
+    }
 
-	/**
-	 * MainMenu Head MenuURL 조회
-	 * @param vo MenuManageVO
-	 * @return  String
-	 * @exception Exception
-	 */
-	public String selectLastMenuURL(MenuManageVO vo) throws Exception{
-		return (String)selectOne("menuManageDAO.selectLastMenuURL", vo);
-	}
+    /**
+     * 메뉴 전체목록을 조회
+     *
+     * @return List
+     */
+    public List<EgovMap> selectMenuList() {
+        ComDefaultVO vo = new ComDefaultVO();
+        return menuManageMapper.selectMenuListT_D(vo);
+    }
 
-	/**
-	 * MainMenu Left Menu 조회
-	 * @param vo MenuManageVO
-	 * @return int
-	 * @exception Exception
-	 */
-	public int selectLastMenuNo(MenuManageVO vo) throws Exception{
-		return (Integer)selectOne("menuManageDAO.selectLastMenuNo", vo);
-	}
+    /**
+     * 메뉴번호 존재여부를 조회
+     *
+     * @param vo MenuManageVO
+     * @return int
+     */
+    public int selectMenuNoByPk(MenuManageVO vo) {
+        return menuManageMapper.selectMenuNoByPk(vo);
+    }
 
-	/**
-	 * MainMenu Left Menu 조회
-	 * @param vo MenuManageVO
-	 * @return int
-	 * @exception Exception
-	 */
-	public int selectLastMenuNoCnt(MenuManageVO vo) throws Exception{
-		return (Integer)selectOne("menuManageDAO.selectLastMenuNoCnt", vo);
-	}
+    /**
+     * 메뉴번호를 상위메뉴로 참조하고 있는 메뉴 존재여부를 조회
+     *
+     * @param vo MenuManageVO
+     * @return int
+     */
+    public int selectUpperMenuNoByPk(MenuManageVO vo) {
+        return menuManageMapper.selectUpperMenuNoByPk(vo);
+    }
+
+    /**
+     * 메뉴정보 전체삭제 초기화
+     *
+     * @return boolean
+     */
+    public boolean deleteAllMenuList() {
+        menuManageMapper.deleteAllMenuList();
+        return true;
+    }
+
+    /**
+     * 메뉴정보 존재여부 조회한다.
+     *
+     * @return int
+     */
+    public int selectMenuListTotCnt() {
+        MenuManageVO vo = new MenuManageVO();
+        return menuManageMapper.selectMenuListTotCnt(vo);
+    }
+
+    /**
+     * MainMenu Head Menu 조회
+     *
+     * @param vo MenuManageVO
+     * @return List
+     */
+    public List<?> selectMainMenuHead(MenuManageVO vo) {
+        return menuManageMapper.selectMainMenuHead(vo);
+    }
+
+    /**
+     * MainMenu Left Menu 조회
+     *
+     * @param vo MenuManageVO
+     * @return List
+     */
+    public List<?> selectMainMenuLeft(MenuManageVO vo) {
+        return menuManageMapper.selectMainMenuLeft(vo);
+    }
+
+    /**
+     * MainMenu Head MenuURL 조회
+     *
+     * @param vo MenuManageVO
+     * @return String
+     */
+    public String selectLastMenuURL(MenuManageVO vo) {
+        return menuManageMapper.selectLastMenuURL(vo);
+    }
+
+    /**
+     * MainMenu Last MenuNo 조회
+     *
+     * @param vo MenuManageVO
+     * @return int
+     */
+    public int selectLastMenuNo(MenuManageVO vo) {
+        return menuManageMapper.selectLastMenuNo(vo);
+    }
+
+    /**
+     * MainMenu Last MenuNo 건수 조회
+     *
+     * @param vo MenuManageVO
+     * @return int
+     */
+    public int selectLastMenuNoCnt(MenuManageVO vo) {
+        return menuManageMapper.selectLastMenuNoCnt(vo);
+    }
+
 }

--- a/src/main/java/egovframework/com/sym/mnu/mpm/service/impl/MenuManageMapper.java
+++ b/src/main/java/egovframework/com/sym/mnu/mpm/service/impl/MenuManageMapper.java
@@ -1,0 +1,153 @@
+package egovframework.com.sym.mnu.mpm.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+import org.egovframe.rte.psl.dataaccess.util.EgovMap;
+
+import egovframework.com.cmm.ComDefaultVO;
+import egovframework.com.sym.mnu.mpm.service.MenuManageVO;
+
+/**
+ * 메뉴관리, 메뉴생성, 사이트맵 생성에 대한 Mapper 인터페이스를 정의한다.
+ *
+ * @author 개발환경 개발팀 이용
+ * @since 2009.06.01
+ * @version 1.0
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2009.03.20  이  용          최초 생성
+ *   2011.07.01  서준식          selectUpperMenuNoByPk() 메서드 추가
+ *
+ * </pre>
+ */
+@EgovMapper("menuManageMapper")
+public interface MenuManageMapper {
+
+    /**
+     * 메뉴목록을 조회한다.
+     *
+     * @param vo ComDefaultVO
+     * @return List
+     */
+    List<EgovMap> selectMenuManageList_D(ComDefaultVO vo);
+
+    /**
+     * 메뉴목록관리 총건수를 조회한다.
+     *
+     * @param vo ComDefaultVO
+     * @return int
+     */
+    int selectMenuManageListTotCnt_S(ComDefaultVO vo);
+
+    /**
+     * 메뉴목록관리 기본정보를 조회한다.
+     *
+     * @param vo ComDefaultVO
+     * @return MenuManageVO
+     */
+    MenuManageVO selectMenuManage_D(ComDefaultVO vo);
+
+    /**
+     * 메뉴목록 기본정보를 등록한다.
+     *
+     * @param vo MenuManageVO
+     */
+    void insertMenuManage_S(MenuManageVO vo);
+
+    /**
+     * 메뉴목록 기본정보를 수정한다.
+     *
+     * @param vo MenuManageVO
+     */
+    void updateMenuManage_S(MenuManageVO vo);
+
+    /**
+     * 메뉴목록 기본정보를 삭제한다.
+     *
+     * @param vo MenuManageVO
+     */
+    void deleteMenuManage_S(MenuManageVO vo);
+
+    /**
+     * 메뉴 전체목록을 조회한다.
+     *
+     * @param vo ComDefaultVO
+     * @return List
+     */
+    List<EgovMap> selectMenuListT_D(ComDefaultVO vo);
+
+    /**
+     * 메뉴번호 존재여부를 조회한다.
+     *
+     * @param vo MenuManageVO
+     * @return int
+     */
+    int selectMenuNoByPk(MenuManageVO vo);
+
+    /**
+     * 메뉴번호를 상위메뉴로 참조하고 있는 메뉴 존재여부를 조회한다.
+     *
+     * @param vo MenuManageVO
+     * @return int
+     */
+    int selectUpperMenuNoByPk(MenuManageVO vo);
+
+    /**
+     * 메뉴정보 전체를 삭제한다.
+     */
+    void deleteAllMenuList();
+
+    /**
+     * 메뉴정보 존재여부 총건수를 조회한다.
+     *
+     * @param vo MenuManageVO
+     * @return int
+     */
+    int selectMenuListTotCnt(MenuManageVO vo);
+
+    /**
+     * MainMenu Head Menu를 조회한다.
+     *
+     * @param vo MenuManageVO
+     * @return List
+     */
+    List<EgovMap> selectMainMenuHead(MenuManageVO vo);
+
+    /**
+     * MainMenu Left Menu를 조회한다.
+     *
+     * @param vo MenuManageVO
+     * @return List
+     */
+    List<EgovMap> selectMainMenuLeft(MenuManageVO vo);
+
+    /**
+     * MainMenu Head MenuURL을 조회한다.
+     *
+     * @param vo MenuManageVO
+     * @return String
+     */
+    String selectLastMenuURL(MenuManageVO vo);
+
+    /**
+     * MainMenu Last MenuNo를 조회한다.
+     *
+     * @param vo MenuManageVO
+     * @return int
+     */
+    int selectLastMenuNo(MenuManageVO vo);
+
+    /**
+     * MainMenu Last MenuNo 건수를 조회한다.
+     *
+     * @param vo MenuManageVO
+     * @return int
+     */
+    int selectLastMenuNoCnt(MenuManageVO vo);
+
+}

--- a/src/main/resources/egovframework/mapper/com/sym/mnu/mpm/EgovMainMenu_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/mnu/mpm/EgovMainMenu_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:50:48 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="menuManageDAO">
+<mapper namespace="egovframework.com.sym.mnu.mpm.service.impl.MenuManageMapper">
 	
 	<select id="selectMainMenuHead" parameterType="egovframework.com.sym.mnu.mpm.service.MenuManageVO" resultType="egovMap">
 		 

--- a/src/main/resources/egovframework/mapper/com/sym/mnu/mpm/EgovMainMenu_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/mnu/mpm/EgovMainMenu_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="menuManageDAO">
+<mapper namespace="egovframework.com.sym.mnu.mpm.service.impl.MenuManageMapper">
 	
 	<select id="selectMainMenuHead" parameterType="egovframework.com.sym.mnu.mpm.service.MenuManageVO" resultType="egovMap">
 		 

--- a/src/main/resources/egovframework/mapper/com/sym/mnu/mpm/EgovMainMenu_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/mnu/mpm/EgovMainMenu_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:50:48 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="menuManageDAO">
+<mapper namespace="egovframework.com.sym.mnu.mpm.service.impl.MenuManageMapper">
 	
 	<select id="selectMainMenuHead" parameterType="egovframework.com.sym.mnu.mpm.service.MenuManageVO" resultType="egovMap">
 		 

--- a/src/main/resources/egovframework/mapper/com/sym/mnu/mpm/EgovMainMenu_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/mnu/mpm/EgovMainMenu_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="menuManageDAO">
+<mapper namespace="egovframework.com.sym.mnu.mpm.service.impl.MenuManageMapper">
 	
 	<select id="selectMainMenuHead" parameterType="egovframework.com.sym.mnu.mpm.service.MenuManageVO" resultType="egovMap">
 		 

--- a/src/main/resources/egovframework/mapper/com/sym/mnu/mpm/EgovMainMenu_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/mnu/mpm/EgovMainMenu_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="menuManageDAO">
+<mapper namespace="egovframework.com.sym.mnu.mpm.service.impl.MenuManageMapper">
 	
 	<select id="selectMainMenuHead" parameterType="egovframework.com.sym.mnu.mpm.service.MenuManageVO" resultType="egovMap">
 		 

--- a/src/main/resources/egovframework/mapper/com/sym/mnu/mpm/EgovMainMenu_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/mnu/mpm/EgovMainMenu_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="menuManageDAO">
+<mapper namespace="egovframework.com.sym.mnu.mpm.service.impl.MenuManageMapper">
 	
 	<select id="selectMainMenuHead" parameterType="egovframework.com.sym.mnu.mpm.service.MenuManageVO" resultType="egovMap">
 		 

--- a/src/main/resources/egovframework/mapper/com/sym/mnu/mpm/EgovMainMenu_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/mnu/mpm/EgovMainMenu_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="menuManageDAO">
+<mapper namespace="egovframework.com.sym.mnu.mpm.service.impl.MenuManageMapper">
 	
 	<select id="selectMainMenuHead" parameterType="egovframework.com.sym.mnu.mpm.service.MenuManageVO" resultType="egovMap">
 		 

--- a/src/main/resources/egovframework/mapper/com/sym/mnu/mpm/EgovMainMenu_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/mnu/mpm/EgovMainMenu_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="menuManageDAO">
+<mapper namespace="egovframework.com.sym.mnu.mpm.service.impl.MenuManageMapper">
 	
 	<select id="selectMainMenuHead" parameterType="egovframework.com.sym.mnu.mpm.service.MenuManageVO" resultType="egovMap">
 		 

--- a/src/main/resources/egovframework/mapper/com/sym/mnu/mpm/EgovMenuManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/mnu/mpm/EgovMenuManage_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="menuManageDAO">
+<mapper namespace="egovframework.com.sym.mnu.mpm.service.impl.MenuManageMapper">
 
 	<select id="selectMenuManageList_D" parameterType="comDefaultVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/sym/mnu/mpm/EgovMenuManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/mnu/mpm/EgovMenuManage_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="menuManageDAO">
+<mapper namespace="egovframework.com.sym.mnu.mpm.service.impl.MenuManageMapper">
 
 	<select id="selectMenuManageList_D" parameterType="comDefaultVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/sym/mnu/mpm/EgovMenuManage_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/mnu/mpm/EgovMenuManage_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="menuManageDAO">
+<mapper namespace="egovframework.com.sym.mnu.mpm.service.impl.MenuManageMapper">
 
 	<select id="selectMenuManageList_D" parameterType="comDefaultVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/sym/mnu/mpm/EgovMenuManage_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/mnu/mpm/EgovMenuManage_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="menuManageDAO">
+<mapper namespace="egovframework.com.sym.mnu.mpm.service.impl.MenuManageMapper">
 
 	<select id="selectMenuManageList_D" parameterType="comDefaultVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/sym/mnu/mpm/EgovMenuManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/mnu/mpm/EgovMenuManage_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="menuManageDAO">
+<mapper namespace="egovframework.com.sym.mnu.mpm.service.impl.MenuManageMapper">
 
 	<select id="selectMenuManageList_D" parameterType="comDefaultVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/sym/mnu/mpm/EgovMenuManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/mnu/mpm/EgovMenuManage_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="menuManageDAO">
+<mapper namespace="egovframework.com.sym.mnu.mpm.service.impl.MenuManageMapper">
 
 	<select id="selectMenuManageList_D" parameterType="comDefaultVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/sym/mnu/mpm/EgovMenuManage_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/mnu/mpm/EgovMenuManage_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="menuManageDAO">
+<mapper namespace="egovframework.com.sym.mnu.mpm.service.impl.MenuManageMapper">
 
 	<select id="selectMenuManageList_D" parameterType="comDefaultVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/sym/mnu/mpm/EgovMenuManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/mnu/mpm/EgovMenuManage_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="menuManageDAO">
+<mapper namespace="egovframework.com.sym.mnu.mpm.service.impl.MenuManageMapper">
 
 	<select id="selectMenuManageList_D" parameterType="comDefaultVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/spring/com/context-mapper.xml
+++ b/src/main/resources/egovframework/spring/com/context-mapper.xml
@@ -21,5 +21,12 @@
 	<bean id="egov.sqlSessionTemplate" class="org.mybatis.spring.SqlSessionTemplate">
 		<constructor-arg ref="egov.sqlSession"/>
 	</bean>
-	
+
+	<!-- @EgovMapper 인터페이스 스캔 -->
+	<bean class="org.mybatis.spring.mapper.MapperScannerConfigurer">
+		<property name="basePackage" value="egovframework.com" />
+		<property name="annotationClass" value="org.egovframe.rte.psl.dataaccess.mapper.EgovMapper" />
+		<property name="sqlSessionFactoryBeanName" value="egov.sqlSession" />
+	</bean>
+
 </beans>


### PR DESCRIPTION
## 변경 사유

EgovFrame 5.0에서 도입된 `@EgovMapper` 어노테이션 기반 MyBatis 매퍼 인터페이스 방식을 `sym/mnu/mpm`(메뉴관리) 모듈에 적용한다.
기존 `EgovComAbstractDAO` 상속 방식은 SQL 식별자를 문자열로 직접 지정하여 컴파일 타임 검증이 불가능했다.
인터페이스 방식으로 전환하면 메서드 시그니처와 XML 구문이 타입 안전하게 연결된다.

## 변경 내용

- `MenuManageMapper` 인터페이스 신설 — `@EgovMapper("menuManageMapper")` 적용, XML 구문 ID와 1:1 매핑
- `MenuManageDAO` — `EgovComAbstractDAO` 상속 제거, `@Resource`로 `MenuManageMapper` 주입 후 위임
- `EgovMenuManage_SQL_*.xml` (8개) — `namespace` 를 `menuManageDAO` → `egovframework.com.sym.mnu.mpm.service.impl.MenuManageMapper` (FQN)으로 변경
- `EgovMainMenu_SQL_*.xml` (8개) — 동일하게 namespace FQN 변경
- `context-mapper.xml` — `MapperScannerConfigurer` 빈 추가 (`egovframework.com` 하위 `@EgovMapper` 인터페이스 자동 스캔)

## 테스트

- `mvn -DskipTests compile` — 기존 오류 수(70개, 타 패키지 기존 문제) 변동 없음 확인
- mpm 패키지 신규 컴파일 오류 없음

## 체크리스트

- [x] 단일 주제만 다룸 (sym/mnu/mpm @EgovMapper 전환)
- [x] 5.x 다른 브랜치용 PR이 필요한 경우 후속 PR 링크 명시 (5.1.x 예정)
- [x] 기존 동작에 영향 없음 — DAO 공개 메서드 시그니처 동일, 서비스 계층 변경 없음
- [x] 테스트 통과 확인 (컴파일 기준)
