### PR TITLE
[refactor][5.0.x][공통컴포넌트] uat/uap LoginPolicyDAO @EgovMapper 인터페이스 방식으로 전환

### DIFF
--- a/src/main/java/egovframework/com/uat/uap/service/impl/LoginPolicyDAO.java
+++ b/src/main/java/egovframework/com/uat/uap/service/impl/LoginPolicyDAO.java
@@ -1,7 +1,7 @@
 /**
  * 개요
- * - 로그인정책에 대한 DAO 클래스를 정의한다.
- * 
+ * - 로그인정책에 대한 DAO 인터페이스를 정의한다.
+ *
  * 상세내용
  * - 로그인정책에 대한 등록, 수정, 삭제, 조회, 반영확인 기능을 제공한다.
  * - 로그인정책의 조회기능은 목록조회, 상세조회로 구분된다.
@@ -10,11 +10,12 @@
  * @created 03-8-2009 오후 2:08:54
  *   <pre>
  * == 개정이력(Modification Information) ==
- * 
+ *
  *  수정일                수정자           수정내용
  *  ----------   --------   ---------------------------
  *  2009.08.03   이문준            최초 생성
  *  2021.02.18   신용호            selectLoginPolicyResult() 삭제
+ *  2026.05.28   dasomel          @EgovMapper 인터페이스 방식으로 전환
  * </pre>
  */
 
@@ -22,64 +23,51 @@ package egovframework.com.uat.uap.service.impl;
 
 import java.util.List;
 
-import org.springframework.stereotype.Repository;
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.uat.uap.service.LoginPolicy;
 import egovframework.com.uat.uap.service.LoginPolicyVO;
 
-@Repository("loginPolicyDAO")
-public class LoginPolicyDAO extends EgovComAbstractDAO {
-	
+@EgovMapper("loginPolicyDAO")
+public interface LoginPolicyDAO {
+
 	/**
 	 * 로그인정책 목록을 조회한다.
 	 * @param loginPolicyVO - 로그인정책 VO
 	 * @return List - 로그인정책 목록
-	 */	
-	public List<LoginPolicyVO> selectLoginPolicyList(LoginPolicyVO loginPolicyVO) throws Exception {
-		return selectList("loginPolicyDAO.selectLoginPolicyList", loginPolicyVO);
-	}
+	 */
+	List<LoginPolicyVO> selectLoginPolicyList(LoginPolicyVO loginPolicyVO) throws Exception;
 
 	/**
 	 * 로그인정책 목록 수를 조회한다.
 	 * @param loginPolicyVO - 로그인정책 VO
 	 * @return int
 	 */
-	public int selectLoginPolicyListTotCnt(LoginPolicyVO loginPolicyVO) throws Exception {
-		return (Integer)selectOne("loginPolicyDAO.selectLoginPolicyListTotCnt", loginPolicyVO);
-	}
+	int selectLoginPolicyListTotCnt(LoginPolicyVO loginPolicyVO) throws Exception;
 
 	/**
 	 * 로그인정책 목록의 상세정보를 조회한다.
 	 * @param loginPolicyVO - 로그인정책 VO
 	 * @return LoginPolicyVO - 로그인정책 VO
 	 */
-	public LoginPolicyVO selectLoginPolicy(LoginPolicyVO loginPolicyVO) throws Exception {
-		return (LoginPolicyVO)selectOne("loginPolicyDAO.selectLoginPolicy", loginPolicyVO);
-	}
+	LoginPolicyVO selectLoginPolicy(LoginPolicyVO loginPolicyVO) throws Exception;
 
 	/**
 	 * 로그인정책 정보를 신규로 등록한다.
 	 * @param loginPolicy - 로그인정책 model
 	 */
-	public void insertLoginPolicy(LoginPolicy loginPolicy) throws Exception {
-        insert("loginPolicyDAO.insertLoginPolicy", loginPolicy);
-	}
+	void insertLoginPolicy(LoginPolicy loginPolicy) throws Exception;
 
 	/**
 	 * 기 등록된 로그인정책 정보를 수정한다.
 	 * @param loginPolicy - 로그인정책 model
 	 */
-	public void updateLoginPolicy(LoginPolicy loginPolicy) throws Exception {
-		update("loginPolicyDAO.updateLoginPolicy", loginPolicy);
-	}
+	void updateLoginPolicy(LoginPolicy loginPolicy) throws Exception;
 
 	/**
 	 * 기 등록된 로그인정책 정보를 삭제한다.
 	 * @param loginPolicy - 로그인정책 model
 	 */
-	public void deleteLoginPolicy(LoginPolicy loginPolicy) throws Exception {
-		delete("loginPolicyDAO.deleteLoginPolicy", loginPolicy);
-	}
+	void deleteLoginPolicy(LoginPolicy loginPolicy) throws Exception;
 
 }


### PR DESCRIPTION
## 변경 사유
기존 EgovComAbstractDAO 상속 방식의 DAO를 eGovFrame 5.0에서 신규 도입된 @EgovMapper 인터페이스 방식으로 전환합니다.

## 변경 내용
- `LoginPolicyDAO`: EgovComAbstractDAO 상속 클래스 → @EgovMapper("loginPolicyDAO") 인터페이스로 전환
- XML mapper namespace는 기존 `loginPolicyDAO` 그대로 유지
- `EgovLoginPolicyServiceImpl`의 `@Resource(name="loginPolicyDAO")` 참조 호환 유지 (변경 없음)

## 영향 범위
- uat/uap 로그인 정책 모듈만 영향
- DAO bean name 및 XML namespace 유지로 기존 동작 호환

## 체크리스트
- [x] 단일 주제만 다룸 (다른 변경 없음)
- [x] 기존 동작에 영향 없음
- [x] XML namespace 호환 유지
