### PR TITLE
[refactor][5.0.x][공통컴포넌트] sec/drm·rgm·gmt 3개 DAO @EgovMapper 인터페이스 방식으로 전환

### DIFF
--- a/src/main/java/egovframework/com/sec/drm/service/impl/DeptAuthorMapper.java
+++ b/src/main/java/egovframework/com/sec/drm/service/impl/DeptAuthorMapper.java
@@ -2,14 +2,13 @@ package egovframework.com.sec.drm.service.impl;
 
 import java.util.List;
 
-import org.springframework.stereotype.Repository;
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
 
 import egovframework.com.sec.drm.service.DeptAuthor;
 import egovframework.com.sec.drm.service.DeptAuthorVO;
-import jakarta.annotation.Resource;
 
 /**
- * 부서권한에 대한 DAO 클래스를 정의한다.
+ * 부서권한에 대한 Mapper 인터페이스를 정의한다.
  * @author 공통서비스 개발팀 이문준
  * @since 2009.06.01
  * @version 1.0
@@ -24,12 +23,8 @@ import jakarta.annotation.Resource;
  *
  * </pre>
  */
-
-@Repository("deptAuthorDAO")
-public class DeptAuthorDAO {
-
-	@Resource(name = "deptAuthorMapper")
-	private DeptAuthorMapper deptAuthorMapper;
+@EgovMapper
+public interface DeptAuthorMapper {
 
 	/**
 	 * 부서별 할당된 권한목록 조회
@@ -37,36 +32,28 @@ public class DeptAuthorDAO {
 	 * @return List<DeptAuthorVO>
 	 * @exception Exception
 	 */
-	public List<DeptAuthorVO> selectDeptAuthorList(DeptAuthorVO deptAuthorVO) throws Exception {
-		return deptAuthorMapper.selectDeptAuthorList(deptAuthorVO);
-	}
+	List<DeptAuthorVO> selectDeptAuthorList(DeptAuthorVO deptAuthorVO) throws Exception;
 
 	/**
 	 * 부서에 해당하는 사용자에게 시스템 메뉴/접근권한을 일괄 할당
 	 * @param deptAuthor DeptAuthor
 	 * @exception Exception
 	 */
-	public void insertDeptAuthor(DeptAuthor deptAuthor) throws Exception {
-		deptAuthorMapper.insertDeptAuthor(deptAuthor);
-	}
+	void insertDeptAuthor(DeptAuthor deptAuthor) throws Exception;
 
 	/**
 	 * 부서별 시스템 메뉴 접근권한을 수정하여 항목의 정합성을 체크하고 수정된 데이터를 데이터베이스에 반영
 	 * @param deptAuthor DeptAuthor
 	 * @exception Exception
 	 */
-	public void updateDeptAuthor(DeptAuthor deptAuthor) throws Exception {
-		deptAuthorMapper.updateDeptAuthor(deptAuthor);
-	}
+	void updateDeptAuthor(DeptAuthor deptAuthor) throws Exception;
 
 	/**
 	 * 불필요한 부서권한를 조회하여 데이터베이스에서 삭제
 	 * @param deptAuthor DeptAuthor
 	 * @exception Exception
 	 */
-	public void deleteDeptAuthor(DeptAuthor deptAuthor) throws Exception {
-		deptAuthorMapper.deleteDeptAuthor(deptAuthor);
-	}
+	void deleteDeptAuthor(DeptAuthor deptAuthor) throws Exception;
 
 	/**
 	 * 부서권한 목록조회 카운트를 반환한다
@@ -74,9 +61,7 @@ public class DeptAuthorDAO {
 	 * @return int
 	 * @exception Exception
 	 */
-	public int selectDeptAuthorListTotCnt(DeptAuthorVO deptAuthorVO) throws Exception {
-		return deptAuthorMapper.selectDeptAuthorListTotCnt(deptAuthorVO);
-	}
+	int selectDeptAuthorListTotCnt(DeptAuthorVO deptAuthorVO) throws Exception;
 
 	/**
 	 * 부서목록 조회
@@ -84,9 +69,7 @@ public class DeptAuthorDAO {
 	 * @return List<DeptAuthorVO>
 	 * @exception Exception
 	 */
-	public List<DeptAuthorVO> selectDeptList(DeptAuthorVO deptAuthorVO) throws Exception {
-		return deptAuthorMapper.selectDeptList(deptAuthorVO);
-	}
+	List<DeptAuthorVO> selectDeptList(DeptAuthorVO deptAuthorVO) throws Exception;
 
 	/**
 	 * 부서목록 조회 카운트를 반환한다
@@ -94,8 +77,6 @@ public class DeptAuthorDAO {
 	 * @return int
 	 * @exception Exception
 	 */
-	public int selectDeptListTotCnt(DeptAuthorVO deptAuthorVO) throws Exception {
-		return deptAuthorMapper.selectDeptListTotCnt(deptAuthorVO);
-	}
+	int selectDeptListTotCnt(DeptAuthorVO deptAuthorVO) throws Exception;
 
 }

--- a/src/main/java/egovframework/com/sec/gmt/service/impl/GroupManageMapper.java
+++ b/src/main/java/egovframework/com/sec/gmt/service/impl/GroupManageMapper.java
@@ -2,14 +2,13 @@ package egovframework.com.sec.gmt.service.impl;
 
 import java.util.List;
 
-import org.springframework.stereotype.Repository;
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
 
 import egovframework.com.sec.gmt.service.GroupManage;
 import egovframework.com.sec.gmt.service.GroupManageVO;
-import jakarta.annotation.Resource;
 
 /**
- * 그룹관리에 대한 DAO 클래스를 정의한다.
+ * 그룹관리에 대한 Mapper 인터페이스를 정의한다.
  * @author 공통서비스 개발팀 이문준
  * @since 2009.06.01
  * @version 1.0
@@ -24,12 +23,8 @@ import jakarta.annotation.Resource;
  *
  * </pre>
  */
-
-@Repository("groupManageDAO")
-public class GroupManageDAO {
-
-	@Resource(name = "groupManageMapper")
-	private GroupManageMapper groupManageMapper;
+@EgovMapper
+public interface GroupManageMapper {
 
 	/**
 	 * 검색조건에 따른 그룹정보를 조회
@@ -37,9 +32,7 @@ public class GroupManageDAO {
 	 * @return GroupManageVO
 	 * @exception Exception
 	 */
-	public GroupManageVO selectGroup(GroupManageVO groupManageVO) throws Exception {
-		return groupManageMapper.selectGroup(groupManageVO);
-	}
+	GroupManageVO selectGroup(GroupManageVO groupManageVO) throws Exception;
 
 	/**
 	 * 시스템사용 목적별 그룹 목록 조회
@@ -47,36 +40,28 @@ public class GroupManageDAO {
 	 * @return List<GroupManageVO>
 	 * @exception Exception
 	 */
-	public List<GroupManageVO> selectGroupList(GroupManageVO groupManageVO) throws Exception {
-		return groupManageMapper.selectGroupList(groupManageVO);
-	}
+	List<GroupManageVO> selectGroupList(GroupManageVO groupManageVO) throws Exception;
 
 	/**
 	 * 그룹 기본정보를 화면에서 입력하여 항목의 정합성을 체크하고 데이터베이스에 저장
 	 * @param groupManage GroupManage
 	 * @exception Exception
 	 */
-	public void insertGroup(GroupManage groupManage) throws Exception {
-		groupManageMapper.insertGroup(groupManage);
-	}
+	void insertGroup(GroupManage groupManage) throws Exception;
 
 	/**
 	 * 화면에 조회된 그룹의 기본정보를 수정하여 항목의 정합성을 체크하고 수정된 데이터를 데이터베이스에 반영
 	 * @param groupManage GroupManage
 	 * @exception Exception
 	 */
-	public void updateGroup(GroupManage groupManage) throws Exception {
-		groupManageMapper.updateGroup(groupManage);
-	}
+	void updateGroup(GroupManage groupManage) throws Exception;
 
 	/**
 	 * 불필요한 그룹정보를 화면에 조회하여 데이터베이스에서 삭제
 	 * @param groupManage GroupManage
 	 * @exception Exception
 	 */
-	public void deleteGroup(GroupManage groupManage) throws Exception {
-		groupManageMapper.deleteGroup(groupManage);
-	}
+	void deleteGroup(GroupManage groupManage) throws Exception;
 
 	/**
 	 * 그룹목록 총 개수를 조회한다.
@@ -84,8 +69,6 @@ public class GroupManageDAO {
 	 * @return int
 	 * @exception Exception
 	 */
-	public int selectGroupListTotCnt(GroupManageVO groupManageVO) throws Exception {
-		return groupManageMapper.selectGroupListTotCnt(groupManageVO);
-	}
+	int selectGroupListTotCnt(GroupManageVO groupManageVO) throws Exception;
 
 }

--- a/src/main/java/egovframework/com/sec/rgm/service/impl/AuthorGroupMapper.java
+++ b/src/main/java/egovframework/com/sec/rgm/service/impl/AuthorGroupMapper.java
@@ -2,14 +2,13 @@ package egovframework.com.sec.rgm.service.impl;
 
 import java.util.List;
 
-import org.springframework.stereotype.Repository;
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
 
 import egovframework.com.sec.rgm.service.AuthorGroup;
 import egovframework.com.sec.rgm.service.AuthorGroupVO;
-import jakarta.annotation.Resource;
 
 /**
- * 권한그룹에 대한 DAO 클래스를 정의한다.
+ * 권한그룹에 대한 Mapper 인터페이스를 정의한다.
  * @author 공통서비스 개발팀 이문준
  * @since 2009.06.01
  * @version 1.0
@@ -24,12 +23,8 @@ import jakarta.annotation.Resource;
  *
  * </pre>
  */
-
-@Repository("authorGroupDAO")
-public class AuthorGroupDAO {
-
-	@Resource(name = "authorGroupMapper")
-	private AuthorGroupMapper authorGroupMapper;
+@EgovMapper
+public interface AuthorGroupMapper {
 
 	/**
 	 * 그룹별 할당된 권한 목록 조회
@@ -37,36 +32,28 @@ public class AuthorGroupDAO {
 	 * @return List<AuthorGroupVO>
 	 * @exception Exception
 	 */
-	public List<AuthorGroupVO> selectAuthorGroupList(AuthorGroupVO authorGroupVO) throws Exception {
-		return authorGroupMapper.selectAuthorGroupList(authorGroupVO);
-	}
+	List<AuthorGroupVO> selectAuthorGroupList(AuthorGroupVO authorGroupVO) throws Exception;
 
 	/**
 	 * 그룹에 권한정보를 할당하여 데이터베이스에 등록
 	 * @param authorGroup AuthorGroup
 	 * @exception Exception
 	 */
-	public void insertAuthorGroup(AuthorGroup authorGroup) throws Exception {
-		authorGroupMapper.insertAuthorGroup(authorGroup);
-	}
+	void insertAuthorGroup(AuthorGroup authorGroup) throws Exception;
 
 	/**
 	 * 화면에 조회된 그룹권한정보를 수정하여 항목의 정합성을 체크하고 수정된 데이터를 데이터베이스에 반영
 	 * @param authorGroup AuthorGroup
 	 * @exception Exception
 	 */
-	public void updateAuthorGroup(AuthorGroup authorGroup) throws Exception {
-		authorGroupMapper.updateAuthorGroup(authorGroup);
-	}
+	void updateAuthorGroup(AuthorGroup authorGroup) throws Exception;
 
 	/**
 	 * 그룹별 할당된 시스템 메뉴 접근권한을 삭제
 	 * @param authorGroup AuthorGroup
 	 * @exception Exception
 	 */
-	public void deleteAuthorGroup(AuthorGroup authorGroup) throws Exception {
-		authorGroupMapper.deleteAuthorGroup(authorGroup);
-	}
+	void deleteAuthorGroup(AuthorGroup authorGroup) throws Exception;
 
 	/**
 	 * 그룹권한목록 총 개수를 조회한다.
@@ -74,8 +61,6 @@ public class AuthorGroupDAO {
 	 * @return int
 	 * @exception Exception
 	 */
-	public int selectAuthorGroupListTotCnt(AuthorGroupVO authorGroupVO) throws Exception {
-		return authorGroupMapper.selectAuthorGroupListTotCnt(authorGroupVO);
-	}
+	int selectAuthorGroupListTotCnt(AuthorGroupVO authorGroupVO) throws Exception;
 
 }

--- a/src/main/resources/egovframework/mapper/com/sec/drm/EgovDeptAuthor_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/sec/drm/EgovDeptAuthor_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="deptAuthorDAO">
+<mapper namespace="egovframework.com.sec.drm.service.impl.DeptAuthorMapper">
 
     <resultMap id="deptAuthor" type="egovframework.com.sec.drm.service.DeptAuthorVO">
         <result property="deptCode" column="DEPT_CODE"/>

--- a/src/main/resources/egovframework/mapper/com/sec/drm/EgovDeptAuthor_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/sec/drm/EgovDeptAuthor_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="deptAuthorDAO">
+<mapper namespace="egovframework.com.sec.drm.service.impl.DeptAuthorMapper">
 
     <resultMap id="deptAuthor" type="egovframework.com.sec.drm.service.DeptAuthorVO">
         <result property="deptCode" column="DEPT_CODE"/>

--- a/src/main/resources/egovframework/mapper/com/sec/drm/EgovDeptAuthor_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/sec/drm/EgovDeptAuthor_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="deptAuthorDAO">
+<mapper namespace="egovframework.com.sec.drm.service.impl.DeptAuthorMapper">
 
     <resultMap id="deptAuthor" type="egovframework.com.sec.drm.service.DeptAuthorVO">
         <result property="deptCode" column="DEPT_CODE"/>

--- a/src/main/resources/egovframework/mapper/com/sec/drm/EgovDeptAuthor_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/sec/drm/EgovDeptAuthor_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="deptAuthorDAO">
+<mapper namespace="egovframework.com.sec.drm.service.impl.DeptAuthorMapper">
 
     <resultMap id="deptAuthor" type="egovframework.com.sec.drm.service.DeptAuthorVO">
         <result property="deptCode" column="DEPT_CODE"/>

--- a/src/main/resources/egovframework/mapper/com/sec/drm/EgovDeptAuthor_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/sec/drm/EgovDeptAuthor_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="deptAuthorDAO">
+<mapper namespace="egovframework.com.sec.drm.service.impl.DeptAuthorMapper">
 
     <resultMap id="deptAuthor" type="egovframework.com.sec.drm.service.DeptAuthorVO">
         <result property="deptCode" column="DEPT_CODE"/>

--- a/src/main/resources/egovframework/mapper/com/sec/drm/EgovDeptAuthor_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/sec/drm/EgovDeptAuthor_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="deptAuthorDAO">
+<mapper namespace="egovframework.com.sec.drm.service.impl.DeptAuthorMapper">
 
     
     <resultMap id="deptAuthor" type="egovframework.com.sec.drm.service.DeptAuthorVO">

--- a/src/main/resources/egovframework/mapper/com/sec/drm/EgovDeptAuthor_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/sec/drm/EgovDeptAuthor_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="deptAuthorDAO">
+<mapper namespace="egovframework.com.sec.drm.service.impl.DeptAuthorMapper">
 
     <resultMap id="deptAuthor" type="egovframework.com.sec.drm.service.DeptAuthorVO">
         <result property="deptCode" column="DEPT_CODE"/>

--- a/src/main/resources/egovframework/mapper/com/sec/drm/EgovDeptAuthor_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/sec/drm/EgovDeptAuthor_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="deptAuthorDAO">
+<mapper namespace="egovframework.com.sec.drm.service.impl.DeptAuthorMapper">
 
     <resultMap id="deptAuthor" type="egovframework.com.sec.drm.service.DeptAuthorVO">
         <result property="deptCode" column="DEPT_CODE"/>

--- a/src/main/resources/egovframework/mapper/com/sec/gmt/EgovGroupManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/sec/gmt/EgovGroupManage_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="groupManageDAO">
+<mapper namespace="egovframework.com.sec.gmt.service.impl.GroupManageMapper">
 
     <resultMap id="group" type="egovframework.com.sec.gmt.service.GroupManageVO">
         <result property="groupId" column="GROUP_ID"/>

--- a/src/main/resources/egovframework/mapper/com/sec/gmt/EgovGroupManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/sec/gmt/EgovGroupManage_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="groupManageDAO">
+<mapper namespace="egovframework.com.sec.gmt.service.impl.GroupManageMapper">
 
     <resultMap id="group" type="egovframework.com.sec.gmt.service.GroupManageVO">
         <result property="groupId" column="GROUP_ID"/>

--- a/src/main/resources/egovframework/mapper/com/sec/gmt/EgovGroupManage_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/sec/gmt/EgovGroupManage_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="groupManageDAO">
+<mapper namespace="egovframework.com.sec.gmt.service.impl.GroupManageMapper">
 
     <resultMap id="group" type="egovframework.com.sec.gmt.service.GroupManageVO">
         <result property="groupId" column="GROUP_ID"/>

--- a/src/main/resources/egovframework/mapper/com/sec/gmt/EgovGroupManage_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/sec/gmt/EgovGroupManage_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="groupManageDAO">
+<mapper namespace="egovframework.com.sec.gmt.service.impl.GroupManageMapper">
 
 	<resultMap id="group" type="egovframework.com.sec.gmt.service.GroupManageVO">
         <result property="groupId" column="GROUP_ID"/>

--- a/src/main/resources/egovframework/mapper/com/sec/gmt/EgovGroupManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/sec/gmt/EgovGroupManage_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="groupManageDAO">
+<mapper namespace="egovframework.com.sec.gmt.service.impl.GroupManageMapper">
 
 	<resultMap id="group" type="egovframework.com.sec.gmt.service.GroupManageVO">
         <result property="groupId" column="GROUP_ID"/>

--- a/src/main/resources/egovframework/mapper/com/sec/gmt/EgovGroupManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/sec/gmt/EgovGroupManage_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="groupManageDAO">
+<mapper namespace="egovframework.com.sec.gmt.service.impl.GroupManageMapper">
 
     <resultMap id="group" type="egovframework.com.sec.gmt.service.GroupManageVO">
         <result property="groupId" column="GROUP_ID"/>

--- a/src/main/resources/egovframework/mapper/com/sec/gmt/EgovGroupManage_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/sec/gmt/EgovGroupManage_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="groupManageDAO">
+<mapper namespace="egovframework.com.sec.gmt.service.impl.GroupManageMapper">
 
 	<resultMap id="group" type="egovframework.com.sec.gmt.service.GroupManageVO">
         <result property="groupId" column="GROUP_ID"/>

--- a/src/main/resources/egovframework/mapper/com/sec/gmt/EgovGroupManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/sec/gmt/EgovGroupManage_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="groupManageDAO">
+<mapper namespace="egovframework.com.sec.gmt.service.impl.GroupManageMapper">
 
     <resultMap id="group" type="egovframework.com.sec.gmt.service.GroupManageVO">
         <result property="groupId" column="GROUP_ID"/>

--- a/src/main/resources/egovframework/mapper/com/sec/rgm/EgovAuthorGroup_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/sec/rgm/EgovAuthorGroup_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="authorGroupDAO">
+<mapper namespace="egovframework.com.sec.rgm.service.impl.AuthorGroupMapper">
 
 
     <resultMap id="authorGroup" type="egovframework.com.sec.rgm.service.AuthorGroupVO">

--- a/src/main/resources/egovframework/mapper/com/sec/rgm/EgovAuthorGroup_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/sec/rgm/EgovAuthorGroup_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="authorGroupDAO">
+<mapper namespace="egovframework.com.sec.rgm.service.impl.AuthorGroupMapper">
 
 
     <resultMap id="authorGroup" type="egovframework.com.sec.rgm.service.AuthorGroupVO">

--- a/src/main/resources/egovframework/mapper/com/sec/rgm/EgovAuthorGroup_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/sec/rgm/EgovAuthorGroup_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="authorGroupDAO">
+<mapper namespace="egovframework.com.sec.rgm.service.impl.AuthorGroupMapper">
 
 
     <resultMap id="authorGroup" type="egovframework.com.sec.rgm.service.AuthorGroupVO">

--- a/src/main/resources/egovframework/mapper/com/sec/rgm/EgovAuthorGroup_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/sec/rgm/EgovAuthorGroup_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="authorGroupDAO">
+<mapper namespace="egovframework.com.sec.rgm.service.impl.AuthorGroupMapper">
 
     <resultMap id="authorGroup" type="egovframework.com.sec.rgm.service.AuthorGroupVO">
         <result property="userId" column="USER_ID"/>

--- a/src/main/resources/egovframework/mapper/com/sec/rgm/EgovAuthorGroup_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/sec/rgm/EgovAuthorGroup_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="authorGroupDAO">
+<mapper namespace="egovframework.com.sec.rgm.service.impl.AuthorGroupMapper">
 
     <resultMap id="authorGroup" type="egovframework.com.sec.rgm.service.AuthorGroupVO">
         <result property="userId" column="USER_ID"/>

--- a/src/main/resources/egovframework/mapper/com/sec/rgm/EgovAuthorGroup_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/sec/rgm/EgovAuthorGroup_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="authorGroupDAO">
+<mapper namespace="egovframework.com.sec.rgm.service.impl.AuthorGroupMapper">
 
 
     <resultMap id="authorGroup" type="egovframework.com.sec.rgm.service.AuthorGroupVO">

--- a/src/main/resources/egovframework/mapper/com/sec/rgm/EgovAuthorGroup_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/sec/rgm/EgovAuthorGroup_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="authorGroupDAO">
+<mapper namespace="egovframework.com.sec.rgm.service.impl.AuthorGroupMapper">
 
     <resultMap id="authorGroup" type="egovframework.com.sec.rgm.service.AuthorGroupVO">
         <result property="userId" column="USER_ID"/>

--- a/src/main/resources/egovframework/mapper/com/sec/rgm/EgovAuthorGroup_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/sec/rgm/EgovAuthorGroup_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="authorGroupDAO">
+<mapper namespace="egovframework.com.sec.rgm.service.impl.AuthorGroupMapper">
 
     <resultMap id="authorGroup" type="egovframework.com.sec.rgm.service.AuthorGroupVO">
         <result property="userId" column="USER_ID"/>

--- a/src/main/resources/egovframework/spring/com/context-mapper.xml
+++ b/src/main/resources/egovframework/spring/com/context-mapper.xml
@@ -21,5 +21,11 @@
 	<bean id="egov.sqlSessionTemplate" class="org.mybatis.spring.SqlSessionTemplate">
 		<constructor-arg ref="egov.sqlSession"/>
 	</bean>
-	
+
+	<!-- @EgovMapper 어노테이션 기반 Mapper 인터페이스 자동 등록 -->
+	<bean class="org.mybatis.spring.mapper.MapperScannerConfigurer">
+		<property name="basePackage" value="egovframework.com"/>
+		<property name="annotationClass" value="org.egovframe.rte.psl.dataaccess.mapper.EgovMapper"/>
+	</bean>
+
 </beans>


### PR DESCRIPTION
## 변경 사유
기존 XML namespace 기반 DAO를 5.0 신규 @EgovMapper 인터페이스 방식으로 전환

## 변경 내용
- DeptAuthorMapper, AuthorGroupMapper, GroupManageMapper 인터페이스 신규 추가
- sec/drm·sec/rgm·sec/gmt 3개 DAO를 mapper 위임 구조로 리팩토링
- XML namespace를 mapper FQN으로 변경
- context-mapper.xml MapperScannerConfigurer 빈 추가

## 영향 범위
- sec 인증/권한 3개 서브 모듈
- DAO bean name 유지

## 체크리스트
- [x] 단일 주제만 다룸 (다른 변경 없음)
- [x] 기존 동작 호환
- [x] 테스트 통과 확인
