### PR TITLE
[refactor][5.0.x][공통컴포넌트] uss/ion/uas UserAbsnceDAO @EgovMapper 인터페이스 방식으로 전환

### DIFF
--- a/src/main/java/egovframework/com/uss/ion/uas/service/impl/UserAbsnceDAO.java
+++ b/src/main/java/egovframework/com/uss/ion/uas/service/impl/UserAbsnceDAO.java
@@ -1,7 +1,7 @@
 /**
  * 개요
  * - 사용자부재에 대한 DAO 클래스를 정의한다.
- * 
+ *
  * 상세내용
  * - 사용자부재에 대한 등록, 수정, 삭제, 조회, 반영확인 기능을 제공한다.
  * - 사용자부재의 조회기능은 목록조회, 상세조회로 구분된다.
@@ -16,38 +16,41 @@ import java.util.List;
 
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.uss.ion.uas.service.UserAbsnceVO;
+import jakarta.annotation.Resource;
 
 @Repository("userAbsnceDAO")
-public class UserAbsnceDAO extends EgovComAbstractDAO {
-	
+public class UserAbsnceDAO {
+
+	@Resource(name = "userAbsnceMapper")
+	private UserAbsnceMapper userAbsnceMapper;
+
 	/**
 	 * 사용자부재정보를 관리하기 위해 등록된 사용자부재 목록을 조회한다.
 	 * @param userAbsnceVO - 사용자부재 VO
 	 * @return List - 사용자부재 목록
-	 */	
+	 */
 	public List<UserAbsnceVO> selectUserAbsnceList(UserAbsnceVO userAbsnceVO) throws Exception {
-		return selectList("userAbsnceDAO.selectUserAbsnceList", userAbsnceVO);
+		return userAbsnceMapper.selectUserAbsnceList(userAbsnceVO);
 	}
 
-    /**
+	/**
 	 * 사용자부재목록 총 개수를 조회한다.
-	 * @param mainImageVO - 사용자부재 VO
+	 * @param userAbsnceVO - 사용자부재 VO
 	 * @return int
 	 * @exception Exception
 	 */
-    public int selectUserAbsnceListTotCnt(UserAbsnceVO userAbsnceVO) throws Exception {
-        return (Integer)selectOne("userAbsnceDAO.selectUserAbsnceListTotCnt", userAbsnceVO);
-    }
-    
+	public int selectUserAbsnceListTotCnt(UserAbsnceVO userAbsnceVO) throws Exception {
+		return userAbsnceMapper.selectUserAbsnceListTotCnt(userAbsnceVO);
+	}
+
 	/**
 	 * 등록된 사용자부재 상세정보를 조회한다.
 	 * @param userAbsnceVO - 사용자부재 VO
 	 * @return UserAbsnceVO - 사용자부재 VO
 	 */
 	public UserAbsnceVO selectUserAbsnce(UserAbsnceVO userAbsnceVO) throws Exception {
-		return (UserAbsnceVO) selectOne("userAbsnceDAO.selectUserAbsnce", userAbsnceVO);
+		return userAbsnceMapper.selectUserAbsnce(userAbsnceVO);
 	}
 
 	/**
@@ -55,7 +58,7 @@ public class UserAbsnceDAO extends EgovComAbstractDAO {
 	 * @param userAbsnceVO - 사용자부재 VO
 	 */
 	public void insertUserAbsnce(UserAbsnceVO userAbsnceVO) throws Exception {
-		insert("userAbsnceDAO.insertUserAbsnce", userAbsnceVO);
+		userAbsnceMapper.insertUserAbsnce(userAbsnceVO);
 	}
 
 	/**
@@ -63,7 +66,7 @@ public class UserAbsnceDAO extends EgovComAbstractDAO {
 	 * @param userAbsnceVO - 사용자부재 VO
 	 */
 	public void updateUserAbsnce(UserAbsnceVO userAbsnceVO) throws Exception {
-		update("userAbsnceDAO.updateUserAbsnce", userAbsnceVO);
+		userAbsnceMapper.updateUserAbsnce(userAbsnceVO);
 	}
 
 	/**
@@ -71,7 +74,7 @@ public class UserAbsnceDAO extends EgovComAbstractDAO {
 	 * @param userAbsnceVO - 사용자부재 VO
 	 */
 	public void deleteUserAbsnce(UserAbsnceVO userAbsnceVO) throws Exception {
-		delete("userAbsnceDAO.deleteUserAbsnce", userAbsnceVO);
+		userAbsnceMapper.deleteUserAbsnce(userAbsnceVO);
 	}
 
 	/**

--- a/src/main/java/egovframework/com/uss/ion/uas/service/impl/UserAbsnceMapper.java
+++ b/src/main/java/egovframework/com/uss/ion/uas/service/impl/UserAbsnceMapper.java
@@ -1,0 +1,66 @@
+package egovframework.com.uss.ion.uas.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.uss.ion.uas.service.UserAbsnceVO;
+
+/**
+ * 사용자부재 Mapper 인터페이스
+ *
+ * @author 이문준
+ * @since 2009.03.08
+ * @version 1.0
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2009.03.08  이문준          최초 생성
+ *
+ * </pre>
+ */
+@EgovMapper("userAbsnceMapper")
+public interface UserAbsnceMapper {
+
+	/**
+	 * 사용자부재 목록을 조회한다.
+	 * @param userAbsnceVO 사용자부재 VO
+	 * @return List 사용자부재 목록
+	 */
+	List<UserAbsnceVO> selectUserAbsnceList(UserAbsnceVO userAbsnceVO);
+
+	/**
+	 * 사용자부재 목록 총 개수를 조회한다.
+	 * @param userAbsnceVO 사용자부재 VO
+	 * @return int 총 개수
+	 */
+	int selectUserAbsnceListTotCnt(UserAbsnceVO userAbsnceVO);
+
+	/**
+	 * 사용자부재 상세정보를 조회한다.
+	 * @param userAbsnceVO 사용자부재 VO
+	 * @return UserAbsnceVO 사용자부재 VO
+	 */
+	UserAbsnceVO selectUserAbsnce(UserAbsnceVO userAbsnceVO);
+
+	/**
+	 * 사용자부재정보를 등록한다.
+	 * @param userAbsnceVO 사용자부재 VO
+	 */
+	void insertUserAbsnce(UserAbsnceVO userAbsnceVO);
+
+	/**
+	 * 사용자부재정보를 수정한다.
+	 * @param userAbsnceVO 사용자부재 VO
+	 */
+	void updateUserAbsnce(UserAbsnceVO userAbsnceVO);
+
+	/**
+	 * 사용자부재정보를 삭제한다.
+	 * @param userAbsnceVO 사용자부재 VO
+	 */
+	void deleteUserAbsnce(UserAbsnceVO userAbsnceVO);
+}

--- a/src/main/resources/egovframework/mapper/com/uss/ion/uas/EgovUserAbsnce_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/uas/EgovUserAbsnce_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="userAbsnceDAO">
+<mapper namespace="egovframework.com.uss.ion.uas.service.impl.UserAbsnceMapper">
 
     <resultMap id="userAbsnce" type="egovframework.com.uss.ion.uas.service.UserAbsnceVO">
         <result property="userId" column="USER_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/uas/EgovUserAbsnce_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/uas/EgovUserAbsnce_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="userAbsnceDAO">
+<mapper namespace="egovframework.com.uss.ion.uas.service.impl.UserAbsnceMapper">
 
     <resultMap id="userAbsnce" type="egovframework.com.uss.ion.uas.service.UserAbsnceVO">
         <result property="userId" column="USER_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/uas/EgovUserAbsnce_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/uas/EgovUserAbsnce_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="userAbsnceDAO">
+<mapper namespace="egovframework.com.uss.ion.uas.service.impl.UserAbsnceMapper">
 
     <resultMap id="userAbsnce" type="egovframework.com.uss.ion.uas.service.UserAbsnceVO">
         <result property="userId" column="USER_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/uas/EgovUserAbsnce_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/uas/EgovUserAbsnce_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="userAbsnceDAO">
+<mapper namespace="egovframework.com.uss.ion.uas.service.impl.UserAbsnceMapper">
 
     <resultMap id="userAbsnce" type="egovframework.com.uss.ion.uas.service.UserAbsnceVO">
         <result property="userId" column="USER_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/uas/EgovUserAbsnce_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/uas/EgovUserAbsnce_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="userAbsnceDAO">
+<mapper namespace="egovframework.com.uss.ion.uas.service.impl.UserAbsnceMapper">
 
     <resultMap id="userAbsnce" type="egovframework.com.uss.ion.uas.service.UserAbsnceVO">
         <result property="userId" column="USER_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/uas/EgovUserAbsnce_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/uas/EgovUserAbsnce_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="userAbsnceDAO">
+<mapper namespace="egovframework.com.uss.ion.uas.service.impl.UserAbsnceMapper">
 
     <resultMap id="userAbsnce" type="egovframework.com.uss.ion.uas.service.UserAbsnceVO">
         <result property="userId" column="USER_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/uas/EgovUserAbsnce_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/uas/EgovUserAbsnce_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="userAbsnceDAO">
+<mapper namespace="egovframework.com.uss.ion.uas.service.impl.UserAbsnceMapper">
     <resultMap id="userAbsnce" type="egovframework.com.uss.ion.uas.service.UserAbsnceVO">
         <result property="userId" column="USER_ID"/>
         <result property="userNm" column="USER_NM"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/uas/EgovUserAbsnce_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/uas/EgovUserAbsnce_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="userAbsnceDAO">
+<mapper namespace="egovframework.com.uss.ion.uas.service.impl.UserAbsnceMapper">
 
     <resultMap id="userAbsnce" type="egovframework.com.uss.ion.uas.service.UserAbsnceVO">
         <result property="userId" column="USER_ID"/>

--- a/src/main/resources/egovframework/spring/com/context-mapper.xml
+++ b/src/main/resources/egovframework/spring/com/context-mapper.xml
@@ -21,5 +21,11 @@
 	<bean id="egov.sqlSessionTemplate" class="org.mybatis.spring.SqlSessionTemplate">
 		<constructor-arg ref="egov.sqlSession"/>
 	</bean>
-	
+
+	<bean class="org.mybatis.spring.mapper.MapperScannerConfigurer">
+		<property name="basePackage" value="egovframework.com" />
+		<property name="annotationClass" value="org.egovframe.rte.psl.dataaccess.mapper.EgovMapper" />
+		<property name="sqlSessionFactoryBeanName" value="egov.sqlSession" />
+	</bean>
+
 </beans>


### PR DESCRIPTION
## 변경 사유

eGovFrame 5.0에서 도입된 `@EgovMapper` 어노테이션 방식을 `uss/ion/uas` 모듈에 적용한다.
기존 `EgovComAbstractDAO`를 상속한 문자열 기반 SQL 참조 방식을 타입 안전한 Mapper 인터페이스 방식으로 전환한다.

## 변경 내용

- `UserAbsnceMapper` 인터페이스 신규 추가 (`@EgovMapper("userAbsnceMapper")` 적용)
  - `selectUserAbsnceList`, `selectUserAbsnceListTotCnt`, `selectUserAbsnce`
  - `insertUserAbsnce`, `updateUserAbsnce`, `deleteUserAbsnce`
- `UserAbsnceDAO`: `EgovComAbstractDAO` 상속 제거, `UserAbsnceMapper` 위임 방식으로 변경
- `EgovUserAbsnce_SQL_*.xml` 8개 파일: namespace를 `userAbsnceDAO` → `egovframework.com.uss.ion.uas.service.impl.UserAbsnceMapper` FQCN으로 수정
- `context-mapper.xml`: `MapperScannerConfigurer` 빈 등록 추가

## 영향 범위

- `EgovUserAbsnceServiceImpl`은 기존 `UserAbsnceDAO` API를 그대로 사용하므로 변경 없음
- 기존 동작에 영향 없음 (SQL 쿼리 내용 변경 없음)

## 체크리스트

- [x] 단일 주제만 다룸 (다른 변경 없음)
- [x] 기존 동작에 영향 없음
- [x] 컴파일 통과 확인
