### PR TITLE
[refactor][5.0.x][공통컴포넌트] sym/sym/bak BackupOpertDao·BackupResultDao @EgovMapper 인터페이스 방식 전환

### DIFF
--- a/src/main/java/egovframework/com/sym/sym/bak/service/impl/BackupOpertDao.java
+++ b/src/main/java/egovframework/com/sym/sym/bak/service/impl/BackupOpertDao.java
@@ -1,11 +1,12 @@
 package egovframework.com.sym.sym.bak.service.impl;
+
 import java.util.List;
 
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.sym.sym.bak.service.BackupOpert;
 import egovframework.com.sym.sym.bak.service.BackupSchdulDfk;
+import jakarta.annotation.Resource;
 
 /**
  * 백업작업관리에 대한 DAO 클래스를 정의한다.
@@ -24,127 +25,119 @@ import egovframework.com.sym.sym.bak.service.BackupSchdulDfk;
  * </pre>
  */
 @Repository("backupOpertDao")
-public class BackupOpertDao extends EgovComAbstractDAO {
+public class BackupOpertDao {
 
-	/**
-	 * 백업작업을 삭제한다.
-	 *
-	 * @param backupOpert    삭제할 백업작업 VO
-	 * @exception Exception Exception
-	 */
-	public void deleteBackupOpert(BackupOpert backupOpert)
-	  throws Exception{
-		// slave 테이블 삭제
-		delete("BackupOpertDao.deleteBackupSchdulDfk", backupOpert.getBackupOpertId());
-		// master 테이블 삭제
-		delete("BackupOpertDao.deleteBackupOpert", backupOpert);
+  @Resource(name = "backupOpertMapper")
+  private BackupOpertMapper backupOpertMapper;
 
-	}
+  /**
+   * 백업작업을 삭제한다.
+   *
+   * @param backupOpert 삭제할 백업작업 VO
+   * @exception Exception Exception
+   */
+  public void deleteBackupOpert(BackupOpert backupOpert) throws Exception {
+    // slave 테이블 삭제
+    backupOpertMapper.deleteBackupSchdulDfk(backupOpert.getBackupOpertId());
+    // master 테이블 삭제
+    backupOpertMapper.deleteBackupOpert(backupOpert);
+  }
 
-	/**
-	 * 백업작업을 등록한다.
-	 *
-	 * @param backupOpert 저장할 백업작업 VO
-	 * @exception Exception Exception
-	 */
-	public void insertBackupOpert(BackupOpert backupOpert)
-	  throws Exception{
-		// master 테이블 인서트
-		insert("BackupOpertDao.insertBackupOpert", backupOpert);
-		// slave 테이블 인서트
-		if (backupOpert.getExecutSchdulDfkSes() != null && backupOpert.getExecutSchdulDfkSes().length != 0) {
-			String backupOpertId = backupOpert.getBackupOpertId();
-			String [] dfkSes = backupOpert.getExecutSchdulDfkSes();
-			for (String element : dfkSes) {
-				BackupSchdulDfk backupSchdulDfk = new BackupSchdulDfk();
-				backupSchdulDfk.setBackupOpertId(backupOpertId);
-				backupSchdulDfk.setExecutSchdulDfkSe(element);
-				insert("BackupOpertDao.insertBackupSchdulDfk", backupSchdulDfk);
-			}
-		}
-
-	}
-
-	/**
-	 * 백업작업정보를 상세조회 한다.
-	 * @return 백업작업정보
-	 *
-	 * @param backupOpert    조회할 KEY가 있는 백업작업 VO
-	 * @exception Exception Exception
-	 */
-	public BackupOpert selectBackupOpert(BackupOpert backupOpert)
-	  throws Exception{
-		BackupOpert result = (BackupOpert)selectOne("BackupOpertDao.selectBackupOpert", backupOpert);
-		// 스케줄요일정보를 가져온다.
-		List<BackupSchdulDfk> dfkSeList = selectList("BackupOpertDao.selectBackupSchdulDfkList", result.getBackupOpertId());
-		String [] dfkSes = new String [dfkSeList.size()];
-		for (int j = 0; j < dfkSeList.size(); j++) {
-			dfkSes[j] = dfkSeList.get(j).getExecutSchdulDfkSe();
-		}
-		result.setExecutSchdulDfkSes(dfkSes);
-		// 화면표시용 실행스케줄 속성을 만든다.
-		result.makeExecutSchdul(dfkSeList);
-
-		return result ;
-	}
-
-	/**
-     * 백업작업정보목록을 조회한다.
-     *
-     * @return 백업작업목록
-     *
-     * @param searchVO 조회조건이 저장된 VO
-     * @exception Exception Exception
-     */
-    public List<BackupOpert> selectBackupOpertList(BackupOpert searchVO) throws Exception {
-        List<BackupOpert> resultList = selectList("BackupOpertDao.selectBackupOpertList", searchVO);
-
-        for (BackupOpert result : resultList) {
-            // 스케줄요일정보를 가져온다.
-            List<BackupSchdulDfk> dfkSeList = selectList("BackupOpertDao.selectBackupSchdulDfkList",
-                    result.getBackupOpertId());
-            result.setExecutSchdulDfkSes(
-                    dfkSeList.stream().map(BackupSchdulDfk::getExecutSchdulDfkSe).toArray(String[]::new));
-            // 화면표시용 실행스케줄 속성을 만든다.
-            result.makeExecutSchdul(dfkSeList);
-        }
-        return resultList;
+  /**
+   * 백업작업을 등록한다.
+   *
+   * @param backupOpert 저장할 백업작업 VO
+   * @exception Exception Exception
+   */
+  public void insertBackupOpert(BackupOpert backupOpert) throws Exception {
+    // master 테이블 인서트
+    backupOpertMapper.insertBackupOpert(backupOpert);
+    // slave 테이블 인서트
+    if (backupOpert.getExecutSchdulDfkSes() != null && backupOpert.getExecutSchdulDfkSes().length != 0) {
+      String backupOpertId = backupOpert.getBackupOpertId();
+      String[] dfkSes = backupOpert.getExecutSchdulDfkSes();
+      for (String element : dfkSes) {
+        BackupSchdulDfk backupSchdulDfk = new BackupSchdulDfk();
+        backupSchdulDfk.setBackupOpertId(backupOpertId);
+        backupSchdulDfk.setExecutSchdulDfkSe(element);
+        backupOpertMapper.insertBackupSchdulDfk(backupSchdulDfk);
+      }
     }
+  }
 
-	/**
-	 * 백업작업 목록 전체 건수를(을) 조회한다.
-	 * @return 목록건수
-	 *
-	 * @param searchVO    조회할 정보가 담긴 VO
-	 * @exception Exception Exception
-	 */
-	public int selectBackupOpertListCnt(BackupOpert searchVO)
-	  throws Exception{
-		return (Integer)selectOne("BackupOpertDao.selectBackupOpertListCnt", searchVO);
-	}
+  /**
+   * 백업작업정보를 상세조회한다.
+   *
+   * @param backupOpert 조회할 KEY가 있는 백업작업 VO
+   * @return 백업작업정보
+   * @exception Exception Exception
+   */
+  public BackupOpert selectBackupOpert(BackupOpert backupOpert) throws Exception {
+    BackupOpert result = backupOpertMapper.selectBackupOpert(backupOpert);
+    // 스케줄요일정보를 가져온다.
+    List<BackupSchdulDfk> dfkSeList = backupOpertMapper.selectBackupSchdulDfkList(result.getBackupOpertId());
+    String[] dfkSes = new String[dfkSeList.size()];
+    for (int j = 0; j < dfkSeList.size(); j++) {
+      dfkSes[j] = dfkSeList.get(j).getExecutSchdulDfkSe();
+    }
+    result.setExecutSchdulDfkSes(dfkSes);
+    // 화면표시용 실행스케줄 속성을 만든다.
+    result.makeExecutSchdul(dfkSeList);
+    return result;
+  }
 
-	/**
-	 * 백업작업정보를 수정한다.
-	 *
-	 * @param backupOpert    수정대상 백업작업 VO
-	 * @exception Exception Exception
-	 */
-	public void updateBackupOpert(BackupOpert backupOpert)
-	  throws Exception{
-		update("BackupOpertDao.updateBackupOpert", backupOpert);
-		// slave 테이블 삭제
-		delete("BackupOpertDao.deleteBackupSchdulDfk", backupOpert.getBackupOpertId());
-		// slave 테이블 인서트
-		if (backupOpert.getExecutSchdulDfkSes() != null && backupOpert.getExecutSchdulDfkSes().length != 0) {
-			String backupOpertId = backupOpert.getBackupOpertId();
-			String [] dfkSes = backupOpert.getExecutSchdulDfkSes();
-			for (String element : dfkSes) {
-				BackupSchdulDfk backupSchdulDfk = new BackupSchdulDfk();
-				backupSchdulDfk.setBackupOpertId(backupOpertId);
-				backupSchdulDfk.setExecutSchdulDfkSe(element);
-				insert("BackupOpertDao.insertBackupSchdulDfk", backupSchdulDfk);
-			}
-		}
-	}
+  /**
+   * 백업작업정보 목록을 조회한다.
+   *
+   * @param searchVO 조회조건이 저장된 VO
+   * @return 백업작업 목록
+   * @exception Exception Exception
+   */
+  public List<BackupOpert> selectBackupOpertList(BackupOpert searchVO) throws Exception {
+    List<BackupOpert> resultList = backupOpertMapper.selectBackupOpertList(searchVO);
+    for (BackupOpert result : resultList) {
+      // 스케줄요일정보를 가져온다.
+      List<BackupSchdulDfk> dfkSeList = backupOpertMapper.selectBackupSchdulDfkList(result.getBackupOpertId());
+      result.setExecutSchdulDfkSes(
+          dfkSeList.stream().map(BackupSchdulDfk::getExecutSchdulDfkSe).toArray(String[]::new));
+      // 화면표시용 실행스케줄 속성을 만든다.
+      result.makeExecutSchdul(dfkSeList);
+    }
+    return resultList;
+  }
+
+  /**
+   * 백업작업 목록 전체 건수를 조회한다.
+   *
+   * @param searchVO 조회할 정보가 담긴 VO
+   * @return 목록건수
+   * @exception Exception Exception
+   */
+  public int selectBackupOpertListCnt(BackupOpert searchVO) throws Exception {
+    return backupOpertMapper.selectBackupOpertListCnt(searchVO);
+  }
+
+  /**
+   * 백업작업정보를 수정한다.
+   *
+   * @param backupOpert 수정대상 백업작업 VO
+   * @exception Exception Exception
+   */
+  public void updateBackupOpert(BackupOpert backupOpert) throws Exception {
+    backupOpertMapper.updateBackupOpert(backupOpert);
+    // slave 테이블 삭제
+    backupOpertMapper.deleteBackupSchdulDfk(backupOpert.getBackupOpertId());
+    // slave 테이블 인서트
+    if (backupOpert.getExecutSchdulDfkSes() != null && backupOpert.getExecutSchdulDfkSes().length != 0) {
+      String backupOpertId = backupOpert.getBackupOpertId();
+      String[] dfkSes = backupOpert.getExecutSchdulDfkSes();
+      for (String element : dfkSes) {
+        BackupSchdulDfk backupSchdulDfk = new BackupSchdulDfk();
+        backupSchdulDfk.setBackupOpertId(backupOpertId);
+        backupSchdulDfk.setExecutSchdulDfkSe(element);
+        backupOpertMapper.insertBackupSchdulDfk(backupSchdulDfk);
+      }
+    }
+  }
 
 }

--- a/src/main/java/egovframework/com/sym/sym/bak/service/impl/BackupOpertMapper.java
+++ b/src/main/java/egovframework/com/sym/sym/bak/service/impl/BackupOpertMapper.java
@@ -1,0 +1,95 @@
+package egovframework.com.sym.sym.bak.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.sym.sym.bak.service.BackupOpert;
+import egovframework.com.sym.sym.bak.service.BackupSchdulDfk;
+
+/**
+ * 백업작업관리에 대한 Mapper 인터페이스를 정의한다.
+ *
+ * @author 김진만
+ * @since 2010.06.21
+ * @version 1.0
+ * @see
+ * <pre>
+ * == 개정이력(Modification Information) ==
+ *
+ *   수정일       수정자           수정내용
+ *  -------     --------    ---------------------------
+ *  2010.06.21   김진만     최초 생성
+ * </pre>
+ */
+@EgovMapper("backupOpertMapper")
+public interface BackupOpertMapper {
+
+  /**
+   * 백업작업을 삭제한다(논리 삭제).
+   *
+   * @param backupOpert 삭제할 백업작업 VO
+   */
+  void deleteBackupOpert(BackupOpert backupOpert);
+
+  /**
+   * 백업스케줄요일정보를 삭제한다.
+   *
+   * @param backupOpertId 삭제할 백업작업 ID
+   */
+  void deleteBackupSchdulDfk(String backupOpertId);
+
+  /**
+   * 백업작업을 등록한다.
+   *
+   * @param backupOpert 저장할 백업작업 VO
+   */
+  void insertBackupOpert(BackupOpert backupOpert);
+
+  /**
+   * 백업스케줄요일정보를 등록한다.
+   *
+   * @param backupSchdulDfk 저장할 스케줄요일 VO
+   */
+  void insertBackupSchdulDfk(BackupSchdulDfk backupSchdulDfk);
+
+  /**
+   * 백업작업정보를 상세조회한다.
+   *
+   * @param backupOpert 조회할 KEY가 있는 백업작업 VO
+   * @return 백업작업정보
+   */
+  BackupOpert selectBackupOpert(BackupOpert backupOpert);
+
+  /**
+   * 백업스케줄요일 목록을 조회한다.
+   *
+   * @param backupOpertId 조회할 백업작업 ID
+   * @return 스케줄요일 목록
+   */
+  List<BackupSchdulDfk> selectBackupSchdulDfkList(String backupOpertId);
+
+  /**
+   * 백업작업정보 목록을 조회한다.
+   *
+   * @param searchVO 조회조건이 저장된 VO
+   * @return 백업작업 목록
+   */
+  List<BackupOpert> selectBackupOpertList(BackupOpert searchVO);
+
+  /**
+   * 백업작업 목록 전체 건수를 조회한다.
+   *
+   * @param searchVO 조회할 정보가 담긴 VO
+   * @return 목록건수
+   */
+  int selectBackupOpertListCnt(BackupOpert searchVO);
+
+  /**
+   * 백업작업정보를 수정한다.
+   *
+   * @param backupOpert 수정대상 백업작업 VO
+   */
+  void updateBackupOpert(BackupOpert backupOpert);
+
+}

--- a/src/main/java/egovframework/com/sym/sym/bak/service/impl/BackupResultDao.java
+++ b/src/main/java/egovframework/com/sym/sym/bak/service/impl/BackupResultDao.java
@@ -1,10 +1,11 @@
 package egovframework.com.sym.sym.bak.service.impl;
+
 import java.util.List;
 
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.sym.sym.bak.service.BackupResult;
+import jakarta.annotation.Resource;
 
 /**
  * 백업결과관리에 대한 DAO 클래스를 정의한다.
@@ -23,75 +24,72 @@ import egovframework.com.sym.sym.bak.service.BackupResult;
  * </pre>
  */
 @Repository("backupResultDao")
-public class BackupResultDao extends EgovComAbstractDAO {
+public class BackupResultDao {
 
-	/**
-	 * 백업결과을 삭제한다.
-	 *
-	 * @param backupResult    삭제할 백업결과 VO
-	 * @exception Exception Exception
-	 */
-	public void deleteBackupResult(BackupResult backupResult)
-	  throws Exception{
-		delete("BackupResultDao.deleteBackupResult", backupResult);
-	}
+  @Resource(name = "backupResultMapper")
+  private BackupResultMapper backupResultMapper;
 
-	/**
-	 * 백업결과을 등록한다.
-	 *
-	 * @param backupResult 저장할 백업결과 VO
-	 * @exception Exception Exception
-	 */
-	public void insertBackupResult(BackupResult backupResult)
-	  throws Exception{
-		insert("BackupResultDao.insertBackupResult", backupResult);
-	}
+  /**
+   * 백업결과를 삭제한다.
+   *
+   * @param backupResult 삭제할 백업결과 VO
+   * @exception Exception Exception
+   */
+  public void deleteBackupResult(BackupResult backupResult) throws Exception {
+    backupResultMapper.deleteBackupResult(backupResult);
+  }
 
-	/**
-	 * 백업결과정보를 상세조회 한다.
-	 * @return 백업결과정보
-	 *
-	 * @param backupResult    조회할 KEY가 있는 백업결과 VO
-	 * @exception Exception Exception
-	 */
-	public BackupResult selectBackupResult(BackupResult backupResult)
-	  throws Exception{
-		return (BackupResult)selectOne("BackupResultDao.selectBackupResult", backupResult);
-	}
+  /**
+   * 백업결과를 등록한다.
+   *
+   * @param backupResult 저장할 백업결과 VO
+   * @exception Exception Exception
+   */
+  public void insertBackupResult(BackupResult backupResult) throws Exception {
+    backupResultMapper.insertBackupResult(backupResult);
+  }
 
-	/**
-	 * 백업결과정보목록을  조회한다.
-	 * @return 백업결과목록
-	 *
-	 * @param searchVO    조회조건이 저장된 VO
-	 * @exception Exception Exception
-	 */
-	public List<BackupResult> selectBackupResultList(BackupResult searchVO)
-	  throws Exception{
-		return selectList("BackupResultDao.selectBackupResultList", searchVO);
-	}
+  /**
+   * 백업결과정보를 상세조회한다.
+   *
+   * @param backupResult 조회할 KEY가 있는 백업결과 VO
+   * @return 백업결과정보
+   * @exception Exception Exception
+   */
+  public BackupResult selectBackupResult(BackupResult backupResult) throws Exception {
+    return backupResultMapper.selectBackupResult(backupResult);
+  }
 
-	/**
-	 * 백업결과 목록 전체 건수를(을) 조회한다.
-	 * @return 목록건수
-	 *
-	 * @param searchVO    조회할 정보가 담긴 VO
-	 * @exception Exception Exception
-	 */
-	public int selectBackupResultListCnt(BackupResult searchVO)
-	  throws Exception{
-		return (Integer)selectOne("BackupResultDao.selectBackupResultListCnt", searchVO);
-	}
+  /**
+   * 백업결과정보 목록을 조회한다.
+   *
+   * @param searchVO 조회조건이 저장된 VO
+   * @return 백업결과 목록
+   * @exception Exception Exception
+   */
+  public List<BackupResult> selectBackupResultList(BackupResult searchVO) throws Exception {
+    return backupResultMapper.selectBackupResultList(searchVO);
+  }
 
-	/**
-	 * 백업결과정보를 수정한다.
-	 *
-	 * @param backupResult    수정대상 백업결과 VO
-	 * @exception Exception Exception
-	 */
-	public void updateBackupResult(BackupResult backupResult)
-	  throws Exception{
-		update("BackupResultDao.updateBackupResult", backupResult);
-	}
+  /**
+   * 백업결과 목록 전체 건수를 조회한다.
+   *
+   * @param searchVO 조회할 정보가 담긴 VO
+   * @return 목록건수
+   * @exception Exception Exception
+   */
+  public int selectBackupResultListCnt(BackupResult searchVO) throws Exception {
+    return backupResultMapper.selectBackupResultListCnt(searchVO);
+  }
+
+  /**
+   * 백업결과정보를 수정한다.
+   *
+   * @param backupResult 수정대상 백업결과 VO
+   * @exception Exception Exception
+   */
+  public void updateBackupResult(BackupResult backupResult) throws Exception {
+    backupResultMapper.updateBackupResult(backupResult);
+  }
 
 }

--- a/src/main/java/egovframework/com/sym/sym/bak/service/impl/BackupResultMapper.java
+++ b/src/main/java/egovframework/com/sym/sym/bak/service/impl/BackupResultMapper.java
@@ -1,0 +1,72 @@
+package egovframework.com.sym.sym.bak.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.sym.sym.bak.service.BackupResult;
+
+/**
+ * 백업결과관리에 대한 Mapper 인터페이스를 정의한다.
+ *
+ * @author 김진만
+ * @since 2010.06.21
+ * @version 1.0
+ * @see
+ * <pre>
+ * == 개정이력(Modification Information) ==
+ *
+ *   수정일       수정자           수정내용
+ *  -------     --------    ---------------------------
+ *  2010.06.21   김진만     최초 생성
+ * </pre>
+ */
+@EgovMapper("backupResultMapper")
+public interface BackupResultMapper {
+
+  /**
+   * 백업결과를 삭제한다.
+   *
+   * @param backupResult 삭제할 백업결과 VO
+   */
+  void deleteBackupResult(BackupResult backupResult);
+
+  /**
+   * 백업결과를 등록한다.
+   *
+   * @param backupResult 저장할 백업결과 VO
+   */
+  void insertBackupResult(BackupResult backupResult);
+
+  /**
+   * 백업결과정보를 상세조회한다.
+   *
+   * @param backupResult 조회할 KEY가 있는 백업결과 VO
+   * @return 백업결과정보
+   */
+  BackupResult selectBackupResult(BackupResult backupResult);
+
+  /**
+   * 백업결과정보 목록을 조회한다.
+   *
+   * @param searchVO 조회조건이 저장된 VO
+   * @return 백업결과 목록
+   */
+  List<BackupResult> selectBackupResultList(BackupResult searchVO);
+
+  /**
+   * 백업결과 목록 전체 건수를 조회한다.
+   *
+   * @param searchVO 조회할 정보가 담긴 VO
+   * @return 목록건수
+   */
+  int selectBackupResultListCnt(BackupResult searchVO);
+
+  /**
+   * 백업결과정보를 수정한다.
+   *
+   * @param backupResult 수정대상 백업결과 VO
+   */
+  void updateBackupResult(BackupResult backupResult);
+
+}

--- a/src/main/resources/egovframework/mapper/com/sym/sym/bak/EgovBackupOpert_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/sym/bak/EgovBackupOpert_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BackupOpertDao">
+<mapper namespace="egovframework.com.sym.sym.bak.service.impl.BackupOpertMapper">
     
     <resultMap id="backupOpertResult" type="egovframework.com.sym.sym.bak.service.BackupOpert">
         <result property="backupOpertId" column="BACKUP_OPERT_ID"/>

--- a/src/main/resources/egovframework/mapper/com/sym/sym/bak/EgovBackupOpert_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/sym/bak/EgovBackupOpert_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BackupOpertDao">
+<mapper namespace="egovframework.com.sym.sym.bak.service.impl.BackupOpertMapper">
     
     <resultMap id="backupOpertResult" type="egovframework.com.sym.sym.bak.service.BackupOpert">
         <result property="backupOpertId" column="BACKUP_OPERT_ID"/>

--- a/src/main/resources/egovframework/mapper/com/sym/sym/bak/EgovBackupOpert_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/sym/bak/EgovBackupOpert_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BackupOpertDao">
+<mapper namespace="egovframework.com.sym.sym.bak.service.impl.BackupOpertMapper">
     
     <resultMap id="backupOpertResult" type="egovframework.com.sym.sym.bak.service.BackupOpert">
         <result property="backupOpertId" column="BACKUP_OPERT_ID"/>

--- a/src/main/resources/egovframework/mapper/com/sym/sym/bak/EgovBackupOpert_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/sym/bak/EgovBackupOpert_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BackupOpertDao">
+<mapper namespace="egovframework.com.sym.sym.bak.service.impl.BackupOpertMapper">
    
     <resultMap id="backupOpertResult" type="egovframework.com.sym.sym.bak.service.BackupOpert">
         <result property="backupOpertId" column="BACKUP_OPERT_ID"/>

--- a/src/main/resources/egovframework/mapper/com/sym/sym/bak/EgovBackupOpert_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/sym/bak/EgovBackupOpert_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BackupOpertDao">
+<mapper namespace="egovframework.com.sym.sym.bak.service.impl.BackupOpertMapper">
    
     <resultMap id="backupOpertResult" type="egovframework.com.sym.sym.bak.service.BackupOpert">
         <result property="backupOpertId" column="BACKUP_OPERT_ID"/>

--- a/src/main/resources/egovframework/mapper/com/sym/sym/bak/EgovBackupOpert_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/sym/bak/EgovBackupOpert_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BackupOpertDao">
+<mapper namespace="egovframework.com.sym.sym.bak.service.impl.BackupOpertMapper">
     
     <resultMap id="backupOpertResult" type="egovframework.com.sym.sym.bak.service.BackupOpert">
         <result property="backupOpertId" column="BACKUP_OPERT_ID"/>

--- a/src/main/resources/egovframework/mapper/com/sym/sym/bak/EgovBackupOpert_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/sym/bak/EgovBackupOpert_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BackupOpertDao">
+<mapper namespace="egovframework.com.sym.sym.bak.service.impl.BackupOpertMapper">
    
     <resultMap id="backupOpertResult" type="egovframework.com.sym.sym.bak.service.BackupOpert">
         <result property="backupOpertId" column="BACKUP_OPERT_ID"/>

--- a/src/main/resources/egovframework/mapper/com/sym/sym/bak/EgovBackupOpert_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/sym/bak/EgovBackupOpert_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BackupOpertDao">
+<mapper namespace="egovframework.com.sym.sym.bak.service.impl.BackupOpertMapper">
     
     <resultMap id="backupOpertResult" type="egovframework.com.sym.sym.bak.service.BackupOpert">
         <result property="backupOpertId" column="BACKUP_OPERT_ID"/>

--- a/src/main/resources/egovframework/mapper/com/sym/sym/bak/EgovBackupResult_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/sym/bak/EgovBackupResult_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BackupResultDao">
+<mapper namespace="egovframework.com.sym.sym.bak.service.impl.BackupResultMapper">
 
     <resultMap id="backupResultResult" type="egovframework.com.sym.sym.bak.service.BackupResult">
         <result property="backupResultId" column="BACKUP_RESULT_ID"/>

--- a/src/main/resources/egovframework/mapper/com/sym/sym/bak/EgovBackupResult_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/sym/bak/EgovBackupResult_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BackupResultDao">
+<mapper namespace="egovframework.com.sym.sym.bak.service.impl.BackupResultMapper">
     
     <resultMap id="backupResultResult" type="egovframework.com.sym.sym.bak.service.BackupResult">
         <result property="backupResultId" column="BACKUP_RESULT_ID"/>

--- a/src/main/resources/egovframework/mapper/com/sym/sym/bak/EgovBackupResult_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/sym/bak/EgovBackupResult_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BackupResultDao">
+<mapper namespace="egovframework.com.sym.sym.bak.service.impl.BackupResultMapper">
 
     <resultMap id="backupResultResult" type="egovframework.com.sym.sym.bak.service.BackupResult">
         <result property="backupResultId" column="BACKUP_RESULT_ID"/>

--- a/src/main/resources/egovframework/mapper/com/sym/sym/bak/EgovBackupResult_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/sym/bak/EgovBackupResult_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BackupResultDao">
+<mapper namespace="egovframework.com.sym.sym.bak.service.impl.BackupResultMapper">
 
     <resultMap id="backupResultResult" type="egovframework.com.sym.sym.bak.service.BackupResult">
         <result property="backupResultId" column="BACKUP_RESULT_ID"/>

--- a/src/main/resources/egovframework/mapper/com/sym/sym/bak/EgovBackupResult_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/sym/bak/EgovBackupResult_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BackupResultDao">
+<mapper namespace="egovframework.com.sym.sym.bak.service.impl.BackupResultMapper">
 
     <resultMap id="backupResultResult" type="egovframework.com.sym.sym.bak.service.BackupResult">
         <result property="backupResultId" column="BACKUP_RESULT_ID"/>

--- a/src/main/resources/egovframework/mapper/com/sym/sym/bak/EgovBackupResult_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/sym/bak/EgovBackupResult_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BackupResultDao">
+<mapper namespace="egovframework.com.sym.sym.bak.service.impl.BackupResultMapper">
     
     <resultMap id="backupResultResult" type="egovframework.com.sym.sym.bak.service.BackupResult">
         <result property="backupResultId" column="BACKUP_RESULT_ID"/>

--- a/src/main/resources/egovframework/mapper/com/sym/sym/bak/EgovBackupResult_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/sym/bak/EgovBackupResult_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BackupResultDao">
+<mapper namespace="egovframework.com.sym.sym.bak.service.impl.BackupResultMapper">
 
     <resultMap id="backupResultResult" type="egovframework.com.sym.sym.bak.service.BackupResult">
         <result property="backupResultId" column="BACKUP_RESULT_ID"/>

--- a/src/main/resources/egovframework/mapper/com/sym/sym/bak/EgovBackupResult_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/sym/bak/EgovBackupResult_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BackupResultDao">
+<mapper namespace="egovframework.com.sym.sym.bak.service.impl.BackupResultMapper">
     
     <resultMap id="backupResultResult" type="egovframework.com.sym.sym.bak.service.BackupResult">
         <result property="backupResultId" column="BACKUP_RESULT_ID"/>

--- a/src/main/resources/egovframework/spring/com/context-mapper.xml
+++ b/src/main/resources/egovframework/spring/com/context-mapper.xml
@@ -21,5 +21,11 @@
 	<bean id="egov.sqlSessionTemplate" class="org.mybatis.spring.SqlSessionTemplate">
 		<constructor-arg ref="egov.sqlSession"/>
 	</bean>
-	
+
+	<!-- @EgovMapper 인터페이스 자동 스캔 -->
+	<bean class="org.egovframe.rte.psl.dataaccess.mapper.MapperConfigurer">
+		<property name="basePackage" value="egovframework.com"/>
+		<property name="sqlSessionFactoryBeanName" value="egov.sqlSession"/>
+	</bean>
+
 </beans>


### PR DESCRIPTION
sym/sym/bak 모듈의 BackupOpertDao, BackupResultDao를 eGovFrame 5.0 @EgovMapper 인터페이스 방식으로 전환합니다.

### 변경 내용

- `BackupOpertMapper` 인터페이스 신설 (`@EgovMapper` 적용)
  - deleteBackupOpert, deleteBackupSchdulDfk, insertBackupOpert, insertBackupSchdulDfk
  - selectBackupOpert, selectBackupSchdulDfkList, selectBackupOpertList, selectBackupOpertListCnt
  - updateBackupOpert
- `BackupResultMapper` 인터페이스 신설 (`@EgovMapper` 적용)
  - deleteBackupResult, insertBackupResult, selectBackupResult, selectBackupResultList, selectBackupResultListCnt, updateBackupResult
- `BackupOpertDao`: `EgovComAbstractDAO` 상속 제거, `@Resource`로 주입된 `BackupOpertMapper`에 위임
- `BackupResultDao`: `EgovComAbstractDAO` 상속 제거, `@Resource`로 주입된 `BackupResultMapper`에 위임
- `EgovBackupOpert_SQL_*.xml` (8종), `EgovBackupResult_SQL_*.xml` (8종): mapper namespace를 FQN으로 변경
- `context-mapper.xml`: `MapperConfigurer` 빈 추가로 `@EgovMapper` 인터페이스 자동 스캔 활성화

### 영향 범위

- `EgovBackupOpertServiceImpl`, `EgovBackupResultServiceImpl`은 `BackupOpertDao`, `BackupResultDao`를 그대로 주입받으므로 변경 없음
- 기존 XML SQL 구문은 그대로 유지되며 namespace 변경만 적용

### 테스트

- `mvn -DskipTests compile` 빌드 정상 (기존 베이스라인 에러 수 149개 유지, 본 변경으로 인한 신규 에러 없음)

- [ ] 단일 주제만 다룸 (다른 변경 없음)
- [ ] 5.x 다른 브랜치용 PR이 필요한 경우 후속 PR 링크 명시
- [ ] 기존 동작에 영향 없음
- [ ] 테스트 통과 확인
