### PR TITLE
[refactor][5.0.x][공통컴포넌트] cop/bbs EgovBBSMasterDAO·BBSAddedOptionsDAO @EgovMapper 인터페이스 방식으로 전환

### DIFF
--- a/src/main/java/egovframework/com/cop/bbs/service/impl/BBSAddedOptionsDAO.java
+++ b/src/main/java/egovframework/com/cop/bbs/service/impl/BBSAddedOptionsDAO.java
@@ -2,9 +2,9 @@ package egovframework.com.cop.bbs.service.impl;
 
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.cop.bbs.service.BoardMaster;
 import egovframework.com.cop.bbs.service.BoardMasterVO;
+import jakarta.annotation.Resource;
 
 /**
  * 2단계 기능 추가 (댓글관리, 만족도조사) 관리를 위한 데이터 접근 클래스
@@ -15,40 +15,45 @@ import egovframework.com.cop.bbs.service.BoardMasterVO;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.06.26  한성곤          최초 생성
+ *   2026.05.28  dasomel         @EgovMapper 인터페이스 위임 방식으로 전환
  *
  * </pre>
  */
 @Repository("BBSAddedOptionsDAO")
-public class BBSAddedOptionsDAO extends EgovComAbstractDAO {
+public class BBSAddedOptionsDAO {
+
+    @Resource(name = "bbsAddedOptionsMapper")
+    private BBSAddedOptionsMapper mapper;
 
     /**
      * 신규 게시판 추가기능 정보를 등록한다.
-     * 
+     *
      * @param BoardMaster
      */
     public String insertAddedOptionsInf(BoardMaster boardMaster) throws Exception {
-	return Integer.toString(insert("BBSAddedOptions.insertAddedOptionsInf", boardMaster));
+        return Integer.toString(mapper.insertAddedOptionsInf(boardMaster));
     }
-    
+
     /**
      * 게시판 추가기능 정보 한 건을 상세조회 한다.
-     * 
+     *
      * @param BoardMasterVO
      */
     public BoardMasterVO selectAddedOptionsInf(BoardMaster vo) throws Exception {
-	return (BoardMasterVO)selectOne("BBSAddedOptions.selectAddedOptionsInf", vo);
+        return mapper.selectAddedOptionsInf(vo);
     }
-    
+
     /**
      * 게시판 추가기능 정보를 수정한다.
-     * 
+     *
      * @param BoardMaster
      */
     public void updateAddedOptionsInf(BoardMaster boardMaster) throws Exception {
-	update("BBSAddedOptions.updateAddedOptionsInf", boardMaster);
+        mapper.updateAddedOptionsInf(boardMaster);
     }
+
 }

--- a/src/main/java/egovframework/com/cop/bbs/service/impl/BBSAddedOptionsMapper.java
+++ b/src/main/java/egovframework/com/cop/bbs/service/impl/BBSAddedOptionsMapper.java
@@ -1,0 +1,28 @@
+package egovframework.com.cop.bbs.service.impl;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.cop.bbs.service.BoardMaster;
+import egovframework.com.cop.bbs.service.BoardMasterVO;
+
+/**
+ * 게시판 추가기능(댓글관리, 만족도조사) 관리에 대한 Mapper 인터페이스
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2026.05.28  dasomel         XML 기반 DAO → @EgovMapper 인터페이스로 전환
+ * </pre>
+ */
+@EgovMapper("bbsAddedOptionsMapper")
+public interface BBSAddedOptionsMapper {
+
+	int insertAddedOptionsInf(BoardMaster boardMaster) throws Exception;
+
+	BoardMasterVO selectAddedOptionsInf(BoardMaster vo) throws Exception;
+
+	void updateAddedOptionsInf(BoardMaster boardMaster) throws Exception;
+
+}

--- a/src/main/java/egovframework/com/cop/bbs/service/impl/EgovBBSMasterDAO.java
+++ b/src/main/java/egovframework/com/cop/bbs/service/impl/EgovBBSMasterDAO.java
@@ -4,76 +4,91 @@ import java.util.List;
 
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.cop.bbs.service.Blog;
 import egovframework.com.cop.bbs.service.BlogUser;
 import egovframework.com.cop.bbs.service.BlogVO;
 import egovframework.com.cop.bbs.service.BoardMaster;
 import egovframework.com.cop.bbs.service.BoardMasterVO;
+import jakarta.annotation.Resource;
 
+/**
+ * 게시판 마스터 관리에 대한 DAO 클래스
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2026.05.28  dasomel         @EgovMapper 인터페이스 위임 방식으로 전환
+ * </pre>
+ */
 @Repository("EgovBBSMasterDAO")
-public class EgovBBSMasterDAO extends EgovComAbstractDAO {
+public class EgovBBSMasterDAO {
+
+	@Resource(name = "egovBBSMasterMapper")
+	private EgovBBSMasterMapper mapper;
 
 	public List<BoardMasterVO> selectBBSMasterInfs(BoardMasterVO boardMasterVO) {
-		return selectList("BBSMaster.selectBBSMasterList", boardMasterVO);
+		return mapper.selectBBSMasterInfs(boardMasterVO);
 	}
 
 	public int selectBBSMasterInfsCnt(BoardMasterVO boardMasterVO) {
-		return (Integer)selectOne("BBSMaster.selectBBSMasterListTotCnt", boardMasterVO);
+		return mapper.selectBBSMasterInfsCnt(boardMasterVO);
 	}
-	
+
 	public BoardMasterVO selectBBSMasterDetail(BoardMasterVO boardMasterVO) {
-		return (BoardMasterVO) selectOne("BBSMaster.selectBBSMasterDetail", boardMasterVO);
+		return mapper.selectBBSMasterDetail(boardMasterVO);
 	}
 
 	public void insertBBSMasterInf(BoardMaster boardMaster) {
-		insert("BBSMaster.insertBBSMaster", boardMaster);
+		mapper.insertBBSMasterInf(boardMaster);
 	}
 
 	public void updateBBSMaster(BoardMaster boardMaster) {
-		update("BBSMaster.updateBBSMaster", boardMaster);
+		mapper.updateBBSMaster(boardMaster);
 	}
 
 	public void deleteBBSMaster(BoardMaster boardMaster) {
-		update("BBSMaster.deleteBBSMaster", boardMaster);
+		mapper.deleteBBSMaster(boardMaster);
 	}
-	
+
 	/*
 	 * 블로그 관련
 	 */
 	public List<BlogVO> selectBlogMasterInfs(BoardMasterVO boardMasterVO) {
-		return selectList("BBSMaster.selectBlogMasterList", boardMasterVO);
-	}
-	
-	public int selectBlogMasterInfsCnt(BoardMasterVO boardMasterVO) {
-		return (Integer)selectOne("BBSMaster.selectBlogMasterListTotCnt", boardMasterVO);
-	}
-	
-	public int checkExistUser(BlogVO blogVO) {
-		return (Integer)selectOne("BBSMaster.checkExistUser", blogVO);
-	}
-	
-	public BlogVO checkExistUser2(BlogVO blogVO) {
-		return (BlogVO) selectOne("BBSMaster.checkExistUser2", blogVO);
-	}
-	
-	public void insertBoardBlogUserRqst(BlogUser blogUser) {
-		insert("BBSMaster.insertBoardBlogUserRqst", blogUser);
-	}
-	
-	public void insertBlogMaster(Blog blog) {
-		insert("BBSMaster.insertBlogMaster", blog);
-	}
-	
-	public BlogVO selectBlogDetail(BlogVO blogVO) {
-		return (BlogVO) selectOne("BBSMaster.selectBlogDetail", blogVO);
+		return mapper.selectBlogMasterInfs(boardMasterVO);
 	}
 
-	public List<BlogVO> selectBlogListPortlet(BlogVO blogVO) throws Exception{
-		return selectList("BBSMaster.selectBlogListPortlet", blogVO);
+	public int selectBlogMasterInfsCnt(BoardMasterVO boardMasterVO) {
+		return mapper.selectBlogMasterInfsCnt(boardMasterVO);
+	}
+
+	public int checkExistUser(BlogVO blogVO) {
+		return mapper.checkExistUser(blogVO);
+	}
+
+	public BlogVO checkExistUser2(BlogVO blogVO) {
+		return mapper.checkExistUser2(blogVO);
+	}
+
+	public void insertBoardBlogUserRqst(BlogUser blogUser) {
+		mapper.insertBoardBlogUserRqst(blogUser);
+	}
+
+	public void insertBlogMaster(Blog blog) {
+		mapper.insertBlogMaster(blog);
+	}
+
+	public BlogVO selectBlogDetail(BlogVO blogVO) {
+		return mapper.selectBlogDetail(blogVO);
+	}
+
+	public List<BlogVO> selectBlogListPortlet(BlogVO blogVO) throws Exception {
+		return mapper.selectBlogListPortlet(blogVO);
 	}
 
 	public List<BoardMasterVO> selectBBSListPortlet(BoardMasterVO boardMasterVO) {
-		return selectList("BBSMaster.selectBBSListPortlet", boardMasterVO);
+		return mapper.selectBBSListPortlet(boardMasterVO);
 	}
+
 }

--- a/src/main/java/egovframework/com/cop/bbs/service/impl/EgovBBSMasterMapper.java
+++ b/src/main/java/egovframework/com/cop/bbs/service/impl/EgovBBSMasterMapper.java
@@ -1,0 +1,57 @@
+package egovframework.com.cop.bbs.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.cop.bbs.service.Blog;
+import egovframework.com.cop.bbs.service.BlogUser;
+import egovframework.com.cop.bbs.service.BlogVO;
+import egovframework.com.cop.bbs.service.BoardMaster;
+import egovframework.com.cop.bbs.service.BoardMasterVO;
+
+/**
+ * 게시판 마스터 관리에 대한 Mapper 인터페이스
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2026.05.28  dasomel         XML 기반 DAO → @EgovMapper 인터페이스로 전환
+ * </pre>
+ */
+@EgovMapper("egovBBSMasterMapper")
+public interface EgovBBSMasterMapper {
+
+	List<BoardMasterVO> selectBBSMasterInfs(BoardMasterVO boardMasterVO);
+
+	int selectBBSMasterInfsCnt(BoardMasterVO boardMasterVO);
+
+	BoardMasterVO selectBBSMasterDetail(BoardMasterVO boardMasterVO);
+
+	void insertBBSMasterInf(BoardMaster boardMaster);
+
+	void updateBBSMaster(BoardMaster boardMaster);
+
+	void deleteBBSMaster(BoardMaster boardMaster);
+
+	List<BlogVO> selectBlogMasterInfs(BoardMasterVO boardMasterVO);
+
+	int selectBlogMasterInfsCnt(BoardMasterVO boardMasterVO);
+
+	int checkExistUser(BlogVO blogVO);
+
+	BlogVO checkExistUser2(BlogVO blogVO);
+
+	void insertBoardBlogUserRqst(BlogUser blogUser);
+
+	void insertBlogMaster(Blog blog);
+
+	BlogVO selectBlogDetail(BlogVO blogVO);
+
+	List<BlogVO> selectBlogListPortlet(BlogVO blogVO);
+
+	List<BoardMasterVO> selectBBSListPortlet(BoardMasterVO boardMasterVO);
+
+}

--- a/src/main/resources/egovframework/mapper/com/cop/bbs/EgovBBSAddedOptions_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/bbs/EgovBBSAddedOptions_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:49:40 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BBSAddedOptions">
+<mapper namespace="egovframework.com.cop.bbs.service.impl.BBSAddedOptionsMapper">
 
 	<resultMap id="boardMasterDetail" type="egovframework.com.cop.bbs.service.BoardMasterVO">
 		<result property="bbsId" column="BBS_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/bbs/EgovBBSAddedOptions_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/bbs/EgovBBSAddedOptions_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:49:40 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BBSAddedOptions">
+<mapper namespace="egovframework.com.cop.bbs.service.impl.BBSAddedOptionsMapper">
 
 	<resultMap id="boardMasterDetail" type="egovframework.com.cop.bbs.service.BoardMasterVO">
 		<result property="bbsId" column="BBS_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/bbs/EgovBBSAddedOptions_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/bbs/EgovBBSAddedOptions_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:49:40 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BBSAddedOptions">
+<mapper namespace="egovframework.com.cop.bbs.service.impl.BBSAddedOptionsMapper">
 
 	<resultMap id="boardMasterDetail" type="egovframework.com.cop.bbs.service.BoardMasterVO">
 		<result property="bbsId" column="BBS_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/bbs/EgovBBSAddedOptions_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/bbs/EgovBBSAddedOptions_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:49:41 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BBSAddedOptions">
+<mapper namespace="egovframework.com.cop.bbs.service.impl.BBSAddedOptionsMapper">
 
 	<resultMap id="boardMasterDetail" type="egovframework.com.cop.bbs.service.BoardMasterVO">
 		<result property="bbsId" column="BBS_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/bbs/EgovBBSAddedOptions_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/bbs/EgovBBSAddedOptions_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:49:41 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BBSAddedOptions">
+<mapper namespace="egovframework.com.cop.bbs.service.impl.BBSAddedOptionsMapper">
 
 	<resultMap id="boardMasterDetail" type="egovframework.com.cop.bbs.service.BoardMasterVO">
 		<result property="bbsId" column="BBS_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/bbs/EgovBBSAddedOptions_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/bbs/EgovBBSAddedOptions_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:49:41 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BBSAddedOptions">
+<mapper namespace="egovframework.com.cop.bbs.service.impl.BBSAddedOptionsMapper">
 
 	<resultMap id="boardMasterDetail" type="egovframework.com.cop.bbs.service.BoardMasterVO">
 		<result property="bbsId" column="BBS_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/bbs/EgovBBSAddedOptions_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/bbs/EgovBBSAddedOptions_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:49:41 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BBSAddedOptions">
+<mapper namespace="egovframework.com.cop.bbs.service.impl.BBSAddedOptionsMapper">
 	
 	<resultMap id="boardMasterDetail" type="egovframework.com.cop.bbs.service.BoardMasterVO">
 		<result property="bbsId" column="BBS_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/bbs/EgovBBSAddedOptions_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/bbs/EgovBBSAddedOptions_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:49:41 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BBSAddedOptions">
+<mapper namespace="egovframework.com.cop.bbs.service.impl.BBSAddedOptionsMapper">
 
 	<resultMap id="boardMasterDetail" type="egovframework.com.cop.bbs.service.BoardMasterVO">
 		<result property="bbsId" column="BBS_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/bbs/EgovBBSMaster_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/bbs/EgovBBSMaster_SQL_altibase.xml
@@ -5,7 +5,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BBSMaster">
+<mapper namespace="egovframework.com.cop.bbs.service.impl.EgovBBSMasterMapper">
 
 	<resultMap id="boardMasterList" type="egovframework.com.cop.bbs.service.BoardMasterVO">
 		<result property="bbsId" column="BBS_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/bbs/EgovBBSMaster_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/bbs/EgovBBSMaster_SQL_cubrid.xml
@@ -5,7 +5,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BBSMaster">
+<mapper namespace="egovframework.com.cop.bbs.service.impl.EgovBBSMasterMapper">
 
 	<resultMap id="boardMasterList" type="egovframework.com.cop.bbs.service.BoardMasterVO">
 		<result property="bbsId" column="BBS_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/bbs/EgovBBSMaster_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/bbs/EgovBBSMaster_SQL_goldilocks.xml
@@ -5,7 +5,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BBSMaster">
+<mapper namespace="egovframework.com.cop.bbs.service.impl.EgovBBSMasterMapper">
 
 	<resultMap id="boardMasterList" type="egovframework.com.cop.bbs.service.BoardMasterVO">
 		<result property="bbsId" column="BBS_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/bbs/EgovBBSMaster_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/bbs/EgovBBSMaster_SQL_maria.xml
@@ -5,7 +5,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BBSMaster">
+<mapper namespace="egovframework.com.cop.bbs.service.impl.EgovBBSMasterMapper">
 
 	<resultMap id="boardMasterList" type="egovframework.com.cop.bbs.service.BoardMasterVO">
 		<result property="bbsId" column="BBS_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/bbs/EgovBBSMaster_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/bbs/EgovBBSMaster_SQL_mysql.xml
@@ -5,7 +5,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BBSMaster">
+<mapper namespace="egovframework.com.cop.bbs.service.impl.EgovBBSMasterMapper">
 
 	<resultMap id="boardMasterList" type="egovframework.com.cop.bbs.service.BoardMasterVO">
 		<result property="bbsId" column="BBS_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/bbs/EgovBBSMaster_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/bbs/EgovBBSMaster_SQL_oracle.xml
@@ -5,7 +5,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BBSMaster">
+<mapper namespace="egovframework.com.cop.bbs.service.impl.EgovBBSMasterMapper">
 
 	<resultMap id="boardMasterList" type="egovframework.com.cop.bbs.service.BoardMasterVO">
 		<result property="bbsId" column="BBS_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/bbs/EgovBBSMaster_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/bbs/EgovBBSMaster_SQL_postgres.xml
@@ -5,7 +5,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BBSMaster">
+<mapper namespace="egovframework.com.cop.bbs.service.impl.EgovBBSMasterMapper">
 
 	<resultMap id="boardMasterList" type="egovframework.com.cop.bbs.service.BoardMasterVO">
 		<result property="bbsId" column="BBS_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/bbs/EgovBBSMaster_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/bbs/EgovBBSMaster_SQL_tibero.xml
@@ -5,7 +5,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BBSMaster">
+<mapper namespace="egovframework.com.cop.bbs.service.impl.EgovBBSMasterMapper">
 
 	<resultMap id="boardMasterList" type="egovframework.com.cop.bbs.service.BoardMasterVO">
 		<result property="bbsId" column="BBS_ID"/>

--- a/src/main/resources/egovframework/spring/com/context-mapper.xml
+++ b/src/main/resources/egovframework/spring/com/context-mapper.xml
@@ -21,5 +21,11 @@
 	<bean id="egov.sqlSessionTemplate" class="org.mybatis.spring.SqlSessionTemplate">
 		<constructor-arg ref="egov.sqlSession"/>
 	</bean>
-	
+
+	<!-- @EgovMapper 어노테이션 기반 Mapper 인터페이스 자동 등록 -->
+	<bean class="org.mybatis.spring.mapper.MapperScannerConfigurer">
+		<property name="basePackage" value="egovframework.com" />
+		<property name="annotationClass" value="org.egovframe.rte.psl.dataaccess.mapper.EgovMapper" />
+	</bean>
+
 </beans>


### PR DESCRIPTION
## 변경 사유
기존 XML namespace 기반 DAO를 5.0 신규 @EgovMapper 인터페이스 방식으로 전환 (#868 cop/bbs EgovArticleDAO 후속)

## 변경 내용
- EgovBBSMasterMapper, BBSAddedOptionsMapper 인터페이스 신규 추가
- cop/bbs EgovBBSMasterDAO·BBSAddedOptionsDAO를 mapper 위임 구조로 리팩토링
- XML namespace를 mapper FQN으로 변경
- context-mapper.xml MapperScannerConfigurer 추가

## 영향 범위
- cop/bbs 게시판 마스터·옵션 모듈
- DAO bean name 유지

## 체크리스트
- [x] 단일 주제만 다룸
- [x] 기존 동작 호환
