### PR TITLE
[refactor][5.0.x][공통컴포넌트] cop/cmt EgovArticleCommentDAO @EgovMapper 인터페이스 방식으로 전환

### DIFF
--- a/src/main/java/egovframework/com/cop/cmt/service/impl/EgovArticleCommentDAO.java
+++ b/src/main/java/egovframework/com/cop/cmt/service/impl/EgovArticleCommentDAO.java
@@ -4,35 +4,49 @@ import java.util.List;
 
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.cop.cmt.service.Comment;
 import egovframework.com.cop.cmt.service.CommentVO;
+import jakarta.annotation.Resource;
 
+/**
+ * 게시판 댓글에 대한 DAO 클래스
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2026.05.28  dasomel         @EgovMapper 인터페이스 위임 방식으로 전환
+ * </pre>
+ */
 @Repository("EgovArticleCommentDAO")
-public class EgovArticleCommentDAO extends EgovComAbstractDAO{
+public class EgovArticleCommentDAO {
+
+	@Resource(name = "egovArticleCommentMapper")
+	private EgovArticleCommentMapper mapper;
 
 	public List<CommentVO> selectArticleCommentList(CommentVO commentVO) {
-		return selectList("ArticleComment.selectArticleCommentList", commentVO);
+		return mapper.selectArticleCommentList(commentVO);
 	}
 
 	public int selectArticleCommentListCnt(CommentVO commentVO) {
-		return (Integer)selectOne("ArticleComment.selectArticleCommentListCnt", commentVO);
+		return mapper.selectArticleCommentListCnt(commentVO);
 	}
 
 	public void insertArticleComment(Comment comment) {
-		insert("ArticleComment.insertArticleComment", comment);
+		mapper.insertArticleComment(comment);
 	}
 
 	public void deleteArticleComment(CommentVO commentVO) {
-		update("ArticleComment.deleteArticleComment", commentVO);
+		mapper.deleteArticleComment(commentVO);
 	}
 
 	public CommentVO selectArticleCommentDetail(CommentVO commentVO) {
-		return (CommentVO) selectOne("ArticleComment.selectArticleCommentDetail", commentVO);
+		return mapper.selectArticleCommentDetail(commentVO);
 	}
 
 	public void updateArticleComment(Comment comment) {
-		update("ArticleComment.updateArticleComment", comment);
+		mapper.updateArticleComment(comment);
 	}
 
 }

--- a/src/main/java/egovframework/com/cop/cmt/service/impl/EgovArticleCommentMapper.java
+++ b/src/main/java/egovframework/com/cop/cmt/service/impl/EgovArticleCommentMapper.java
@@ -1,0 +1,36 @@
+package egovframework.com.cop.cmt.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.cop.cmt.service.Comment;
+import egovframework.com.cop.cmt.service.CommentVO;
+
+/**
+ * 게시판 댓글에 대한 Mapper 인터페이스
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2026.05.28  dasomel         XML 기반 DAO → @EgovMapper 인터페이스로 전환
+ * </pre>
+ */
+@EgovMapper("egovArticleCommentMapper")
+public interface EgovArticleCommentMapper {
+
+	List<CommentVO> selectArticleCommentList(CommentVO commentVO);
+
+	int selectArticleCommentListCnt(CommentVO commentVO);
+
+	void insertArticleComment(Comment comment);
+
+	void deleteArticleComment(CommentVO commentVO);
+
+	CommentVO selectArticleCommentDetail(CommentVO commentVO);
+
+	void updateArticleComment(Comment comment);
+
+}

--- a/src/main/resources/egovframework/mapper/com/cop/cmt/EgovArticleComment_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/cmt/EgovArticleComment_SQL_altibase.xml
@@ -8,7 +8,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ArticleComment">
+<mapper namespace="egovframework.com.cop.cmt.service.impl.EgovArticleCommentMapper">
 	
 	<resultMap id="commentList" type="egovframework.com.cop.cmt.service.CommentVO">
 		<result property="commentNo" column="ANSWER_NO"/>

--- a/src/main/resources/egovframework/mapper/com/cop/cmt/EgovArticleComment_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/cmt/EgovArticleComment_SQL_cubrid.xml
@@ -8,7 +8,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ArticleComment">
+<mapper namespace="egovframework.com.cop.cmt.service.impl.EgovArticleCommentMapper">
 
 	<resultMap id="commentList" type="egovframework.com.cop.cmt.service.CommentVO">
 		<result property="commentNo" column="ANSWER_NO"/>

--- a/src/main/resources/egovframework/mapper/com/cop/cmt/EgovArticleComment_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/cmt/EgovArticleComment_SQL_goldilocks.xml
@@ -8,7 +8,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ArticleComment">
+<mapper namespace="egovframework.com.cop.cmt.service.impl.EgovArticleCommentMapper">
 	
 	<resultMap id="commentList" type="egovframework.com.cop.cmt.service.CommentVO">
 		<result property="commentNo" column="ANSWER_NO"/>

--- a/src/main/resources/egovframework/mapper/com/cop/cmt/EgovArticleComment_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/cmt/EgovArticleComment_SQL_maria.xml
@@ -8,7 +8,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ArticleComment">
+<mapper namespace="egovframework.com.cop.cmt.service.impl.EgovArticleCommentMapper">
 	
 	<resultMap id="commentList" type="egovframework.com.cop.cmt.service.CommentVO">
 		<result property="commentNo" column="ANSWER_NO"/>

--- a/src/main/resources/egovframework/mapper/com/cop/cmt/EgovArticleComment_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/cmt/EgovArticleComment_SQL_mysql.xml
@@ -8,7 +8,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ArticleComment">
+<mapper namespace="egovframework.com.cop.cmt.service.impl.EgovArticleCommentMapper">
 	
 	<resultMap id="commentList" type="egovframework.com.cop.cmt.service.CommentVO">
 		<result property="commentNo" column="ANSWER_NO"/>

--- a/src/main/resources/egovframework/mapper/com/cop/cmt/EgovArticleComment_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/cmt/EgovArticleComment_SQL_oracle.xml
@@ -8,7 +8,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ArticleComment">
+<mapper namespace="egovframework.com.cop.cmt.service.impl.EgovArticleCommentMapper">
 	
 	<resultMap id="commentList" type="egovframework.com.cop.cmt.service.CommentVO">
 		<result property="commentNo" column="ANSWER_NO"/>

--- a/src/main/resources/egovframework/mapper/com/cop/cmt/EgovArticleComment_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/cmt/EgovArticleComment_SQL_postgres.xml
@@ -8,7 +8,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ArticleComment">
+<mapper namespace="egovframework.com.cop.cmt.service.impl.EgovArticleCommentMapper">
 	
 	<resultMap id="commentList" type="egovframework.com.cop.cmt.service.CommentVO">
 		<result property="commentNo" column="ANSWER_NO"/>

--- a/src/main/resources/egovframework/mapper/com/cop/cmt/EgovArticleComment_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/cmt/EgovArticleComment_SQL_tibero.xml
@@ -8,7 +8,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ArticleComment">
+<mapper namespace="egovframework.com.cop.cmt.service.impl.EgovArticleCommentMapper">
 	
 	<resultMap id="commentList" type="egovframework.com.cop.cmt.service.CommentVO">
 		<result property="commentNo" column="ANSWER_NO"/>

--- a/src/main/resources/egovframework/spring/com/context-mapper.xml
+++ b/src/main/resources/egovframework/spring/com/context-mapper.xml
@@ -21,5 +21,11 @@
 	<bean id="egov.sqlSessionTemplate" class="org.mybatis.spring.SqlSessionTemplate">
 		<constructor-arg ref="egov.sqlSession"/>
 	</bean>
-	
+
+	<!-- @EgovMapper 어노테이션 기반 Mapper 인터페이스 자동 등록 -->
+	<bean class="org.mybatis.spring.mapper.MapperScannerConfigurer">
+		<property name="basePackage" value="egovframework.com" />
+		<property name="annotationClass" value="org.egovframe.rte.psl.dataaccess.mapper.EgovMapper" />
+	</bean>
+
 </beans>


### PR DESCRIPTION
## 변경 사유
기존 XML namespace 기반 DAO를 5.0 신규 @EgovMapper 인터페이스 방식으로 전환

## 변경 내용
- EgovArticleCommentMapper 인터페이스 신규 추가
- DAO를 mapper 위임 구조로 리팩토링
- XML namespace를 mapper FQN으로 변경

## 영향 범위
- cop/cmt 게시판 댓글 모듈만 영향
- DAO bean name 유지

## 체크리스트
- [x] 단일 주제만 다룸 (다른 변경 없음)
- [x] 기존 동작에 영향 없음
- [x] DAO bean name("EgovArticleCommentDAO") 유지로 기존 서비스 호환
