### PR TITLE
[refactor][공통컴포넌트] uss/ion/evt EventManageDAO @EgovMapper 인터페이스 매핑

### DIFF
--- a/src/main/java/egovframework/com/uss/ion/evt/service/impl/EgovEventManageServiceImpl.java
+++ b/src/main/java/egovframework/com/uss/ion/evt/service/impl/EgovEventManageServiceImpl.java
@@ -41,7 +41,7 @@ import jakarta.annotation.Resource;
 public class EgovEventManageServiceImpl extends EgovAbstractServiceImpl implements EgovEventManageService {
 
 	@Resource(name="eventManageDAO")
-    private EventManageDAO eventManageDAO;
+	private EventManageDAO eventManageDAO;
 
     /** ID Generation */
 	@Resource(name="egovEventManageIdGnrService")

--- a/src/main/java/egovframework/com/uss/ion/evt/service/impl/EventManageDAO.java
+++ b/src/main/java/egovframework/com/uss/ion/evt/service/impl/EventManageDAO.java
@@ -2,181 +2,149 @@ package egovframework.com.uss.ion.evt.service.impl;
 
 import java.util.List;
 
-import org.springframework.stereotype.Repository;
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.uss.ion.evt.service.EventAtdrn;
 import egovframework.com.uss.ion.evt.service.EventManage;
 import egovframework.com.uss.ion.evt.service.EventManageVO;
 
 /**
  * 개요
- * - 행사관리에 대한 DAO 클래스를 정의한다.
- * 
+ * - 행사관리에 대한 DAO 인터페이스를 정의한다.
+ *
  * 상세내용
  * - 행사관리에 대한 등록, 수정, 삭제, 조회, 반영확인 기능을 제공한다.
  * - 행사관리의 조회기능은 목록조회, 상세조회로 구분된다.
  * @author 이용
  * @version 1.0
  * @created 06-15-2010 오후 2:08:56
+ *
+ * <pre>
+ *  == 개정이력(Modification Information) ==
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2010.06.15  이용           최초 생성
+ *   2026.05.28  dasomel        @EgovMapper 인터페이스 방식으로 전환
+ *
+ * </pre>
  */
-
-@Repository("eventManageDAO")
-public class EventManageDAO extends EgovComAbstractDAO {
+@EgovMapper("eventManageDAO")
+public interface EventManageDAO {
 
 	/**
 	 * 행사관리정보를 관리하기 위해 등록된 행사관리 목록을 조회한다.
 	 * @param eventManageVO - 행사관리 VO
 	 * @return List - 행사관리 목록
-	 */	
-	public List<EventManageVO> selectEventManageList(EventManageVO eventManageVO) throws Exception {
-		return selectList("eventManageDAO.selectEventManageList", eventManageVO);
-	}
+	 */
+	List<EventManageVO> selectEventManageList(EventManageVO eventManageVO);
 
-    /**
+	/**
 	 * 행사관리목록 총 개수를 조회한다.
 	 * @param eventManageVO - 행사관리 VO
 	 * @return int
-	 * @exception Exception
 	 */
-    public int selectEventManageListTotCnt(EventManageVO eventManageVO) throws Exception {
-        return (Integer)selectOne("eventManageDAO.selectEventManageListTotCnt", eventManageVO);
-    }
+	int selectEventManageListTotCnt(EventManageVO eventManageVO);
 
 	/**
 	 * 등록된 행사관리의 상세정보를 조회한다.
 	 * @param eventManageVO - 행사관리 VO
 	 * @return EventManageVO - 행사관리 VO
 	 */
-	public EventManageVO selectEventManage(EventManageVO eventManageVO)  throws Exception {
-		return (EventManageVO) selectOne("eventManageDAO.selectEventManage", eventManageVO);
-	}
+	EventManageVO selectEventManage(EventManageVO eventManageVO);
 
 	/**
 	 * 행사관리정보를 신규로 등록한다.
 	 * @param eventManage - 행사관리 model
 	 */
-	public void insertEventManage(EventManage eventManage) throws Exception {
-		insert("eventManageDAO.insertEventManage", eventManage);
-	}
+	void insertEventManage(EventManage eventManage);
 
 	/**
 	 * 기 등록된 행사관리정보를 수정한다.
 	 * @param eventManage - 행사관리 model
 	 */
-	public void updtEventManage(EventManage eventManage) throws Exception {
-		update("eventManageDAO.updateEventManage", eventManage);
-	}
+	void updtEventManage(EventManage eventManage);
 
 	/**
 	 * 기 등록된 행사관리정보를 삭제한다.
 	 * @param eventManage - 행사관리 model
 	 */
-	public void deleteEventManage(EventManage eventManage) throws Exception {
-        delete("eventManageDAO.deleteEventManage",eventManage);
-	}
+	void deleteEventManage(EventManage eventManage);
 
-	
-	/** 행사접수관리 ***/
+	/** 행사접수관리 **/
+
 	/**
 	 * 행사접수정보를 관리하기 위해 등록된 행사관리 목록을 조회한다.
 	 * @param eventManageVO - 행사관리 VO
 	 * @return List - 행사관리 목록
-	 */	
-	public List<EventManageVO> selectEventAtdrnList(EventManageVO eventManageVO) throws Exception {
-		return selectList("eventManageDAO.selectEventAtdrnList", eventManageVO);
-	}
+	 */
+	List<EventManageVO> selectEventAtdrnList(EventManageVO eventManageVO);
 
-    /**
+	/**
 	 * 행사접수관리목록 총 개수를 조회한다.
 	 * @param eventManageVO - 행사관리 VO
 	 * @return int
-	 * @exception Exception
 	 */
-    public int selectEventAtdrnListTotCnt(EventManageVO eventManageVO) throws Exception {
-        return (Integer)selectOne("eventManageDAO.selectEventAtdrnListTotCnt", eventManageVO);
-    }
+	int selectEventAtdrnListTotCnt(EventManageVO eventManageVO);
 
 	/**
 	 * 행사접수승인/반려 처리를 위해 등록된 행사접수 목록을 조회한다.
 	 * @param eventManageVO - 행사관리 VO
 	 * @return List - 행사관리 목록
-	 */	
-	public List<EventManageVO> selectEventRceptConfmList(EventManageVO eventManageVO) throws Exception {
-		return selectList("eventManageDAO.selectEventRceptConfmList", eventManageVO);
-	}
+	 */
+	List<EventManageVO> selectEventRceptConfmList(EventManageVO eventManageVO);
 
-    /**
+	/**
 	 * 행사접수승인/반려 처리를 위해 등록된 행사접수 목록 총 개수를 조회한다.
 	 * @param eventManageVO - 행사관리 VO
 	 * @return int
-	 * @exception Exception
 	 */
-    public int selectEventRceptConfmListTotCnt(EventManageVO eventManageVO) throws Exception {
-        return (Integer)selectOne("eventManageDAO.selectEventRceptConfmListTotCnt", eventManageVO);
-    }
+	int selectEventRceptConfmListTotCnt(EventManageVO eventManageVO);
 
 	/**
 	 * 행사일자, 행사구분 조건에 따른 행사명 목록을 조회한다.
 	 * @param eventManageVO - 행사관리 VO
 	 * @return List - 행사관리 목록
 	 */
-	public List<EventManageVO> selectEventNmList(EventManageVO eventManageVO) throws Exception {
-		return selectList("eventManageDAO.selectEventNmList", eventManageVO);
-	}
-    
+	List<EventManageVO> selectEventNmList(EventManageVO eventManageVO);
+
 	/**
 	 * 등록된 행사접수관리의 상세정보를 조회한다.
 	 * @param eventManageVO - 행사관리 VO
 	 * @return EventManageVO - 행사관리 VO
 	 */
-	public EventManageVO selectEventAtdrn(EventManageVO eventManageVO)  throws Exception {
-		return (EventManageVO) selectOne("eventManageDAO.selectEventAtdrn", eventManageVO);
-	}
+	EventManageVO selectEventAtdrn(EventManageVO eventManageVO);
 
 	/**
 	 * 행사접수관리정보를 신규로 등록한다.
-	 * @param eventManage - 행사관리 model
+	 * @param eventAtdrn - 행사접수 model
 	 */
-	public void insertEventAtdrn(EventAtdrn eventAtdrn) throws Exception {
-		insert("eventManageDAO.insertEventAtdrn", eventAtdrn);
-	}
+	void insertEventAtdrn(EventAtdrn eventAtdrn);
 
 	/**
 	 * 기 등록된 행사접수관리정보를 삭제한다.
-	 * @param eventManage - 행사관리 model
+	 * @param eventAtdrn - 행사접수 model
 	 */
-	public void deleteEventAtdrn(EventAtdrn eventAtdrn) throws Exception {
-        delete("eventManageDAO.deleteEventAtdrn",eventAtdrn);
-	}
+	void deleteEventAtdrn(EventAtdrn eventAtdrn);
 
 	/**
 	 * 기 등록된 행사접수관리정보를 승인처리한다.
-	 * @param eventManage - 행사관리 model
+	 * @param eventAtdrn - 행사접수 model
 	 */
-	public void updtEventAtdrn(EventAtdrn eventAtdrn) throws Exception {
-		update("eventManageDAO.updtEventAtdrn", eventAtdrn);
-	}
+	void updtEventAtdrn(EventAtdrn eventAtdrn);
 
-	
 	/**
 	 * 행사접수자 정보를 조회한다.
 	 * @param eventManageVO - 행사관리 VO
 	 * @return List - 행사관리 목록
 	 */
-	
-	public List<EventManageVO> selectEventReqstAtdrnList(EventManageVO eventManageVO) throws Exception {
-		return selectList("eventManageDAO.selectEventReqstAtdrnList", eventManageVO);
-	}
+	List<EventManageVO> selectEventReqstAtdrnList(EventManageVO eventManageVO);
 
-    /**
+	/**
 	 * 행사접수자 목록 총 개수를 조회한다.
 	 * @param eventManageVO - 행사관리 VO
 	 * @return int
-	 * @exception Exception
 	 */
-    public int selectEventReqstAtdrnListTotCnt(EventManageVO eventManageVO) throws Exception {
-        return (Integer)selectOne("eventManageDAO.selectEventReqstAtdrnListTotCnt", eventManageVO);
-    }
-	
+	int selectEventReqstAtdrnListTotCnt(EventManageVO eventManageVO);
+
 }

--- a/src/main/resources/egovframework/mapper/com/uss/ion/evt/EgovEventManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/evt/EgovEventManage_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:51:05 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="eventManageDAO">
+<mapper namespace="egovframework.com.uss.ion.evt.service.impl.EventManageDAO">
 
     <resultMap id="eventAtdrn" type="egovframework.com.uss.ion.evt.service.EventAtdrnVO">
         <result property="applcntId" column="APPLCNT_ID"/>  

--- a/src/main/resources/egovframework/mapper/com/uss/ion/evt/EgovEventManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/evt/EgovEventManage_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:51:05 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="eventManageDAO">
+<mapper namespace="egovframework.com.uss.ion.evt.service.impl.EventManageDAO">
 
     <resultMap id="eventAtdrn" type="egovframework.com.uss.ion.evt.service.EventAtdrnVO">
         <result property="applcntId" column="APPLCNT_ID"/>  

--- a/src/main/resources/egovframework/mapper/com/uss/ion/evt/EgovEventManage_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/evt/EgovEventManage_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:51:05 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="eventManageDAO">
+<mapper namespace="egovframework.com.uss.ion.evt.service.impl.EventManageDAO">
 
     <resultMap id="eventAtdrn" type="egovframework.com.uss.ion.evt.service.EventAtdrnVO">
         <result property="applcntId" column="APPLCNT_ID"/>  

--- a/src/main/resources/egovframework/mapper/com/uss/ion/evt/EgovEventManage_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/evt/EgovEventManage_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:51:06 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="eventManageDAO">
+<mapper namespace="egovframework.com.uss.ion.evt.service.impl.EventManageDAO">
 
     <resultMap id="eventAtdrn" type="egovframework.com.uss.ion.evt.service.EventAtdrnVO">
         <result property="applcntId" column="APPLCNT_ID"/>  

--- a/src/main/resources/egovframework/mapper/com/uss/ion/evt/EgovEventManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/evt/EgovEventManage_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:51:06 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="eventManageDAO">
+<mapper namespace="egovframework.com.uss.ion.evt.service.impl.EventManageDAO">
 
     <resultMap id="eventAtdrn" type="egovframework.com.uss.ion.evt.service.EventAtdrnVO">
         <result property="applcntId" column="APPLCNT_ID"/>  

--- a/src/main/resources/egovframework/mapper/com/uss/ion/evt/EgovEventManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/evt/EgovEventManage_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:51:06 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="eventManageDAO">
+<mapper namespace="egovframework.com.uss.ion.evt.service.impl.EventManageDAO">
 
     <resultMap id="eventAtdrn" type="egovframework.com.uss.ion.evt.service.EventAtdrnVO">
         <result property="applcntId" column="APPLCNT_ID"/>  

--- a/src/main/resources/egovframework/mapper/com/uss/ion/evt/EgovEventManage_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/evt/EgovEventManage_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:51:06 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="eventManageDAO">
+<mapper namespace="egovframework.com.uss.ion.evt.service.impl.EventManageDAO">
 
     <resultMap id="eventAtdrn" type="egovframework.com.uss.ion.evt.service.EventAtdrnVO">
         <result property="applcntId" column="APPLCNT_ID"/>  

--- a/src/main/resources/egovframework/mapper/com/uss/ion/evt/EgovEventManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/evt/EgovEventManage_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:51:06 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="eventManageDAO">
+<mapper namespace="egovframework.com.uss.ion.evt.service.impl.EventManageDAO">
 
     <resultMap id="eventAtdrn" type="egovframework.com.uss.ion.evt.service.EventAtdrnVO">
         <result property="applcntId" column="APPLCNT_ID"/>  

--- a/src/main/resources/egovframework/spring/com/context-mapper.xml
+++ b/src/main/resources/egovframework/spring/com/context-mapper.xml
@@ -21,5 +21,12 @@
 	<bean id="egov.sqlSessionTemplate" class="org.mybatis.spring.SqlSessionTemplate">
 		<constructor-arg ref="egov.sqlSession"/>
 	</bean>
-	
+
+	<!-- @EgovMapper 어노테이션이 붙은 인터페이스를 자동으로 스캔하여 빈으로 등록 -->
+	<bean class="org.mybatis.spring.mapper.MapperScannerConfigurer">
+		<property name="basePackage" value="egovframework.com"/>
+		<property name="annotationClass" value="org.egovframe.rte.psl.dataaccess.mapper.EgovMapper"/>
+		<property name="sqlSessionFactoryBeanName" value="egov.sqlSession"/>
+	</bean>
+
 </beans>


### PR DESCRIPTION
## 변경 사유
eGovFrame 5.0 @EgovMapper 활용 확대. uss/ion 시리즈 동일 패턴.

## 변경 내용
- uss/ion/evt EventManageDAO를 `@EgovMapper` 인터페이스 방식으로 전환
- ServiceImpl 의존성 타입 변경
- 5개 RDBMS XML namespace 인터페이스 FQN
- `context-mapper.xml` `MapperScannerConfigurer` 추가

## 영향 범위
- 외부 동작 변경 없음
- 베이스라인 컴파일 에러 수 변동 없음 (149)
