### PR TITLE
[refactor][5.0.x][공통컴포넌트] cmm FileManageDAO @EgovMapper 인터페이스 방식으로 전환

### DIFF
--- a/src/main/java/egovframework/com/cmm/service/impl/FileManageDAO.java
+++ b/src/main/java/egovframework/com/cmm/service/impl/FileManageDAO.java
@@ -6,15 +6,17 @@ import java.util.List;
 import org.springframework.stereotype.Repository;
 
 import egovframework.com.cmm.service.FileVO;
+import jakarta.annotation.Resource;
 
 /**
- * @Class Name : EgovFileMngDAO.java
+ * @Class Name : FileManageDAO.java
  * @Description : 파일정보 관리를 위한 데이터 처리 클래스
  * @Modification Information
  *
  *    수정일       수정자         수정내용
  *    -------        -------     -------------------
  *    2009. 3. 25.     이삼섭    최초생성
+ *    2025.05.28.      이백행    @EgovMapper 인터페이스 방식으로 전환
  *
  * @author 공통 서비스 개발팀 이삼섭
  * @since 2009. 3. 25.
@@ -23,7 +25,10 @@ import egovframework.com.cmm.service.FileVO;
  *
  */
 @Repository("FileManageDAO")
-public class FileManageDAO extends EgovComAbstractDAO {
+public class FileManageDAO {
+
+	@Resource(name = "fileMngMapper")
+	private FileMngMapper fileMngMapper;
 
 	/**
 	 * 여러 개의 파일에 대한 정보(속성 및 상세)를 등록한다.
@@ -36,13 +41,12 @@ public class FileManageDAO extends EgovComAbstractDAO {
 		FileVO vo = fileList.get(0);
 		String atchFileId = vo.getAtchFileId();
 
-		insert("FileManageDAO.insertFileMaster", vo);
+		fileMngMapper.insertFileMaster(vo);
 
 		Iterator<FileVO> iter = fileList.iterator();
 		while (iter.hasNext()) {
 			vo = iter.next();
-
-			insert("FileManageDAO.insertFileDetail", vo);
+			fileMngMapper.insertFileDetail(vo);
 		}
 
 		return atchFileId;
@@ -55,8 +59,8 @@ public class FileManageDAO extends EgovComAbstractDAO {
 	 * @throws Exception
 	 */
 	public void insertFileInf(FileVO vo) throws Exception {
-		insert("FileManageDAO.insertFileMaster", vo);
-		insert("FileManageDAO.insertFileDetail", vo);
+		fileMngMapper.insertFileMaster(vo);
+		fileMngMapper.insertFileDetail(vo);
 	}
 
 	/**
@@ -66,11 +70,9 @@ public class FileManageDAO extends EgovComAbstractDAO {
 	 * @throws Exception
 	 */
 	public void updateFileInfs(List<FileVO> fileList) throws Exception {
-		FileVO vo;
 		Iterator<FileVO> iter = fileList.iterator();
 		while (iter.hasNext()) {
-			vo = iter.next();
-			insert("FileManageDAO.insertFileDetail", vo);
+			fileMngMapper.insertFileDetail(iter.next());
 		}
 	}
 
@@ -82,11 +84,8 @@ public class FileManageDAO extends EgovComAbstractDAO {
 	 */
 	public void deleteFileInfs(List<FileVO> fileList) throws Exception {
 		Iterator<FileVO> iter = fileList.iterator();
-		FileVO vo;
 		while (iter.hasNext()) {
-			vo = iter.next();
-
-			delete("FileManageDAO.deleteFileDetail", vo);
+			fileMngMapper.deleteFileDetail(iter.next());
 		}
 	}
 
@@ -97,7 +96,7 @@ public class FileManageDAO extends EgovComAbstractDAO {
 	 * @throws Exception
 	 */
 	public void deleteFileInf(FileVO fvo) throws Exception {
-		delete("FileManageDAO.deleteFileDetail", fvo);
+		fileMngMapper.deleteFileDetail(fvo);
 	}
 
 	/**
@@ -108,7 +107,7 @@ public class FileManageDAO extends EgovComAbstractDAO {
 	 * @throws Exception
 	 */
 	public List<FileVO> selectFileInfs(FileVO vo) throws Exception {
-		return selectList("FileManageDAO.selectFileList", vo);
+		return fileMngMapper.selectFileList(vo);
 	}
 
 	/**
@@ -119,7 +118,7 @@ public class FileManageDAO extends EgovComAbstractDAO {
 	 * @throws Exception
 	 */
 	public int getMaxFileSN(FileVO fvo) throws Exception {
-		return (Integer) selectOne("FileManageDAO.getMaxFileSN", fvo);
+		return fileMngMapper.getMaxFileSN(fvo);
 	}
 
 	/**
@@ -130,7 +129,7 @@ public class FileManageDAO extends EgovComAbstractDAO {
 	 * @throws Exception
 	 */
 	public FileVO selectFileInf(FileVO fvo) throws Exception {
-		return (FileVO) selectOne("FileManageDAO.selectFileInf", fvo);
+		return fileMngMapper.selectFileInf(fvo);
 	}
 
 	/**
@@ -140,18 +139,18 @@ public class FileManageDAO extends EgovComAbstractDAO {
 	 * @throws Exception
 	 */
 	public void deleteAllFileInf(FileVO fvo) throws Exception {
-		update("FileManageDAO.deleteCOMTNFILE", fvo);
+		fileMngMapper.deleteCOMTNFILE(fvo);
 	}
 
 	/**
 	 * 파일명 검색에 대한 목록을 조회한다.
 	 *
-	 * @param vo
+	 * @param fvo
 	 * @return
 	 * @throws Exception
 	 */
 	public List<FileVO> selectFileListByFileNm(FileVO fvo) throws Exception {
-		return selectList("FileManageDAO.selectFileListByFileNm", fvo);
+		return fileMngMapper.selectFileListByFileNm(fvo);
 	}
 
 	/**
@@ -162,7 +161,7 @@ public class FileManageDAO extends EgovComAbstractDAO {
 	 * @throws Exception
 	 */
 	public int selectFileListCntByFileNm(FileVO fvo) throws Exception {
-		return (Integer) selectOne("FileManageDAO.selectFileListCntByFileNm", fvo);
+		return fileMngMapper.selectFileListCntByFileNm(fvo);
 	}
 
 	/**
@@ -173,6 +172,6 @@ public class FileManageDAO extends EgovComAbstractDAO {
 	 * @throws Exception
 	 */
 	public List<FileVO> selectImageFileList(FileVO vo) throws Exception {
-		return selectList("FileManageDAO.selectImageFileList", vo);
+		return fileMngMapper.selectImageFileList(vo);
 	}
 }

--- a/src/main/java/egovframework/com/cmm/service/impl/FileMngMapper.java
+++ b/src/main/java/egovframework/com/cmm/service/impl/FileMngMapper.java
@@ -1,0 +1,103 @@
+package egovframework.com.cmm.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.cmm.service.FileVO;
+
+/**
+ * @Class Name : FileMngMapper.java
+ * @Description : 파일정보 관리를 위한 MyBatis 매퍼 인터페이스
+ * @Modification Information
+ *
+ *    수정일       수정자         수정내용
+ *    -------        -------     -------------------
+ *    2025.05.28.    이백행       @EgovMapper 인터페이스 방식으로 전환
+ *
+ * @author 공통 서비스 개발팀
+ * @since 2025.05.28.
+ * @version 1.0
+ * @see
+ *
+ */
+@EgovMapper("fileMngMapper")
+public interface FileMngMapper {
+
+	/**
+	 * 파일 마스터 정보를 등록한다.
+	 *
+	 * @param vo
+	 */
+	void insertFileMaster(FileVO vo);
+
+	/**
+	 * 파일 상세 정보를 등록한다.
+	 *
+	 * @param vo
+	 */
+	void insertFileDetail(FileVO vo);
+
+	/**
+	 * 파일 상세 정보를 삭제한다.
+	 *
+	 * @param vo
+	 */
+	void deleteFileDetail(FileVO vo);
+
+	/**
+	 * 파일에 대한 목록을 조회한다.
+	 *
+	 * @param vo
+	 * @return
+	 */
+	List<FileVO> selectFileList(FileVO vo);
+
+	/**
+	 * 파일 구분자에 대한 최대값을 구한다.
+	 *
+	 * @param fvo
+	 * @return
+	 */
+	int getMaxFileSN(FileVO fvo);
+
+	/**
+	 * 파일에 대한 상세정보를 조회한다.
+	 *
+	 * @param fvo
+	 * @return
+	 */
+	FileVO selectFileInf(FileVO fvo);
+
+	/**
+	 * 전체 파일을 삭제한다. (USE_AT = 'N' 처리)
+	 *
+	 * @param fvo
+	 */
+	void deleteCOMTNFILE(FileVO fvo);
+
+	/**
+	 * 파일명 검색에 대한 목록을 조회한다.
+	 *
+	 * @param fvo
+	 * @return
+	 */
+	List<FileVO> selectFileListByFileNm(FileVO fvo);
+
+	/**
+	 * 파일명 검색에 대한 목록 전체 건수를 조회한다.
+	 *
+	 * @param fvo
+	 * @return
+	 */
+	int selectFileListCntByFileNm(FileVO fvo);
+
+	/**
+	 * 이미지 파일에 대한 목록을 조회한다.
+	 *
+	 * @param vo
+	 * @return
+	 */
+	List<FileVO> selectImageFileList(FileVO vo);
+
+}

--- a/src/main/resources/egovframework/mapper/com/cmm/fms/EgovFile_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/cmm/fms/EgovFile_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:49:38 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="FileManageDAO">
+<mapper namespace="egovframework.com.cmm.service.impl.FileMngMapper">
 
 	<resultMap id="fileList" type="egovframework.com.cmm.service.FileVO">
 		<result property="atchFileId" column="ATCH_FILE_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cmm/fms/EgovFile_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/cmm/fms/EgovFile_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:49:38 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="FileManageDAO">
+<mapper namespace="egovframework.com.cmm.service.impl.FileMngMapper">
 
 	<resultMap id="fileList" type="egovframework.com.cmm.service.FileVO">
 		<result property="atchFileId" column="ATCH_FILE_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cmm/fms/EgovFile_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/cmm/fms/EgovFile_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:49:38 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="FileManageDAO">
+<mapper namespace="egovframework.com.cmm.service.impl.FileMngMapper">
 
 	<resultMap id="fileList" type="egovframework.com.cmm.service.FileVO">
 		<result property="atchFileId" column="ATCH_FILE_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cmm/fms/EgovFile_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/cmm/fms/EgovFile_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:49:38 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="FileManageDAO">
+<mapper namespace="egovframework.com.cmm.service.impl.FileMngMapper">
 
 	<resultMap id="fileList" type="egovframework.com.cmm.service.FileVO">
 		<result property="atchFileId" column="ATCH_FILE_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cmm/fms/EgovFile_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/cmm/fms/EgovFile_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:49:38 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="FileManageDAO">
+<mapper namespace="egovframework.com.cmm.service.impl.FileMngMapper">
 
 	<resultMap id="fileList" type="egovframework.com.cmm.service.FileVO">
 		<result property="atchFileId" column="ATCH_FILE_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cmm/fms/EgovFile_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/cmm/fms/EgovFile_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:49:38 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="FileManageDAO">
+<mapper namespace="egovframework.com.cmm.service.impl.FileMngMapper">
 
 	<resultMap id="fileList" type="egovframework.com.cmm.service.FileVO">
 		<result property="atchFileId" column="ATCH_FILE_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cmm/fms/EgovFile_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/cmm/fms/EgovFile_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:49:38 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="FileManageDAO">
+<mapper namespace="egovframework.com.cmm.service.impl.FileMngMapper">
 
 	<resultMap id="fileList" type="egovframework.com.cmm.service.FileVO">
 		<result property="atchFileId" column="ATCH_FILE_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cmm/fms/EgovFile_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/cmm/fms/EgovFile_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:49:38 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="FileManageDAO">
+<mapper namespace="egovframework.com.cmm.service.impl.FileMngMapper">
 
 	<resultMap id="fileList" type="egovframework.com.cmm.service.FileVO">
 		<result property="atchFileId" column="ATCH_FILE_ID"/>

--- a/src/main/resources/egovframework/spring/com/context-mapper.xml
+++ b/src/main/resources/egovframework/spring/com/context-mapper.xml
@@ -21,5 +21,12 @@
 	<bean id="egov.sqlSessionTemplate" class="org.mybatis.spring.SqlSessionTemplate">
 		<constructor-arg ref="egov.sqlSession"/>
 	</bean>
-	
+
+	<!-- @EgovMapper 인터페이스 스캔 -->
+	<bean class="org.mybatis.spring.mapper.MapperScannerConfigurer">
+		<property name="basePackage" value="egovframework.com"/>
+		<property name="annotationClass" value="org.egovframe.rte.psl.dataaccess.mapper.EgovMapper"/>
+		<property name="sqlSessionFactoryBeanName" value="egov.sqlSession"/>
+	</bean>
+
 </beans>


### PR DESCRIPTION
## 변경 사유

기존 XML namespace 기반 DAO를 eGovFrame 5.0 신규 `@EgovMapper` 인터페이스 방식으로 전환한다.
`EgovComAbstractDAO`를 상속하는 레거시 패턴에서 인터페이스 기반 매퍼로 전환하여 유지보수성을 높인다.

## 변경 내용

- `FileMngMapper.java` 신규 추가: `@EgovMapper` 인터페이스로 단일 SQL 조작 선언
- `FileManageDAO.java` 변경: `EgovComAbstractDAO` 상속 제거, `FileMngMapper` 주입 후 위임 구조로 리팩토링 (다중 SQL 조합 로직은 DAO에서 유지)
- `EgovFile_SQL_*.xml` 8개 (altibase/cubrid/goldilocks/maria/mysql/oracle/postgres/tibero): `namespace="FileManageDAO"` → `namespace="egovframework.com.cmm.service.impl.FileMngMapper"` 변경
- `context-mapper.xml`: `MapperScannerConfigurer` 빈 추가 (`@EgovMapper` 인터페이스 자동 스캔)

## 영향 범위

- cmm 파일관리 모듈만 영향
- `FileManageDAO` bean name 유지 (`@Repository("FileManageDAO")`) — `EgovFileMngServiceImpl`의 `@Resource(name="FileManageDAO")` 주입 구조 변경 없음
- `MapperScannerConfigurer`는 `@EgovMapper` 어노테이션 인터페이스만 스캔하므로 기존 `@Repository` 클래스와 충돌 없음

## 체크리스트

- [x] 단일 주제만 다룸 (다른 변경 없음)
- [x] 5.x 다른 브랜치용 PR이 필요한 경우 후속 PR 링크 명시
- [x] 기존 동작에 영향 없음 (호출 시그니처 및 bean name 호환 유지)
- [x] 컴파일 확인 (cmm 모듈 관련 신규 오류 없음)
