### PR TITLE
[refactor][5.0.x][공통컴포넌트] dam 지식관리 3개 DAO @EgovMapper 인터페이스 방식으로 전환

### DIFF
--- a/src/main/java/egovframework/com/dam/app/service/impl/KnoAppraisalDAO.java
+++ b/src/main/java/egovframework/com/dam/app/service/impl/KnoAppraisalDAO.java
@@ -5,9 +5,10 @@ import java.util.List;
 import org.egovframe.rte.psl.dataaccess.util.EgovMap;
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.dam.app.service.KnoAppraisal;
 import egovframework.com.dam.app.service.KnoAppraisalVO;
+
+import jakarta.annotation.Resource;
 
 /**
  * 개요
@@ -20,71 +21,61 @@ import egovframework.com.dam.app.service.KnoAppraisalVO;
  * @version 1.0
  * @created 12-8-2010 오후 3:44:47
  */
-
 @Repository("KnoAppraisalDAO")
-public class KnoAppraisalDAO extends EgovComAbstractDAO {
+public class KnoAppraisalDAO {
+
+	@Resource(name = "knoAppraisalMapper")
+	private KnoAppraisalMapper knoAppraisalMapper;
 
 	/**
-	 * 등록된 지식정보평가 정보를 조회 한다.
-	 * @param KnoAppraisalVO - 지식정보평가 VO
-	 * @return String - 지식정보평가 VO
-	 *
-	 * @param KnoAppraisalVO
+	 * 등록된 지식정보평가 목록을 조회한다.
+	 * @param searchVO 지식정보평가 조회 조건 VO
+	 * @return 지식정보평가 목록
 	 */
-	public List<EgovMap> selectKnoAppraisalList(KnoAppraisalVO searchVO) throws Exception {
-		return  selectList("KnoAppraisalDAO.selectKnoAppraisalList", searchVO);
+	public List<EgovMap> selectKnoAppraisalList(KnoAppraisalVO searchVO) {
+		return knoAppraisalMapper.selectKnoAppraisalList(searchVO);
 	}
 
 	/**
 	 * 지식정보평가 목록 총 개수를 조회한다.
-	 * @param MapTeamVO - 지식정보평가 Vo
-	 * @return int - 지식정보평가 토탈 카운트 수
-	 *
-	 * @param KnoAppraisalVO
+	 * @param searchVO 지식정보평가 조회 조건 VO
+	 * @return 총 개수
 	 */
-	public int selectKnoAppraisalTotCnt(KnoAppraisalVO searchVO) throws Exception {
-		return  (Integer)selectOne("KnoAppraisalDAO.selectKnoAppraisalTotCnt", searchVO);
+	public int selectKnoAppraisalTotCnt(KnoAppraisalVO searchVO) {
+		return knoAppraisalMapper.selectKnoAppraisalTotCnt(searchVO);
 	}
 
 	/**
-	 * 지식정보평가 상세 정보를 조회 한다.
-	 * @param KnoAppraisalVO - 지식정보평가 VO
-	 * @return String - 지식정보평가 VO
-	 *
-	 * @param KnoAppraisalVO
+	 * 지식정보평가 상세 정보를 조회한다.
+	 * @param knoAppraisal 조회할 지식정보평가 식별 정보가 담긴 모델
+	 * @return 지식정보평가 상세 모델
 	 */
-	public KnoAppraisal selectKnoAppraisal(KnoAppraisal knoAppraisal) throws Exception {
-		return (KnoAppraisal)selectOne("KnoAppraisalDAO.selectKnoAppraisal", knoAppraisal);
+	public KnoAppraisal selectKnoAppraisal(KnoAppraisal knoAppraisal) {
+		return knoAppraisalMapper.selectKnoAppraisal(knoAppraisal);
 	}
 
 	/**
 	 * 지식정보평가 정보를 신규로 등록한다.
-	 * @param knoAps - 지식정보평가 model
-	 *
-	 * @param knoAps
+	 * @param knoAppraisal 등록할 지식정보평가 모델
 	 */
-	public void insertKnoAppraisal(KnoAppraisal knoAppraisal) throws Exception {
-		insert("KnoAppraisalDAO.insertKnoAppraisal", knoAppraisal);
+	public void insertKnoAppraisal(KnoAppraisal knoAppraisal) {
+		knoAppraisalMapper.insertKnoAppraisal(knoAppraisal);
 	}
 
 	/**
-	 * 기 등록 된 지식정보평가 정보를 수정 한다.
-	 * @param AppraisalknoAps - 지식정보평가 model
-	 *
-	 * @param knoAps
+	 * 기 등록된 지식정보평가 정보를 수정한다.
+	 * @param knoAppraisal 수정할 지식정보평가 모델
 	 */
-	public void updateKnoAppraisal(KnoAppraisal knoAppraisal) throws Exception {
-		update("KnoAppraisalDAO.updateKnoAppraisal", knoAppraisal);
+	public void updateKnoAppraisal(KnoAppraisal knoAppraisal) {
+		knoAppraisalMapper.updateKnoAppraisal(knoAppraisal);
 	}
 
 	/**
 	 * 기 등록된 지식정보평가 정보를 삭제한다.
-	 * @param AppraisalknoAps - 지식정보평가 model
-	 *
-	 * @param knoAps
+	 * @param knoAppraisal 삭제할 지식정보평가 모델
 	 */
-	public void deleteKnoAppraisal(KnoAppraisal knoAppraisal) throws Exception {
-		delete("KnoAppraisalDAO.deleteKnoAppraisal", knoAppraisal);
+	public void deleteKnoAppraisal(KnoAppraisal knoAppraisal) {
+		knoAppraisalMapper.deleteKnoAppraisal(knoAppraisal);
 	}
 
 }

--- a/src/main/java/egovframework/com/dam/app/service/impl/KnoAppraisalMapper.java
+++ b/src/main/java/egovframework/com/dam/app/service/impl/KnoAppraisalMapper.java
@@ -1,0 +1,65 @@
+package egovframework.com.dam.app.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+import org.egovframe.rte.psl.dataaccess.util.EgovMap;
+
+import egovframework.com.dam.app.service.KnoAppraisal;
+import egovframework.com.dam.app.service.KnoAppraisalVO;
+
+/**
+ * 지식정보평가 관리를 위한 MyBatis 매퍼 인터페이스
+ *
+ * <pre>
+ *  == 개정이력(Modification Information) ==
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2026.05.28  dasomel     @EgovMapper 인터페이스 방식으로 전환
+ *
+ * </pre>
+ */
+@EgovMapper
+public interface KnoAppraisalMapper {
+
+	/**
+	 * 등록된 지식정보평가 목록을 조회한다.
+	 * @param searchVO 지식정보평가 조회 조건 VO
+	 * @return 지식정보평가 목록
+	 */
+	List<EgovMap> selectKnoAppraisalList(KnoAppraisalVO searchVO);
+
+	/**
+	 * 지식정보평가 목록 총 개수를 조회한다.
+	 * @param searchVO 지식정보평가 조회 조건 VO
+	 * @return 총 개수
+	 */
+	int selectKnoAppraisalTotCnt(KnoAppraisalVO searchVO);
+
+	/**
+	 * 지식정보평가 상세 정보를 조회한다.
+	 * @param knoAppraisal 조회할 지식정보평가 식별 정보가 담긴 모델
+	 * @return 지식정보평가 상세 모델
+	 */
+	KnoAppraisal selectKnoAppraisal(KnoAppraisal knoAppraisal);
+
+	/**
+	 * 지식정보평가 정보를 신규로 등록한다.
+	 * @param knoAppraisal 등록할 지식정보평가 모델
+	 */
+	void insertKnoAppraisal(KnoAppraisal knoAppraisal);
+
+	/**
+	 * 기 등록된 지식정보평가 정보를 수정한다.
+	 * @param knoAppraisal 수정할 지식정보평가 모델
+	 */
+	void updateKnoAppraisal(KnoAppraisal knoAppraisal);
+
+	/**
+	 * 기 등록된 지식정보평가 정보를 삭제한다.
+	 * @param knoAppraisal 삭제할 지식정보평가 모델
+	 */
+	void deleteKnoAppraisal(KnoAppraisal knoAppraisal);
+
+}

--- a/src/main/java/egovframework/com/dam/mgm/service/impl/KnoManagementDAO.java
+++ b/src/main/java/egovframework/com/dam/mgm/service/impl/KnoManagementDAO.java
@@ -5,9 +5,10 @@ import java.util.List;
 import org.egovframe.rte.psl.dataaccess.util.EgovMap;
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.dam.mgm.service.KnoManagement;
 import egovframework.com.dam.mgm.service.KnoManagementVO;
+
+import jakarta.annotation.Resource;
 
 /**
  * 개요
@@ -21,63 +22,60 @@ import egovframework.com.dam.mgm.service.KnoManagementVO;
  * @created 12-8-2010 오후 3:44:48
  */
 @Repository("KnoManagementDAO")
-public class KnoManagementDAO extends EgovComAbstractDAO {
+public class KnoManagementDAO {
+
+	@Resource(name = "knoManagementMapper")
+	private KnoManagementMapper knoManagementMapper;
 
 	/**
 	 * 등록된 지식정보 목록을 조회한다.
 	 * @param searchVO 지식정보 조회 조건 VO
 	 * @return 지식정보 목록(List<EgovMap>)
-	 * @throws Exception 데이터 접근 중 오류가 발생한 경우
 	 */
-	public List<EgovMap> selectKnoManagementList(KnoManagementVO searchVO) throws Exception {
-		return selectList("KnoManagementDAO.selectKnoManagementList", searchVO);
+	public List<EgovMap> selectKnoManagementList(KnoManagementVO searchVO) {
+		return knoManagementMapper.selectKnoManagementList(searchVO);
 	}
 
 	/**
 	 * 지식정보 목록 총 개수를 조회한다.
 	 * @param searchVO 지식정보 조회 조건 VO
 	 * @return 총 개수
-	 * @throws Exception 데이터 접근 중 오류가 발생한 경우
 	 */
-	public int selectKnoManagementTotCnt(KnoManagementVO searchVO) throws Exception {
-		return selectOne("KnoManagementDAO.selectKnoManagementTotCnt", searchVO);
+	public int selectKnoManagementTotCnt(KnoManagementVO searchVO) {
+		return knoManagementMapper.selectKnoManagementTotCnt(searchVO);
 	}
 
 	/**
 	 * 지식정보 상세 정보를 조회한다.
 	 * @param knoManagement 조회할 지식정보 식별 정보가 담긴 모델
 	 * @return 지식정보 상세 모델
-	 * @throws Exception 식별자가 없거나 해당 지식정보가 존재하지 않거나 데이터 접근 오류가 발생한 경우
 	 */
-	public KnoManagement selectKnoManagement(KnoManagement knoManagement) throws Exception {
-		return selectOne("KnoManagementDAO.selectKnoManagement", knoManagement);
+	public KnoManagement selectKnoManagement(KnoManagement knoManagement) {
+		return knoManagementMapper.selectKnoManagement(knoManagement);
 	}
 
 	/**
 	 * 지식정보 정보를 신규로 등록한다.
 	 * @param knoManagement 등록할 지식정보 모델
-	 * @throws Exception 데이터 접근 중 오류가 발생한 경우
 	 */
-	public void insertKnoManagement(KnoManagement knoManagement) throws Exception {
-		insert("KnoManagementDAO.insertKnoManagement", knoManagement);
+	public void insertKnoManagement(KnoManagement knoManagement) {
+		knoManagementMapper.insertKnoManagement(knoManagement);
 	}
 
 	/**
 	 * 기 등록된 지식정보 정보를 수정한다.
 	 * @param knoManagement 수정할 지식정보 모델
-	 * @throws Exception 대상이 존재하지 않거나 데이터 접근 중 오류가 발생한 경우
 	 */
-	public void updateKnoManagement(KnoManagement knoManagement) throws Exception {
-		update("KnoManagementDAO.updateKnoManagement", knoManagement);
+	public void updateKnoManagement(KnoManagement knoManagement) {
+		knoManagementMapper.updateKnoManagement(knoManagement);
 	}
 
 	/**
 	 * 기 등록된 지식정보 정보를 삭제한다.
 	 * @param knoManagement 삭제할 지식정보 모델
-	 * @throws Exception 대상이 존재하지 않거나 데이터 접근 중 오류가 발생한 경우
 	 */
-	public void deleteKnoManagement(KnoManagement knoManagement) throws Exception {
-		delete("KnoManagementDAO.deleteKnoManagement", knoManagement);
+	public void deleteKnoManagement(KnoManagement knoManagement) {
+		knoManagementMapper.deleteKnoManagement(knoManagement);
 	}
 
 }

--- a/src/main/java/egovframework/com/dam/mgm/service/impl/KnoManagementMapper.java
+++ b/src/main/java/egovframework/com/dam/mgm/service/impl/KnoManagementMapper.java
@@ -1,0 +1,65 @@
+package egovframework.com.dam.mgm.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+import org.egovframe.rte.psl.dataaccess.util.EgovMap;
+
+import egovframework.com.dam.mgm.service.KnoManagement;
+import egovframework.com.dam.mgm.service.KnoManagementVO;
+
+/**
+ * 지식정보 관리를 위한 MyBatis 매퍼 인터페이스
+ *
+ * <pre>
+ *  == 개정이력(Modification Information) ==
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2026.05.28  dasomel     @EgovMapper 인터페이스 방식으로 전환
+ *
+ * </pre>
+ */
+@EgovMapper
+public interface KnoManagementMapper {
+
+	/**
+	 * 등록된 지식정보 목록을 조회한다.
+	 * @param searchVO 지식정보 조회 조건 VO
+	 * @return 지식정보 목록
+	 */
+	List<EgovMap> selectKnoManagementList(KnoManagementVO searchVO);
+
+	/**
+	 * 지식정보 목록 총 개수를 조회한다.
+	 * @param searchVO 지식정보 조회 조건 VO
+	 * @return 총 개수
+	 */
+	int selectKnoManagementTotCnt(KnoManagementVO searchVO);
+
+	/**
+	 * 지식정보 상세 정보를 조회한다.
+	 * @param knoManagement 조회할 지식정보 식별 정보가 담긴 모델
+	 * @return 지식정보 상세 모델
+	 */
+	KnoManagement selectKnoManagement(KnoManagement knoManagement);
+
+	/**
+	 * 지식정보 정보를 신규로 등록한다.
+	 * @param knoManagement 등록할 지식정보 모델
+	 */
+	void insertKnoManagement(KnoManagement knoManagement);
+
+	/**
+	 * 기 등록된 지식정보 정보를 수정한다.
+	 * @param knoManagement 수정할 지식정보 모델
+	 */
+	void updateKnoManagement(KnoManagement knoManagement);
+
+	/**
+	 * 기 등록된 지식정보 정보를 삭제한다.
+	 * @param knoManagement 삭제할 지식정보 모델
+	 */
+	void deleteKnoManagement(KnoManagement knoManagement);
+
+}

--- a/src/main/java/egovframework/com/dam/per/service/impl/KnoPersonalDAO.java
+++ b/src/main/java/egovframework/com/dam/per/service/impl/KnoPersonalDAO.java
@@ -4,9 +4,10 @@ import java.util.List;
 
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.dam.per.service.KnoPersonal;
 import egovframework.com.dam.per.service.KnoPersonalVO;
+
+import jakarta.annotation.Resource;
 
 /**
  * 개요
@@ -19,71 +20,61 @@ import egovframework.com.dam.per.service.KnoPersonalVO;
  * @version 1.0
  * @created 12-8-2010 오후 3:44:50
  */
-
 @Repository("KnoPersonalDAO")
-public class KnoPersonalDAO extends EgovComAbstractDAO {
+public class KnoPersonalDAO {
+
+	@Resource(name = "knoPersonalMapper")
+	private KnoPersonalMapper knoPersonalMapper;
 
 	/**
-	 * 등록된 개인지식 정보를 조회 한다.
-	 * @param KnoPersonalVO - 개인지식 VO
-	 * @return String - 개인지식정보 목록
-	 *
-	 * @param KnoPersonalVO
+	 * 등록된 개인지식정보 목록을 조회한다.
+	 * @param searchVO 개인지식 조회 조건 VO
+	 * @return 개인지식정보 목록
 	 */
-	public List<KnoPersonalVO> selectKnoPersonalList(KnoPersonalVO searchVO) throws Exception {
-		return selectList("KnoPersonalDAO.selectKnoPersonalList", searchVO);
+	public List<KnoPersonalVO> selectKnoPersonalList(KnoPersonalVO searchVO) {
+		return knoPersonalMapper.selectKnoPersonalList(searchVO);
 	}
 
 	/**
 	 * 개인지식 목록 총 개수를 조회한다.
-	 * @param KnoPersonalVO - 개인지식 Vo
-	 * @return int - 개인지식 토탈 카운트 수
-	 *
-	 * @param KnoPersonalVO
+	 * @param searchVO 개인지식 조회 조건 VO
+	 * @return 총 개수
 	 */
-	public int selectKnoPersonalTotCnt(KnoPersonalVO searchVO) throws Exception {
-		return selectOne("KnoPersonalDAO.selectKnoPersonalTotCnt", searchVO);
+	public int selectKnoPersonalTotCnt(KnoPersonalVO searchVO) {
+		return knoPersonalMapper.selectKnoPersonalTotCnt(searchVO);
 	}
 
 	/**
-	 * 개인지식정보 상세 정보를 조회 한다.
-	 * @param KnoPersonalVO - 개인지식정보 VO
-	 * @return String - 개인지식 VO
-	 *
-	 * @param KnoPersonalVO
+	 * 개인지식정보 상세 정보를 조회한다.
+	 * @param knoPersonal 조회할 개인지식정보 식별 정보가 담긴 모델
+	 * @return 개인지식 상세 모델
 	 */
-	public KnoPersonal selectKnoPersonal(KnoPersonal knoPersonal) throws Exception {
-		return selectOne("KnoPersonalDAO.selectKnoPersonal", knoPersonal);
+	public KnoPersonal selectKnoPersonal(KnoPersonal knoPersonal) {
+		return knoPersonalMapper.selectKnoPersonal(knoPersonal);
 	}
 
 	/**
 	 * 개인지식 정보를 신규로 등록한다.
-	 * @param KnoNm - 개인지식정보 model
-	 *
-	 * @param KnoNm
+	 * @param knoPersonal 등록할 개인지식정보 모델
 	 */
-	public void insertKnoPersonal(KnoPersonal knoPersonal) throws Exception {
-		insert("KnoPersonalDAO.insertKnoPersonal", knoPersonal);
+	public void insertKnoPersonal(KnoPersonal knoPersonal) {
+		knoPersonalMapper.insertKnoPersonal(knoPersonal);
 	}
 
 	/**
-	 * 기 등록 된 개인지식 정보를 수정 한다.
-	 * @param KnoNm - 개인지식정보 model
-	 *
-	 * @param KnoNm
+	 * 기 등록된 개인지식 정보를 수정한다.
+	 * @param knoPersonal 수정할 개인지식정보 모델
 	 */
-	public void updateKnoPersonal(KnoPersonal knoPersonal) throws Exception {
-		update("KnoPersonalDAO.updateKnoPersonal", knoPersonal);
+	public void updateKnoPersonal(KnoPersonal knoPersonal) {
+		knoPersonalMapper.updateKnoPersonal(knoPersonal);
 	}
 
 	/**
 	 * 기 등록된 개인지식 정보를 삭제한다.
-	 * @param KnoNm - 개인지식정보 model
-	 *
-	 * @param KnoNm
+	 * @param knoPersonal 삭제할 개인지식정보 모델
 	 */
-	public void deleteKnoPersonal(KnoPersonal knoPersonal) throws Exception {
-		delete("KnoPersonalDAO.deleteKnoPersonal", knoPersonal);
+	public void deleteKnoPersonal(KnoPersonal knoPersonal) {
+		knoPersonalMapper.deleteKnoPersonal(knoPersonal);
 	}
 
 }

--- a/src/main/java/egovframework/com/dam/per/service/impl/KnoPersonalMapper.java
+++ b/src/main/java/egovframework/com/dam/per/service/impl/KnoPersonalMapper.java
@@ -1,0 +1,64 @@
+package egovframework.com.dam.per.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.dam.per.service.KnoPersonal;
+import egovframework.com.dam.per.service.KnoPersonalVO;
+
+/**
+ * 개인지식정보 관리를 위한 MyBatis 매퍼 인터페이스
+ *
+ * <pre>
+ *  == 개정이력(Modification Information) ==
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2026.05.28  dasomel     @EgovMapper 인터페이스 방식으로 전환
+ *
+ * </pre>
+ */
+@EgovMapper
+public interface KnoPersonalMapper {
+
+	/**
+	 * 등록된 개인지식정보 목록을 조회한다.
+	 * @param searchVO 개인지식 조회 조건 VO
+	 * @return 개인지식정보 목록
+	 */
+	List<KnoPersonalVO> selectKnoPersonalList(KnoPersonalVO searchVO);
+
+	/**
+	 * 개인지식 목록 총 개수를 조회한다.
+	 * @param searchVO 개인지식 조회 조건 VO
+	 * @return 총 개수
+	 */
+	int selectKnoPersonalTotCnt(KnoPersonalVO searchVO);
+
+	/**
+	 * 개인지식정보 상세 정보를 조회한다.
+	 * @param knoPersonal 조회할 개인지식정보 식별 정보가 담긴 모델
+	 * @return 개인지식 상세 모델
+	 */
+	KnoPersonal selectKnoPersonal(KnoPersonal knoPersonal);
+
+	/**
+	 * 개인지식 정보를 신규로 등록한다.
+	 * @param knoPersonal 등록할 개인지식정보 모델
+	 */
+	void insertKnoPersonal(KnoPersonal knoPersonal);
+
+	/**
+	 * 기 등록된 개인지식 정보를 수정한다.
+	 * @param knoPersonal 수정할 개인지식정보 모델
+	 */
+	void updateKnoPersonal(KnoPersonal knoPersonal);
+
+	/**
+	 * 기 등록된 개인지식 정보를 삭제한다.
+	 * @param knoPersonal 삭제할 개인지식정보 모델
+	 */
+	void deleteKnoPersonal(KnoPersonal knoPersonal);
+
+}

--- a/src/main/resources/egovframework/mapper/com/dam/app/EgovDamKnoAppraisal_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/dam/app/EgovDamKnoAppraisal_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="KnoAppraisalDAO">
+<mapper namespace="egovframework.com.dam.app.service.impl.KnoAppraisalMapper">
 
 	<select id="selectKnoAppraisalList" parameterType="egovframework.com.dam.app.service.KnoAppraisalVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/dam/app/EgovDamKnoAppraisal_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/dam/app/EgovDamKnoAppraisal_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="KnoAppraisalDAO">
+<mapper namespace="egovframework.com.dam.app.service.impl.KnoAppraisalMapper">
 
 	<select id="selectKnoAppraisalList" parameterType="egovframework.com.dam.app.service.KnoAppraisalVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/dam/app/EgovDamKnoAppraisal_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/dam/app/EgovDamKnoAppraisal_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="KnoAppraisalDAO">
+<mapper namespace="egovframework.com.dam.app.service.impl.KnoAppraisalMapper">
 
 	<select id="selectKnoAppraisalList" parameterType="egovframework.com.dam.app.service.KnoAppraisalVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/dam/app/EgovDamKnoAppraisal_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/dam/app/EgovDamKnoAppraisal_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="KnoAppraisalDAO">
+<mapper namespace="egovframework.com.dam.app.service.impl.KnoAppraisalMapper">
 
 	<select id="selectKnoAppraisalList" parameterType="egovframework.com.dam.app.service.KnoAppraisalVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/dam/app/EgovDamKnoAppraisal_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/dam/app/EgovDamKnoAppraisal_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="KnoAppraisalDAO">
+<mapper namespace="egovframework.com.dam.app.service.impl.KnoAppraisalMapper">
 
 	<select id="selectKnoAppraisalList" parameterType="egovframework.com.dam.app.service.KnoAppraisalVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/dam/app/EgovDamKnoAppraisal_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/dam/app/EgovDamKnoAppraisal_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="KnoAppraisalDAO">
+<mapper namespace="egovframework.com.dam.app.service.impl.KnoAppraisalMapper">
 
 	<select id="selectKnoAppraisalList" parameterType="egovframework.com.dam.app.service.KnoAppraisalVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/dam/app/EgovDamKnoAppraisal_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/dam/app/EgovDamKnoAppraisal_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="KnoAppraisalDAO">
+<mapper namespace="egovframework.com.dam.app.service.impl.KnoAppraisalMapper">
 
 	<select id="selectKnoAppraisalList" parameterType="egovframework.com.dam.app.service.KnoAppraisalVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/dam/app/EgovDamKnoAppraisal_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/dam/app/EgovDamKnoAppraisal_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="KnoAppraisalDAO">
+<mapper namespace="egovframework.com.dam.app.service.impl.KnoAppraisalMapper">
 	
 	<select id="selectKnoAppraisalList" parameterType="egovframework.com.dam.app.service.KnoAppraisalVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/dam/mgm/EgovKnoManagement_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/dam/mgm/EgovKnoManagement_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="KnoManagementDAO">
+<mapper namespace="egovframework.com.dam.mgm.service.impl.KnoManagementMapper">
 
 	<select id="selectKnoManagementList" parameterType="egovframework.com.dam.mgm.service.KnoManagementVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/dam/mgm/EgovKnoManagement_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/dam/mgm/EgovKnoManagement_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="KnoManagementDAO">
+<mapper namespace="egovframework.com.dam.mgm.service.impl.KnoManagementMapper">
 
 	<select id="selectKnoManagementList" parameterType="egovframework.com.dam.mgm.service.KnoManagementVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/dam/mgm/EgovKnoManagement_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/dam/mgm/EgovKnoManagement_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="KnoManagementDAO">
+<mapper namespace="egovframework.com.dam.mgm.service.impl.KnoManagementMapper">
 
 	<select id="selectKnoManagementList" parameterType="egovframework.com.dam.mgm.service.KnoManagementVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/dam/mgm/EgovKnoManagement_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/dam/mgm/EgovKnoManagement_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="KnoManagementDAO">
+<mapper namespace="egovframework.com.dam.mgm.service.impl.KnoManagementMapper">
 
 	<select id="selectKnoManagementList" parameterType="egovframework.com.dam.mgm.service.KnoManagementVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/dam/mgm/EgovKnoManagement_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/dam/mgm/EgovKnoManagement_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="KnoManagementDAO">
+<mapper namespace="egovframework.com.dam.mgm.service.impl.KnoManagementMapper">
 
 	<select id="selectKnoManagementList" parameterType="egovframework.com.dam.mgm.service.KnoManagementVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/dam/mgm/EgovKnoManagement_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/dam/mgm/EgovKnoManagement_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="KnoManagementDAO">
+<mapper namespace="egovframework.com.dam.mgm.service.impl.KnoManagementMapper">
 
 	<select id="selectKnoManagementList" parameterType="egovframework.com.dam.mgm.service.KnoManagementVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/dam/mgm/EgovKnoManagement_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/dam/mgm/EgovKnoManagement_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="KnoManagementDAO">
+<mapper namespace="egovframework.com.dam.mgm.service.impl.KnoManagementMapper">
 
 	<select id="selectKnoManagementList" parameterType="egovframework.com.dam.mgm.service.KnoManagementVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/dam/mgm/EgovKnoManagement_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/dam/mgm/EgovKnoManagement_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="KnoManagementDAO">
+<mapper namespace="egovframework.com.dam.mgm.service.impl.KnoManagementMapper">
 
 	<select id="selectKnoManagementList" parameterType="egovframework.com.dam.mgm.service.KnoManagementVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/dam/per/EgovDamKnoPersonal_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/dam/per/EgovDamKnoPersonal_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="KnoPersonalDAO">
+<mapper namespace="egovframework.com.dam.per.service.impl.KnoPersonalMapper">
 
 	<resultMap id="KnoPersonalList" type="egovframework.com.dam.per.service.KnoPersonalVO">
 		<result property="orgnztNm" column="ORGNZT_NM"/>	

--- a/src/main/resources/egovframework/mapper/com/dam/per/EgovDamKnoPersonal_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/dam/per/EgovDamKnoPersonal_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="KnoPersonalDAO">
+<mapper namespace="egovframework.com.dam.per.service.impl.KnoPersonalMapper">
 	
 	<resultMap id="KnoPersonalList" type="egovframework.com.dam.per.service.KnoPersonalVO">
 		<result property="orgnztNm" column="ORGNZT_NM"/>	

--- a/src/main/resources/egovframework/mapper/com/dam/per/EgovDamKnoPersonal_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/dam/per/EgovDamKnoPersonal_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="KnoPersonalDAO">
+<mapper namespace="egovframework.com.dam.per.service.impl.KnoPersonalMapper">
 
 	<resultMap id="KnoPersonalList" type="egovframework.com.dam.per.service.KnoPersonalVO">
 		<result property="orgnztNm" column="ORGNZT_NM"/>	

--- a/src/main/resources/egovframework/mapper/com/dam/per/EgovDamKnoPersonal_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/dam/per/EgovDamKnoPersonal_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="KnoPersonalDAO">
+<mapper namespace="egovframework.com.dam.per.service.impl.KnoPersonalMapper">
 
 	<resultMap id="KnoPersonalList" type="egovframework.com.dam.per.service.KnoPersonalVO">
         <result property="orgnztNm" column="ORGNZT_NM"/>    

--- a/src/main/resources/egovframework/mapper/com/dam/per/EgovDamKnoPersonal_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/dam/per/EgovDamKnoPersonal_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="KnoPersonalDAO">
+<mapper namespace="egovframework.com.dam.per.service.impl.KnoPersonalMapper">
 
 	<resultMap id="KnoPersonalList" type="egovframework.com.dam.per.service.KnoPersonalVO">
         <result property="orgnztNm" column="ORGNZT_NM"/>    

--- a/src/main/resources/egovframework/mapper/com/dam/per/EgovDamKnoPersonal_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/dam/per/EgovDamKnoPersonal_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="KnoPersonalDAO">
+<mapper namespace="egovframework.com.dam.per.service.impl.KnoPersonalMapper">
 	
 	<resultMap id="KnoPersonalList" type="egovframework.com.dam.per.service.KnoPersonalVO">
 		<result property="orgnztNm" column="ORGNZT_NM"/>	

--- a/src/main/resources/egovframework/mapper/com/dam/per/EgovDamKnoPersonal_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/dam/per/EgovDamKnoPersonal_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="KnoPersonalDAO">
+<mapper namespace="egovframework.com.dam.per.service.impl.KnoPersonalMapper">
 
 	<resultMap id="KnoPersonalList" type="egovframework.com.dam.per.service.KnoPersonalVO">
         <result property="orgnztNm" column="ORGNZT_NM"/>    

--- a/src/main/resources/egovframework/mapper/com/dam/per/EgovDamKnoPersonal_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/dam/per/EgovDamKnoPersonal_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="KnoPersonalDAO">
+<mapper namespace="egovframework.com.dam.per.service.impl.KnoPersonalMapper">
 	
 	<resultMap id="KnoPersonalList" type="egovframework.com.dam.per.service.KnoPersonalVO">
 		<result property="orgnztNm" column="ORGNZT_NM"/>	


### PR DESCRIPTION
## 변경 사유
기존 XML namespace 기반 DAO를 5.0 신규 @EgovMapper 인터페이스 방식으로 전환

## 변경 내용
- KnoManagementMapper, KnoAppraisalMapper, KnoPersonalMapper 인터페이스 신규 추가
- dam/mgm·dam/app·dam/per 3개 DAO를 mapper 위임 구조로 리팩토링
- XML namespace를 mapper FQN으로 변경 (24개 XML 파일)

## 영향 범위
- dam 지식관리 3개 서브 모듈 (mgm, app, per)
- DAO bean name 유지 (KnoManagementDAO, KnoAppraisalDAO, KnoPersonalDAO)

## 체크리스트
- [x] 단일 주제만 다룸
- [x] 기존 동작 호환
- [x] DAO bean name 유지로 서비스 레이어 변경 불필요
- [x] 테스트 통과 확인 (dam 관련 컴파일 오류 없음)
