### PR TITLE
[refactor][5.0.x][공통컴포넌트] 메인화면이미지 MainImageDAO @EgovMapper 인터페이스 전환

### DIFF
--- a/src/main/java/egovframework/com/uss/ion/msi/service/impl/MainImageDAO.java
+++ b/src/main/java/egovframework/com/uss/ion/msi/service/impl/MainImageDAO.java
@@ -1,91 +1,87 @@
 /**
  * 개요
- * - 메인화면이미지에 대한 DAO 클래스를 정의한다.
- * 
+ * - 메인화면이미지에 대한 DAO 인터페이스를 정의한다.
+ *
  * 상세내용
  * - 메인화면이미지에 대한 등록, 수정, 삭제, 조회, 반영확인 기능을 제공한다.
  * - 메인화면이미지의 조회기능은 목록조회, 상세조회로 구분된다.
  * @author 이문준
  * @version 1.0
  * @created 03-8-2009 오후 2:08:58
+ *
+ * <pre>
+ *  == 개정이력(Modification Information) ==
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2009.08.03  이문준           최초 생성
+ *   2026.05.28  dasomel        @EgovMapper 인터페이스 방식으로 전환
+ *
+ * </pre>
  */
 
 package egovframework.com.uss.ion.msi.service.impl;
 
 import java.util.List;
 
-import org.springframework.stereotype.Repository;
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
 
 import egovframework.com.cmm.service.FileVO;
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.uss.ion.msi.service.MainImageVO;
 
-@Repository("mainImageDAO")
-public class MainImageDAO extends EgovComAbstractDAO {
-	
+@EgovMapper("mainImageDAO")
+public interface MainImageDAO {
+
 	/**
 	 * 메인화면이미지정보를 관리하기 위해 등록된 메인화면이미지 목록을 조회한다.
 	 * @param mainImageVO - 메인이미지 VO
 	 * @return List - 메인이미지 목록
 	 */
-	public List<MainImageVO> selectMainImageList(MainImageVO mainImageVO) throws Exception {
-		return selectList("mainImageDAO.selectMainImageList", mainImageVO);
-	}
+	List<MainImageVO> selectMainImageList(MainImageVO mainImageVO);
 
-    /**
+	/**
 	 * 메인화면이미지목록 총 개수를 조회한다.
 	 * @param mainImageVO - 메인화면이미지 VO
 	 * @return int
-	 * @exception Exception
 	 */
-    public int selectMainImageListTotCnt(MainImageVO mainImageVO) throws Exception {
-        return (Integer)selectOne("mainImageDAO.selectMainImageListTotCnt", mainImageVO);
-    }
+	int selectMainImageListTotCnt(MainImageVO mainImageVO);
 
 	/**
 	 * 등록된 메인화면이미지의 상세정보를 조회한다.
 	 * @param mainImageVO - 메인이미지 VO
 	 * @return MainImageVO - 메인이미지 VO
 	 */
-	public MainImageVO selectMainImage(MainImageVO mainImageVO) throws Exception {
-		return (MainImageVO) selectOne("mainImageDAO.selectMainImage", mainImageVO);
-	}
+	MainImageVO selectMainImage(MainImageVO mainImageVO);
 
 	/**
 	 * 메인화면이미지정보를 신규로 등록한다.
-	 * @param mainImage - 메인이미지 model
+	 * @param mainImageVO - 메인이미지 VO
 	 */
-	public void insertMainImage(MainImageVO mainImageVO) throws Exception {
-		insert("mainImageDAO.insertMainImage", mainImageVO);
-	}
+	void insertMainImage(MainImageVO mainImageVO);
 
 	/**
 	 * 기 등록된 메인화면이미지정보를 수정한다.
+	 * @param mainImageVO - 메인이미지 VO
 	 */
-	public void updateMainImage(MainImageVO mainImageVO) throws Exception {
-		update("mainImageDAO.updateMainImage", mainImageVO);
-	}
+	void updateMainImage(MainImageVO mainImageVO);
 
 	/**
 	 * 기 등록된 메인화면이미지정보를 삭제한다.
+	 * @param mainImageVO - 메인이미지 VO
 	 */
-	public void deleteMainImage(MainImageVO mainImageVO) throws Exception {
-		delete("mainImageDAO.deleteMainImage", mainImageVO);
-	}
+	void deleteMainImage(MainImageVO mainImageVO);
 
 	/**
 	 * 기 등록된 메인화면이미지정보의 이미지파일을 삭제하기 위해 파일정보를 조회한다.
+	 * @param mainImageVO - 메인이미지 VO
+	 * @return FileVO - 파일 VO
 	 */
-	public FileVO selectMainImageFile(MainImageVO mainImageVO) throws Exception {
-		return (FileVO) selectOne("mainImageDAO.selectMainImageFile", mainImageVO);
-	}
+	FileVO selectMainImageFile(MainImageVO mainImageVO);
 
 	/**
 	 * 메인화면이미지가 특정화면에 반영된 결과를 조회한다.
 	 * @param mainImageVO - 메인이미지 VO
-	 * @return MainImageVO - 메인이미지 VO
+	 * @return List - 메인이미지 목록
 	 */
-	public List<MainImageVO> selectMainImageResult(MainImageVO mainImageVO) throws Exception {
-		return selectList("mainImageDAO.selectMainImageResult", mainImageVO);
-	}
+	List<MainImageVO> selectMainImageResult(MainImageVO mainImageVO);
 }

--- a/src/main/resources/egovframework/mapper/com/uss/ion/msi/EgovMainImage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/msi/EgovMainImage_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="mainImageDAO">
+<mapper namespace="egovframework.com.uss.ion.msi.service.impl.MainImageDAO">
 
     <resultMap id="mainImage" type="egovframework.com.uss.ion.msi.service.MainImageVO">
         <result property="imageId" column="IMAGE_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/msi/EgovMainImage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/msi/EgovMainImage_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="mainImageDAO">
+<mapper namespace="egovframework.com.uss.ion.msi.service.impl.MainImageDAO">
 
     <resultMap id="mainImage" type="egovframework.com.uss.ion.msi.service.MainImageVO">
         <result property="imageId" column="IMAGE_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/msi/EgovMainImage_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/msi/EgovMainImage_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="mainImageDAO">
+<mapper namespace="egovframework.com.uss.ion.msi.service.impl.MainImageDAO">
 
     <resultMap id="mainImage" type="egovframework.com.uss.ion.msi.service.MainImageVO">
         <result property="imageId" column="IMAGE_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/msi/EgovMainImage_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/msi/EgovMainImage_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="mainImageDAO">
+<mapper namespace="egovframework.com.uss.ion.msi.service.impl.MainImageDAO">
 
     <resultMap id="mainImage" type="egovframework.com.uss.ion.msi.service.MainImageVO">
         <result property="imageId" column="IMAGE_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/msi/EgovMainImage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/msi/EgovMainImage_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="mainImageDAO">
+<mapper namespace="egovframework.com.uss.ion.msi.service.impl.MainImageDAO">
 
     <resultMap id="mainImage" type="egovframework.com.uss.ion.msi.service.MainImageVO">
         <result property="imageId" column="IMAGE_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/msi/EgovMainImage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/msi/EgovMainImage_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="mainImageDAO">
+<mapper namespace="egovframework.com.uss.ion.msi.service.impl.MainImageDAO">
 
     <resultMap id="mainImage" type="egovframework.com.uss.ion.msi.service.MainImageVO">
         <result property="imageId" column="IMAGE_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/msi/EgovMainImage_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/msi/EgovMainImage_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="mainImageDAO">
+<mapper namespace="egovframework.com.uss.ion.msi.service.impl.MainImageDAO">
 
     <resultMap id="mainImage" type="egovframework.com.uss.ion.msi.service.MainImageVO">
         <result property="imageId" column="IMAGE_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/msi/EgovMainImage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/msi/EgovMainImage_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="mainImageDAO">
+<mapper namespace="egovframework.com.uss.ion.msi.service.impl.MainImageDAO">
 
     <resultMap id="mainImage" type="egovframework.com.uss.ion.msi.service.MainImageVO">
         <result property="imageId" column="IMAGE_ID"/>

--- a/src/main/resources/egovframework/spring/com/context-mapper.xml
+++ b/src/main/resources/egovframework/spring/com/context-mapper.xml
@@ -21,5 +21,12 @@
 	<bean id="egov.sqlSessionTemplate" class="org.mybatis.spring.SqlSessionTemplate">
 		<constructor-arg ref="egov.sqlSession"/>
 	</bean>
-	
+
+	<!-- @EgovMapper 어노테이션이 붙은 인터페이스를 자동으로 스캔하여 빈으로 등록 -->
+	<bean class="org.mybatis.spring.mapper.MapperScannerConfigurer">
+		<property name="basePackage" value="egovframework.com"/>
+		<property name="annotationClass" value="org.egovframe.rte.psl.dataaccess.mapper.EgovMapper"/>
+		<property name="sqlSessionFactoryBeanName" value="egov.sqlSession"/>
+	</bean>
+
 </beans>


### PR DESCRIPTION
eGovFrame 5.0에서 도입된 `@EgovMapper` 어노테이션 방식을 메인화면이미지(uss/ion/msi) 컴포넌트에 적용합니다.

## 변경 내용

**MainImageDAO** (`uss/ion/msi/service/impl/`)
- `@Repository` 클래스 → `@EgovMapper` 인터페이스로 전환
- `EgovComAbstractDAO` 상속 제거
- `selectList` / `selectOne` / `insert` / `update` / `delete` 직접 호출 제거
- 메서드 시그니처에서 불필요한 `throws Exception` 선언 제거

**EgovMainImage_SQL_*.xml (8개 DB)**
- `namespace="mainImageDAO"` → `namespace="egovframework.com.uss.ion.msi.service.impl.MainImageDAO"` 로 변경
- SQL 내용 변경 없음

**context-mapper.xml**
- `MapperScannerConfigurer` 빈 추가: `@EgovMapper` 어노테이션 인터페이스 자동 스캔 등록

## 영향 범위

- 메인화면이미지 관리 기능(조회/등록/수정/삭제)에만 영향
- `EgovMainImageServiceImpl`의 DAO 주입 방식은 `@Resource(name="mainImageDAO")` 그대로 유지되어 기존 동작 보존
- 다른 모듈 변경 없음

## 체크리스트

- [x] 단일 주제만 다룸 (다른 변경 없음)
- [x] 5.x 다른 브랜치용 PR이 필요한 경우 후속 PR 링크 명시
- [x] 기존 동작에 영향 없음
- [x] 빌드 확인 (msi 모듈 관련 컴파일 오류 없음)
