### PR TITLE
[refactor][5.0.x][공통컴포넌트] uat/uia LoginDAO @EgovMapper 인터페이스 방식으로 전환

### DIFF
--- a/src/main/java/egovframework/com/uat/uia/service/impl/LoginMapper.java
+++ b/src/main/java/egovframework/com/uat/uia/service/impl/LoginMapper.java
@@ -2,13 +2,12 @@ package egovframework.com.uat.uia.service.impl;
 
 import java.util.Map;
 
-import org.springframework.stereotype.Repository;
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
 
 import egovframework.com.cmm.LoginVO;
-import jakarta.annotation.Resource;
 
 /**
- * 일반 로그인, 인증서 로그인을 처리하는 DAO 클래스
+ * 일반 로그인, 인증서 로그인을 처리하는 Mapper 인터페이스
  * @author 공통서비스 개발팀 박지욱
  * @since 2009.03.06
  * @version 1.0
@@ -26,22 +25,16 @@ import jakarta.annotation.Resource;
  *  2021.05.30   정진오            디지털원패스 인증 회원 조회
  *  </pre>
  */
-@Repository("loginDAO")
-public class LoginDAO {
-
-    @Resource(name = "loginMapper")
-    private LoginMapper loginMapper;
+@EgovMapper
+public interface LoginMapper {
 
     /**
-     * 2011.08.26
      * EsntlId를 이용한 로그인을 처리한다
      * @param vo LoginVO
      * @return LoginVO
      * @exception Exception
      */
-    public LoginVO actionLoginByEsntlId(LoginVO vo) throws Exception {
-        return loginMapper.actionLoginByEsntlId(vo);
-    }
+    LoginVO actionLoginByEsntlId(LoginVO vo) throws Exception;
 
     /**
      * 일반 로그인을 처리한다
@@ -49,9 +42,7 @@ public class LoginDAO {
      * @return LoginVO
      * @exception Exception
      */
-    public LoginVO actionLogin(LoginVO vo) throws Exception {
-        return loginMapper.actionLogin(vo);
-    }
+    LoginVO actionLogin(LoginVO vo) throws Exception;
 
     /**
      * 인증서 로그인을 처리한다
@@ -59,9 +50,7 @@ public class LoginDAO {
      * @return LoginVO
      * @exception Exception
      */
-    public LoginVO actionCrtfctLogin(LoginVO vo) throws Exception {
-        return loginMapper.actionCrtfctLogin(vo);
-    }
+    LoginVO actionCrtfctLogin(LoginVO vo) throws Exception;
 
     /**
      * 아이디를 찾는다.
@@ -69,9 +58,7 @@ public class LoginDAO {
      * @return LoginVO
      * @exception Exception
      */
-    public LoginVO searchId(LoginVO vo) throws Exception {
-        return loginMapper.searchId(vo);
-    }
+    LoginVO searchId(LoginVO vo) throws Exception;
 
     /**
      * 비밀번호를 찾는다.
@@ -79,18 +66,14 @@ public class LoginDAO {
      * @return LoginVO
      * @exception Exception
      */
-    public LoginVO searchPassword(LoginVO vo) throws Exception {
-        return loginMapper.searchPassword(vo);
-    }
+    LoginVO searchPassword(LoginVO vo) throws Exception;
 
     /**
      * 변경된 비밀번호를 저장한다.
      * @param vo LoginVO
      * @exception Exception
      */
-    public void updatePassword(LoginVO vo) throws Exception {
-        loginMapper.updatePassword(vo);
-    }
+    void updatePassword(LoginVO vo) throws Exception;
 
     /**
      * 로그인인증제한 내역을 조회한다.
@@ -98,25 +81,28 @@ public class LoginDAO {
      * @return Map
      * @exception Exception
      */
-    public Map<?, ?> selectLoginIncorrect(LoginVO vo) throws Exception {
-        return loginMapper.selectLoginIncorrect(vo);
-    }
+    Map<?, ?> selectLoginIncorrect(LoginVO vo) throws Exception;
 
     /**
-     * 로그인인증제한 내역을 업데이트 한다.
+     * 로그인인증제한 내역을 업데이트 한다. (일반회원)
      * @param map 파라미터 Map
      * @exception Exception
      */
-    public void updateLoginIncorrect(Map<?, ?> map) throws Exception {
-        String userSe = (String) map.get("USER_SE");
-        if ("GNR".equals(userSe)) {
-            loginMapper.updateLoginIncorrectGNR(map);
-        } else if ("ENT".equals(userSe)) {
-            loginMapper.updateLoginIncorrectENT(map);
-        } else {
-            loginMapper.updateLoginIncorrectUSR(map);
-        }
-    }
+    void updateLoginIncorrectGNR(Map<?, ?> map) throws Exception;
+
+    /**
+     * 로그인인증제한 내역을 업데이트 한다. (기업회원)
+     * @param map 파라미터 Map
+     * @exception Exception
+     */
+    void updateLoginIncorrectENT(Map<?, ?> map) throws Exception;
+
+    /**
+     * 로그인인증제한 내역을 업데이트 한다. (업무사용자)
+     * @param map 파라미터 Map
+     * @exception Exception
+     */
+    void updateLoginIncorrectUSR(Map<?, ?> map) throws Exception;
 
     /**
      * 비밀번호를 수정한후 경과한 날짜를 조회한다.
@@ -124,9 +110,7 @@ public class LoginDAO {
      * @return int
      * @exception Exception
      */
-    public int selectPassedDayChangePWD(LoginVO vo) throws Exception {
-        return loginMapper.selectPassedDayChangePWD(vo);
-    }
+    int selectPassedDayChangePWD(LoginVO vo) throws Exception;
 
     /**
      * 디지털원패스 인증 회원 조회한다.
@@ -134,8 +118,6 @@ public class LoginDAO {
      * @return LoginVO
      * @exception Exception
      */
-    public LoginVO onepassLogin(String id) throws Exception {
-        return loginMapper.onepassLogin(id);
-    }
+    LoginVO onepassLogin(String id) throws Exception;
 
 }

--- a/src/main/resources/egovframework/mapper/com/uat/uia/EgovLoginUsr_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/uat/uia/EgovLoginUsr_SQL_altibase.xml
@@ -9,7 +9,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="LoginUsr">
+<mapper namespace="egovframework.com.uat.uia.service.impl.LoginMapper">
 
 	<!-- 로그인 처리를 위한 resultMap -->
 	<resultMap id="login" type="egovframework.com.cmm.LoginVO">

--- a/src/main/resources/egovframework/mapper/com/uat/uia/EgovLoginUsr_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/uat/uia/EgovLoginUsr_SQL_cubrid.xml
@@ -9,7 +9,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="LoginUsr">
+<mapper namespace="egovframework.com.uat.uia.service.impl.LoginMapper">
 
 	<!-- 로그인 처리를 위한 resultMap -->
 	<resultMap id="login" type="egovframework.com.cmm.LoginVO">

--- a/src/main/resources/egovframework/mapper/com/uat/uia/EgovLoginUsr_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/uat/uia/EgovLoginUsr_SQL_goldilocks.xml
@@ -9,7 +9,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="LoginUsr">
+<mapper namespace="egovframework.com.uat.uia.service.impl.LoginMapper">
 
 	<!-- 로그인 처리를 위한 resultMap -->
 	<resultMap id="login" type="egovframework.com.cmm.LoginVO">

--- a/src/main/resources/egovframework/mapper/com/uat/uia/EgovLoginUsr_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/uat/uia/EgovLoginUsr_SQL_maria.xml
@@ -9,7 +9,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="LoginUsr">
+<mapper namespace="egovframework.com.uat.uia.service.impl.LoginMapper">
 
 
 	<!-- 로그인 처리를 위한 resultMap -->

--- a/src/main/resources/egovframework/mapper/com/uat/uia/EgovLoginUsr_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/uat/uia/EgovLoginUsr_SQL_mysql.xml
@@ -9,7 +9,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="LoginUsr">
+<mapper namespace="egovframework.com.uat.uia.service.impl.LoginMapper">
 
 	<!-- 로그인 처리를 위한 resultMap -->
 	<resultMap id="login" type="egovframework.com.cmm.LoginVO">

--- a/src/main/resources/egovframework/mapper/com/uat/uia/EgovLoginUsr_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/uat/uia/EgovLoginUsr_SQL_oracle.xml
@@ -9,7 +9,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="LoginUsr">
+<mapper namespace="egovframework.com.uat.uia.service.impl.LoginMapper">
 
 	<!-- 로그인 처리를 위한 resultMap -->
 	<resultMap id="login" type="egovframework.com.cmm.LoginVO">

--- a/src/main/resources/egovframework/mapper/com/uat/uia/EgovLoginUsr_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/uat/uia/EgovLoginUsr_SQL_postgres.xml
@@ -9,7 +9,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="LoginUsr">
+<mapper namespace="egovframework.com.uat.uia.service.impl.LoginMapper">
 
 
 	<!-- 로그인 처리를 위한 resultMap -->

--- a/src/main/resources/egovframework/mapper/com/uat/uia/EgovLoginUsr_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/uat/uia/EgovLoginUsr_SQL_tibero.xml
@@ -9,7 +9,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="LoginUsr">
+<mapper namespace="egovframework.com.uat.uia.service.impl.LoginMapper">
 
 	<!-- 로그인 처리를 위한 resultMap -->
 	<resultMap id="login" type="egovframework.com.cmm.LoginVO">

--- a/src/main/resources/egovframework/spring/com/context-mapper.xml
+++ b/src/main/resources/egovframework/spring/com/context-mapper.xml
@@ -21,5 +21,11 @@
 	<bean id="egov.sqlSessionTemplate" class="org.mybatis.spring.SqlSessionTemplate">
 		<constructor-arg ref="egov.sqlSession"/>
 	</bean>
-	
+
+	<!-- @EgovMapper 어노테이션 기반 Mapper 인터페이스 자동 등록 -->
+	<bean class="org.mybatis.spring.mapper.MapperScannerConfigurer">
+		<property name="basePackage" value="egovframework.com"/>
+		<property name="annotationClass" value="org.egovframe.rte.psl.dataaccess.mapper.EgovMapper"/>
+	</bean>
+
 </beans>


### PR DESCRIPTION
## 변경 사유

기존 `EgovComAbstractDAO` 상속 방식의 LoginDAO를 eGovFrame 5.0에서 신규 도입된 `@EgovMapper` 인터페이스 위임 방식으로 전환한다.

## 변경 내용

- `LoginMapper` 인터페이스 신규 추가: `@EgovMapper` 어노테이션 적용, LoginDAO가 제공하던 모든 메서드 선언 포함
- `LoginDAO` 재작성: `EgovComAbstractDAO` 상속 제거, `@Resource(name="loginMapper")`로 주입받아 위임, `updateLoginIncorrect`의 동적 구분 로직(GNR/ENT/USR)은 DAO 내 분기로 처리
- `EgovLoginUsr_SQL_*.xml` 8개(altibase/cubrid/goldilocks/maria/mysql/oracle/postgres/tibero): `namespace="LoginUsr"` → `namespace="egovframework.com.uat.uia.service.impl.LoginMapper"` 변경
- `context-mapper.xml`: `MapperScannerConfigurer` 빈 추가 — `@EgovMapper` 스캔 대상 패키지 `egovframework.com` 등록

## 영향 범위

- uat/uia 로그인 모듈만 영향
- `EgovLoginServiceImpl`은 `LoginDAO` 인터페이스를 그대로 사용하므로 변경 없음
- 기존 동작 동일하게 유지

## 체크리스트

- [x] 단일 주제만 다룸 (다른 변경 없음)
- [x] 기존 동작에 영향 없음
- [x] LoginDAO bean name(`loginDAO`) 유지
