### PR TITLE
[refactor][5.0.x][공통컴포넌트] uss/ion/nts NoteTrnsmitDao @EgovMapper 인터페이스 방식으로 전환

### DIFF
--- a/src/main/java/egovframework/com/uss/ion/nts/service/impl/EgovNoteTrnsmitServiceImpl.java
+++ b/src/main/java/egovframework/com/uss/ion/nts/service/impl/EgovNoteTrnsmitServiceImpl.java
@@ -40,7 +40,7 @@ public class EgovNoteTrnsmitServiceImpl extends EgovAbstractServiceImpl
      */
     @Override
 	public List<EgovMap> selectNoteTrnsmitList(NoteTrnsmit noteTrnsmit) throws Exception {
-    	return dao.selectNoteTrnsmitList(noteTrnsmit);
+    	return dao.selectNoteTrnsmit(noteTrnsmit);
     }
 
     /**
@@ -51,7 +51,7 @@ public class EgovNoteTrnsmitServiceImpl extends EgovAbstractServiceImpl
      */
     @Override
 	public int selectNoteTrnsmitListCnt(NoteTrnsmit noteTrnsmit) throws Exception {
-        return dao.selectNoteTrnsmitListCnt(noteTrnsmit);
+        return dao.selectNoteTrnsmitCnt(noteTrnsmit);
     }
 
     /**

--- a/src/main/java/egovframework/com/uss/ion/nts/service/impl/NoteTrnsmitDao.java
+++ b/src/main/java/egovframework/com/uss/ion/nts/service/impl/NoteTrnsmitDao.java
@@ -3,13 +3,13 @@ package egovframework.com.uss.ion.nts.service.impl;
 import java.util.List;
 import java.util.Map;
 
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
 import org.egovframe.rte.psl.dataaccess.util.EgovMap;
-import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.uss.ion.nts.service.NoteTrnsmit;
+
 /**
- * 보낸쪽지함관리를 처리하는 Dao Class 구현
+ * 보낸쪽지함관리를 처리하는 Mapper 인터페이스
  * @author 공통콤포넌트 장동한
  * @since 2010.06.16
  * @version 1.0
@@ -19,97 +19,70 @@ import egovframework.com.uss.ion.nts.service.NoteTrnsmit;
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.07.03  장동한          최초 생성
- *   2017.09.14	 장동한 		   표준프레임워크 3.7 개선
+ *   2017.09.14  장동한          표준프레임워크 3.7 개선
+ *   2026.05.28  dasomel         @EgovMapper 인터페이스 방식으로 전환
  *
  * </pre>
  */
-@Repository("noteTrnsmitDao")
-public class NoteTrnsmitDao extends EgovComAbstractDAO {
+@EgovMapper("noteTrnsmitDao")
+public interface NoteTrnsmitDao {
 
     /**
      * 보낸쪽지함관리를(을) 목록을 한다.
      * @param noteTrnsmit -조회할 정보가 담긴 객체
      * @return List -조회한목록이담긴List
-     * @throws Exception
      */
-    public List<EgovMap> selectNoteTrnsmitList(NoteTrnsmit noteTrnsmit) throws Exception {
-    	return selectList("NoteTrnsmit.selectNoteTrnsmit", noteTrnsmit);
-    }
+    List<EgovMap> selectNoteTrnsmit(NoteTrnsmit noteTrnsmit);
 
     /**
      * 보낸쪽지함관리를(을) 목록 전체 건수를(을) 조회한다.
      * @param noteTrnsmit -조회할 정보가 담긴 객체
      * @return int -조회한건수가담긴Integer
-     * @throws Exception
      */
-    public int selectNoteTrnsmitListCnt(NoteTrnsmit noteTrnsmit) throws Exception {
-    	return (Integer)selectOne("NoteTrnsmit.selectNoteTrnsmitCnt", noteTrnsmit);
-    }
+    int selectNoteTrnsmitCnt(NoteTrnsmit noteTrnsmit);
 
     /**
      * 보낸쪽지함관리를(을) 상세조회 한다.
      * @param noteTrnsmit -보낸쪽지함관리 정보가 담김 객체
      * @return Map -조회한정보가담긴Map
-     * @throws Exception
      */
-    public Map<?, ?> selectNoteTrnsmitDetail(NoteTrnsmit noteTrnsmit) throws Exception {
-    	return (Map<?, ?>)selectOne("NoteTrnsmit.selectNoteTrnsmitDetail", noteTrnsmit);
-    }
+    Map<?, ?> selectNoteTrnsmitDetail(NoteTrnsmit noteTrnsmit);
 
     /**
      * 보낸쪽지함관리를(을) 삭제한다.
      * @param noteTrnsmit -보낸쪽지함관리 정보가 담김 객체
-     * @throws Exception
      */
-    public void deleteNoteTrnsmit(NoteTrnsmit noteTrnsmit) throws Exception {
-        delete("NoteTrnsmit.deleteNoteTrnsmit" , noteTrnsmit);
-    }
+    void deleteNoteTrnsmit(NoteTrnsmit noteTrnsmit);
 
     /**
      * 받은쪽지함를(을) 삭제한다.
      * @param noteTrnsmit -보낸쪽지함관리 정보가 담김 객체
-     * @throws Exception
      */
-    public void deleteNoteRecptn(NoteTrnsmit noteTrnsmit) throws Exception {
-        delete("NoteTrnsmit.deleteNoteRecptn" , noteTrnsmit);
-    }
+    void deleteNoteRecptn(NoteTrnsmit noteTrnsmit);
 
     /**
      * 쪽지를(을) 삭제한다.
      * @param noteTrnsmit -보낸쪽지함관리 정보가 담김 객체
-     * @throws Exception
      */
-    public void deleteNoteManage(NoteTrnsmit noteTrnsmit) throws Exception {
-        delete("NoteTrnsmit.deleteNoteManage" , noteTrnsmit);
-    }
+    void deleteNoteManage(NoteTrnsmit noteTrnsmit);
 
     /**
-     * 쪽지관리/보낸족지함삭제
+     * 쪽지관리/보낸쪽지함삭제
      * @param noteTrnsmit -보낸쪽지함관리 정보가 담김 객체
-     * @throws Exception
      */
-    public void deleteNoteTrnsmitRelation(NoteTrnsmit noteTrnsmit) throws Exception {
-        delete("NoteTrnsmit.deleteNoteTrnsmitRelation" , noteTrnsmit);
-    }
+    void deleteNoteTrnsmitRelation(NoteTrnsmit noteTrnsmit);
 
     /**
      * 받은편지함 건수를 조회한다.
      * @param noteTrnsmit -보낸쪽지함관리 정보가 담김 객체
      * @return int -조회한건수가담긴Integer
-     * @throws Exception
      */
-    public int selectTrnsmitRelationCnt(NoteTrnsmit noteTrnsmit) throws Exception {
-    	return (Integer)selectOne("NoteTrnsmit.selectTrnsmitRelationCnt", noteTrnsmit);
-    }
-
+    int selectTrnsmitRelationCnt(NoteTrnsmit noteTrnsmit);
 
     /**
      * 수신자목록을 조회한다.
      * @param noteTrnsmit -보낸쪽지함관리 정보가 담김 객체
      * @return List -조회한목록이담긴List
-     * @throws Exception
      */
-    public List<EgovMap> selectNoteTrnsmitCnfirm(NoteTrnsmit noteTrnsmit) throws Exception {
-    	return selectList("NoteTrnsmit.selectNoteTrnsmitCnfirm", noteTrnsmit);
-    }
+    List<EgovMap> selectNoteTrnsmitCnfirm(NoteTrnsmit noteTrnsmit);
 }

--- a/src/main/resources/egovframework/mapper/com/uss/ion/nts/EgovNoteTrnsmit_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/nts/EgovNoteTrnsmit_SQL_altibase.xml
@@ -6,7 +6,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="NoteTrnsmit">
+<mapper namespace="egovframework.com.uss.ion.nts.service.impl.NoteTrnsmitDao">
 
 	<!-- ::ResultMap 선언 -->
 	<resultMap id="NoteTrnsmitVO" type="egovframework.com.uss.ion.nts.service.NoteTrnsmit">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/nts/EgovNoteTrnsmit_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/nts/EgovNoteTrnsmit_SQL_cubrid.xml
@@ -6,7 +6,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="NoteTrnsmit">
+<mapper namespace="egovframework.com.uss.ion.nts.service.impl.NoteTrnsmitDao">
 
 	<!-- ::ResultMap 선언 -->
 	<resultMap id="NoteTrnsmitVO" type="egovframework.com.uss.ion.nts.service.NoteTrnsmit">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/nts/EgovNoteTrnsmit_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/nts/EgovNoteTrnsmit_SQL_goldilocks.xml
@@ -6,7 +6,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="NoteTrnsmit">
+<mapper namespace="egovframework.com.uss.ion.nts.service.impl.NoteTrnsmitDao">
 
 	<!-- ::ResultMap 선언 -->
 	<resultMap id="NoteTrnsmitVO" type="egovframework.com.uss.ion.nts.service.NoteTrnsmit">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/nts/EgovNoteTrnsmit_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/nts/EgovNoteTrnsmit_SQL_maria.xml
@@ -6,7 +6,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="NoteTrnsmit">
+<mapper namespace="egovframework.com.uss.ion.nts.service.impl.NoteTrnsmitDao">
 	
 	<!-- ::ResultMap 선언 -->
 	<resultMap id="NoteTrnsmitVO" type="egovframework.com.uss.ion.nts.service.NoteTrnsmit">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/nts/EgovNoteTrnsmit_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/nts/EgovNoteTrnsmit_SQL_mysql.xml
@@ -6,7 +6,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="NoteTrnsmit">
+<mapper namespace="egovframework.com.uss.ion.nts.service.impl.NoteTrnsmitDao">
 	
 	<!-- ::ResultMap 선언 -->
 	<resultMap id="NoteTrnsmitVO" type="egovframework.com.uss.ion.nts.service.NoteTrnsmit">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/nts/EgovNoteTrnsmit_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/nts/EgovNoteTrnsmit_SQL_oracle.xml
@@ -6,7 +6,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="NoteTrnsmit">
+<mapper namespace="egovframework.com.uss.ion.nts.service.impl.NoteTrnsmitDao">
 
 	<!-- ::ResultMap 선언 -->
 	<resultMap id="NoteTrnsmitVO" type="egovframework.com.uss.ion.nts.service.NoteTrnsmit">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/nts/EgovNoteTrnsmit_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/nts/EgovNoteTrnsmit_SQL_postgres.xml
@@ -6,7 +6,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="NoteTrnsmit">
+<mapper namespace="egovframework.com.uss.ion.nts.service.impl.NoteTrnsmitDao">
 	
 	<!-- ::ResultMap 선언 -->
 	<resultMap id="NoteTrnsmitVO" type="egovframework.com.uss.ion.nts.service.NoteTrnsmit">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/nts/EgovNoteTrnsmit_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/nts/EgovNoteTrnsmit_SQL_tibero.xml
@@ -6,7 +6,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="NoteTrnsmit">
+<mapper namespace="egovframework.com.uss.ion.nts.service.impl.NoteTrnsmitDao">
 
 	<!-- ::ResultMap 선언 -->
 	<resultMap id="NoteTrnsmitVO" type="egovframework.com.uss.ion.nts.service.NoteTrnsmit">

--- a/src/main/resources/egovframework/spring/com/context-mapper.xml
+++ b/src/main/resources/egovframework/spring/com/context-mapper.xml
@@ -21,5 +21,12 @@
 	<bean id="egov.sqlSessionTemplate" class="org.mybatis.spring.SqlSessionTemplate">
 		<constructor-arg ref="egov.sqlSession"/>
 	</bean>
-	
+
+	<!-- @EgovMapper 어노테이션이 붙은 인터페이스를 자동으로 스캔하여 빈으로 등록 -->
+	<bean class="org.mybatis.spring.mapper.MapperScannerConfigurer">
+		<property name="basePackage" value="egovframework.com"/>
+		<property name="annotationClass" value="org.egovframe.rte.psl.dataaccess.mapper.EgovMapper"/>
+		<property name="sqlSessionFactoryBeanName" value="egov.sqlSession"/>
+	</bean>
+
 </beans>


### PR DESCRIPTION
eGovFrame 5.0에서 도입된 `@EgovMapper` 어노테이션 방식을 보낸쪽지함관리(`uss/ion/nts`) 컴포넌트에 적용합니다.

기존 `EgovComAbstractDAO` 상속 방식은 SqlSession을 직접 다루는 레거시 패턴입니다. 인터페이스 기반 `@EgovMapper` 방식으로 전환하면 MyBatis 표준 방식과 일치하고 코드가 더 간결해집니다.

**변경 내용**

- `NoteTrnsmitDao`: `@Repository` 클래스 → `@EgovMapper` 인터페이스로 전환
  - `EgovComAbstractDAO` 상속 제거
  - `selectList` / `selectOne` / `delete` 직접 호출 제거
  - 메서드명을 XML statement id와 일치하도록 정렬 (`selectNoteTrnsmit`, `selectNoteTrnsmitCnt`)
- `EgovNoteTrnsmitServiceImpl`: 변경된 DAO 메서드명에 맞게 위임 호출 수정
- `EgovNoteTrnsmit_SQL_*.xml` (8개 DB 방언): `namespace`를 인터페이스 FQCN으로 변경 (SQL 내용 변경 없음)
- `context-mapper.xml`: `MapperScannerConfigurer` 빈 추가

**체크리스트**

- [x] 단일 주제만 다룸 (다른 변경 없음)
- [x] 기존 동작에 영향 없음 (SQL 변경 없음, 서비스 인터페이스 유지)
- [x] 8개 DB 방언 XML 모두 namespace 업데이트
