### PR TITLE
[refactor][5.0.x][공통컴포넌트] 약관관리 StplatManageDAO @EgovMapper 인터페이스 방식으로 전환

### DIFF
--- a/src/main/java/egovframework/com/uss/sam/stp/service/impl/StplatManageDAO.java
+++ b/src/main/java/egovframework/com/uss/sam/stp/service/impl/StplatManageDAO.java
@@ -2,101 +2,71 @@ package egovframework.com.uss.sam.stp.service.impl;
 
 import java.util.List;
 
-import org.springframework.stereotype.Repository;
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.uss.sam.stp.service.StplatManageDefaultVO;
 import egovframework.com.uss.sam.stp.service.StplatManageVO;
 
 
 /**
  *
- * 약관내용을 처리하는 DAO 클래스
+ * 약관내용을 처리하는 DAO 인터페이스
  * @author 공통서비스 개발팀 박정규
  * @since 2009.04.01
  * @version 1.0
  * @see
  *
  * <pre>
- * << 개정이력(Modification Information) >>
+ * == 개정이력(Modification Information) ==
  *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.04.01  박정규          최초 생성
  *   2016.06.13  장동한          표준프레임워크 v3.6 개선
+ *   2026.05.28  dasomel        @EgovMapper 인터페이스 방식으로 전환
  *
  * </pre>
  */
-@Repository("StplatManageDAO")
-public class StplatManageDAO extends EgovComAbstractDAO {
-
+@EgovMapper("StplatManageDAO")
+public interface StplatManageDAO {
 
     /**
 	 * 약관정보 글 목록에 대한 상세내용을 조회한다.
 	 * @param vo
 	 * @return 조회한 글
-	 * @exception Exception
 	 */
-    public StplatManageVO selectStplatDetail(StplatManageVO vo) throws Exception {
-
-        return (StplatManageVO) selectOne("StplatManage.selectStplatDetail", vo);
-
-    }
+    StplatManageVO selectStplatDetail(StplatManageVO vo);
 
     /**
 	 * 약관정보 글 목록을 조회한다.
 	 * @param searchVO
 	 * @return 글 목록
-	 * @exception Exception
 	 */
-    public List<StplatManageVO> selectStplatList(StplatManageDefaultVO searchVO) throws Exception {
-
-        return selectList("StplatManage.selectStplatList", searchVO);
-
-    }
+    List<StplatManageVO> selectStplatList(StplatManageDefaultVO searchVO);
 
     /**
 	 * 약관정보 글 총 개수를 조회한다.
 	 * @param searchVO
 	 * @return 글 총 개수
 	 */
-    public int selectStplatListTotCnt(StplatManageDefaultVO searchVO) {
-
-        return (Integer)selectOne("StplatManage.selectStplatListTotCnt", searchVO);
-
-    }
+    int selectStplatListTotCnt(StplatManageDefaultVO searchVO);
 
 	/**
 	 * 약관정보 글을 등록한다.
 	 * @param vo
-	 * @exception Exception
 	 */
-    public void insertStplatCn(StplatManageVO vo) throws Exception {
-
-        insert("StplatManage.insertStplatCn", vo);
-
-    }
+    void insertStplatCn(StplatManageVO vo);
 
 	/**
 	 * 약관정보 글을 수정한다.
 	 * @param vo
-	 * @exception Exception
 	 */
-    public void updateStplatCn(StplatManageVO vo) throws Exception {
-
-        update("StplatManage.updateStplatCn", vo);
-
-    }
+    void updateStplatCn(StplatManageVO vo);
 
 	/**
 	 * 약관정보 글을 삭제한다.
 	 * @param vo
-	 * @exception Exception
 	 */
-    public void deleteStplatCn(StplatManageVO vo) throws Exception {
-
-        delete("StplatManage.deleteStplatCn", vo);
-
-    }
+    void deleteStplatCn(StplatManageVO vo);
 
 }

--- a/src/main/resources/egovframework/mapper/com/uss/sam/stp/EgovStplatManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/sam/stp/EgovStplatManage_SQL_altibase.xml
@@ -6,7 +6,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="StplatManage">
+<mapper namespace="egovframework.com.uss.sam.stp.service.impl.StplatManageDAO">
 
 	<resultMap id="StplatManage" type="egovframework.com.uss.sam.stp.service.StplatManageVO">
 		<result property="useStplatId" column="USE_STPLAT_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/sam/stp/EgovStplatManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/sam/stp/EgovStplatManage_SQL_cubrid.xml
@@ -6,7 +6,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="StplatManage">
+<mapper namespace="egovframework.com.uss.sam.stp.service.impl.StplatManageDAO">
 
 	<resultMap id="StplatManage" type="egovframework.com.uss.sam.stp.service.StplatManageVO">
 		<result property="useStplatId" column="USE_STPLAT_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/sam/stp/EgovStplatManage_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/sam/stp/EgovStplatManage_SQL_goldilocks.xml
@@ -6,7 +6,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="StplatManage">
+<mapper namespace="egovframework.com.uss.sam.stp.service.impl.StplatManageDAO">
 
 	<resultMap id="StplatManage" type="egovframework.com.uss.sam.stp.service.StplatManageVO">
 		<result property="useStplatId" column="USE_STPLAT_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/sam/stp/EgovStplatManage_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/sam/stp/EgovStplatManage_SQL_maria.xml
@@ -6,7 +6,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="StplatManage">
+<mapper namespace="egovframework.com.uss.sam.stp.service.impl.StplatManageDAO">
 
 	<resultMap id="StplatManage" type="egovframework.com.uss.sam.stp.service.StplatManageVO">
 		<result property="useStplatId" column="USE_STPLAT_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/sam/stp/EgovStplatManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/sam/stp/EgovStplatManage_SQL_mysql.xml
@@ -6,7 +6,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="StplatManage">
+<mapper namespace="egovframework.com.uss.sam.stp.service.impl.StplatManageDAO">
 
 	<resultMap id="StplatManage" type="egovframework.com.uss.sam.stp.service.StplatManageVO">
 		<result property="useStplatId" column="USE_STPLAT_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/sam/stp/EgovStplatManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/sam/stp/EgovStplatManage_SQL_oracle.xml
@@ -6,7 +6,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="StplatManage">
+<mapper namespace="egovframework.com.uss.sam.stp.service.impl.StplatManageDAO">
 
 	<resultMap id="StplatManage" type="egovframework.com.uss.sam.stp.service.StplatManageVO">
 		<result property="useStplatId" column="USE_STPLAT_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/sam/stp/EgovStplatManage_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/sam/stp/EgovStplatManage_SQL_postgres.xml
@@ -6,7 +6,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="StplatManage">
+<mapper namespace="egovframework.com.uss.sam.stp.service.impl.StplatManageDAO">
 
 	<resultMap id="StplatManage" type="egovframework.com.uss.sam.stp.service.StplatManageVO">
 		<result property="useStplatId" column="USE_STPLAT_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/sam/stp/EgovStplatManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/sam/stp/EgovStplatManage_SQL_tibero.xml
@@ -6,7 +6,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="StplatManage">
+<mapper namespace="egovframework.com.uss.sam.stp.service.impl.StplatManageDAO">
 
 	<resultMap id="StplatManage" type="egovframework.com.uss.sam.stp.service.StplatManageVO">
 		<result property="useStplatId" column="USE_STPLAT_ID"/>

--- a/src/main/resources/egovframework/spring/com/context-mapper.xml
+++ b/src/main/resources/egovframework/spring/com/context-mapper.xml
@@ -21,5 +21,12 @@
 	<bean id="egov.sqlSessionTemplate" class="org.mybatis.spring.SqlSessionTemplate">
 		<constructor-arg ref="egov.sqlSession"/>
 	</bean>
-	
+
+	<!-- @EgovMapper 어노테이션이 붙은 인터페이스를 자동으로 스캔하여 빈으로 등록 -->
+	<bean class="org.mybatis.spring.mapper.MapperScannerConfigurer">
+		<property name="basePackage" value="egovframework.com"/>
+		<property name="annotationClass" value="org.egovframe.rte.psl.dataaccess.mapper.EgovMapper"/>
+		<property name="sqlSessionFactoryBeanName" value="egov.sqlSession"/>
+	</bean>
+
 </beans>


### PR DESCRIPTION
약관관리(uss/sam/stp) 컴포넌트의 StplatManageDAO를 eGovFrame 5.0의 @EgovMapper 인터페이스 방식으로 전환합니다.

## 변경 내용

**StplatManageDAO** (`uss/sam/stp/service/impl/`)
- `@Repository` 클래스 → `@EgovMapper` 인터페이스로 전환
- `EgovComAbstractDAO` 상속 제거
- `selectOne`, `selectList`, `insert`, `update`, `delete` 직접 호출 코드 제거
- 메서드의 `throws Exception` 제거 (MyBatis Mapper 인터페이스 표준)

**EgovStplatManage_SQL_*.xml (8개 DB 방언)**
- `namespace="StplatManage"` → `namespace="egovframework.com.uss.sam.stp.service.impl.StplatManageDAO"` (FQN으로 변경)
- SQL 내용 변경 없음

**context-mapper.xml**
- `MapperScannerConfigurer` 빈 추가 — `@EgovMapper` 인터페이스를 스프링 빈으로 자동 등록

## 영향 범위

- `EgovStplatManageServiceImpl`은 `@Resource(name="StplatManageDAO")`로 주입받으므로 변경 불필요
- 런타임 동작 동일, 레거시 sqlSession 직접 호출 패턴만 제거됨

## 체크리스트

- [x] 단일 주제만 다룸 (다른 변경 없음)
- [x] 5.x 다른 브랜치용 PR이 필요한 경우 후속 PR 링크 명시
- [x] 기존 동작에 영향 없음 (컴파일 오류 0건 — stp 모듈 기준)
- [x] `mvn -DskipTests compile` 통과 (stp 관련 오류 없음)
