### PR TITLE
[refactor][5.0.x][공통컴포넌트] cop/bbs EgovArticleDAO @EgovMapper 인터페이스 방식으로 전환

### DIFF
--- a/src/main/java/egovframework/com/cop/bbs/service/impl/EgovArticleDAO.java
+++ b/src/main/java/egovframework/com/cop/bbs/service/impl/EgovArticleDAO.java
@@ -4,97 +4,98 @@ import java.util.List;
 
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.cop.bbs.service.Board;
 import egovframework.com.cop.bbs.service.BoardMasterVO;
 import egovframework.com.cop.bbs.service.BoardVO;
+import jakarta.annotation.Resource;
 
 @Repository("EgovArticleDAO")
-public class EgovArticleDAO extends EgovComAbstractDAO {
+public class EgovArticleDAO {
+
+	@Resource(name = "egovArticleMapper")
+	private EgovArticleMapper egovArticleMapper;
 
 	public List<BoardVO> selectArticleList(BoardVO boardVO) {
-		return selectList("BBSArticle.selectArticleList", boardVO);
+		return egovArticleMapper.selectArticleList(boardVO);
 	}
 
 	public int selectArticleListCnt(BoardVO boardVO) {
-		return (Integer)selectOne("BBSArticle.selectArticleListCnt", boardVO);
+		return egovArticleMapper.selectArticleListCnt(boardVO);
 	}
 
 	public int selectMaxInqireCo(BoardVO boardVO) {
-		return (Integer)selectOne("BBSArticle.selectMaxInqireCo", boardVO);
+		return egovArticleMapper.selectMaxInqireCo(boardVO);
 	}
 
 	public void updateInqireCo(BoardVO boardVO) {
-		update("BBSArticle.updateInqireCo", boardVO);
+		egovArticleMapper.updateInqireCo(boardVO);
 	}
 
 	public BoardVO selectArticleDetail(BoardVO boardVO) {
-		return (BoardVO) selectOne("BBSArticle.selectArticleDetail", boardVO);
+		return egovArticleMapper.selectArticleDetail(boardVO);
 	}
-	
+
 	public void replyArticle(Board board) {
-		insert("BBSArticle.replyArticle", board);
+		egovArticleMapper.replyArticle(board);
 	}
 
 	public void insertArticle(Board board) {
-		insert("BBSArticle.insertArticle", board);
+		egovArticleMapper.insertArticle(board);
 	}
 
 	public void updateArticle(Board board) {
-		update("BBSArticle.updateArticle", board);
+		egovArticleMapper.updateArticle(board);
 	}
 
 	public void deleteArticle(Board board) {
-		update("BBSArticle.deleteArticle", board);
-		
+		egovArticleMapper.deleteArticle(board);
 	}
 
 	public List<BoardVO> selectNoticeArticleList(BoardVO boardVO) {
-		return selectList("BBSArticle.selectNoticeArticleList", boardVO);
+		return egovArticleMapper.selectNoticeArticleList(boardVO);
 	}
-	
+
 	public List<BoardVO> selectGuestArticleList(BoardVO vo) {
-		return selectList("BBSArticle.selectGuestArticleList", vo);
+		return egovArticleMapper.selectGuestArticleList(vo);
 	}
 
 	public int selectGuestArticleListCnt(BoardVO vo) {
-		return (Integer)selectOne("BBSArticle.selectGuestArticleListCnt", vo);
+		return egovArticleMapper.selectGuestArticleListCnt(vo);
 	}
-	
+
 	/*
 	 * 블로그 관련
 	 */
 	public BoardVO selectArticleCnOne(BoardVO boardVO) {
-		return (BoardVO) selectOne("BBSArticle.selectArticleCnOne", boardVO);
+		return egovArticleMapper.selectArticleCnOne(boardVO);
 	}
-	
+
 	public List<BoardVO> selectBlogNmList(BoardVO boardVO) {
-		return selectList("BBSArticle.selectBlogNmList", boardVO);
+		return egovArticleMapper.selectBlogNmList(boardVO);
 	}
-	
+
 	public List<BoardMasterVO> selectBlogListManager(BoardVO vo) {
-		return selectList("BBSArticle.selectBlogListManager", vo);
+		return egovArticleMapper.selectBlogListManager(vo);
 	}
-	
+
 	public int selectBlogListManagerCnt(BoardVO vo) {
-		return (Integer)selectOne("BBSArticle.selectBlogListManagerCnt", vo);
+		return egovArticleMapper.selectBlogListManagerCnt(vo);
 	}
-	
+
 	public List<BoardVO> selectArticleDetailDefault(BoardVO boardVO) {
-		return selectList("BBSArticle.selectArticleDetailDefault", boardVO);
+		return egovArticleMapper.selectArticleDetailDefault(boardVO);
 	}
-	
+
 	public int selectArticleDetailDefaultCnt(BoardVO boardVO) {
-		return (Integer)selectOne("BBSArticle.selectArticleDetailDefaultCnt", boardVO);
+		return egovArticleMapper.selectArticleDetailDefaultCnt(boardVO);
 	}
-	
+
 	public List<BoardVO> selectArticleDetailCn(BoardVO boardVO) {
-		return selectList("BBSArticle.selectArticleDetailCn", boardVO);
+		return egovArticleMapper.selectArticleDetailCn(boardVO);
 	}
-	
+
 	public int selectLoginUser(BoardVO boardVO) {
-		return (Integer)selectOne("BBSArticle.selectLoginUser", boardVO);
+		return egovArticleMapper.selectLoginUser(boardVO);
 	}
-	
 
 }

--- a/src/main/java/egovframework/com/cop/bbs/service/impl/EgovArticleMapper.java
+++ b/src/main/java/egovframework/com/cop/bbs/service/impl/EgovArticleMapper.java
@@ -1,0 +1,161 @@
+package egovframework.com.cop.bbs.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.cop.bbs.service.Board;
+import egovframework.com.cop.bbs.service.BoardMasterVO;
+import egovframework.com.cop.bbs.service.BoardVO;
+
+/**
+ * 게시물 관리를 위한 Mapper 인터페이스
+ *
+ * <pre>
+ *  == 개정이력(Modification Information) ==
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2026.05.28  dasomel     @EgovMapper 인터페이스 방식으로 전환
+ *
+ * </pre>
+ */
+@EgovMapper
+public interface EgovArticleMapper {
+
+	/**
+	 * 게시물 목록을 조회한다.
+	 * @param boardVO - 게시물 VO
+	 * @return List - 게시물 목록
+	 */
+	List<BoardVO> selectArticleList(BoardVO boardVO);
+
+	/**
+	 * 게시물 목록 총 개수를 조회한다.
+	 * @param boardVO - 게시물 VO
+	 * @return int - 게시물 카운트 수
+	 */
+	int selectArticleListCnt(BoardVO boardVO);
+
+	/**
+	 * 최대 조회수를 조회한다.
+	 * @param boardVO - 게시물 VO
+	 * @return int - 최대 조회수
+	 */
+	int selectMaxInqireCo(BoardVO boardVO);
+
+	/**
+	 * 조회수를 업데이트한다.
+	 * @param boardVO - 게시물 VO
+	 */
+	void updateInqireCo(BoardVO boardVO);
+
+	/**
+	 * 게시물 상세 정보를 조회한다.
+	 * @param boardVO - 게시물 VO
+	 * @return BoardVO - 게시물 VO
+	 */
+	BoardVO selectArticleDetail(BoardVO boardVO);
+
+	/**
+	 * 답글 게시물을 등록한다.
+	 * @param board - 게시물 model
+	 */
+	void replyArticle(Board board);
+
+	/**
+	 * 게시물을 신규 등록한다.
+	 * @param board - 게시물 model
+	 */
+	void insertArticle(Board board);
+
+	/**
+	 * 게시물을 수정한다.
+	 * @param board - 게시물 model
+	 */
+	void updateArticle(Board board);
+
+	/**
+	 * 게시물을 삭제한다.
+	 * @param board - 게시물 model
+	 */
+	void deleteArticle(Board board);
+
+	/**
+	 * 공지 게시물 목록을 조회한다.
+	 * @param boardVO - 게시물 VO
+	 * @return List - 공지 게시물 목록
+	 */
+	List<BoardVO> selectNoticeArticleList(BoardVO boardVO);
+
+	/**
+	 * 방명록 게시물 목록을 조회한다.
+	 * @param vo - 게시물 VO
+	 * @return List - 방명록 게시물 목록
+	 */
+	List<BoardVO> selectGuestArticleList(BoardVO vo);
+
+	/**
+	 * 방명록 게시물 목록 총 개수를 조회한다.
+	 * @param vo - 게시물 VO
+	 * @return int - 방명록 게시물 카운트 수
+	 */
+	int selectGuestArticleListCnt(BoardVO vo);
+
+	/**
+	 * 블로그 게시물 본문을 조회한다.
+	 * @param boardVO - 게시물 VO
+	 * @return BoardVO - 게시물 VO
+	 */
+	BoardVO selectArticleCnOne(BoardVO boardVO);
+
+	/**
+	 * 블로그 게시판 명 목록을 조회한다.
+	 * @param boardVO - 게시물 VO
+	 * @return List - 게시판 명 목록
+	 */
+	List<BoardVO> selectBlogNmList(BoardVO boardVO);
+
+	/**
+	 * 블로그 관리자용 게시판 목록을 조회한다.
+	 * @param vo - 게시물 VO
+	 * @return List - 게시판 목록
+	 */
+	List<BoardMasterVO> selectBlogListManager(BoardVO vo);
+
+	/**
+	 * 블로그 관리자용 게시판 목록 총 개수를 조회한다.
+	 * @param vo - 게시물 VO
+	 * @return int - 게시판 카운트 수
+	 */
+	int selectBlogListManagerCnt(BoardVO vo);
+
+	/**
+	 * 기본 게시물 상세 목록을 조회한다.
+	 * @param boardVO - 게시물 VO
+	 * @return List - 게시물 목록
+	 */
+	List<BoardVO> selectArticleDetailDefault(BoardVO boardVO);
+
+	/**
+	 * 기본 게시물 상세 목록 총 개수를 조회한다.
+	 * @param boardVO - 게시물 VO
+	 * @return int - 게시물 카운트 수
+	 */
+	int selectArticleDetailDefaultCnt(BoardVO boardVO);
+
+	/**
+	 * 게시물 본문 상세 목록을 조회한다.
+	 * @param boardVO - 게시물 VO
+	 * @return List - 게시물 목록
+	 */
+	List<BoardVO> selectArticleDetailCn(BoardVO boardVO);
+
+	/**
+	 * 로그인 사용자 여부를 조회한다.
+	 * @param boardVO - 게시물 VO
+	 * @return int - 로그인 사용자 카운트 수
+	 */
+	int selectLoginUser(BoardVO boardVO);
+
+}

--- a/src/main/resources/egovframework/mapper/com/cop/bbs/EgovArticle_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/bbs/EgovArticle_SQL_altibase.xml
@@ -7,7 +7,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BBSArticle">
+<mapper namespace="egovframework.com.cop.bbs.service.impl.EgovArticleMapper">
 
 	<resultMap id="boardList" type="egovframework.com.cop.bbs.service.BoardVO">
 		<result property="bbsId" column="BBS_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/bbs/EgovArticle_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/bbs/EgovArticle_SQL_cubrid.xml
@@ -7,7 +7,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BBSArticle">
+<mapper namespace="egovframework.com.cop.bbs.service.impl.EgovArticleMapper">
 
 	<resultMap id="boardList" type="egovframework.com.cop.bbs.service.BoardVO">
 		<result property="bbsId" column="BBS_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/bbs/EgovArticle_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/bbs/EgovArticle_SQL_goldilocks.xml
@@ -7,7 +7,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BBSArticle">
+<mapper namespace="egovframework.com.cop.bbs.service.impl.EgovArticleMapper">
 
 	<resultMap id="boardList" type="egovframework.com.cop.bbs.service.BoardVO">
 		<result property="bbsId" column="BBS_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/bbs/EgovArticle_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/bbs/EgovArticle_SQL_maria.xml
@@ -5,7 +5,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BBSArticle">
+<mapper namespace="egovframework.com.cop.bbs.service.impl.EgovArticleMapper">
 
 	<resultMap id="boardList" type="egovframework.com.cop.bbs.service.BoardVO">
 		<result property="bbsId" column="BBS_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/bbs/EgovArticle_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/bbs/EgovArticle_SQL_mysql.xml
@@ -5,7 +5,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BBSArticle">
+<mapper namespace="egovframework.com.cop.bbs.service.impl.EgovArticleMapper">
 
 	<resultMap id="boardList" type="egovframework.com.cop.bbs.service.BoardVO">
 		<result property="bbsId" column="BBS_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/bbs/EgovArticle_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/bbs/EgovArticle_SQL_oracle.xml
@@ -7,7 +7,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BBSArticle">
+<mapper namespace="egovframework.com.cop.bbs.service.impl.EgovArticleMapper">
 
 	<resultMap id="boardList" type="egovframework.com.cop.bbs.service.BoardVO">
 		<result property="bbsId" column="BBS_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/bbs/EgovArticle_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/bbs/EgovArticle_SQL_postgres.xml
@@ -5,7 +5,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BBSArticle">
+<mapper namespace="egovframework.com.cop.bbs.service.impl.EgovArticleMapper">
 
 	<resultMap id="boardList" type="egovframework.com.cop.bbs.service.BoardVO">
 		<result property="bbsId" column="BBS_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/bbs/EgovArticle_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/bbs/EgovArticle_SQL_tibero.xml
@@ -7,7 +7,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BBSArticle">
+<mapper namespace="egovframework.com.cop.bbs.service.impl.EgovArticleMapper">
 
 	<resultMap id="boardList" type="egovframework.com.cop.bbs.service.BoardVO">
 		<result property="bbsId" column="BBS_ID"/>

--- a/src/main/resources/egovframework/spring/com/context-mapper.xml
+++ b/src/main/resources/egovframework/spring/com/context-mapper.xml
@@ -21,5 +21,11 @@
 	<bean id="egov.sqlSessionTemplate" class="org.mybatis.spring.SqlSessionTemplate">
 		<constructor-arg ref="egov.sqlSession"/>
 	</bean>
-	
+
+	<!-- @EgovMapper 어노테이션 기반 MapperScannerConfigurer -->
+	<bean class="org.mybatis.spring.mapper.MapperScannerConfigurer">
+		<property name="basePackage" value="egovframework.com" />
+		<property name="annotationClass" value="org.egovframe.rte.psl.dataaccess.mapper.EgovMapper" />
+	</bean>
+
 </beans>


### PR DESCRIPTION
## 변경 사유
기존 EgovComAbstractDAO 기반 XML 네임스페이스 호출 방식을 5.0에 신규 반영된 @EgovMapper 인터페이스 방식으로 전환

## 변경 내용
- EgovArticleMapper 인터페이스 신규 추가 (@EgovMapper)
- EgovArticleDAO를 mapper 위임 구조로 리팩토링 (EgovComAbstractDAO 상속 제거)
- EgovArticle_SQL_*.xml 8개 파일의 namespace를 EgovArticleMapper FQN으로 변경
- context-mapper.xml MapperScannerConfigurer 빈 추가

## 영향 범위
- cop/bbs 모듈만 영향 (게시판 게시글 서비스)
- 외부 호출 시그니처(EgovArticleService) 변경 없음
- DAO bean name(`EgovArticleDAO`) 유지로 기존 @Resource 주입 호환

## 체크리스트
- [x] 단일 주제만 다룸 (다른 변경 없음)
- [x] 의존성 PR 없음 (context-mapper.xml MapperScannerConfigurer 이번 PR에 포함)
- [x] 기존 동작 호환 (DAO bean name 유지)
- [x] 빌드 확인 (cop/bbs 관련 컴파일 에러 없음)
