### PR TITLE
[refactor][5.0.x][공통컴포넌트] cop/scp EgovArticleScrapDAO @EgovMapper 인터페이스 방식으로 전환

### DIFF
--- a/src/main/java/egovframework/com/cop/scp/service/impl/EgovArticleScrapDAO.java
+++ b/src/main/java/egovframework/com/cop/scp/service/impl/EgovArticleScrapDAO.java
@@ -2,37 +2,41 @@ package egovframework.com.cop.scp.service.impl;
 
 import java.util.List;
 
+import jakarta.annotation.Resource;
+
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.cop.scp.service.Scrap;
 import egovframework.com.cop.scp.service.ScrapVO;
 
 @Repository("EgovArticleScrapDAO")
-public class EgovArticleScrapDAO extends EgovComAbstractDAO{
+public class EgovArticleScrapDAO {
+
+	@Resource(name = "egovArticleScrapMapper")
+	private EgovArticleScrapMapper egovArticleScrapMapper;
 
 	public List<ScrapVO> selectArticleScrapList(ScrapVO scrapVO) {
-		return selectList("ArticleScrap.selectArticleScrapList", scrapVO);
+		return egovArticleScrapMapper.selectArticleScrapList(scrapVO);
 	}
 
 	public int selectArticleScrapListCnt(ScrapVO scrapVO) {
-		return (Integer)selectOne("ArticleScrap.selectArticleScrapListCnt", scrapVO);
+		return egovArticleScrapMapper.selectArticleScrapListCnt(scrapVO);
 	}
 
 	public void insertArticleScrap(Scrap scrap) {
-		insert("ArticleScrap.insertArticleScrap", scrap);
+		egovArticleScrapMapper.insertArticleScrap(scrap);
 	}
 
 	public ScrapVO selectArticleScrapDetail(ScrapVO scrapVO) {
-		return (ScrapVO) selectOne("ArticleScrap.selectArticleScrapDetail", scrapVO);
+		return egovArticleScrapMapper.selectArticleScrapDetail(scrapVO);
 	}
 
 	public void deleteArticleScrap(ScrapVO scrapVO) {
-		update("ArticleScrap.deleteArticleScrap", scrapVO);
+		egovArticleScrapMapper.deleteArticleScrap(scrapVO);
 	}
 
 	public void updateArticleScrap(Scrap scrap) {
-		update("ArticleScrap.updateArticleScrap", scrap);
+		egovArticleScrapMapper.updateArticleScrap(scrap);
 	}
 
 }

--- a/src/main/java/egovframework/com/cop/scp/service/impl/EgovArticleScrapMapper.java
+++ b/src/main/java/egovframework/com/cop/scp/service/impl/EgovArticleScrapMapper.java
@@ -1,0 +1,60 @@
+package egovframework.com.cop.scp.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.cop.scp.service.Scrap;
+import egovframework.com.cop.scp.service.ScrapVO;
+
+/**
+ * 개요
+ * - 게시글스크랩에 대한 Mapper 인터페이스를 정의한다.
+ *
+ * 상세내용
+ * - 게시글스크랩에 대한 등록, 수정, 삭제, 조회 등의 기능을 제공한다.
+ * - 게시글스크랩의 조회기능은 목록조회, 상세조회로 구분된다.
+ */
+@EgovMapper
+public interface EgovArticleScrapMapper {
+
+	/**
+	 * 스크랩목록을 조회한다.
+	 * @param scrapVO - 스크랩 VO
+	 * @return List - 스크랩 목록
+	 */
+	List<ScrapVO> selectArticleScrapList(ScrapVO scrapVO);
+
+	/**
+	 * 스크랩목록 총 개수를 조회한다.
+	 * @param scrapVO - 스크랩 VO
+	 * @return int - 스크랩 카운트 수
+	 */
+	int selectArticleScrapListCnt(ScrapVO scrapVO);
+
+	/**
+	 * 스크랩을 등록한다.
+	 * @param scrap - 스크랩 모델
+	 */
+	void insertArticleScrap(Scrap scrap);
+
+	/**
+	 * 스크랩 상세내용을 조회한다.
+	 * @param scrapVO - 스크랩 VO
+	 * @return ScrapVO - 스크랩 VO
+	 */
+	ScrapVO selectArticleScrapDetail(ScrapVO scrapVO);
+
+	/**
+	 * 스크랩을 삭제한다.
+	 * @param scrapVO - 스크랩 VO
+	 */
+	void deleteArticleScrap(ScrapVO scrapVO);
+
+	/**
+	 * 스크랩을 수정한다.
+	 * @param scrap - 스크랩 모델
+	 */
+	void updateArticleScrap(Scrap scrap);
+
+}

--- a/src/main/resources/egovframework/mapper/com/cop/scp/EgovArticleScrap_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/scp/EgovArticleScrap_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ArticleScrap">
+<mapper namespace="egovframework.com.cop.scp.service.impl.EgovArticleScrapMapper">
 	
 	<resultMap id="scrapList" type="egovframework.com.cop.scp.service.ScrapVO">
 		<result property="scrapId" column="SCRAP_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/scp/EgovArticleScrap_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/scp/EgovArticleScrap_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ArticleScrap">
+<mapper namespace="egovframework.com.cop.scp.service.impl.EgovArticleScrapMapper">
 	
 	<resultMap id="scrapList" type="egovframework.com.cop.scp.service.ScrapVO">
 		<result property="scrapId" column="SCRAP_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/scp/EgovArticleScrap_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/scp/EgovArticleScrap_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ArticleScrap">
+<mapper namespace="egovframework.com.cop.scp.service.impl.EgovArticleScrapMapper">
 	
 	<resultMap id="scrapList" type="egovframework.com.cop.scp.service.ScrapVO">
 		<result property="scrapId" column="SCRAP_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/scp/EgovArticleScrap_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/scp/EgovArticleScrap_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ArticleScrap">
+<mapper namespace="egovframework.com.cop.scp.service.impl.EgovArticleScrapMapper">
 	
 	<resultMap id="scrapList" type="egovframework.com.cop.scp.service.ScrapVO">
 		<result property="scrapId" column="SCRAP_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/scp/EgovArticleScrap_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/scp/EgovArticleScrap_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ArticleScrap">
+<mapper namespace="egovframework.com.cop.scp.service.impl.EgovArticleScrapMapper">
 	
 	<resultMap id="scrapList" type="egovframework.com.cop.scp.service.ScrapVO">
 		<result property="scrapId" column="SCRAP_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/scp/EgovArticleScrap_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/scp/EgovArticleScrap_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ArticleScrap">
+<mapper namespace="egovframework.com.cop.scp.service.impl.EgovArticleScrapMapper">
 	
 	<resultMap id="scrapList" type="egovframework.com.cop.scp.service.ScrapVO">
 		<result property="scrapId" column="SCRAP_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/scp/EgovArticleScrap_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/scp/EgovArticleScrap_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ArticleScrap">
+<mapper namespace="egovframework.com.cop.scp.service.impl.EgovArticleScrapMapper">
 	
 	<resultMap id="scrapList" type="egovframework.com.cop.scp.service.ScrapVO">
 		<result property="scrapId" column="SCRAP_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/scp/EgovArticleScrap_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/scp/EgovArticleScrap_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ArticleScrap">
+<mapper namespace="egovframework.com.cop.scp.service.impl.EgovArticleScrapMapper">
 
 	<resultMap id="scrapList" type="egovframework.com.cop.scp.service.ScrapVO">
 		<result property="scrapId" column="SCRAP_ID"/>

--- a/src/main/resources/egovframework/spring/com/context-mapper.xml
+++ b/src/main/resources/egovframework/spring/com/context-mapper.xml
@@ -21,5 +21,11 @@
 	<bean id="egov.sqlSessionTemplate" class="org.mybatis.spring.SqlSessionTemplate">
 		<constructor-arg ref="egov.sqlSession"/>
 	</bean>
-	
+
+	<!-- @EgovMapper 어노테이션 기반 Mapper 인터페이스 자동 등록 -->
+	<bean class="org.mybatis.spring.mapper.MapperScannerConfigurer">
+		<property name="basePackage" value="egovframework.com"/>
+		<property name="annotationClass" value="org.egovframe.rte.psl.dataaccess.mapper.EgovMapper"/>
+	</bean>
+
 </beans>


### PR DESCRIPTION
## 변경 사유
기존 XML namespace 기반 DAO를 5.0 신규 @EgovMapper 인터페이스 방식으로 전환

## 변경 내용
- EgovArticleScrapMapper 인터페이스 신규 추가
- DAO를 mapper 위임 구조로 리팩토링
- XML namespace를 mapper FQN으로 변경
- context-mapper.xml에 MapperScannerConfigurer 설정 추가

## 영향 범위
- cop/scp 게시글 스크랩 모듈만 영향
- DAO bean name(EgovArticleScrapDAO) 유지로 기존 호환성 보장

## 체크리스트
- [x] 단일 주제만 다룸 (다른 변경 없음)
- [x] 기존 동작에 영향 없음 (DAO bean name 유지)
- [x] 테스트 통과 확인
