### PR TITLE
[refactor][5.0.x][공통컴포넌트] ssi/syi 연계관리 4개 DAO @EgovMapper 인터페이스 방식으로 전환

### DIFF
--- a/src/main/java/egovframework/com/ssi/syi/iis/service/impl/CntcInsttDAO.java
+++ b/src/main/java/egovframework/com/ssi/syi/iis/service/impl/CntcInsttDAO.java
@@ -5,7 +5,6 @@ import java.util.List;
 import org.egovframe.rte.psl.dataaccess.util.EgovMap;
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.ssi.syi.iis.service.CntcInstt;
 import egovframework.com.ssi.syi.iis.service.CntcInsttVO;
 import egovframework.com.ssi.syi.iis.service.CntcService;
@@ -14,26 +13,31 @@ import egovframework.com.ssi.syi.iis.service.CntcSystem;
 import egovframework.com.ssi.syi.iis.service.CntcSystemVO;
 
 /**
- *
  * 연계기관에 대한 데이터 접근 클래스를 정의한다
+ *
  * @author 공통서비스 개발팀 이중호
  * @since 2009.04.01
  * @version 1.0
  * @see
  *
  * <pre>
- * << 개정이력(Modification Information) >>
+ * == 개정이력(Modification Information) ==
  *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.04.01  이중호          최초 생성
+ *   2026.05.28  dasomel        @EgovMapper 인터페이스 방식으로 전환
  *
- * Copyright (C) 2009 by MOPAS  All rights reserved.
  * </pre>
  */
 @Repository("CntcInsttDAO")
-public class CntcInsttDAO extends EgovComAbstractDAO {
+public class CntcInsttDAO {
 
+	private final CntcInsttMapper cntcInsttMapper;
+
+	public CntcInsttDAO(CntcInsttMapper cntcInsttMapper) {
+		this.cntcInsttMapper = cntcInsttMapper;
+	}
 
 	/**
 	 * 연계기관을 삭제한다.
@@ -41,25 +45,25 @@ public class CntcInsttDAO extends EgovComAbstractDAO {
 	 * @throws Exception
 	 */
 	public void deleteCntcInstt(CntcInstt cntcInstt) throws Exception {
-		delete("CntcInsttDAO.deleteCntcInstt", cntcInstt);
+		cntcInsttMapper.deleteCntcInstt(cntcInstt);
 	}
 
 	/**
 	 * 연계시스템을 삭제한다.
-	 * @param cntcInstt
+	 * @param cntcSystem
 	 * @throws Exception
 	 */
 	public void deleteCntcSystem(CntcSystem cntcSystem) throws Exception {
-		delete("CntcInsttDAO.deleteCntcSystem", cntcSystem);
+		cntcInsttMapper.deleteCntcSystem(cntcSystem);
 	}
 
 	/**
 	 * 연계서비스를 삭제한다.
-	 * @param cntcInstt
+	 * @param cntcService
 	 * @throws Exception
 	 */
 	public void deleteCntcService(CntcService cntcService) throws Exception {
-        delete("CntcInsttDAO.deleteCntcService", cntcService);
+		cntcInsttMapper.deleteCntcService(cntcService);
 	}
 
 	/**
@@ -68,25 +72,25 @@ public class CntcInsttDAO extends EgovComAbstractDAO {
 	 * @throws Exception
 	 */
 	public void insertCntcInstt(CntcInstt cntcInstt) throws Exception {
-        insert("CntcInsttDAO.insertCntcInstt", cntcInstt);
+		cntcInsttMapper.insertCntcInstt(cntcInstt);
 	}
 
 	/**
 	 * 연계시스템을 등록한다.
-	 * @param cntcInstt
+	 * @param cntcSystem
 	 * @throws Exception
 	 */
 	public void insertCntcSystem(CntcSystem cntcSystem) throws Exception {
-        insert("CntcInsttDAO.insertCntcSystem", cntcSystem);
+		cntcInsttMapper.insertCntcSystem(cntcSystem);
 	}
 
 	/**
 	 * 연계서비스를 등록한다.
-	 * @param cntcInstt
+	 * @param cntcService
 	 * @throws Exception
 	 */
 	public void insertCntcService(CntcService cntcService) throws Exception {
-        insert("CntcInsttDAO.insertCntcService", cntcService);
+		cntcInsttMapper.insertCntcService(cntcService);
 	}
 
 	/**
@@ -95,109 +99,109 @@ public class CntcInsttDAO extends EgovComAbstractDAO {
 	 * @return CntcInstt(연계기관)
 	 */
 	public CntcInstt selectCntcInsttDetail(CntcInstt cntcInstt) throws Exception {
-		return (CntcInstt) selectOne("CntcInsttDAO.selectCntcInsttDetail", cntcInstt);
+		return cntcInsttMapper.selectCntcInsttDetail(cntcInstt);
 	}
 
 	/**
 	 * 연계시스템 상세항목을 조회한다.
-	 * @param cntcInstt
-	 * @return CntcInstt(연계기관)
+	 * @param cntcSystem
+	 * @return CntcSystem(연계시스템)
 	 */
 	public CntcSystem selectCntcSystemDetail(CntcSystem cntcSystem) throws Exception {
-		return (CntcSystem) selectOne("CntcInsttDAO.selectCntcSystemDetail", cntcSystem);
+		return cntcInsttMapper.selectCntcSystemDetail(cntcSystem);
 	}
 
 	/**
 	 * 연계서비스 상세항목을 조회한다.
-	 * @param cntcInstt
-	 * @return CntcInstt(연계기관)
+	 * @param cntcService
+	 * @return CntcService(연계서비스)
 	 */
 	public CntcService selectCntcServiceDetail(CntcService cntcService) throws Exception {
-		return (CntcService) selectOne("CntcInsttDAO.selectCntcServiceDetail", cntcService);
+		return cntcInsttMapper.selectCntcServiceDetail(cntcService);
 	}
 
-    /**
+	/**
 	 * 연계기관 목록을 조회한다.
-     * @param searchVO
-     * @return List(연계기관 목록)
-     * @throws Exception
-     */
-    public List<EgovMap> selectCntcInsttList(CntcInsttVO searchVO) throws Exception {
-        return selectList("CntcInsttDAO.selectCntcInsttList", searchVO);
-    }
+	 * @param searchVO
+	 * @return List(연계기관 목록)
+	 * @throws Exception
+	 */
+	public List<EgovMap> selectCntcInsttList(CntcInsttVO searchVO) throws Exception {
+		return cntcInsttMapper.selectCntcInsttList(searchVO);
+	}
 
-    /**
+	/**
 	 * 연계기관 총 개수를 조회한다.
-     * @param searchVO
-     * @return int(연계기관 총 개수)
-     */
-    public int selectCntcInsttListTotCnt(CntcInsttVO searchVO) throws Exception {
-        return (Integer)selectOne("CntcInsttDAO.selectCntcInsttListTotCnt", searchVO);
-    }
+	 * @param searchVO
+	 * @return int(연계기관 총 개수)
+	 */
+	public int selectCntcInsttListTotCnt(CntcInsttVO searchVO) throws Exception {
+		return cntcInsttMapper.selectCntcInsttListTotCnt(searchVO);
+	}
 
-    /**
+	/**
 	 * 연계시스템 목록을 조회한다.
-     * @param searchVO
-     * @return List(연계시스템 목록)
-     * @throws Exception
-     */
-    public List<EgovMap> selectCntcSystemList(CntcSystemVO searchVO) throws Exception {
-        return selectList("CntcInsttDAO.selectCntcSystemList", searchVO);
-    }
+	 * @param searchVO
+	 * @return List(연계시스템 목록)
+	 * @throws Exception
+	 */
+	public List<EgovMap> selectCntcSystemList(CntcSystemVO searchVO) throws Exception {
+		return cntcInsttMapper.selectCntcSystemList(searchVO);
+	}
 
-    /**
+	/**
 	 * 연계시스템 총 개수를 조회한다.
-     * @param searchVO
-     * @return int(연계시스템 총 개수)
-     */
-    public int selectCntcSystemListTotCnt(CntcSystemVO searchVO) throws Exception {
-        return (Integer)selectOne("CntcInsttDAO.selectCntcSystemListTotCnt", searchVO);
-    }
+	 * @param searchVO
+	 * @return int(연계시스템 총 개수)
+	 */
+	public int selectCntcSystemListTotCnt(CntcSystemVO searchVO) throws Exception {
+		return cntcInsttMapper.selectCntcSystemListTotCnt(searchVO);
+	}
 
-    /**
+	/**
 	 * 연계서비스 목록을 조회한다.
-     * @param searchVO
-     * @return List(연계서비스 목록)
-     * @throws Exception
-     */
-    public List<EgovMap> selectCntcServiceList(CntcServiceVO searchVO) throws Exception {
-        return selectList("CntcInsttDAO.selectCntcServiceList", searchVO);
-    }
+	 * @param searchVO
+	 * @return List(연계서비스 목록)
+	 * @throws Exception
+	 */
+	public List<EgovMap> selectCntcServiceList(CntcServiceVO searchVO) throws Exception {
+		return cntcInsttMapper.selectCntcServiceList(searchVO);
+	}
 
-    /**
+	/**
 	 * 연계서비스 총 개수를 조회한다.
-     * @param searchVO
-     * @return int(연계서비스 총 개수)
-     */
-    public int selectCntcServiceListTotCnt(CntcServiceVO searchVO) throws Exception {
-        return (Integer)selectOne("CntcInsttDAO.selectCntcServiceListTotCnt", searchVO);
-    }
+	 * @param searchVO
+	 * @return int(연계서비스 총 개수)
+	 */
+	public int selectCntcServiceListTotCnt(CntcServiceVO searchVO) throws Exception {
+		return cntcInsttMapper.selectCntcServiceListTotCnt(searchVO);
+	}
 
-    /**
+	/**
 	 * 연계기관을 수정한다.
 	 * @param cntcInstt
 	 * @throws Exception
 	 */
 	public void updateCntcInstt(CntcInstt cntcInstt) throws Exception {
-		update("CntcInsttDAO.updateCntcInstt", cntcInstt);
+		cntcInsttMapper.updateCntcInstt(cntcInstt);
 	}
 
 	/**
 	 * 연계시스템을 수정한다.
-	 * @param cntcInstt
+	 * @param cntcSystem
 	 * @throws Exception
 	 */
 	public void updateCntcSystem(CntcSystem cntcSystem) throws Exception {
-        update("CntcInsttDAO.updateCntcSystem", cntcSystem);
+		cntcInsttMapper.updateCntcSystem(cntcSystem);
 	}
 
 	/**
-	 * 연계시스템을 수정한다.
-	 * @param cntcInstt
+	 * 연계서비스를 수정한다.
+	 * @param cntcService
 	 * @throws Exception
 	 */
 	public void updateCntcService(CntcService cntcService) throws Exception {
-        update("CntcInsttDAO.updateCntcService", cntcService);
+		cntcInsttMapper.updateCntcService(cntcService);
 	}
 
 }

--- a/src/main/java/egovframework/com/ssi/syi/iis/service/impl/CntcInsttMapper.java
+++ b/src/main/java/egovframework/com/ssi/syi/iis/service/impl/CntcInsttMapper.java
@@ -1,0 +1,153 @@
+package egovframework.com.ssi.syi.iis.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+import org.egovframe.rte.psl.dataaccess.util.EgovMap;
+
+import egovframework.com.ssi.syi.iis.service.CntcInstt;
+import egovframework.com.ssi.syi.iis.service.CntcInsttVO;
+import egovframework.com.ssi.syi.iis.service.CntcService;
+import egovframework.com.ssi.syi.iis.service.CntcServiceVO;
+import egovframework.com.ssi.syi.iis.service.CntcSystem;
+import egovframework.com.ssi.syi.iis.service.CntcSystemVO;
+
+/**
+ * 연계기관에 대한 매퍼 인터페이스를 정의한다
+ *
+ * @author 공통서비스 개발팀 이중호
+ * @since 2009.04.01
+ * @version 1.0
+ * @see
+ *
+ * <pre>
+ * == 개정이력(Modification Information) ==
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2009.04.01  이중호          최초 생성
+ *   2026.05.28  dasomel        @EgovMapper 인터페이스 방식으로 전환
+ *
+ * </pre>
+ */
+@EgovMapper("CntcInsttMapper")
+public interface CntcInsttMapper {
+
+	/**
+	 * 연계기관을 삭제한다.
+	 * @param cntcInstt
+	 */
+	void deleteCntcInstt(CntcInstt cntcInstt);
+
+	/**
+	 * 연계시스템을 삭제한다.
+	 * @param cntcSystem
+	 */
+	void deleteCntcSystem(CntcSystem cntcSystem);
+
+	/**
+	 * 연계서비스를 삭제한다.
+	 * @param cntcService
+	 */
+	void deleteCntcService(CntcService cntcService);
+
+	/**
+	 * 연계기관을 등록한다.
+	 * @param cntcInstt
+	 */
+	void insertCntcInstt(CntcInstt cntcInstt);
+
+	/**
+	 * 연계시스템을 등록한다.
+	 * @param cntcSystem
+	 */
+	void insertCntcSystem(CntcSystem cntcSystem);
+
+	/**
+	 * 연계서비스를 등록한다.
+	 * @param cntcService
+	 */
+	void insertCntcService(CntcService cntcService);
+
+	/**
+	 * 연계기관 상세항목을 조회한다.
+	 * @param cntcInstt
+	 * @return CntcInstt(연계기관)
+	 */
+	CntcInstt selectCntcInsttDetail(CntcInstt cntcInstt);
+
+	/**
+	 * 연계시스템 상세항목을 조회한다.
+	 * @param cntcSystem
+	 * @return CntcSystem(연계시스템)
+	 */
+	CntcSystem selectCntcSystemDetail(CntcSystem cntcSystem);
+
+	/**
+	 * 연계서비스 상세항목을 조회한다.
+	 * @param cntcService
+	 * @return CntcService(연계서비스)
+	 */
+	CntcService selectCntcServiceDetail(CntcService cntcService);
+
+	/**
+	 * 연계기관 목록을 조회한다.
+	 * @param searchVO
+	 * @return List(연계기관 목록)
+	 */
+	List<EgovMap> selectCntcInsttList(CntcInsttVO searchVO);
+
+	/**
+	 * 연계기관 총 개수를 조회한다.
+	 * @param searchVO
+	 * @return int(연계기관 총 개수)
+	 */
+	int selectCntcInsttListTotCnt(CntcInsttVO searchVO);
+
+	/**
+	 * 연계시스템 목록을 조회한다.
+	 * @param searchVO
+	 * @return List(연계시스템 목록)
+	 */
+	List<EgovMap> selectCntcSystemList(CntcSystemVO searchVO);
+
+	/**
+	 * 연계시스템 총 개수를 조회한다.
+	 * @param searchVO
+	 * @return int(연계시스템 총 개수)
+	 */
+	int selectCntcSystemListTotCnt(CntcSystemVO searchVO);
+
+	/**
+	 * 연계서비스 목록을 조회한다.
+	 * @param searchVO
+	 * @return List(연계서비스 목록)
+	 */
+	List<EgovMap> selectCntcServiceList(CntcServiceVO searchVO);
+
+	/**
+	 * 연계서비스 총 개수를 조회한다.
+	 * @param searchVO
+	 * @return int(연계서비스 총 개수)
+	 */
+	int selectCntcServiceListTotCnt(CntcServiceVO searchVO);
+
+	/**
+	 * 연계기관을 수정한다.
+	 * @param cntcInstt
+	 */
+	void updateCntcInstt(CntcInstt cntcInstt);
+
+	/**
+	 * 연계시스템을 수정한다.
+	 * @param cntcSystem
+	 */
+	void updateCntcSystem(CntcSystem cntcSystem);
+
+	/**
+	 * 연계서비스를 수정한다.
+	 * @param cntcService
+	 */
+	void updateCntcService(CntcService cntcService);
+
+}

--- a/src/main/java/egovframework/com/ssi/syi/ims/service/impl/CntcMessageDAO.java
+++ b/src/main/java/egovframework/com/ssi/syi/ims/service/impl/CntcMessageDAO.java
@@ -5,32 +5,37 @@ import java.util.List;
 import org.egovframe.rte.psl.dataaccess.util.EgovMap;
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.ssi.syi.ims.service.CntcMessage;
 import egovframework.com.ssi.syi.ims.service.CntcMessageItem;
 import egovframework.com.ssi.syi.ims.service.CntcMessageItemVO;
 import egovframework.com.ssi.syi.ims.service.CntcMessageVO;
 
 /**
- *
  * 연계메시지에 대한 데이터 접근 클래스를 정의한다
+ *
  * @author 공통서비스 개발팀 이중호
  * @since 2009.04.01
  * @version 1.0
  * @see
  *
  * <pre>
- * << 개정이력(Modification Information) >>
+ * == 개정이력(Modification Information) ==
  *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.04.01  이중호          최초 생성
+ *   2026.05.28  dasomel        @EgovMapper 인터페이스 방식으로 전환
  *
- * Copyright (C) 2009 by MOPAS  All rights reserved.
  * </pre>
  */
 @Repository("CntcMessageDAO")
-public class CntcMessageDAO extends EgovComAbstractDAO {
+public class CntcMessageDAO {
+
+	private final CntcMessageMapper cntcMessageMapper;
+
+	public CntcMessageDAO(CntcMessageMapper cntcMessageMapper) {
+		this.cntcMessageMapper = cntcMessageMapper;
+	}
 
 	/**
 	 * 연계메시지를 삭제한다.
@@ -38,16 +43,16 @@ public class CntcMessageDAO extends EgovComAbstractDAO {
 	 * @throws Exception
 	 */
 	public void deleteCntcMessage(CntcMessage cntcMessage) throws Exception {
-		delete("CntcMessageDAO.deleteCntcMessage", cntcMessage);
+		cntcMessageMapper.deleteCntcMessage(cntcMessage);
 	}
 
 	/**
 	 * 연계메시지 항목을 삭제한다.
-	 * @param cntcMessage
+	 * @param cntcMessageItem
 	 * @throws Exception
 	 */
 	public void deleteCntcMessageItem(CntcMessageItem cntcMessageItem) throws Exception {
-		delete("CntcMessageDAO.deleteCntcMessageItem", cntcMessageItem);
+		cntcMessageMapper.deleteCntcMessageItem(cntcMessageItem);
 	}
 
 	/**
@@ -56,16 +61,16 @@ public class CntcMessageDAO extends EgovComAbstractDAO {
 	 * @throws Exception
 	 */
 	public void insertCntcMessage(CntcMessage cntcMessage) throws Exception {
-		insert("CntcMessageDAO.insertCntcMessage", cntcMessage);
+		cntcMessageMapper.insertCntcMessage(cntcMessage);
 	}
 
 	/**
 	 * 연계메시지 항목을 등록한다.
-	 * @param cntcMessage
+	 * @param cntcMessageItem
 	 * @throws Exception
 	 */
 	public void insertCntcMessageItem(CntcMessageItem cntcMessageItem) throws Exception {
-		insert("CntcMessageDAO.insertCntcMessageItem", cntcMessageItem);
+		cntcMessageMapper.insertCntcMessageItem(cntcMessageItem);
 	}
 
 	/**
@@ -74,16 +79,16 @@ public class CntcMessageDAO extends EgovComAbstractDAO {
 	 * @return CntcMessage(연계메시지)
 	 */
 	public CntcMessage selectCntcMessageDetail(CntcMessage cntcMessage) throws Exception {
-		return (CntcMessage) selectOne("CntcMessageDAO.selectCntcMessageDetail", cntcMessage);
+		return cntcMessageMapper.selectCntcMessageDetail(cntcMessage);
 	}
 
 	/**
 	 * 연계메시지항목 상세항목을 조회한다.
-	 * @param cntcMessage
-	 * @return CntcMessage(연계메시지)
+	 * @param cntcMessageItem
+	 * @return CntcMessageItem(연계메시지항목)
 	 */
 	public CntcMessageItem selectCntcMessageItemDetail(CntcMessageItem cntcMessageItem) throws Exception {
-		return (CntcMessageItem) selectOne("CntcMessageDAO.selectCntcMessageItemDetail", cntcMessageItem);
+		return cntcMessageMapper.selectCntcMessageItemDetail(cntcMessageItem);
 	}
 
 	/**
@@ -93,7 +98,7 @@ public class CntcMessageDAO extends EgovComAbstractDAO {
 	 * @throws Exception
 	 */
 	public List<EgovMap> selectCntcMessageList(CntcMessageVO searchVO) throws Exception {
-		return selectList("CntcMessageDAO.selectCntcMessageList", searchVO);
+		return cntcMessageMapper.selectCntcMessageList(searchVO);
 	}
 
 	/**
@@ -102,26 +107,26 @@ public class CntcMessageDAO extends EgovComAbstractDAO {
 	 * @return int(연계메시지 총 개수)
 	 */
 	public int selectCntcMessageListTotCnt(CntcMessageVO searchVO) throws Exception {
-		return (Integer) selectOne("CntcMessageDAO.selectCntcMessageListTotCnt", searchVO);
+		return cntcMessageMapper.selectCntcMessageListTotCnt(searchVO);
 	}
 
 	/**
 	 * 연계메시지항목 목록을 조회한다.
 	 * @param searchVO
-	 * @return List(연계메시지 목록)
+	 * @return List(연계메시지항목 목록)
 	 * @throws Exception
 	 */
 	public List<EgovMap> selectCntcMessageItemList(CntcMessageItemVO searchVO) throws Exception {
-		return selectList("CntcMessageDAO.selectCntcMessageItemList", searchVO);
+		return cntcMessageMapper.selectCntcMessageItemList(searchVO);
 	}
 
 	/**
 	 * 연계메시지항목 총 개수를 조회한다.
 	 * @param searchVO
-	 * @return int(연계메시지 총 개수)
+	 * @return int(연계메시지항목 총 개수)
 	 */
 	public int selectCntcMessageItemListTotCnt(CntcMessageItemVO searchVO) throws Exception {
-		return (Integer) selectOne("CntcMessageDAO.selectCntcMessageItemListTotCnt", searchVO);
+		return cntcMessageMapper.selectCntcMessageItemListTotCnt(searchVO);
 	}
 
 	/**
@@ -130,16 +135,16 @@ public class CntcMessageDAO extends EgovComAbstractDAO {
 	 * @throws Exception
 	 */
 	public void updateCntcMessage(CntcMessage cntcMessage) throws Exception {
-		update("CntcMessageDAO.updateCntcMessage", cntcMessage);
+		cntcMessageMapper.updateCntcMessage(cntcMessage);
 	}
 
 	/**
 	 * 연계메시지 항목을 수정한다.
-	 * @param cntcMessage
+	 * @param cntcMessageItem
 	 * @throws Exception
 	 */
 	public void updateCntcMessageItem(CntcMessageItem cntcMessageItem) throws Exception {
-		update("CntcMessageDAO.updateCntcMessageItem", cntcMessageItem);
+		cntcMessageMapper.updateCntcMessageItem(cntcMessageItem);
 	}
 
 }

--- a/src/main/java/egovframework/com/ssi/syi/ims/service/impl/CntcMessageMapper.java
+++ b/src/main/java/egovframework/com/ssi/syi/ims/service/impl/CntcMessageMapper.java
@@ -1,0 +1,112 @@
+package egovframework.com.ssi.syi.ims.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+import org.egovframe.rte.psl.dataaccess.util.EgovMap;
+
+import egovframework.com.ssi.syi.ims.service.CntcMessage;
+import egovframework.com.ssi.syi.ims.service.CntcMessageItem;
+import egovframework.com.ssi.syi.ims.service.CntcMessageItemVO;
+import egovframework.com.ssi.syi.ims.service.CntcMessageVO;
+
+/**
+ * 연계메시지에 대한 매퍼 인터페이스를 정의한다
+ *
+ * @author 공통서비스 개발팀 이중호
+ * @since 2009.04.01
+ * @version 1.0
+ * @see
+ *
+ * <pre>
+ * == 개정이력(Modification Information) ==
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2009.04.01  이중호          최초 생성
+ *   2026.05.28  dasomel        @EgovMapper 인터페이스 방식으로 전환
+ *
+ * </pre>
+ */
+@EgovMapper("CntcMessageMapper")
+public interface CntcMessageMapper {
+
+	/**
+	 * 연계메시지를 삭제한다.
+	 * @param cntcMessage
+	 */
+	void deleteCntcMessage(CntcMessage cntcMessage);
+
+	/**
+	 * 연계메시지 항목을 삭제한다.
+	 * @param cntcMessageItem
+	 */
+	void deleteCntcMessageItem(CntcMessageItem cntcMessageItem);
+
+	/**
+	 * 연계메시지를 등록한다.
+	 * @param cntcMessage
+	 */
+	void insertCntcMessage(CntcMessage cntcMessage);
+
+	/**
+	 * 연계메시지 항목을 등록한다.
+	 * @param cntcMessageItem
+	 */
+	void insertCntcMessageItem(CntcMessageItem cntcMessageItem);
+
+	/**
+	 * 연계메시지 상세항목을 조회한다.
+	 * @param cntcMessage
+	 * @return CntcMessage(연계메시지)
+	 */
+	CntcMessage selectCntcMessageDetail(CntcMessage cntcMessage);
+
+	/**
+	 * 연계메시지항목 상세항목을 조회한다.
+	 * @param cntcMessageItem
+	 * @return CntcMessageItem(연계메시지항목)
+	 */
+	CntcMessageItem selectCntcMessageItemDetail(CntcMessageItem cntcMessageItem);
+
+	/**
+	 * 연계메시지 목록을 조회한다.
+	 * @param searchVO
+	 * @return List(연계메시지 목록)
+	 */
+	List<EgovMap> selectCntcMessageList(CntcMessageVO searchVO);
+
+	/**
+	 * 연계메시지 총 개수를 조회한다.
+	 * @param searchVO
+	 * @return int(연계메시지 총 개수)
+	 */
+	int selectCntcMessageListTotCnt(CntcMessageVO searchVO);
+
+	/**
+	 * 연계메시지항목 목록을 조회한다.
+	 * @param searchVO
+	 * @return List(연계메시지항목 목록)
+	 */
+	List<EgovMap> selectCntcMessageItemList(CntcMessageItemVO searchVO);
+
+	/**
+	 * 연계메시지항목 총 개수를 조회한다.
+	 * @param searchVO
+	 * @return int(연계메시지항목 총 개수)
+	 */
+	int selectCntcMessageItemListTotCnt(CntcMessageItemVO searchVO);
+
+	/**
+	 * 연계메시지를 수정한다.
+	 * @param cntcMessage
+	 */
+	void updateCntcMessage(CntcMessage cntcMessage);
+
+	/**
+	 * 연계메시지 항목을 수정한다.
+	 * @param cntcMessageItem
+	 */
+	void updateCntcMessageItem(CntcMessageItem cntcMessageItem);
+
+}

--- a/src/main/java/egovframework/com/ssi/syi/ist/service/impl/CntcSttusDAO.java
+++ b/src/main/java/egovframework/com/ssi/syi/ist/service/impl/CntcSttusDAO.java
@@ -5,13 +5,12 @@ import java.util.List;
 import org.egovframe.rte.psl.dataaccess.util.EgovMap;
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.ssi.syi.ist.service.CntcSttus;
 import egovframework.com.ssi.syi.ist.service.CntcSttusVO;
 
 /**
  * 연계현황에 대한 데이터 접근 클래스를 정의한다
- * 
+ *
  * @author 공통서비스 개발팀 이중호
  * @since 2009.04.01
  * @version 1.0
@@ -25,41 +24,48 @@ import egovframework.com.ssi.syi.ist.service.CntcSttusVO;
  *   2009.04.01  이중호          최초 생성
  *   2025.06.28  이백행          컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-FormalParameterNamingConventions(변수명에 밑줄 사용)
  *   2025.06.28  이백행          컨트리뷰션 형 변환 제거-(CntcSttus), (Integer)
+ *   2026.05.28  dasomel        @EgovMapper 인터페이스 방식으로 전환
  *
  *      </pre>
  */
 @Repository("CntcSttusDAO")
-public class CntcSttusDAO extends EgovComAbstractDAO {
+public class CntcSttusDAO {
+
+	private final CntcSttusMapper cntcSttusMapper;
+
+	public CntcSttusDAO(CntcSttusMapper cntcSttusMapper) {
+		this.cntcSttusMapper = cntcSttusMapper;
+	}
 
 	/**
 	 * 연계현황 상세항목을 조회한다.
-	 * 
+	 *
 	 * @param cntcSttus
 	 * @return CntcSttus(연계현황)
 	 */
 	public CntcSttus selectCntcSttusDetail(CntcSttus cntcSttus) throws Exception {
-		return selectOne("CntcSttusDAO.selectCntcSttusDetail", cntcSttus);
+		return cntcSttusMapper.selectCntcSttusDetail(cntcSttus);
 	}
 
 	/**
 	 * 연계현황 목록을 조회한다.
-	 * 
+	 *
 	 * @param searchVO
 	 * @return List(연계현황 목록)
 	 * @throws Exception
 	 */
 	public List<EgovMap> selectCntcSttusList(CntcSttusVO searchVO) throws Exception {
-		return selectList("CntcSttusDAO.selectCntcSttusList", searchVO);
+		return cntcSttusMapper.selectCntcSttusList(searchVO);
 	}
 
 	/**
 	 * 연계현황 총 개수를 조회한다.
-	 * 
+	 *
 	 * @param searchVO
 	 * @return int(연계현황 총 개수)
 	 */
 	public int selectCntcSttusListTotCnt(CntcSttusVO searchVO) throws Exception {
-		return selectOne("CntcSttusDAO.selectCntcSttusListTotCnt", searchVO);
+		return cntcSttusMapper.selectCntcSttusListTotCnt(searchVO);
 	}
 
 }

--- a/src/main/java/egovframework/com/ssi/syi/ist/service/impl/CntcSttusMapper.java
+++ b/src/main/java/egovframework/com/ssi/syi/ist/service/impl/CntcSttusMapper.java
@@ -1,0 +1,56 @@
+package egovframework.com.ssi.syi.ist.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+import org.egovframe.rte.psl.dataaccess.util.EgovMap;
+
+import egovframework.com.ssi.syi.ist.service.CntcSttus;
+import egovframework.com.ssi.syi.ist.service.CntcSttusVO;
+
+/**
+ * 연계현황에 대한 매퍼 인터페이스를 정의한다
+ *
+ * @author 공통서비스 개발팀 이중호
+ * @since 2009.04.01
+ * @version 1.0
+ * @see
+ *
+ *      <pre>
+ *  == 개정이력(Modification Information) ==
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2009.04.01  이중호          최초 생성
+ *   2026.05.28  dasomel        @EgovMapper 인터페이스 방식으로 전환
+ *
+ *      </pre>
+ */
+@EgovMapper("CntcSttusMapper")
+public interface CntcSttusMapper {
+
+	/**
+	 * 연계현황 상세항목을 조회한다.
+	 *
+	 * @param cntcSttus
+	 * @return CntcSttus(연계현황)
+	 */
+	CntcSttus selectCntcSttusDetail(CntcSttus cntcSttus);
+
+	/**
+	 * 연계현황 목록을 조회한다.
+	 *
+	 * @param searchVO
+	 * @return List(연계현황 목록)
+	 */
+	List<EgovMap> selectCntcSttusList(CntcSttusVO searchVO);
+
+	/**
+	 * 연계현황 총 개수를 조회한다.
+	 *
+	 * @param searchVO
+	 * @return int(연계현황 총 개수)
+	 */
+	int selectCntcSttusListTotCnt(CntcSttusVO searchVO);
+
+}

--- a/src/main/java/egovframework/com/ssi/syi/sim/service/impl/SystemCntcDAO.java
+++ b/src/main/java/egovframework/com/ssi/syi/sim/service/impl/SystemCntcDAO.java
@@ -5,30 +5,35 @@ import java.util.List;
 import org.egovframe.rte.psl.dataaccess.util.EgovMap;
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.ssi.syi.sim.service.SystemCntc;
 import egovframework.com.ssi.syi.sim.service.SystemCntcVO;
 
 /**
- *
  * 시스템연계에 대한 데이터 접근 클래스를 정의한다
+ *
  * @author 공통서비스 개발팀 이중호
  * @since 2009.04.01
  * @version 1.0
  * @see
  *
  * <pre>
- * << 개정이력(Modification Information) >>
+ * == 개정이력(Modification Information) ==
  *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.04.01  이중호          최초 생성
+ *   2026.05.28  dasomel        @EgovMapper 인터페이스 방식으로 전환
  *
- * Copyright (C) 2009 by MOPAS  All rights reserved.
  * </pre>
  */
 @Repository("SystemCntcDAO")
-public class SystemCntcDAO extends EgovComAbstractDAO {
+public class SystemCntcDAO {
+
+	private final SystemCntcMapper systemCntcMapper;
+
+	public SystemCntcDAO(SystemCntcMapper systemCntcMapper) {
+		this.systemCntcMapper = systemCntcMapper;
+	}
 
 	/**
 	 * 시스템연계를 삭제한다.
@@ -36,7 +41,7 @@ public class SystemCntcDAO extends EgovComAbstractDAO {
 	 * @throws Exception
 	 */
 	public void deleteSystemCntc(SystemCntc systemCntc) throws Exception {
-        delete("SystemCntcDAO.deleteSystemCntc", systemCntc);
+		systemCntcMapper.deleteSystemCntc(systemCntc);
 	}
 
 	/**
@@ -45,7 +50,7 @@ public class SystemCntcDAO extends EgovComAbstractDAO {
 	 * @throws Exception
 	 */
 	public void insertSystemCntc(SystemCntc systemCntc) throws Exception {
-        insert("SystemCntcDAO.insertSystemCntc", systemCntc);
+		systemCntcMapper.insertSystemCntc(systemCntc);
 	}
 
 	/**
@@ -54,7 +59,7 @@ public class SystemCntcDAO extends EgovComAbstractDAO {
 	 * @return SystemCntc(시스템연계)
 	 */
 	public SystemCntc selectSystemCntcDetail(SystemCntc systemCntc) throws Exception {
-		return (SystemCntc) selectOne("SystemCntcDAO.selectSystemCntcDetail", systemCntc);
+		return systemCntcMapper.selectSystemCntcDetail(systemCntc);
 	}
 
 	/**
@@ -63,28 +68,27 @@ public class SystemCntcDAO extends EgovComAbstractDAO {
 	 * @throws Exception
 	 */
 	public void confirmSystemCntc(SystemCntc systemCntc) throws Exception {
-        update("SystemCntcDAO.confirmSystemCntc", systemCntc);
+		systemCntcMapper.confirmSystemCntc(systemCntc);
 	}
 
-
-    /**
+	/**
 	 * 시스템연계 목록을 조회한다.
-     * @param searchVO
-     * @return List(시스템연계 목록)
-     * @throws Exception
-     */
-    public List<EgovMap> selectSystemCntcList(SystemCntcVO searchVO) throws Exception {
-        return selectList("SystemCntcDAO.selectSystemCntcList", searchVO);
-    }
+	 * @param searchVO
+	 * @return List(시스템연계 목록)
+	 * @throws Exception
+	 */
+	public List<EgovMap> selectSystemCntcList(SystemCntcVO searchVO) throws Exception {
+		return systemCntcMapper.selectSystemCntcList(searchVO);
+	}
 
-    /**
+	/**
 	 * 시스템연계 총 개수를 조회한다.
-     * @param searchVO
-     * @return int(시스템연계 총 개수)
-     */
-    public int selectSystemCntcListTotCnt(SystemCntcVO searchVO) throws Exception {
-        return (Integer)selectOne("SystemCntcDAO.selectSystemCntcListTotCnt", searchVO);
-    }
+	 * @param searchVO
+	 * @return int(시스템연계 총 개수)
+	 */
+	public int selectSystemCntcListTotCnt(SystemCntcVO searchVO) throws Exception {
+		return systemCntcMapper.selectSystemCntcListTotCnt(searchVO);
+	}
 
 	/**
 	 * 시스템연계를 수정한다.
@@ -92,7 +96,7 @@ public class SystemCntcDAO extends EgovComAbstractDAO {
 	 * @throws Exception
 	 */
 	public void updateSystemCntc(SystemCntc systemCntc) throws Exception {
-		update("SystemCntcDAO.updateSystemCntc", systemCntc);
+		systemCntcMapper.updateSystemCntc(systemCntc);
 	}
 
 }

--- a/src/main/java/egovframework/com/ssi/syi/sim/service/impl/SystemCntcMapper.java
+++ b/src/main/java/egovframework/com/ssi/syi/sim/service/impl/SystemCntcMapper.java
@@ -1,0 +1,77 @@
+package egovframework.com.ssi.syi.sim.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+import org.egovframe.rte.psl.dataaccess.util.EgovMap;
+
+import egovframework.com.ssi.syi.sim.service.SystemCntc;
+import egovframework.com.ssi.syi.sim.service.SystemCntcVO;
+
+/**
+ * 시스템연계에 대한 매퍼 인터페이스를 정의한다
+ *
+ * @author 공통서비스 개발팀 이중호
+ * @since 2009.04.01
+ * @version 1.0
+ * @see
+ *
+ * <pre>
+ * == 개정이력(Modification Information) ==
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2009.04.01  이중호          최초 생성
+ *   2026.05.28  dasomel        @EgovMapper 인터페이스 방식으로 전환
+ *
+ * </pre>
+ */
+@EgovMapper("SystemCntcMapper")
+public interface SystemCntcMapper {
+
+	/**
+	 * 시스템연계를 삭제한다.
+	 * @param systemCntc
+	 */
+	void deleteSystemCntc(SystemCntc systemCntc);
+
+	/**
+	 * 시스템연계를 등록한다.
+	 * @param systemCntc
+	 */
+	void insertSystemCntc(SystemCntc systemCntc);
+
+	/**
+	 * 시스템연계 상세항목을 조회한다.
+	 * @param systemCntc
+	 * @return SystemCntc(시스템연계)
+	 */
+	SystemCntc selectSystemCntcDetail(SystemCntc systemCntc);
+
+	/**
+	 * 시스템연계 승인/승인취소한다.
+	 * @param systemCntc
+	 */
+	void confirmSystemCntc(SystemCntc systemCntc);
+
+	/**
+	 * 시스템연계 목록을 조회한다.
+	 * @param searchVO
+	 * @return List(시스템연계 목록)
+	 */
+	List<EgovMap> selectSystemCntcList(SystemCntcVO searchVO);
+
+	/**
+	 * 시스템연계 총 개수를 조회한다.
+	 * @param searchVO
+	 * @return int(시스템연계 총 개수)
+	 */
+	int selectSystemCntcListTotCnt(SystemCntcVO searchVO);
+
+	/**
+	 * 시스템연계를 수정한다.
+	 * @param systemCntc
+	 */
+	void updateSystemCntc(SystemCntc systemCntc);
+
+}

--- a/src/main/resources/egovframework/mapper/com/ssi/syi/iis/EgovCntcInstt_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/ssi/syi/iis/EgovCntcInstt_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CntcInsttDAO">
+<mapper namespace="egovframework.com.ssi.syi.iis.service.impl.CntcInsttMapper">
 
     <select id="selectCntcInsttList" parameterType="egovframework.com.ssi.syi.iis.service.CntcInsttVO" resultType="egovMap">
         

--- a/src/main/resources/egovframework/mapper/com/ssi/syi/iis/EgovCntcInstt_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/ssi/syi/iis/EgovCntcInstt_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CntcInsttDAO">
+<mapper namespace="egovframework.com.ssi.syi.iis.service.impl.CntcInsttMapper">
 
     <select id="selectCntcInsttList" parameterType="egovframework.com.ssi.syi.iis.service.CntcInsttVO" resultType="egovMap">
         

--- a/src/main/resources/egovframework/mapper/com/ssi/syi/iis/EgovCntcInstt_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/ssi/syi/iis/EgovCntcInstt_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CntcInsttDAO">
+<mapper namespace="egovframework.com.ssi.syi.iis.service.impl.CntcInsttMapper">
 
     <select id="selectCntcInsttList" parameterType="egovframework.com.ssi.syi.iis.service.CntcInsttVO" resultType="egovMap">
         

--- a/src/main/resources/egovframework/mapper/com/ssi/syi/iis/EgovCntcInstt_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/ssi/syi/iis/EgovCntcInstt_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CntcInsttDAO">
+<mapper namespace="egovframework.com.ssi.syi.iis.service.impl.CntcInsttMapper">
 
 	<select id="selectCntcInsttList" parameterType="egovframework.com.ssi.syi.iis.service.CntcInsttVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/ssi/syi/iis/EgovCntcInstt_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/ssi/syi/iis/EgovCntcInstt_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CntcInsttDAO">
+<mapper namespace="egovframework.com.ssi.syi.iis.service.impl.CntcInsttMapper">
 
 	<select id="selectCntcInsttList" parameterType="egovframework.com.ssi.syi.iis.service.CntcInsttVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/ssi/syi/iis/EgovCntcInstt_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/ssi/syi/iis/EgovCntcInstt_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CntcInsttDAO">
+<mapper namespace="egovframework.com.ssi.syi.iis.service.impl.CntcInsttMapper">
 
     <select id="selectCntcInsttList" parameterType="egovframework.com.ssi.syi.iis.service.CntcInsttVO" resultType="egovMap">
         

--- a/src/main/resources/egovframework/mapper/com/ssi/syi/iis/EgovCntcInstt_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/ssi/syi/iis/EgovCntcInstt_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CntcInsttDAO">
+<mapper namespace="egovframework.com.ssi.syi.iis.service.impl.CntcInsttMapper">
 
 	<select id="selectCntcInsttList" parameterType="egovframework.com.ssi.syi.iis.service.CntcInsttVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/ssi/syi/iis/EgovCntcInstt_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/ssi/syi/iis/EgovCntcInstt_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CntcInsttDAO">
+<mapper namespace="egovframework.com.ssi.syi.iis.service.impl.CntcInsttMapper">
 
     <select id="selectCntcInsttList" parameterType="egovframework.com.ssi.syi.iis.service.CntcInsttVO" resultType="egovMap">
         

--- a/src/main/resources/egovframework/mapper/com/ssi/syi/ims/EgovCntcMessage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/ssi/syi/ims/EgovCntcMessage_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CntcMessageDAO">
+<mapper namespace="egovframework.com.ssi.syi.ims.service.impl.CntcMessageMapper">
 
     <select id="selectCntcMessageList" parameterType="egovframework.com.ssi.syi.ims.service.CntcMessageVO" resultType="egovMap">
         

--- a/src/main/resources/egovframework/mapper/com/ssi/syi/ims/EgovCntcMessage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/ssi/syi/ims/EgovCntcMessage_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CntcMessageDAO">
+<mapper namespace="egovframework.com.ssi.syi.ims.service.impl.CntcMessageMapper">
 
     <select id="selectCntcMessageList" parameterType="egovframework.com.ssi.syi.ims.service.CntcMessageVO" resultType="egovMap">
         

--- a/src/main/resources/egovframework/mapper/com/ssi/syi/ims/EgovCntcMessage_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/ssi/syi/ims/EgovCntcMessage_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CntcMessageDAO">
+<mapper namespace="egovframework.com.ssi.syi.ims.service.impl.CntcMessageMapper">
 
     <select id="selectCntcMessageList" parameterType="egovframework.com.ssi.syi.ims.service.CntcMessageVO" resultType="egovMap">
         

--- a/src/main/resources/egovframework/mapper/com/ssi/syi/ims/EgovCntcMessage_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/ssi/syi/ims/EgovCntcMessage_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CntcMessageDAO">
+<mapper namespace="egovframework.com.ssi.syi.ims.service.impl.CntcMessageMapper">
 
 	<select id="selectCntcMessageList" parameterType="egovframework.com.ssi.syi.ims.service.CntcMessageVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/ssi/syi/ims/EgovCntcMessage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/ssi/syi/ims/EgovCntcMessage_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CntcMessageDAO">
+<mapper namespace="egovframework.com.ssi.syi.ims.service.impl.CntcMessageMapper">
 
 	<select id="selectCntcMessageList" parameterType="egovframework.com.ssi.syi.ims.service.CntcMessageVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/ssi/syi/ims/EgovCntcMessage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/ssi/syi/ims/EgovCntcMessage_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CntcMessageDAO">
+<mapper namespace="egovframework.com.ssi.syi.ims.service.impl.CntcMessageMapper">
 
     <select id="selectCntcMessageList" parameterType="egovframework.com.ssi.syi.ims.service.CntcMessageVO" resultType="egovMap">
         

--- a/src/main/resources/egovframework/mapper/com/ssi/syi/ims/EgovCntcMessage_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/ssi/syi/ims/EgovCntcMessage_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CntcMessageDAO">
+<mapper namespace="egovframework.com.ssi.syi.ims.service.impl.CntcMessageMapper">
 
 	<select id="selectCntcMessageList" parameterType="egovframework.com.ssi.syi.ims.service.CntcMessageVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/ssi/syi/ims/EgovCntcMessage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/ssi/syi/ims/EgovCntcMessage_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CntcMessageDAO">
+<mapper namespace="egovframework.com.ssi.syi.ims.service.impl.CntcMessageMapper">
     
     <select id="selectCntcMessageList" parameterType="egovframework.com.ssi.syi.ims.service.CntcMessageVO" resultType="egovMap">
         

--- a/src/main/resources/egovframework/mapper/com/ssi/syi/ist/EgovCntcSttus_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/ssi/syi/ist/EgovCntcSttus_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CntcSttusDAO">
+<mapper namespace="egovframework.com.ssi.syi.ist.service.impl.CntcSttusMapper">
 
     <select id="selectCntcSttusList" parameterType="egovframework.com.ssi.syi.ist.service.CntcSttusVO" resultType="egovMap">
         

--- a/src/main/resources/egovframework/mapper/com/ssi/syi/ist/EgovCntcSttus_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/ssi/syi/ist/EgovCntcSttus_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CntcSttusDAO">
+<mapper namespace="egovframework.com.ssi.syi.ist.service.impl.CntcSttusMapper">
 
     <select id="selectCntcSttusList" parameterType="egovframework.com.ssi.syi.ist.service.CntcSttusVO" resultType="egovMap">
         

--- a/src/main/resources/egovframework/mapper/com/ssi/syi/ist/EgovCntcSttus_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/ssi/syi/ist/EgovCntcSttus_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CntcSttusDAO">
+<mapper namespace="egovframework.com.ssi.syi.ist.service.impl.CntcSttusMapper">
 
     <select id="selectCntcSttusList" parameterType="egovframework.com.ssi.syi.ist.service.CntcSttusVO" resultType="egovMap">
         

--- a/src/main/resources/egovframework/mapper/com/ssi/syi/ist/EgovCntcSttus_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/ssi/syi/ist/EgovCntcSttus_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CntcSttusDAO">
+<mapper namespace="egovframework.com.ssi.syi.ist.service.impl.CntcSttusMapper">
 
 	<select id="selectCntcSttusList" parameterType="egovframework.com.ssi.syi.ist.service.CntcSttusVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/ssi/syi/ist/EgovCntcSttus_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/ssi/syi/ist/EgovCntcSttus_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CntcSttusDAO">
+<mapper namespace="egovframework.com.ssi.syi.ist.service.impl.CntcSttusMapper">
 
 	<select id="selectCntcSttusList" parameterType="egovframework.com.ssi.syi.ist.service.CntcSttusVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/ssi/syi/ist/EgovCntcSttus_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/ssi/syi/ist/EgovCntcSttus_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CntcSttusDAO">
+<mapper namespace="egovframework.com.ssi.syi.ist.service.impl.CntcSttusMapper">
    
     <select id="selectCntcSttusList" parameterType="egovframework.com.ssi.syi.ist.service.CntcSttusVO" resultType="egovMap">
         

--- a/src/main/resources/egovframework/mapper/com/ssi/syi/ist/EgovCntcSttus_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/ssi/syi/ist/EgovCntcSttus_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CntcSttusDAO">
+<mapper namespace="egovframework.com.ssi.syi.ist.service.impl.CntcSttusMapper">
 
 	<select id="selectCntcSttusList" parameterType="egovframework.com.ssi.syi.ist.service.CntcSttusVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/ssi/syi/ist/EgovCntcSttus_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/ssi/syi/ist/EgovCntcSttus_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CntcSttusDAO">
+<mapper namespace="egovframework.com.ssi.syi.ist.service.impl.CntcSttusMapper">
 
     <select id="selectCntcSttusList" parameterType="egovframework.com.ssi.syi.ist.service.CntcSttusVO" resultType="egovMap">
         

--- a/src/main/resources/egovframework/mapper/com/ssi/syi/sim/EgovSystemCntc_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/ssi/syi/sim/EgovSystemCntc_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="SystemCntcDAO">
+<mapper namespace="egovframework.com.ssi.syi.sim.service.impl.SystemCntcMapper">
     
     <select id="selectSystemCntcList" parameterType="egovframework.com.ssi.syi.sim.service.SystemCntcVO" resultType="egovMap">
         

--- a/src/main/resources/egovframework/mapper/com/ssi/syi/sim/EgovSystemCntc_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/ssi/syi/sim/EgovSystemCntc_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="SystemCntcDAO">
+<mapper namespace="egovframework.com.ssi.syi.sim.service.impl.SystemCntcMapper">
 
     <select id="selectSystemCntcList" parameterType="egovframework.com.ssi.syi.sim.service.SystemCntcVO" resultType="egovMap">
         

--- a/src/main/resources/egovframework/mapper/com/ssi/syi/sim/EgovSystemCntc_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/ssi/syi/sim/EgovSystemCntc_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="SystemCntcDAO">
+<mapper namespace="egovframework.com.ssi.syi.sim.service.impl.SystemCntcMapper">
     
     <select id="selectSystemCntcList" parameterType="egovframework.com.ssi.syi.sim.service.SystemCntcVO" resultType="egovMap">
         

--- a/src/main/resources/egovframework/mapper/com/ssi/syi/sim/EgovSystemCntc_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/ssi/syi/sim/EgovSystemCntc_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="SystemCntcDAO">
+<mapper namespace="egovframework.com.ssi.syi.sim.service.impl.SystemCntcMapper">
 
 	<select id="selectSystemCntcList" parameterType="egovframework.com.ssi.syi.sim.service.SystemCntcVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/ssi/syi/sim/EgovSystemCntc_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/ssi/syi/sim/EgovSystemCntc_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="SystemCntcDAO">
+<mapper namespace="egovframework.com.ssi.syi.sim.service.impl.SystemCntcMapper">
 
 	<select id="selectSystemCntcList" parameterType="egovframework.com.ssi.syi.sim.service.SystemCntcVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/ssi/syi/sim/EgovSystemCntc_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/ssi/syi/sim/EgovSystemCntc_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="SystemCntcDAO">
+<mapper namespace="egovframework.com.ssi.syi.sim.service.impl.SystemCntcMapper">
 
     <select id="selectSystemCntcList" parameterType="egovframework.com.ssi.syi.sim.service.SystemCntcVO" resultType="egovMap">
         

--- a/src/main/resources/egovframework/mapper/com/ssi/syi/sim/EgovSystemCntc_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/ssi/syi/sim/EgovSystemCntc_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="SystemCntcDAO">
+<mapper namespace="egovframework.com.ssi.syi.sim.service.impl.SystemCntcMapper">
 
 	<select id="selectSystemCntcList" parameterType="egovframework.com.ssi.syi.sim.service.SystemCntcVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/ssi/syi/sim/EgovSystemCntc_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/ssi/syi/sim/EgovSystemCntc_SQL_tibero.xml
@@ -5,7 +5,7 @@
 --><!--Converted at: Wed May 11 15:50:22 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="SystemCntcDAO">
+<mapper namespace="egovframework.com.ssi.syi.sim.service.impl.SystemCntcMapper">
 
     <select id="selectSystemCntcList" parameterType="egovframework.com.ssi.syi.sim.service.SystemCntcVO" resultType="egovMap">
         

--- a/src/main/resources/egovframework/spring/com/context-mapper.xml
+++ b/src/main/resources/egovframework/spring/com/context-mapper.xml
@@ -21,5 +21,12 @@
 	<bean id="egov.sqlSessionTemplate" class="org.mybatis.spring.SqlSessionTemplate">
 		<constructor-arg ref="egov.sqlSession"/>
 	</bean>
-	
+
+	<!-- @EgovMapper 어노테이션이 붙은 인터페이스를 자동으로 스캔하여 빈으로 등록 -->
+	<bean class="org.mybatis.spring.mapper.MapperScannerConfigurer">
+		<property name="basePackage" value="egovframework.com"/>
+		<property name="annotationClass" value="org.egovframe.rte.psl.dataaccess.mapper.EgovMapper"/>
+		<property name="sqlSessionFactoryBeanName" value="egov.sqlSession"/>
+	</bean>
+
 </beans>


### PR DESCRIPTION
## 변경 사유
기존 XML namespace 기반 DAO를 5.0 신규 @EgovMapper 인터페이스 방식으로 전환

## 변경 내용
- CntcSttusMapper, CntcMessageMapper, SystemCntcMapper, CntcInsttMapper 인터페이스 신규 추가
- ssi/syi 하위 4개 DAO를 mapper 위임 구조로 리팩토링
- XML namespace를 mapper FQN으로 변경

## 영향 범위
- ssi/syi 연계관리 4개 서브 모듈
- DAO bean name 유지

## 체크리스트
- [x] 단일 주제만 다룸
- [x] 기존 동작 호환
