### PR TITLE
[refactor][5.0.x][공통컴포넌트] sym/ccm/zip ZipManageDAO+RdnmadZipDAO @EgovMapper 인터페이스 방식으로 전환

### DIFF
--- a/src/main/java/egovframework/com/sym/ccm/zip/service/impl/RdnmadZipMapper.java
+++ b/src/main/java/egovframework/com/sym/ccm/zip/service/impl/RdnmadZipMapper.java
@@ -2,16 +2,14 @@ package egovframework.com.sym.ccm.zip.service.impl;
 
 import java.util.List;
 
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
 import org.egovframe.rte.psl.dataaccess.util.EgovMap;
-import org.springframework.stereotype.Repository;
 
 import egovframework.com.sym.ccm.zip.service.Zip;
 import egovframework.com.sym.ccm.zip.service.ZipVO;
-import jakarta.annotation.Resource;
 
 /**
- *
- * 우편번호에 대한 데이터 접근 클래스를 정의한다
+ * 도로명주소 우편번호 관리에 대한 데이터 접근 매퍼 인터페이스
  * @author 공통서비스 개발팀 이기하
  * @since 2011.11.21
  * @version 1.0
@@ -26,80 +24,56 @@ import jakarta.annotation.Resource;
  *
  * </pre>
  */
-@Repository("RdnmadZipDAO")
-public class RdnmadZipDAO {
-
-	@Resource(name = "RdnmadZipMapper")
-	private RdnmadZipMapper rdnmadZipMapper;
+@EgovMapper("RdnmadZipMapper")
+public interface RdnmadZipMapper {
 
 	/**
 	 * 우편번호를 삭제한다.
 	 * @param zip
-	 * @throws Exception
 	 */
-	public void deleteZip(Zip zip) throws Exception {
-		rdnmadZipMapper.deleteZip(zip);
-	}
+	void deleteZip(Zip zip);
 
 	/**
 	 * 우편번호 전체를 삭제한다.
-	 * @throws Exception
 	 */
-	public void deleteAllZip() throws Exception {
-		rdnmadZipMapper.deleteAllZip();
-	}
+	void deleteAllZip();
 
 	/**
 	 * 우편번호를 등록한다.
 	 * @param zip
 	 */
-	public void insertZip(Zip zip) {
-		rdnmadZipMapper.insertZip(zip);
-	}
+	void insertZip(Zip zip);
 
 	/**
 	 * 우편번호 엑셀파일을 등록한다.
-	 * @throws Exception
 	 */
-	public void insertExcelZip() throws Exception {
-		rdnmadZipMapper.insertExcelZip();
-	}
+	void insertExcelZip();
 
 	/**
 	 * 우편번호 상세항목을 조회한다.
 	 * @param zip
 	 * @return Zip(우편번호)
 	 */
-	public Zip selectZipDetail(Zip zip) throws Exception {
-		return rdnmadZipMapper.selectZipDetail(zip);
-	}
+	Zip selectZipDetail(Zip zip);
 
 	/**
 	 * 우편번호 목록을 조회한다.
 	 * @param searchVO
 	 * @return List(우편번호 목록)
-	 * @throws Exception
 	 */
-	public List<EgovMap> selectZipList(ZipVO searchVO) throws Exception {
-		return rdnmadZipMapper.selectZipList(searchVO);
-	}
+	List<EgovMap> selectZipList(ZipVO searchVO);
 
 	/**
 	 * 우편번호 총 개수를 조회한다.
 	 * @param searchVO
 	 * @return int(우편번호 총 개수)
 	 */
-	public int selectZipListTotCnt(ZipVO searchVO) throws Exception {
-		return rdnmadZipMapper.selectZipListTotCnt(searchVO);
-	}
+	int selectZipListTotCnt(ZipVO searchVO);
 
 	/**
 	 * 우편번호를 수정한다.
 	 * @param zip
-	 * @throws Exception
 	 */
-	public void updateZip(Zip zip) throws Exception {
-		rdnmadZipMapper.updateZip(zip);
-	}
+	void updateZip(Zip zip);
 
 }

--- a/src/main/java/egovframework/com/sym/ccm/zip/service/impl/ZipManageMapper.java
+++ b/src/main/java/egovframework/com/sym/ccm/zip/service/impl/ZipManageMapper.java
@@ -2,16 +2,14 @@ package egovframework.com.sym.ccm.zip.service.impl;
 
 import java.util.List;
 
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
 import org.egovframe.rte.psl.dataaccess.util.EgovMap;
-import org.springframework.stereotype.Repository;
 
 import egovframework.com.sym.ccm.zip.service.Zip;
 import egovframework.com.sym.ccm.zip.service.ZipVO;
-import jakarta.annotation.Resource;
 
 /**
- *
- * 우편번호에 대한 데이터 접근 클래스를 정의한다
+ * 우편번호 관리에 대한 데이터 접근 매퍼 인터페이스
  * @author 공통서비스 개발팀 이중호
  * @since 2009.04.01
  * @version 1.0
@@ -26,80 +24,56 @@ import jakarta.annotation.Resource;
  *
  * </pre>
  */
-@Repository("ZipManageDAO")
-public class ZipManageDAO {
-
-	@Resource(name = "ZipManageMapper")
-	private ZipManageMapper zipManageMapper;
+@EgovMapper("ZipManageMapper")
+public interface ZipManageMapper {
 
 	/**
 	 * 우편번호를 삭제한다.
 	 * @param zip
-	 * @throws Exception
 	 */
-	public void deleteZip(Zip zip) throws Exception {
-		zipManageMapper.deleteZip(zip);
-	}
+	void deleteZip(Zip zip);
 
 	/**
 	 * 우편번호 전체를 삭제한다.
-	 * @throws Exception
 	 */
-	public void deleteAllZip() throws Exception {
-		zipManageMapper.deleteAllZip();
-	}
+	void deleteAllZip();
 
 	/**
 	 * 우편번호를 등록한다.
 	 * @param zip
 	 */
-	public void insertZip(Zip zip) {
-		zipManageMapper.insertZip(zip);
-	}
+	void insertZip(Zip zip);
 
 	/**
 	 * 우편번호 엑셀파일을 등록한다.
-	 * @throws Exception
 	 */
-	public void insertExcelZip() throws Exception {
-		zipManageMapper.insertExcelZip();
-	}
+	void insertExcelZip();
 
 	/**
 	 * 우편번호 상세항목을 조회한다.
 	 * @param zip
 	 * @return Zip(우편번호)
 	 */
-	public Zip selectZipDetail(Zip zip) throws Exception {
-		return zipManageMapper.selectZipDetail(zip);
-	}
+	Zip selectZipDetail(Zip zip);
 
 	/**
 	 * 우편번호 목록을 조회한다.
 	 * @param searchVO
 	 * @return List(우편번호 목록)
-	 * @throws Exception
 	 */
-	public List<EgovMap> selectZipList(ZipVO searchVO) throws Exception {
-		return zipManageMapper.selectZipList(searchVO);
-	}
+	List<EgovMap> selectZipList(ZipVO searchVO);
 
 	/**
 	 * 우편번호 총 개수를 조회한다.
 	 * @param searchVO
 	 * @return int(우편번호 총 개수)
 	 */
-	public int selectZipListTotCnt(ZipVO searchVO) throws Exception {
-		return zipManageMapper.selectZipListTotCnt(searchVO);
-	}
+	int selectZipListTotCnt(ZipVO searchVO);
 
 	/**
 	 * 우편번호를 수정한다.
 	 * @param zip
-	 * @throws Exception
 	 */
-	public void updateZip(Zip zip) throws Exception {
-		zipManageMapper.updateZip(zip);
-	}
+	void updateZip(Zip zip);
 
 }

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/zip/EgovRdnmadZip_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/zip/EgovRdnmadZip_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="RdnmadZipDAO">
+<mapper namespace="egovframework.com.sym.ccm.zip.service.impl.RdnmadZipMapper">
 
 	<select id="selectZipList" parameterType="egovframework.com.sym.ccm.zip.service.ZipVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/zip/EgovRdnmadZip_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/zip/EgovRdnmadZip_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="RdnmadZipDAO">
+<mapper namespace="egovframework.com.sym.ccm.zip.service.impl.RdnmadZipMapper">
 
 	<select id="selectZipList" parameterType="egovframework.com.sym.ccm.zip.service.ZipVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/zip/EgovRdnmadZip_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/zip/EgovRdnmadZip_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="RdnmadZipDAO">
+<mapper namespace="egovframework.com.sym.ccm.zip.service.impl.RdnmadZipMapper">
 
 	<select id="selectZipList" parameterType="egovframework.com.sym.ccm.zip.service.ZipVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/zip/EgovRdnmadZip_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/zip/EgovRdnmadZip_SQL_maria.xml
@@ -5,7 +5,7 @@
 --><!--Converted at: Wed May 11 15:50:38 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="RdnmadZipDAO">
+<mapper namespace="egovframework.com.sym.ccm.zip.service.impl.RdnmadZipMapper">
 
 	<select id="selectZipList" parameterType="egovframework.com.sym.ccm.zip.service.ZipVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/zip/EgovRdnmadZip_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/zip/EgovRdnmadZip_SQL_mysql.xml
@@ -5,7 +5,7 @@
 --><!--Converted at: Wed May 11 15:50:38 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="RdnmadZipDAO">
+<mapper namespace="egovframework.com.sym.ccm.zip.service.impl.RdnmadZipMapper">
 
 	<select id="selectZipList" parameterType="egovframework.com.sym.ccm.zip.service.ZipVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/zip/EgovRdnmadZip_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/zip/EgovRdnmadZip_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="RdnmadZipDAO">
+<mapper namespace="egovframework.com.sym.ccm.zip.service.impl.RdnmadZipMapper">
 
 	<select id="selectZipList" parameterType="egovframework.com.sym.ccm.zip.service.ZipVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/zip/EgovRdnmadZip_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/zip/EgovRdnmadZip_SQL_postgres.xml
@@ -5,7 +5,7 @@
 --><!--Converted at: Wed May 11 15:50:38 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="RdnmadZipDAO">
+<mapper namespace="egovframework.com.sym.ccm.zip.service.impl.RdnmadZipMapper">
 
 	<select id="selectZipList" parameterType="egovframework.com.sym.ccm.zip.service.ZipVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/zip/EgovRdnmadZip_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/zip/EgovRdnmadZip_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="RdnmadZipDAO">
+<mapper namespace="egovframework.com.sym.ccm.zip.service.impl.RdnmadZipMapper">
 
 	<select id="selectZipList" parameterType="egovframework.com.sym.ccm.zip.service.ZipVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/zip/EgovZipManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/zip/EgovZipManage_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ZipManageDAO">
+<mapper namespace="egovframework.com.sym.ccm.zip.service.impl.ZipManageMapper">
 
 	<select id="selectZipList" parameterType="egovframework.com.sym.ccm.zip.service.ZipVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/zip/EgovZipManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/zip/EgovZipManage_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ZipManageDAO">
+<mapper namespace="egovframework.com.sym.ccm.zip.service.impl.ZipManageMapper">
 
 	<select id="selectZipList" parameterType="egovframework.com.sym.ccm.zip.service.ZipVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/zip/EgovZipManage_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/zip/EgovZipManage_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ZipManageDAO">
+<mapper namespace="egovframework.com.sym.ccm.zip.service.impl.ZipManageMapper">
 
 	<select id="selectZipList" parameterType="egovframework.com.sym.ccm.zip.service.ZipVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/zip/EgovZipManage_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/zip/EgovZipManage_SQL_maria.xml
@@ -5,7 +5,7 @@
 --><!--Converted at: Wed May 11 15:50:39 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ZipManageDAO">
+<mapper namespace="egovframework.com.sym.ccm.zip.service.impl.ZipManageMapper">
 
 	<select id="selectZipList" parameterType="egovframework.com.sym.ccm.zip.service.ZipVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/zip/EgovZipManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/zip/EgovZipManage_SQL_mysql.xml
@@ -5,7 +5,7 @@
 --><!--Converted at: Wed May 11 15:50:39 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ZipManageDAO">
+<mapper namespace="egovframework.com.sym.ccm.zip.service.impl.ZipManageMapper">
 
 	<select id="selectZipList" parameterType="egovframework.com.sym.ccm.zip.service.ZipVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/zip/EgovZipManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/zip/EgovZipManage_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ZipManageDAO">
+<mapper namespace="egovframework.com.sym.ccm.zip.service.impl.ZipManageMapper">
 
 	<select id="selectZipList" parameterType="egovframework.com.sym.ccm.zip.service.ZipVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/zip/EgovZipManage_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/zip/EgovZipManage_SQL_postgres.xml
@@ -5,7 +5,7 @@
 --><!--Converted at: Wed May 11 15:50:39 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ZipManageDAO">
+<mapper namespace="egovframework.com.sym.ccm.zip.service.impl.ZipManageMapper">
 
 	<select id="selectZipList" parameterType="egovframework.com.sym.ccm.zip.service.ZipVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/zip/EgovZipManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/zip/EgovZipManage_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ZipManageDAO">
+<mapper namespace="egovframework.com.sym.ccm.zip.service.impl.ZipManageMapper">
 
 	<select id="selectZipList" parameterType="egovframework.com.sym.ccm.zip.service.ZipVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/spring/com/context-mapper.xml
+++ b/src/main/resources/egovframework/spring/com/context-mapper.xml
@@ -21,5 +21,11 @@
 	<bean id="egov.sqlSessionTemplate" class="org.mybatis.spring.SqlSessionTemplate">
 		<constructor-arg ref="egov.sqlSession"/>
 	</bean>
-	
+
+	<!-- @Mapper 인터페이스 스캔 설정 -->
+	<bean class="org.egovframe.rte.psl.dataaccess.mapper.MapperConfigurer">
+		<property name="basePackage" value="egovframework.com" />
+		<property name="sqlSessionFactoryBeanName" value="egov.sqlSession" />
+	</bean>
+
 </beans>


### PR DESCRIPTION
## 변경 사유

eGovFrame 5.0에서 도입된 `@EgovMapper` 인터페이스 방식을 활용하여,
`EgovComAbstractDAO` 상속 기반의 `ZipManageDAO`와 `RdnmadZipDAO`를
MyBatis 매퍼 인터페이스 방식으로 전환합니다.

## 변경 내용

- `ZipManageMapper` 인터페이스 신설 — `@EgovMapper("ZipManageMapper")` 적용
- `RdnmadZipMapper` 인터페이스 신설 — `@EgovMapper("RdnmadZipMapper")` 적용
- `ZipManageDAO`: `EgovComAbstractDAO` 상속 제거, `ZipManageMapper`를 `@Resource`로 주입받아 위임
- `RdnmadZipDAO`: `EgovComAbstractDAO` 상속 제거, `RdnmadZipMapper`를 `@Resource`로 주입받아 위임
- `EgovZipManage_SQL_*.xml` (8개): `namespace="ZipManageDAO"` → `namespace="egovframework.com.sym.ccm.zip.service.impl.ZipManageMapper"`
- `EgovRdnmadZip_SQL_*.xml` (8개): `namespace="RdnmadZipDAO"` → `namespace="egovframework.com.sym.ccm.zip.service.impl.RdnmadZipMapper"`
- `context-mapper.xml`: `MapperConfigurer` 빈 추가 (`basePackage: egovframework.com`, `sqlSessionFactoryBeanName: egov.sqlSession`)

## 테스트

- `mvn -DskipTests compile` — 기존 오류 수(149개) 변동 없음 확인

## 체크리스트

- [x] 단일 주제만 다룸 (다른 변경 없음)
- [x] 기존 동작에 영향 없음 (DAO 공개 메서드 시그니처 동일)
- [x] 컴파일 통과 확인
