### PR TITLE
[refactor][5.0.x][공통컴포넌트] cop/com·stf·adb 3개 DAO @EgovMapper 인터페이스 방식으로 전환

### DIFF
--- a/src/main/java/egovframework/com/cop/adb/service/impl/AddressBookDAO.java
+++ b/src/main/java/egovframework/com/cop/adb/service/impl/AddressBookDAO.java
@@ -4,15 +4,14 @@ import java.util.List;
 
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.cop.adb.service.AddressBook;
 import egovframework.com.cop.adb.service.AddressBookUser;
 import egovframework.com.cop.adb.service.AddressBookUserVO;
 import egovframework.com.cop.adb.service.AddressBookVO;
-
+import jakarta.annotation.Resource;
 
 /**
- * @Class Name : AdressBookDAO.java
+ * @Class Name : AddressBookDAO.java
  * @Description : 주소록을 관리하는 서비스를 정의하기위한 데이터 접근 클래스
  * @Modification Information
  *
@@ -20,6 +19,7 @@ import egovframework.com.cop.adb.service.AddressBookVO;
  *   -------        -------     -------------------
  *    2009.9.25.    윤성록       최초 생성
  *    2016.12.13    최두영       클래스명 변경
+ *    2026.05.28    dasomel      AddressBookMapper 위임 구조로 전환
  * @author 공통 컴포넌트 개발팀 윤성록
  * @since 2009. 9. 25.
  * @version
@@ -27,152 +27,158 @@ import egovframework.com.cop.adb.service.AddressBookVO;
  *
  */
 @Repository("AdressBookDAO")
-public class AddressBookDAO extends EgovComAbstractDAO{
-    
+public class AddressBookDAO {
+
+    @Resource(name = "AdressBookDAO")
+    private AddressBookMapper mapper;
+
     /**
      * 주어진 조건에 따른 주소록목록을 불러온다.
-     * 
-     * @param AddressBookVO
+     *
+     * @param adbkVO
      * @return
      * @throws Exception
      */
-	public List<AddressBookVO> selectAdressBookList(AddressBookVO adbkVO) throws Exception {
-        return selectList("AdressBookDAO.selectAdressBookList", adbkVO);
+    public List<AddressBookVO> selectAdressBookList(AddressBookVO adbkVO) throws Exception {
+        return mapper.selectAdressBookList(adbkVO);
     }
-    
+
     /**
      * 주어진 조건에 따라 주소록에 추가할 사용자목록을 불러온다.
-     * 
-     * @param AddressBookUserVO
+     *
+     * @param adbkUserVO
      * @return
      * @throws Exception
      */
     public List<AddressBookUserVO> selectManList(AddressBookUserVO adbkUserVO) throws Exception {
-        return selectList("AdressBookDAO.selectManList", adbkUserVO);
+        return mapper.selectManList(adbkUserVO);
     }
-    
+
     /**
      * 주어진 조건에 따라 주소록에 추가할 명함목록을 불러온다.
-     * 
-     * @param AddressBookUserVO
+     *
+     * @param adbkUserVO
      * @return
      * @throws Exception
      */
     public List<AddressBookUserVO> selectCardList(AddressBookUserVO adbkUserVO) throws Exception {
-        return selectList("AdressBookDAO.selectCardList", adbkUserVO);
+        return mapper.selectCardList(adbkUserVO);
     }
-    
+
     /**
      * 주어진 조건에 따라 주소록에 기등록된 구성원의 목록을 불러온다.
-     * 
-     * @param AddressBookVO
+     *
+     * @param adbkVO
      * @return
      * @throws Exception
      */
     public List<AddressBookUser> selectUserList(AddressBookVO adbkVO) throws Exception {
-        return selectList("AdressBookDAO.selectUserList", adbkVO);
-    }  
+        return mapper.selectUserList(adbkVO);
+    }
 
     /**
      * 주어진 조건에 맞는 주소록을 불러온다.
-     * 
-     * @param AddressBookVO
+     *
+     * @param adbkVO
      * @return
      * @throws Exception
      */
     public AddressBookVO selectAdressBook(AddressBookVO adbkVO) throws Exception {
-        return (AddressBookVO)selectOne("AdressBookDAO.selectAdressBook", adbkVO);
-    }        
-    
+        return mapper.selectAdressBook(adbkVO);
+    }
+
     /**
      * 주소록 정보를 등록한다.
-     * 
-     * @param AddressBook
+     *
+     * @param addressBook
      * @throws Exception
      */
     public void insertAdressBook(AddressBook addressBook) throws Exception {
-        insert("AdressBookDAO.insertAdressBook", addressBook);
+        mapper.insertAdressBook(addressBook);
     }
-    
+
     /**
      * 주소록을 구성하는 구성원을 등록한다.
-     * 
-     * @param AddressBookUser
+     *
+     * @param addressBookUser
      * @throws Exception
      */
     public void insertAdressBookUser(AddressBookUser addressBookUser) throws Exception {
-        insert("AdressBookDAO.insertAdressBookUser", addressBookUser);
+        mapper.insertAdressBookUser(addressBookUser);
     }
 
     /**
      * 주소록 정보를 수정한다.
-     * 
-     * @param AddressBook
+     *
+     * @param addressBook
      * @throws Exception
      */
     public void updateAdressBook(AddressBook addressBook) throws Exception {
-        update("AdressBookDAO.updateAdressBook", addressBook);
+        mapper.updateAdressBook(addressBook);
     }
-    
+
     /**
      * 주소록 구성원을 삭제한다.
-     * 
-     * @param AddressBookUser
+     *
+     * @param adbkUser
      * @throws Exception
      */
     public void deleteAdressBookUser(AddressBookUser adbkUser) throws Exception {
-        delete("AdressBookDAO.deleteAdressBookUser", adbkUser);
-    }    
-    
+        mapper.deleteAdressBookUser(adbkUser);
+    }
+
     /**
      * 주소록 목록에 대한 전체 건수를 조회한다.
-     * 
-     * @param AddressBookUser
+     *
+     * @param adbkVO
+     * @return
      * @throws Exception
      */
     public int selectAdressBookListCnt(AddressBookVO adbkVO) throws Exception {
-        return (Integer)selectOne("AdressBookDAO.selectAdressBookListCnt", adbkVO);
+        return mapper.selectAdressBookListCnt(adbkVO);
     }
-    
+
     /**
      * 사용자 목록에 대한 전체 건수를 조회한다.
-     * 
-     * @param AddressBookUser
+     *
+     * @param adbkUserVO
+     * @return
      * @throws Exception
      */
     public int selectManListCnt(AddressBookUserVO adbkUserVO) throws Exception {
-        return (Integer)selectOne("AdressBookDAO.selectManListCnt", adbkUserVO);
+        return mapper.selectManListCnt(adbkUserVO);
     }
-    
+
     /**
      * 명함 목록에 대한 전체 건수를 조회한다.
-     * 
-     * @param AddressBookUser
+     *
+     * @param adbkUserVO
+     * @return
      * @throws Exception
      */
     public int selectCardListCnt(AddressBookUserVO adbkUserVO) throws Exception {
-        return (Integer)selectOne("AdressBookDAO.selectCardListCnt", adbkUserVO);
+        return mapper.selectCardListCnt(adbkUserVO);
     }
-    
+
     /**
      * 주소록을 구성할 사용자의 정보를 조회한다.
-     * 
-     * @param AddressBookUser
+     *
+     * @param id
+     * @return
      * @throws Exception
      */
     public AddressBookUser selectManUser(String id) throws Exception {
-        return (AddressBookUser)selectOne("AdressBookDAO.selectManUser", id);
+        return mapper.selectManUser(id);
     }
-    
+
     /**
      * 주소록을 구성할 명함의 정보를 조회한다.
-     * 
-     * @param AddressBookUser
+     *
+     * @param id
+     * @return
      * @throws Exception
      */
     public AddressBookUser selectCardUser(String id) throws Exception {
-        return (AddressBookUser)selectOne("AdressBookDAO.selectCardUser", id);
+        return mapper.selectCardUser(id);
     }
-
 }
-

--- a/src/main/java/egovframework/com/cop/adb/service/impl/AddressBookMapper.java
+++ b/src/main/java/egovframework/com/cop/adb/service/impl/AddressBookMapper.java
@@ -1,0 +1,139 @@
+package egovframework.com.cop.adb.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.cop.adb.service.AddressBook;
+import egovframework.com.cop.adb.service.AddressBookUser;
+import egovframework.com.cop.adb.service.AddressBookUserVO;
+import egovframework.com.cop.adb.service.AddressBookVO;
+
+/**
+ * 주소록을 관리하는 Mapper 인터페이스
+ * @author 공통 컴포넌트 개발팀 윤성록
+ * @since 2009.09.25
+ * @version 1.0
+ * @see
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *    수정일          수정자         수정내용
+ *   -------        -------     -------------------
+ *    2009.9.25.    윤성록       최초 생성
+ *    2016.12.13    최두영       클래스명 변경
+ *    2026.05.28    dasomel      @EgovMapper 인터페이스 방식으로 전환
+ * </pre>
+ */
+@EgovMapper("AdressBookDAO")
+public interface AddressBookMapper {
+
+    /**
+     * 주어진 조건에 따른 주소록목록을 불러온다.
+     *
+     * @param adbkVO
+     * @return
+     */
+    List<AddressBookVO> selectAdressBookList(AddressBookVO adbkVO);
+
+    /**
+     * 주어진 조건에 따라 주소록에 추가할 사용자목록을 불러온다.
+     *
+     * @param adbkUserVO
+     * @return
+     */
+    List<AddressBookUserVO> selectManList(AddressBookUserVO adbkUserVO);
+
+    /**
+     * 주어진 조건에 따라 주소록에 추가할 명함목록을 불러온다.
+     *
+     * @param adbkUserVO
+     * @return
+     */
+    List<AddressBookUserVO> selectCardList(AddressBookUserVO adbkUserVO);
+
+    /**
+     * 주어진 조건에 따라 주소록에 기등록된 구성원의 목록을 불러온다.
+     *
+     * @param adbkVO
+     * @return
+     */
+    List<AddressBookUser> selectUserList(AddressBookVO adbkVO);
+
+    /**
+     * 주어진 조건에 맞는 주소록을 불러온다.
+     *
+     * @param adbkVO
+     * @return
+     */
+    AddressBookVO selectAdressBook(AddressBookVO adbkVO);
+
+    /**
+     * 주소록 정보를 등록한다.
+     *
+     * @param addressBook
+     */
+    void insertAdressBook(AddressBook addressBook);
+
+    /**
+     * 주소록을 구성하는 구성원을 등록한다.
+     *
+     * @param addressBookUser
+     */
+    void insertAdressBookUser(AddressBookUser addressBookUser);
+
+    /**
+     * 주소록 정보를 수정한다.
+     *
+     * @param addressBook
+     */
+    void updateAdressBook(AddressBook addressBook);
+
+    /**
+     * 주소록 구성원을 삭제한다.
+     *
+     * @param adbkUser
+     */
+    void deleteAdressBookUser(AddressBookUser adbkUser);
+
+    /**
+     * 주소록 목록에 대한 전체 건수를 조회한다.
+     *
+     * @param adbkVO
+     * @return
+     */
+    int selectAdressBookListCnt(AddressBookVO adbkVO);
+
+    /**
+     * 사용자 목록에 대한 전체 건수를 조회한다.
+     *
+     * @param adbkUserVO
+     * @return
+     */
+    int selectManListCnt(AddressBookUserVO adbkUserVO);
+
+    /**
+     * 명함 목록에 대한 전체 건수를 조회한다.
+     *
+     * @param adbkUserVO
+     * @return
+     */
+    int selectCardListCnt(AddressBookUserVO adbkUserVO);
+
+    /**
+     * 주소록을 구성할 사용자의 정보를 조회한다.
+     *
+     * @param id
+     * @return
+     */
+    AddressBookUser selectManUser(String id);
+
+    /**
+     * 주소록을 구성할 명함의 정보를 조회한다.
+     *
+     * @param id
+     * @return
+     */
+    AddressBookUser selectCardUser(String id);
+}

--- a/src/main/java/egovframework/com/cop/com/service/impl/EgovUserInfManageDAO.java
+++ b/src/main/java/egovframework/com/cop/com/service/impl/EgovUserInfManageDAO.java
@@ -4,8 +4,8 @@ import java.util.List;
 
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.cop.com.service.UserInfVO;
+import jakarta.annotation.Resource;
 
 /**
  * 협업 활용 사용자 정보 조회를 위한 데이터 접근 클래스
@@ -20,20 +20,24 @@ import egovframework.com.cop.com.service.UserInfVO;
  *   수정일          수정자       수정내용
  *  -----------    --------    ---------------------------
  *   2009.04.06     이삼섭       최초 생성
+ *   2026.05.28     dasomel      EgovUserInfManageMapper 위임 구조로 전환
  *
  * </pre>
  */
 @Repository("EgovUserInfManageDAO")
-public class EgovUserInfManageDAO extends EgovComAbstractDAO {
+public class EgovUserInfManageDAO {
+
+    @Resource(name = "EgovUserInfManageDAO")
+    private EgovUserInfManageMapper mapper;
+
     /**
      * 사용자 정보에 대한 목록을 조회한다.
      *
      * @param userVO
      * @return
-     * @throws Exception
      */
     public List<UserInfVO> selectUserList(UserInfVO userVO) {
-        return selectList("EgovUserInfManageDAO.selectUserList", userVO);
+        return mapper.selectUserList(userVO);
     }
 
     /**
@@ -41,10 +45,9 @@ public class EgovUserInfManageDAO extends EgovComAbstractDAO {
      *
      * @param userVO
      * @return
-     * @throws Exception
      */
     public int selectUserListCnt(UserInfVO userVO) {
-        return selectOne("EgovUserInfManageDAO.selectUserListCnt", userVO);
+        return mapper.selectUserListCnt(userVO);
     }
 
     /**
@@ -52,10 +55,9 @@ public class EgovUserInfManageDAO extends EgovComAbstractDAO {
      *
      * @param userVO
      * @return
-     * @throws Exception
      */
     public List<UserInfVO> selectCmmntyUserList(UserInfVO userVO) {
-        return selectList("EgovUserInfManageDAO.selectCmmntyUserList", userVO);
+        return mapper.selectCmmntyUserList(userVO);
     }
 
     /**
@@ -63,10 +65,9 @@ public class EgovUserInfManageDAO extends EgovComAbstractDAO {
      *
      * @param userVO
      * @return
-     * @throws Exception
      */
     public int selectCmmntyUserListCnt(UserInfVO userVO) {
-        return selectOne("EgovUserInfManageDAO.selectCmmntyUserListCnt", userVO);
+        return mapper.selectCmmntyUserListCnt(userVO);
     }
 
     /**
@@ -74,10 +75,9 @@ public class EgovUserInfManageDAO extends EgovComAbstractDAO {
      *
      * @param userVO
      * @return
-     * @throws Exception
      */
     public List<UserInfVO> selectCmmntyMngrList(UserInfVO userVO) {
-        return selectList("EgovUserInfManageDAO.selectCmmntyMngrList", userVO);
+        return mapper.selectCmmntyMngrList(userVO);
     }
 
     /**
@@ -85,10 +85,9 @@ public class EgovUserInfManageDAO extends EgovComAbstractDAO {
      *
      * @param userVO
      * @return
-     * @throws Exception
      */
     public int selectCmmntyMngrListCnt(UserInfVO userVO) {
-        return selectOne("EgovUserInfManageDAO.selectCmmntyMngrListCnt", userVO);
+        return mapper.selectCmmntyMngrListCnt(userVO);
     }
 
     /**
@@ -99,7 +98,7 @@ public class EgovUserInfManageDAO extends EgovComAbstractDAO {
      * @throws Exception
      */
     public List<UserInfVO> selectClubUserList(UserInfVO userVO) throws Exception {
-        return selectList("EgovUserInfManageDAO.selectClubUserList", userVO);
+        return mapper.selectClubUserList(userVO);
     }
 
     /**
@@ -110,7 +109,7 @@ public class EgovUserInfManageDAO extends EgovComAbstractDAO {
      * @throws Exception
      */
     public int selectClubUserListCnt(UserInfVO userVO) throws Exception {
-        return selectOne("EgovUserInfManageDAO.selectClubUserListCnt", userVO);
+        return mapper.selectClubUserListCnt(userVO);
     }
 
     /**
@@ -121,7 +120,7 @@ public class EgovUserInfManageDAO extends EgovComAbstractDAO {
      * @throws Exception
      */
     public List<UserInfVO> selectClubOprtrList(UserInfVO userVO) throws Exception {
-        return selectList("EgovUserInfManageDAO.selectClubOprtrList", userVO);
+        return mapper.selectClubOprtrList(userVO);
     }
 
     /**
@@ -132,7 +131,7 @@ public class EgovUserInfManageDAO extends EgovComAbstractDAO {
      * @throws Exception
      */
     public int selectClubOprtrListCnt(UserInfVO userVO) throws Exception {
-        return selectOne("EgovUserInfManageDAO.selectClubOprtrListCnt", userVO);
+        return mapper.selectClubOprtrListCnt(userVO);
     }
 
     /**
@@ -143,7 +142,7 @@ public class EgovUserInfManageDAO extends EgovComAbstractDAO {
      * @throws Exception
      */
     public List<UserInfVO> selectAllClubUser(UserInfVO userVO) throws Exception {
-        return selectList("EgovUserInfManageDAO.selectAllClubUser", userVO);
+        return mapper.selectAllClubUser(userVO);
     }
 
     /**
@@ -151,9 +150,8 @@ public class EgovUserInfManageDAO extends EgovComAbstractDAO {
      *
      * @param userVO
      * @return
-     * @throws Exception
      */
     public List<UserInfVO> selectAllCmmntyUser(UserInfVO userVO) {
-        return selectList("EgovUserInfManageDAO.selectAllCmmntyUser", userVO);
+        return mapper.selectAllCmmntyUser(userVO);
     }
 }

--- a/src/main/java/egovframework/com/cop/com/service/impl/EgovUserInfManageMapper.java
+++ b/src/main/java/egovframework/com/cop/com/service/impl/EgovUserInfManageMapper.java
@@ -1,0 +1,124 @@
+package egovframework.com.cop.com.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.cop.com.service.UserInfVO;
+
+/**
+ * 협업 활용 사용자 정보 조회를 위한 Mapper 인터페이스
+ * @author 공통서비스개발팀 이삼섭
+ * @since 2009.06.01
+ * @version 1.0
+ * @see
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일          수정자       수정내용
+ *  -----------    --------    ---------------------------
+ *   2009.04.06     이삼섭       최초 생성
+ *   2026.05.28     dasomel      @EgovMapper 인터페이스 방식으로 전환
+ *
+ * </pre>
+ */
+@EgovMapper("EgovUserInfManageDAO")
+public interface EgovUserInfManageMapper {
+
+    /**
+     * 사용자 정보에 대한 목록을 조회한다.
+     *
+     * @param userVO
+     * @return
+     */
+    List<UserInfVO> selectUserList(UserInfVO userVO);
+
+    /**
+     * 사용자 정보에 대한 목록 전체 건수를 조회한다.
+     *
+     * @param userVO
+     * @return
+     */
+    int selectUserListCnt(UserInfVO userVO);
+
+    /**
+     * 커뮤니티 사용자 목록을 조회한다.
+     *
+     * @param userVO
+     * @return
+     */
+    List<UserInfVO> selectCmmntyUserList(UserInfVO userVO);
+
+    /**
+     * 커뮤니티 사용자 목록에 대한 전체 건수를 조회한다.
+     *
+     * @param userVO
+     * @return
+     */
+    int selectCmmntyUserListCnt(UserInfVO userVO);
+
+    /**
+     * 커뮤니티 관리자 목록을 조회한다.
+     *
+     * @param userVO
+     * @return
+     */
+    List<UserInfVO> selectCmmntyMngrList(UserInfVO userVO);
+
+    /**
+     * 커뮤니티 관리자 목록에 대한 전체 건수를 조회한다.
+     *
+     * @param userVO
+     * @return
+     */
+    int selectCmmntyMngrListCnt(UserInfVO userVO);
+
+    /**
+     * 동호회 사용자 목록을 조회한다.
+     *
+     * @param userVO
+     * @return
+     */
+    List<UserInfVO> selectClubUserList(UserInfVO userVO);
+
+    /**
+     * 동호회 사용자 목록에 대한 전체 건수를 조회한다.
+     *
+     * @param userVO
+     * @return
+     */
+    int selectClubUserListCnt(UserInfVO userVO);
+
+    /**
+     * 동호회 운영자 목록을 조회한다.
+     *
+     * @param userVO
+     * @return
+     */
+    List<UserInfVO> selectClubOprtrList(UserInfVO userVO);
+
+    /**
+     * 동호회 운영자 목록에 대한 전체 건수를 조회한다.
+     *
+     * @param userVO
+     * @return
+     */
+    int selectClubOprtrListCnt(UserInfVO userVO);
+
+    /**
+     * 동호회에 대한 모든 사용자 목록을 조회한다.
+     *
+     * @param userVO
+     * @return
+     */
+    List<UserInfVO> selectAllClubUser(UserInfVO userVO);
+
+    /**
+     * 커뮤니티에 대한 모든 사용자 목록을 조회한다.
+     *
+     * @param userVO
+     * @return
+     */
+    List<UserInfVO> selectAllCmmntyUser(UserInfVO userVO);
+}

--- a/src/main/java/egovframework/com/cop/stf/service/impl/BBSSatisfactionDAO.java
+++ b/src/main/java/egovframework/com/cop/stf/service/impl/BBSSatisfactionDAO.java
@@ -4,9 +4,9 @@ import java.util.List;
 
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.cop.bbs.service.Satisfaction;
 import egovframework.com.cop.bbs.service.SatisfactionVO;
+import jakarta.annotation.Resource;
 
 /**
  * 만족도조사를 위한 데이터 접근 클래스
@@ -17,98 +17,102 @@ import egovframework.com.cop.bbs.service.SatisfactionVO;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.06.29  한성곤          최초 생성
+ *   2026.05.28  dasomel         BBSSatisfactionMapper 위임 구조로 전환
  *
  * </pre>
  */
 @Repository("BBSSatisfactionDAO")
-public class BBSSatisfactionDAO extends EgovComAbstractDAO {
+public class BBSSatisfactionDAO {
+
+    @Resource(name = "BBSSatisfactionDAO")
+    private BBSSatisfactionMapper mapper;
 
     /**
      * 만족도조사에 대한 목록을 조회 한다.
-     * 
+     *
      * @param satisfactionVO
      * @return
      * @throws Exception
      */
     public List<SatisfactionVO> selectSatisfactionList(SatisfactionVO satisfactionVO) throws Exception {
-	return selectList("BBSSatisfactionDAO.selectSatisfactionList", satisfactionVO);
+        return mapper.selectSatisfactionList(satisfactionVO);
     }
-    
+
     /**
      * 만족도조사에 대한 목록 건수를 조회 한다.
-     * 
+     *
      * @param satisfactionVO
      * @return
      * @throws Exception
      */
     public int selectSatisfactionListCnt(SatisfactionVO satisfactionVO) throws Exception {
-	return (Integer)selectOne("BBSSatisfactionDAO.selectSatisfactionListCnt", satisfactionVO);
+        return mapper.selectSatisfactionListCnt(satisfactionVO);
     }
-    
+
     /**
      * 만족도조사를 등록한다.
-     * 
+     *
      * @param satisfaction
      * @throws Exception
      */
-    public void insertSatisfaction(Satisfaction satisfaction) throws Exception {	
-	insert("BBSSatisfactionDAO.insertSatisfaction", satisfaction);
+    public void insertSatisfaction(Satisfaction satisfaction) throws Exception {
+        mapper.insertSatisfaction(satisfaction);
     }
-    
+
     /**
      * 만족도조사를 삭제한다.
-     * 
+     *
      * @param satisfactionVO
      * @throws Exception
      */
     public void deleteSatisfaction(SatisfactionVO satisfactionVO) throws Exception {
-	update("BBSSatisfactionDAO.deleteSatisfaction", satisfactionVO);
+        mapper.deleteSatisfaction(satisfactionVO);
     }
-    
+
     /**
      * 만족도조사에 대한 내용을 조회한다.
-     * 
+     *
      * @param satisfactionVO
      * @return
      * @throws Exception
      */
     public Satisfaction selectSatisfaction(SatisfactionVO satisfactionVO) throws Exception {
-	return (Satisfaction)selectOne("BBSSatisfactionDAO.selectSatisfaction", satisfactionVO);
+        return mapper.selectSatisfaction(satisfactionVO);
     }
-    
+
     /**
      * 만족도조사에 대한 내용을 수정한다.
-     * 
+     *
      * @param satisfaction
      * @throws Exception
      */
-    public void updateSatisfaction(Satisfaction satisfaction) throws Exception {	
-	insert("BBSSatisfactionDAO.updateSatisfaction", satisfaction);
+    public void updateSatisfaction(Satisfaction satisfaction) throws Exception {
+        mapper.updateSatisfaction(satisfaction);
     }
-    
+
     /**
      * 만족도조사에 대한 패스워드를 조회 한다.
-     * 
+     *
      * @param satisfaction
      * @return
      * @throws Exception
      */
     public String getSatisfactionPassword(Satisfaction satisfaction) throws Exception {
-	return (String)selectOne("BBSSatisfactionDAO.getSatisfactionPassword", satisfaction);
+        return mapper.getSatisfactionPassword(satisfaction);
     }
-    
+
     /**
      * 만족도 전체 점수를 제공한다.
-     * 
+     *
      * @param satisfactionVO
      * @return
      * @throws Exception
      */
     public Float getSummary(SatisfactionVO satisfactionVO) throws Exception {
-	return (Float)selectOne("BBSSatisfactionDAO.getSummary", satisfactionVO);
+        return mapper.getSummary(satisfactionVO);
     }
 }

--- a/src/main/java/egovframework/com/cop/stf/service/impl/BBSSatisfactionMapper.java
+++ b/src/main/java/egovframework/com/cop/stf/service/impl/BBSSatisfactionMapper.java
@@ -1,0 +1,90 @@
+package egovframework.com.cop.stf.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.cop.bbs.service.Satisfaction;
+import egovframework.com.cop.bbs.service.SatisfactionVO;
+
+/**
+ * 만족도조사를 위한 Mapper 인터페이스
+ * @author 공통컴포넌트개발팀 한성곤
+ * @since 2009.06.29
+ * @version 1.0
+ * @see
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2009.06.29  한성곤          최초 생성
+ *   2026.05.28  dasomel         @EgovMapper 인터페이스 방식으로 전환
+ *
+ * </pre>
+ */
+@EgovMapper("BBSSatisfactionDAO")
+public interface BBSSatisfactionMapper {
+
+    /**
+     * 만족도조사에 대한 목록을 조회 한다.
+     *
+     * @param satisfactionVO
+     * @return
+     */
+    List<SatisfactionVO> selectSatisfactionList(SatisfactionVO satisfactionVO);
+
+    /**
+     * 만족도조사에 대한 목록 건수를 조회 한다.
+     *
+     * @param satisfactionVO
+     * @return
+     */
+    int selectSatisfactionListCnt(SatisfactionVO satisfactionVO);
+
+    /**
+     * 만족도조사를 등록한다.
+     *
+     * @param satisfaction
+     */
+    void insertSatisfaction(Satisfaction satisfaction);
+
+    /**
+     * 만족도조사를 삭제한다.
+     *
+     * @param satisfactionVO
+     */
+    void deleteSatisfaction(SatisfactionVO satisfactionVO);
+
+    /**
+     * 만족도조사에 대한 내용을 조회한다.
+     *
+     * @param satisfactionVO
+     * @return
+     */
+    Satisfaction selectSatisfaction(SatisfactionVO satisfactionVO);
+
+    /**
+     * 만족도조사에 대한 내용을 수정한다.
+     *
+     * @param satisfaction
+     */
+    void updateSatisfaction(Satisfaction satisfaction);
+
+    /**
+     * 만족도조사에 대한 패스워드를 조회 한다.
+     *
+     * @param satisfaction
+     * @return
+     */
+    String getSatisfactionPassword(Satisfaction satisfaction);
+
+    /**
+     * 만족도 전체 점수를 제공한다.
+     *
+     * @param satisfactionVO
+     * @return
+     */
+    Float getSummary(SatisfactionVO satisfactionVO);
+}

--- a/src/main/resources/egovframework/mapper/com/cop/adb/EgovAdbk_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/adb/EgovAdbk_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="AdressBookDAO">
+<mapper namespace="egovframework.com.cop.adb.service.impl.AddressBookMapper">
 
 	<resultMap id="ManInfs" type="egovframework.com.cop.adb.service.AddressBookUserVO">
 		<result property="emplyrId" column="EMPLYR_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/adb/EgovAdbk_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/adb/EgovAdbk_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="AdressBookDAO">
+<mapper namespace="egovframework.com.cop.adb.service.impl.AddressBookMapper">
 	
 	<resultMap id="ManInfs" type="egovframework.com.cop.adb.service.AddressBookUserVO">
 		<result property="emplyrId" column="EMPLYR_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/adb/EgovAdbk_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/adb/EgovAdbk_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="AdressBookDAO">
+<mapper namespace="egovframework.com.cop.adb.service.impl.AddressBookMapper">
 
 	<resultMap id="ManInfs" type="egovframework.com.cop.adb.service.AddressBookUserVO">
 		<result property="emplyrId" column="EMPLYR_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/adb/EgovAdbk_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/adb/EgovAdbk_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="AdressBookDAO">
+<mapper namespace="egovframework.com.cop.adb.service.impl.AddressBookMapper">
 
 	<resultMap id="ManInfs" type="egovframework.com.cop.adb.service.AddressBookUserVO">
 		<result property="emplyrId" column="EMPLYR_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/adb/EgovAdbk_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/adb/EgovAdbk_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="AdressBookDAO">
+<mapper namespace="egovframework.com.cop.adb.service.impl.AddressBookMapper">
 
 	<resultMap id="ManInfs" type="egovframework.com.cop.adb.service.AddressBookUserVO">
 		<result property="emplyrId" column="EMPLYR_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/adb/EgovAdbk_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/adb/EgovAdbk_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="AdressBookDAO">
+<mapper namespace="egovframework.com.cop.adb.service.impl.AddressBookMapper">
 	
 	<resultMap id="ManInfs" type="egovframework.com.cop.adb.service.AddressBookUserVO">
 		<result property="emplyrId" column="EMPLYR_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/adb/EgovAdbk_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/adb/EgovAdbk_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="AdressBookDAO">
+<mapper namespace="egovframework.com.cop.adb.service.impl.AddressBookMapper">
 
 	<resultMap id="ManInfs" type="egovframework.com.cop.adb.service.AddressBookUserVO">
 		<result property="emplyrId" column="EMPLYR_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/adb/EgovAdbk_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/adb/EgovAdbk_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:49:40 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="AdressBookDAO">
+<mapper namespace="egovframework.com.cop.adb.service.impl.AddressBookMapper">
 	
 	<resultMap id="ManInfs" type="egovframework.com.cop.adb.service.AddressBookUserVO">
 		<result property="emplyrId" column="EMPLYR_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/com/EgovUserInf_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/com/EgovUserInf_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:49:50 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="EgovUserInfManageDAO">
+<mapper namespace="egovframework.com.cop.com.service.impl.EgovUserInfManageMapper">
 
 	<resultMap id="UserInfs" type="egovframework.com.cop.com.service.UserInfVO">
 		<result property="uniqId" column="ESNTL_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/com/EgovUserInf_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/com/EgovUserInf_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:49:50 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="EgovUserInfManageDAO">
+<mapper namespace="egovframework.com.cop.com.service.impl.EgovUserInfManageMapper">
 
 	<resultMap id="UserInfs" type="egovframework.com.cop.com.service.UserInfVO">
 		<result property="uniqId" column="ESNTL_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/com/EgovUserInf_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/com/EgovUserInf_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:49:50 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="EgovUserInfManageDAO">
+<mapper namespace="egovframework.com.cop.com.service.impl.EgovUserInfManageMapper">
 
 	<resultMap id="UserInfs" type="egovframework.com.cop.com.service.UserInfVO">
 		<result property="uniqId" column="ESNTL_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/com/EgovUserInf_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/com/EgovUserInf_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:49:51 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="EgovUserInfManageDAO">
+<mapper namespace="egovframework.com.cop.com.service.impl.EgovUserInfManageMapper">
 
 	<resultMap id="UserInfs" type="egovframework.com.cop.com.service.UserInfVO">
 		<result property="uniqId" column="ESNTL_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/com/EgovUserInf_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/com/EgovUserInf_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:49:51 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="EgovUserInfManageDAO">
+<mapper namespace="egovframework.com.cop.com.service.impl.EgovUserInfManageMapper">
 
 	<resultMap id="UserInfs" type="egovframework.com.cop.com.service.UserInfVO">
 		<result property="uniqId" column="ESNTL_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/com/EgovUserInf_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/com/EgovUserInf_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:49:51 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="EgovUserInfManageDAO">
+<mapper namespace="egovframework.com.cop.com.service.impl.EgovUserInfManageMapper">
 
 	<resultMap id="UserInfs" type="egovframework.com.cop.com.service.UserInfVO">
 		<result property="uniqId" column="ESNTL_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/com/EgovUserInf_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/com/EgovUserInf_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:49:51 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="EgovUserInfManageDAO">
+<mapper namespace="egovframework.com.cop.com.service.impl.EgovUserInfManageMapper">
 
 	<resultMap id="UserInfs" type="egovframework.com.cop.com.service.UserInfVO">
 		<result property="uniqId" column="ESNTL_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/com/EgovUserInf_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/com/EgovUserInf_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:49:51 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="EgovUserInfManageDAO">
+<mapper namespace="egovframework.com.cop.com.service.impl.EgovUserInfManageMapper">
 
 	<resultMap id="UserInfs" type="egovframework.com.cop.com.service.UserInfVO">
 		<result property="uniqId" column="ESNTL_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/stf/EgovBBSSatisfaction_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/stf/EgovBBSSatisfaction_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BBSSatisfactionDAO">
+<mapper namespace="egovframework.com.cop.stf.service.impl.BBSSatisfactionMapper">
 	
 	<resultMap id="satisfactionList" type="egovframework.com.cop.bbs.service.SatisfactionVO">
 		<result property="stsfdgNo" column="STSFDG_NO"/>

--- a/src/main/resources/egovframework/mapper/com/cop/stf/EgovBBSSatisfaction_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/stf/EgovBBSSatisfaction_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BBSSatisfactionDAO">
+<mapper namespace="egovframework.com.cop.stf.service.impl.BBSSatisfactionMapper">
 	
 	<resultMap id="satisfactionList" type="egovframework.com.cop.bbs.service.SatisfactionVO">
 		<result property="stsfdgNo" column="STSFDG_NO"/>

--- a/src/main/resources/egovframework/mapper/com/cop/stf/EgovBBSSatisfaction_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/stf/EgovBBSSatisfaction_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BBSSatisfactionDAO">
+<mapper namespace="egovframework.com.cop.stf.service.impl.BBSSatisfactionMapper">
 	
 	<resultMap id="satisfactionList" type="egovframework.com.cop.bbs.service.SatisfactionVO">
 		<result property="stsfdgNo" column="STSFDG_NO"/>

--- a/src/main/resources/egovframework/mapper/com/cop/stf/EgovBBSSatisfaction_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/stf/EgovBBSSatisfaction_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BBSSatisfactionDAO">
+<mapper namespace="egovframework.com.cop.stf.service.impl.BBSSatisfactionMapper">
 	
 	<resultMap id="satisfactionList" type="egovframework.com.cop.bbs.service.SatisfactionVO">
 		<result property="stsfdgNo" column="STSFDG_NO"/>

--- a/src/main/resources/egovframework/mapper/com/cop/stf/EgovBBSSatisfaction_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/stf/EgovBBSSatisfaction_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BBSSatisfactionDAO">
+<mapper namespace="egovframework.com.cop.stf.service.impl.BBSSatisfactionMapper">
 	
 	<resultMap id="satisfactionList" type="egovframework.com.cop.bbs.service.SatisfactionVO">
 		<result property="stsfdgNo" column="STSFDG_NO"/>

--- a/src/main/resources/egovframework/mapper/com/cop/stf/EgovBBSSatisfaction_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/stf/EgovBBSSatisfaction_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BBSSatisfactionDAO">
+<mapper namespace="egovframework.com.cop.stf.service.impl.BBSSatisfactionMapper">
 	
 	<resultMap id="satisfactionList" type="egovframework.com.cop.bbs.service.SatisfactionVO">
 		<result property="stsfdgNo" column="STSFDG_NO"/>

--- a/src/main/resources/egovframework/mapper/com/cop/stf/EgovBBSSatisfaction_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/stf/EgovBBSSatisfaction_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BBSSatisfactionDAO">
+<mapper namespace="egovframework.com.cop.stf.service.impl.BBSSatisfactionMapper">
 	
 	<resultMap id="satisfactionList" type="egovframework.com.cop.bbs.service.SatisfactionVO">
 		<result property="stsfdgNo" column="STSFDG_NO"/>

--- a/src/main/resources/egovframework/mapper/com/cop/stf/EgovBBSSatisfaction_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/stf/EgovBBSSatisfaction_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BBSSatisfactionDAO">
+<mapper namespace="egovframework.com.cop.stf.service.impl.BBSSatisfactionMapper">
 	
 	<resultMap id="satisfactionList" type="egovframework.com.cop.bbs.service.SatisfactionVO">
 		<result property="stsfdgNo" column="STSFDG_NO"/>

--- a/src/main/resources/egovframework/spring/com/context-mapper.xml
+++ b/src/main/resources/egovframework/spring/com/context-mapper.xml
@@ -21,5 +21,12 @@
 	<bean id="egov.sqlSessionTemplate" class="org.mybatis.spring.SqlSessionTemplate">
 		<constructor-arg ref="egov.sqlSession"/>
 	</bean>
-	
+
+	<!-- @EgovMapper 어노테이션이 붙은 인터페이스를 자동으로 스캔하여 빈으로 등록 -->
+	<bean class="org.mybatis.spring.mapper.MapperScannerConfigurer">
+		<property name="basePackage" value="egovframework.com"/>
+		<property name="annotationClass" value="org.egovframe.rte.psl.dataaccess.mapper.EgovMapper"/>
+		<property name="sqlSessionFactoryBeanName" value="egov.sqlSession"/>
+	</bean>
+
 </beans>


### PR DESCRIPTION
## 변경 사유
기존 XML namespace 기반 DAO를 5.0 신규 @EgovMapper 인터페이스 방식으로 전환

## 변경 내용
- EgovUserInfManageMapper, BBSSatisfactionMapper, AddressBookMapper 인터페이스 신규 추가
- cop/com·cop/stf·cop/adb 3개 DAO를 mapper 위임 구조로 리팩토링
- XML namespace를 mapper FQN으로 변경
- context-mapper.xml에 MapperScannerConfigurer 설정 추가

## 영향 범위
- cop 협업 3개 서브 모듈 (cop/com, cop/stf, cop/adb)
- DAO bean name 유지로 기존 ServiceImpl 호환성 보장

## 체크리스트
- [x] 단일 주제만 다룸
- [x] 기존 동작 호환
- [x] 5.x 다른 브랜치용 PR이 필요한 경우 후속 PR 링크 명시
