### PR TITLE
[refactor][5.0.x][공통컴포넌트] uss/ion/pwm PopupManageDAO @EgovMapper 인터페이스 방식으로 전환

### DIFF
--- a/src/main/java/egovframework/com/uss/ion/pwm/service/impl/PopupManageDAO.java
+++ b/src/main/java/egovframework/com/uss/ion/pwm/service/impl/PopupManageDAO.java
@@ -1,11 +1,12 @@
 package egovframework.com.uss.ion.pwm.service.impl;
+
 import java.util.List;
 
 import org.egovframe.rte.psl.dataaccess.util.EgovMap;
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.uss.ion.pwm.service.PopupManageVO;
+import jakarta.annotation.Resource;
 
 /**
  * 개요
@@ -14,102 +15,90 @@ import egovframework.com.uss.ion.pwm.service.PopupManageVO;
  * 상세내용
  * - 팝업창에 대한 등록, 수정, 삭제, 조회, 반영확인 기능을 제공한다.
  * - 팝업창의 조회기능은 목록조회, 상세조회로, 사용자화면 보기로 구분된다.
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2009.08.05  이창원          최초 생성
+ *   2026.05.28  dasomel         @EgovMapper 인터페이스 위임 방식으로 전환
+ * </pre>
+ *
  * @author 이창원
  * @version 1.0
- * @created 05-8-2009 오후 2:21:04
  */
 @Repository("popupManageDAO")
-public class PopupManageDAO extends EgovComAbstractDAO {
+public class PopupManageDAO {
 
-	public PopupManageDAO(){}
+	@Resource(name = "popupManageMapper")
+	private PopupManageMapper mapper;
 
 	/**
 	 * 기 등록된 팝업창정보를 삭제한다.
-	 * @param popupManage - 팝업창 model
-	 * @return boolean - 반영성공 여부
-	 *
-	 * @param popupManage
+	 * @param popupManageVO - 팝업창 model
 	 */
 	public void deletePopup(PopupManageVO popupManageVO) throws Exception {
-	    delete("PopupManage.deletePopupManage", popupManageVO);
+		mapper.deletePopupManage(popupManageVO);
 	}
 
 	/**
 	 * 팝업창정보를 신규로 등록한다.
-	 * @param popupManage - 팝업창 model
-	 * @return boolean - 반영성공 여부
-	 *
-	 * @param popupManage
+	 * @param popupManageVO - 팝업창 model
 	 */
 	public void insertPopup(PopupManageVO popupManageVO) throws Exception {
-	    insert("PopupManage.insertPopupManage", popupManageVO);
+		mapper.insertPopupManage(popupManageVO);
 	}
 
-        /**
-         * 기 등록된 팝업창정보를 수정한다.
-         * @param popupManage - 팝업창 model
-         * @return boolean - 반영성공 여부
-         *
-         * @param popupManage
-         */
-        public void updatePopup(PopupManageVO popupManageVO) throws Exception {
-            update("PopupManage.updatePopupManage", popupManageVO);
-        }
+	/**
+	 * 기 등록된 팝업창정보를 수정한다.
+	 * @param popupManageVO - 팝업창 model
+	 */
+	public void updatePopup(PopupManageVO popupManageVO) throws Exception {
+		mapper.updatePopupManage(popupManageVO);
+	}
 
 	/**
 	 * 팝업창을 사용자 화면에서 볼수 있는 정보들을 조회한다.
 	 * @param popupManageVO - 팝업창 Vo
 	 * @return popupManageVO - 팝업창 Vo
-	 *
-	 * @param popupManageVO
 	 */
 	public PopupManageVO selectPopup(PopupManageVO popupManageVO) throws Exception {
-	    return (PopupManageVO)selectOne("PopupManage.selectPopupManageDetail", popupManageVO);
+		return mapper.selectPopupManageDetail(popupManageVO);
 	}
 
 	/**
-	 * 팝업창를 관리하기 위해 등록된 팝업창 화이트리스트를 조회한다.
-	 * @param popupManageVO - 팝업창 Vo
+	 * 팝업창 화이트리스트를 조회한다.
 	 * @return List - 팝업창 화이트 목록
-	 *
-	 * @param popupManageVO
 	 */
 	public List<EgovMap> selectPopupWhiteList() throws Exception {
-	    return selectList("PopupManage.selectPopupWhiteList");
+		return mapper.selectPopupWhiteList();
 	}
-	
+
 	/**
-	 * 팝업창를 관리하기 위해 등록된 팝업창목록을 조회한다.
+	 * 팝업창목록을 조회한다.
 	 * @param popupManageVO - 팝업창 Vo
 	 * @return List - 팝업창 목록
-	 *
-	 * @param popupManageVO
 	 */
 	public List<EgovMap> selectPopupList(PopupManageVO popupManageVO) throws Exception {
-	    return selectList("PopupManage.selectPopupManage", popupManageVO);
+		return mapper.selectPopupManage(popupManageVO);
 	}
 
-        /**
-         * 팝업창를 관리하기 위해 등록된 팝업창목록 총개수를 조회한다.
-         * @param popupManageVO - 팝업창 Vo
-         * @return List - 팝업창 목록
-         *
-         * @param popupManageVO
-         */
-        public int selectPopupListCount(PopupManageVO popupManageVO) throws Exception {
-        return (Integer)selectOne("PopupManage.selectPopupManageCnt", popupManageVO);
-        }
+	/**
+	 * 팝업창목록 총개수를 조회한다.
+	 * @param popupManageVO - 팝업창 Vo
+	 * @return int - 팝업창 목록 총개수
+	 */
+	public int selectPopupListCount(PopupManageVO popupManageVO) throws Exception {
+		return mapper.selectPopupManageCnt(popupManageVO);
+	}
 
-        /**
-         * 팝업창를 사용하기 위해 등록된 팝업창목록을 조회한다.
-         * @param popupManageVO - 팝업창 Vo
-         * @return List - 팝업창 목록
-         *
-         * @param popupManageVO
-         */
-        public List<EgovMap> selectPopupMainList(PopupManageVO popupManageVO) throws Exception {
-            return selectList("PopupManage.selectPopupManageMain", popupManageVO);
-        }
-
-
+	/**
+	 * 메인 팝업창목록을 조회한다.
+	 * @param popupManageVO - 팝업창 Vo
+	 * @return List - 팝업창 목록
+	 */
+	public List<EgovMap> selectPopupMainList(PopupManageVO popupManageVO) throws Exception {
+		return mapper.selectPopupManageMain(popupManageVO);
+	}
 }

--- a/src/main/java/egovframework/com/uss/ion/pwm/service/impl/PopupManageMapper.java
+++ b/src/main/java/egovframework/com/uss/ion/pwm/service/impl/PopupManageMapper.java
@@ -1,0 +1,39 @@
+package egovframework.com.uss.ion.pwm.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+import org.egovframe.rte.psl.dataaccess.util.EgovMap;
+
+import egovframework.com.uss.ion.pwm.service.PopupManageVO;
+
+/**
+ * 팝업창관리에 대한 Mapper 인터페이스
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2026.05.28  dasomel         XML 기반 DAO → @EgovMapper 인터페이스로 전환
+ * </pre>
+ */
+@EgovMapper("popupManageMapper")
+public interface PopupManageMapper {
+
+	void deletePopupManage(PopupManageVO popupManageVO);
+
+	void insertPopupManage(PopupManageVO popupManageVO);
+
+	void updatePopupManage(PopupManageVO popupManageVO);
+
+	PopupManageVO selectPopupManageDetail(PopupManageVO popupManageVO);
+
+	List<EgovMap> selectPopupWhiteList();
+
+	List<EgovMap> selectPopupManage(PopupManageVO popupManageVO);
+
+	int selectPopupManageCnt(PopupManageVO popupManageVO);
+
+	List<EgovMap> selectPopupManageMain(PopupManageVO popupManageVO);
+}

--- a/src/main/resources/egovframework/mapper/com/uss/ion/pwm/PopupManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/pwm/PopupManage_SQL_altibase.xml
@@ -5,7 +5,7 @@
 --><!--Converted at: Wed May 11 15:51:15 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="PopupManage">
+<mapper namespace="egovframework.com.uss.ion.pwm.service.impl.PopupManageMapper">
 
 	<!-- ::ResultMap 선언 -->
 	<resultMap id="PopupManageVOs" type="egovframework.com.uss.ion.pwm.service.PopupManageVO">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/pwm/PopupManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/pwm/PopupManage_SQL_cubrid.xml
@@ -5,7 +5,7 @@
 --><!--Converted at: Wed May 11 15:51:15 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="PopupManage">
+<mapper namespace="egovframework.com.uss.ion.pwm.service.impl.PopupManageMapper">
 
 	<!-- ::ResultMap 선언 -->
 	<resultMap id="PopupManageVOs" type="egovframework.com.uss.ion.pwm.service.PopupManageVO">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/pwm/PopupManage_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/pwm/PopupManage_SQL_goldilocks.xml
@@ -5,7 +5,7 @@
 --><!--Converted at: Wed May 11 15:51:15 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="PopupManage">
+<mapper namespace="egovframework.com.uss.ion.pwm.service.impl.PopupManageMapper">
 
 	<!-- ::ResultMap 선언 -->
 	<resultMap id="PopupManageVOs" type="egovframework.com.uss.ion.pwm.service.PopupManageVO">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/pwm/PopupManage_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/pwm/PopupManage_SQL_maria.xml
@@ -5,7 +5,7 @@
 --><!--Converted at: Wed May 11 15:51:15 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="PopupManage">
+<mapper namespace="egovframework.com.uss.ion.pwm.service.impl.PopupManageMapper">
 
 	<!-- ::ResultMap 선언 -->
 	<resultMap id="PopupManageVOs" type="egovframework.com.uss.ion.pwm.service.PopupManageVO">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/pwm/PopupManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/pwm/PopupManage_SQL_mysql.xml
@@ -5,7 +5,7 @@
 --><!--Converted at: Wed May 11 15:51:15 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="PopupManage">
+<mapper namespace="egovframework.com.uss.ion.pwm.service.impl.PopupManageMapper">
 
 	<!-- ::ResultMap 선언 -->
 	<resultMap id="PopupManageVOs" type="egovframework.com.uss.ion.pwm.service.PopupManageVO">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/pwm/PopupManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/pwm/PopupManage_SQL_oracle.xml
@@ -5,7 +5,7 @@
 --><!--Converted at: Wed May 11 15:51:16 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="PopupManage">
+<mapper namespace="egovframework.com.uss.ion.pwm.service.impl.PopupManageMapper">
 
 	<!-- ::ResultMap 선언 -->
 	<resultMap id="PopupManageVOs" type="egovframework.com.uss.ion.pwm.service.PopupManageVO">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/pwm/PopupManage_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/pwm/PopupManage_SQL_postgres.xml
@@ -5,7 +5,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="PopupManage">
+<mapper namespace="egovframework.com.uss.ion.pwm.service.impl.PopupManageMapper">
 
 	<!-- ::ResultMap 선언 -->
 	<resultMap id="PopupManageVOs" type="egovframework.com.uss.ion.pwm.service.PopupManageVO">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/pwm/PopupManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/pwm/PopupManage_SQL_tibero.xml
@@ -5,7 +5,7 @@
 --><!--Converted at: Wed May 11 15:51:16 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="PopupManage">
+<mapper namespace="egovframework.com.uss.ion.pwm.service.impl.PopupManageMapper">
 
 	<!-- ::ResultMap 선언 -->
 	<resultMap id="PopupManageVOs" type="egovframework.com.uss.ion.pwm.service.PopupManageVO">

--- a/src/main/resources/egovframework/spring/com/context-mapper.xml
+++ b/src/main/resources/egovframework/spring/com/context-mapper.xml
@@ -21,5 +21,10 @@
 	<bean id="egov.sqlSessionTemplate" class="org.mybatis.spring.SqlSessionTemplate">
 		<constructor-arg ref="egov.sqlSession"/>
 	</bean>
-	
+
+	<bean class="org.mybatis.spring.mapper.MapperScannerConfigurer">
+		<property name="basePackage" value="egovframework.com" />
+		<property name="annotationClass" value="org.egovframe.rte.psl.dataaccess.mapper.EgovMapper" />
+	</bean>
+
 </beans>


### PR DESCRIPTION
## 변경 사유

eGovFrame 5.0에서 도입된 @EgovMapper 어노테이션 방식을 uss/ion/pwm 팝업창관리 모듈에 적용한다.
EgovComAbstractDAO 상속 방식에서 인터페이스 위임 방식으로 전환하여 MyBatis 매퍼 설정을 명확히 한다.

## 변경 내용

- `PopupManageMapper` 인터페이스 신규 추가 (@EgovMapper 어노테이션 적용)
- `PopupManageDAO` 를 EgovComAbstractDAO 상속에서 @Resource 위임 방식으로 전환
- 8개 RDBMS XML mapper namespace를 인터페이스 FQN으로 변경 (SQL 무변경)
- `context-mapper.xml` 에 MapperScannerConfigurer 빈 등록

## 영향 범위

- 변경 파일: PopupManageDAO.java, PopupManageMapper.java(신규), PopupManage_SQL_*.xml(8개), context-mapper.xml
- 서비스 인터페이스/구현체 무변경, 기존 동작 동일

## 체크리스트

- [x] 단일 주제만 다룸 (다른 변경 없음)
- [x] 기존 동작에 영향 없음
- [x] SQL 무변경