### PR TITLE
[refactor][5.0.x][공통컴포넌트] utl/pao PrntngOutptDAO @EgovMapper 인터페이스 방식으로 전환

### DIFF
--- a/src/main/java/egovframework/com/utl/pao/service/impl/PrntngOutptDAO.java
+++ b/src/main/java/egovframework/com/utl/pao/service/impl/PrntngOutptDAO.java
@@ -2,8 +2,8 @@ package egovframework.com.utl.pao.service.impl;
 
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.utl.pao.service.PrntngOutptVO;
+import jakarta.annotation.Resource;
 
 /**
  *
@@ -23,7 +23,10 @@ import egovframework.com.utl.pao.service.PrntngOutptVO;
  * </pre>
  */
 @Repository("PrntngOutptDAO")
-public class PrntngOutptDAO extends EgovComAbstractDAO {
+public class PrntngOutptDAO {
+
+    @Resource(name = "prntngOutptMapper")
+    private PrntngOutptMapper prntngOutptMapper;
 
     /**
 	 * 주어진 조건에 따른 공통코드를 불러온다.
@@ -31,9 +34,8 @@ public class PrntngOutptDAO extends EgovComAbstractDAO {
 	 * @return
 	 * @throws Exception
 	 */
-	public PrntngOutptVO selectErncsl(PrntngOutptVO vo) throws Exception{
-		String queryId = "PrntngOutptDAO.selectErncsl";
-		return (PrntngOutptVO) selectOne(queryId, vo);
+	public PrntngOutptVO selectErncsl(PrntngOutptVO vo) throws Exception {
+		return prntngOutptMapper.selectErncsl(vo);
 	}
 
 }

--- a/src/main/java/egovframework/com/utl/pao/service/impl/PrntngOutptMapper.java
+++ b/src/main/java/egovframework/com/utl/pao/service/impl/PrntngOutptMapper.java
@@ -1,0 +1,36 @@
+package egovframework.com.utl.pao.service.impl;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.utl.pao.service.PrntngOutptVO;
+
+/**
+ * 인쇄출력(전자관인) MyBatis 매퍼 인터페이스
+ *
+ * @author 공통서비스 개발팀 이중호
+ * @since 2009.02.01
+ * @version 1.0
+ * @see
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2009.02.01  이중호          최초 생성
+ *
+ * </pre>
+ */
+@EgovMapper("prntngOutptMapper")
+public interface PrntngOutptMapper {
+
+    /**
+     * 주어진 조건에 따른 전자관인 정보를 조회한다.
+     *
+     * @param vo 조회 조건
+     * @return PrntngOutptVO
+     * @throws Exception
+     */
+    PrntngOutptVO selectErncsl(PrntngOutptVO vo) throws Exception;
+
+}

--- a/src/main/resources/egovframework/mapper/com/utl/pao/EgovPrntngOutpt_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/pao/EgovPrntngOutpt_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="PrntngOutptDA">
+<mapper namespace="egovframework.com.utl.pao.service.impl.PrntngOutptMapper">
 
 	<resultMap id="PrntngOutptResult" type="egovframework.com.utl.pao.service.PrntngOutptVO">
 		<result property="imgInfo" column="IMAGE_INFO"/>

--- a/src/main/resources/egovframework/mapper/com/utl/pao/EgovPrntngOutpt_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/pao/EgovPrntngOutpt_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="PrntngOutptDA">
+<mapper namespace="egovframework.com.utl.pao.service.impl.PrntngOutptMapper">
 
 	<resultMap id="PrntngOutptResult" type="egovframework.com.utl.pao.service.PrntngOutptVO">
 		<result property="imgInfo" column="IMAGE_INFO"/>

--- a/src/main/resources/egovframework/mapper/com/utl/pao/EgovPrntngOutpt_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/pao/EgovPrntngOutpt_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="PrntngOutptDA">
+<mapper namespace="egovframework.com.utl.pao.service.impl.PrntngOutptMapper">
 
 	<resultMap id="PrntngOutptResult" type="egovframework.com.utl.pao.service.PrntngOutptVO">
 		<result property="imgInfo" column="IMAGE_INFO"/>

--- a/src/main/resources/egovframework/mapper/com/utl/pao/EgovPrntngOutpt_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/pao/EgovPrntngOutpt_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="PrntngOutptDA">
+<mapper namespace="egovframework.com.utl.pao.service.impl.PrntngOutptMapper">
 
 	<resultMap id="PrntngOutptResult" type="egovframework.com.utl.pao.service.PrntngOutptVO">
 		<result property="imgInfo" column="IMAGE_INFO"/>

--- a/src/main/resources/egovframework/mapper/com/utl/pao/EgovPrntngOutpt_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/pao/EgovPrntngOutpt_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="PrntngOutptDA">
+<mapper namespace="egovframework.com.utl.pao.service.impl.PrntngOutptMapper">
 
 	<resultMap id="PrntngOutptResult" type="egovframework.com.utl.pao.service.PrntngOutptVO">
 		<result property="imgInfo" column="IMAGE_INFO"/>

--- a/src/main/resources/egovframework/mapper/com/utl/pao/EgovPrntngOutpt_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/pao/EgovPrntngOutpt_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="PrntngOutptDA">
+<mapper namespace="egovframework.com.utl.pao.service.impl.PrntngOutptMapper">
 
 	<resultMap id="PrntngOutptResult" type="egovframework.com.utl.pao.service.PrntngOutptVO">
 		<result property="imgInfo" column="IMAGE_INFO"/>

--- a/src/main/resources/egovframework/mapper/com/utl/pao/EgovPrntngOutpt_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/pao/EgovPrntngOutpt_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="PrntngOutptDA">
+<mapper namespace="egovframework.com.utl.pao.service.impl.PrntngOutptMapper">
 
 	<resultMap id="PrntngOutptResult" type="egovframework.com.utl.pao.service.PrntngOutptVO">
 		<result property="imgInfo" column="IMAGE_INFO"/>

--- a/src/main/resources/egovframework/mapper/com/utl/pao/EgovPrntngOutpt_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/pao/EgovPrntngOutpt_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="PrntngOutptDA">
+<mapper namespace="egovframework.com.utl.pao.service.impl.PrntngOutptMapper">
 
 	<resultMap id="PrntngOutptResult" type="egovframework.com.utl.pao.service.PrntngOutptVO">
 		<result property="imgInfo" column="IMAGE_INFO"/>

--- a/src/main/resources/egovframework/spring/com/context-mapper.xml
+++ b/src/main/resources/egovframework/spring/com/context-mapper.xml
@@ -21,5 +21,12 @@
 	<bean id="egov.sqlSessionTemplate" class="org.mybatis.spring.SqlSessionTemplate">
 		<constructor-arg ref="egov.sqlSession"/>
 	</bean>
-	
+
+	<!-- @Mapper 인터페이스 자동 스캔 -->
+	<bean class="org.mybatis.spring.mapper.MapperScannerConfigurer">
+		<property name="basePackage" value="egovframework.com"/>
+		<property name="annotationClass" value="org.egovframe.rte.psl.dataaccess.mapper.EgovMapper"/>
+		<property name="sqlSessionFactoryBeanName" value="egov.sqlSession"/>
+	</bean>
+
 </beans>


### PR DESCRIPTION
utl/pao 모듈의 PrntngOutptDAO를 EgovComAbstractDAO 상속 방식에서 @EgovMapper 인터페이스 위임 방식으로 전환한다.

### 변경 내용

- `PrntngOutptMapper` 인터페이스 신설: `@EgovMapper("prntngOutptMapper")` 어노테이션 적용, PrntngOutptDAO가 제공하던 `selectErncsl` 메서드 선언 포함
- `PrntngOutptDAO` 재작성: `EgovComAbstractDAO` 상속 제거, `@Resource(name="prntngOutptMapper")`로 주입받아 위임
- `EgovPrntngOutpt_SQL_*.xml` 8개(altibase/cubrid/goldilocks/maria/mysql/oracle/postgres/tibero): `namespace="PrntngOutptDA"` → `namespace="egovframework.com.utl.pao.service.impl.PrntngOutptMapper"` 변경
- `context-mapper.xml`: `MapperScannerConfigurer` 빈 추가 (basePackage=`egovframework.com`, annotationClass=`EgovMapper`)

### 영향 범위

- utl/pao 인쇄출력관리 모듈만 영향
- DAO bean name(`PrntngOutptDAO`) 및 서비스 인터페이스 유지로 기존 동작 호환

### 체크리스트

- [x] 단일 주제만 다룸 (다른 변경 없음)
- [x] 기존 동작에 영향 없음 (bean name 유지, 메서드 시그니처 동일)
- [x] 테스트 통과 확인
