### PR TITLE
[refactor][5.0.x][공통컴포넌트] sts/rst·dst·bst 3개 통계 DAO @EgovMapper 인터페이스 방식으로 전환

### DIFF
--- a/src/main/java/egovframework/com/sts/bst/service/impl/BbsStatsDAO.java
+++ b/src/main/java/egovframework/com/sts/bst/service/impl/BbsStatsDAO.java
@@ -2,9 +2,10 @@ package egovframework.com.sts.bst.service.impl;
 
 import java.util.List;
 
+import jakarta.annotation.Resource;
+
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.sts.com.StatsVO;
 
 /**
@@ -28,7 +29,10 @@ import egovframework.com.sts.com.StatsVO;
  *  </pre>
  */
 @Repository("bbsStatsDAO")
-public class BbsStatsDAO extends EgovComAbstractDAO {
+public class BbsStatsDAO {
+
+	@Resource(name = "bbsStatsMapper")
+	private BbsStatsMapper bbsStatsMapper;
 
 	/**
 	 * 게시물 생성글수 통계를 조회한다
@@ -36,408 +40,408 @@ public class BbsStatsDAO extends EgovComAbstractDAO {
 	 * @return List
 	 * @exception Exception
 	 */
-    public List<StatsVO> selectBbsCretCntStats(StatsVO vo) throws Exception {
-        return selectList("BbsStatsDAO.selectBbsCretCntStats", vo);
-    }
+	public List<StatsVO> selectBbsCretCntStats(StatsVO vo) throws Exception {
+		return bbsStatsMapper.selectBbsCretCntStats(vo);
+	}
 
-    /**
+	/**
 	 * 게시물 총조회수 통계를 조회한다
 	 * @param vo StatsVO
 	 * @return List
 	 * @exception Exception
 	 */
-    public List<StatsVO> selectBbsTotCntStats(StatsVO vo) throws Exception {
-        return selectList("BbsStatsDAO.selectBbsTotCntStats", vo);
-    }
+	public List<StatsVO> selectBbsTotCntStats(StatsVO vo) throws Exception {
+		return bbsStatsMapper.selectBbsTotCntStats(vo);
+	}
 
-    /**
+	/**
 	 * 게시물 평균조회수 통계를 조회한다
 	 * @param vo StatsVO
 	 * @return List
 	 * @exception Exception
 	 */
-    public List<StatsVO> selectBbsAvgCntStats(StatsVO vo) throws Exception {
-        return selectList("BbsStatsDAO.selectBbsAvgCntStats", vo);
-    }
+	public List<StatsVO> selectBbsAvgCntStats(StatsVO vo) throws Exception {
+		return bbsStatsMapper.selectBbsAvgCntStats(vo);
+	}
 
-    /**
+	/**
 	 * 최고조회 게시물 통계정보를 조회한다
 	 * @param vo StatsVO
 	 * @return List
 	 * @exception Exception
 	 */
-    public List<StatsVO> selectBbsMaxCntStats(StatsVO vo) throws Exception {
-        return selectList("BbsStatsDAO.selectBbsMaxCntStats", vo);
-    }
+	public List<StatsVO> selectBbsMaxCntStats(StatsVO vo) throws Exception {
+		return bbsStatsMapper.selectBbsMaxCntStats(vo);
+	}
 
-    /**
+	/**
 	 * 최소조회 게시물 통계정보를 조회한다
 	 * @param vo StatsVO
 	 * @return List
 	 * @exception Exception
 	 */
-    public List<StatsVO> selectBbsMinCntStats(StatsVO vo) throws Exception {
-        return selectList("BbsStatsDAO.selectBbsMinCntStats", vo);
-    }
+	public List<StatsVO> selectBbsMinCntStats(StatsVO vo) throws Exception {
+		return bbsStatsMapper.selectBbsMinCntStats(vo);
+	}
 
-    /**
+	/**
 	 * 게시물 최고게시자 통계를 조회한다
 	 * @param vo StatsVO
 	 * @return List
 	 * @exception Exception
 	 */
-    public List<StatsVO> selectBbsMaxUserStats(StatsVO vo) throws Exception {
-        return selectList("BbsStatsDAO.selectBbsMaxUserStats", vo);
-    }
+	public List<StatsVO> selectBbsMaxUserStats(StatsVO vo) throws Exception {
+		return bbsStatsMapper.selectBbsMaxUserStats(vo);
+	}
 
-    /**
+	/**
 	 * 게시물 통계를 위한 집계를 하루단위로 작업하는 배치 프로그램
 	 * @exception Exception
 	 */
-    public void summaryBbsStats() throws Exception {
+	public void summaryBbsStats() throws Exception {
 
-    	StatsVO parVO = new StatsVO();
+		StatsVO parVO = new StatsVO();
 
-    	StatsVO sumVO = null;
-    	StatsVO resultVO = null;
+		StatsVO sumVO = null;
+		StatsVO resultVO = null;
 
-    	// 게시판 유형별
-    	// 1. 통합게시판
-    	sumVO = new StatsVO();
-    	sumVO.setStatsKind("COM101");
-    	sumVO.setDetailStatsKind("BBST01");
-    	parVO.setStatsKind("COM101");
-    	parVO.setDetailStatsKind("BBST01");
-    	// 1-0. 집계 여부 조회
-    	resultVO = (StatsVO)selectOne("BbsStatsDAO.selectBbsSummary", parVO);
-    	if (resultVO == null || resultVO.getStatsKind() == null || "".equals(resultVO.getStatsKind())) {
-    		// 1-1. 생성글수
-        	resultVO = (StatsVO)selectOne("BbsStatsDAO.selectBbsCreatCo", parVO);
-            if (resultVO != null) {
+		// 게시판 유형별
+		// 1. 통합게시판
+		sumVO = new StatsVO();
+		sumVO.setStatsKind("COM101");
+		sumVO.setDetailStatsKind("BBST01");
+		parVO.setStatsKind("COM101");
+		parVO.setDetailStatsKind("BBST01");
+		// 1-0. 집계 여부 조회
+		resultVO = bbsStatsMapper.selectBbsSummary(parVO);
+		if (resultVO == null || resultVO.getStatsKind() == null || "".equals(resultVO.getStatsKind())) {
+			// 1-1. 생성글수
+			resultVO = bbsStatsMapper.selectBbsCreatCo(parVO);
+			if (resultVO != null) {
 				sumVO.setCreatCo(resultVO.getCreatCo());
 			} else {
 				sumVO.setCreatCo(0);
 			}
-            // 1-2. 총조회수
-        	resultVO = (StatsVO)selectOne("BbsStatsDAO.selectBbsTotInqireCo", parVO);
-        	if (resultVO != null) {
+			// 1-2. 총조회수
+			resultVO = bbsStatsMapper.selectBbsTotInqireCo(parVO);
+			if (resultVO != null) {
 				sumVO.setTotInqireCo(resultVO.getTotInqireCo());
 			} else {
 				sumVO.setTotInqireCo(0);
 			}
-            // 1-3. 평균조회수
-        	resultVO = (StatsVO)selectOne("BbsStatsDAO.selectBbsAvrgInqireCo", parVO);
-        	if (resultVO != null) {
+			// 1-3. 평균조회수
+			resultVO = bbsStatsMapper.selectBbsAvrgInqireCo(parVO);
+			if (resultVO != null) {
 				sumVO.setAvrgInqireCo(resultVO.getAvrgInqireCo());
 			} else {
 				sumVO.setAvrgInqireCo(0);
 			}
-            // 1-4. 최고조회게시물ID
-        	resultVO = (StatsVO)selectOne("BbsStatsDAO.selectBbsMxmmInqireBbsId", parVO);
-        	if (resultVO != null && resultVO.getMxmmInqireBbsId() != null) {
+			// 1-4. 최고조회게시물ID
+			resultVO = bbsStatsMapper.selectBbsMxmmInqireBbsId(parVO);
+			if (resultVO != null && resultVO.getMxmmInqireBbsId() != null) {
 				sumVO.setMxmmInqireBbsId(resultVO.getMxmmInqireBbsId());
 			} else {
 				sumVO.setMxmmInqireBbsId("");
 			}
-            // 1-5. 최소조회게시물ID
-        	resultVO = (StatsVO)selectOne("BbsStatsDAO.selectBbsMummInqireBbsId", parVO);
-        	if (resultVO != null && resultVO.getMummInqireBbsId() != null) {
+			// 1-5. 최소조회게시물ID
+			resultVO = bbsStatsMapper.selectBbsMummInqireBbsId(parVO);
+			if (resultVO != null && resultVO.getMummInqireBbsId() != null) {
 				sumVO.setMummInqireBbsId(resultVO.getMummInqireBbsId());
 			} else {
 				sumVO.setMummInqireBbsId("");
 			}
-            // 1-6. 최고게시자ID
-        	resultVO = (StatsVO)selectOne("BbsStatsDAO.selectBbsTopNtcepersonId", parVO);
-        	if (resultVO != null && resultVO.getTopNtcepersonId() != null) {
+			// 1-6. 최고게시자ID
+			resultVO = bbsStatsMapper.selectBbsTopNtcepersonId(parVO);
+			if (resultVO != null && resultVO.getTopNtcepersonId() != null) {
 				sumVO.setTopNtcepersonId(resultVO.getTopNtcepersonId());
 			} else {
 				sumVO.setTopNtcepersonId("");
 			}
 
-        	// 1-7. 집계 등록
-        	insert("BbsStatsDAO.summaryBbsStats", sumVO);
-    	}
+			// 1-7. 집계 등록
+			bbsStatsMapper.summaryBbsStats(sumVO);
+		}
 
-    	// 2. 블로그게시판
-    	sumVO = new StatsVO();
-    	sumVO.setStatsKind("COM101");
-    	sumVO.setDetailStatsKind("BBST02");
-    	parVO.setStatsKind("COM101");
-    	parVO.setDetailStatsKind("BBST02");
-    	// 2-0. 집계 여부 조회
-    	resultVO = (StatsVO)selectOne("BbsStatsDAO.selectBbsSummary", parVO);
-    	if (resultVO == null || resultVO.getStatsKind() == null || "".equals(resultVO.getStatsKind())) {
-    		// 2-1. 생성글수
-        	resultVO = (StatsVO)selectOne("BbsStatsDAO.selectBbsCreatCo", parVO);
-            if (resultVO != null) {
+		// 2. 블로그게시판
+		sumVO = new StatsVO();
+		sumVO.setStatsKind("COM101");
+		sumVO.setDetailStatsKind("BBST02");
+		parVO.setStatsKind("COM101");
+		parVO.setDetailStatsKind("BBST02");
+		// 2-0. 집계 여부 조회
+		resultVO = bbsStatsMapper.selectBbsSummary(parVO);
+		if (resultVO == null || resultVO.getStatsKind() == null || "".equals(resultVO.getStatsKind())) {
+			// 2-1. 생성글수
+			resultVO = bbsStatsMapper.selectBbsCreatCo(parVO);
+			if (resultVO != null) {
 				sumVO.setCreatCo(resultVO.getCreatCo());
 			} else {
 				sumVO.setCreatCo(0);
 			}
-            // 2-2. 총조회수
-        	resultVO = (StatsVO)selectOne("BbsStatsDAO.selectBbsTotInqireCo", parVO);
-        	if (resultVO != null) {
+			// 2-2. 총조회수
+			resultVO = bbsStatsMapper.selectBbsTotInqireCo(parVO);
+			if (resultVO != null) {
 				sumVO.setTotInqireCo(resultVO.getTotInqireCo());
 			} else {
 				sumVO.setTotInqireCo(0);
 			}
-            // 2-3. 평균조회수
-        	resultVO = (StatsVO)selectOne("BbsStatsDAO.selectBbsAvrgInqireCo", parVO);
-        	if (resultVO != null) {
+			// 2-3. 평균조회수
+			resultVO = bbsStatsMapper.selectBbsAvrgInqireCo(parVO);
+			if (resultVO != null) {
 				sumVO.setAvrgInqireCo(resultVO.getAvrgInqireCo());
 			} else {
 				sumVO.setAvrgInqireCo(0);
 			}
-            // 2-4. 최고조회게시물ID
-        	resultVO = (StatsVO)selectOne("BbsStatsDAO.selectBbsMxmmInqireBbsId", parVO);
-        	if (resultVO != null && resultVO.getMxmmInqireBbsId() != null) {
+			// 2-4. 최고조회게시물ID
+			resultVO = bbsStatsMapper.selectBbsMxmmInqireBbsId(parVO);
+			if (resultVO != null && resultVO.getMxmmInqireBbsId() != null) {
 				sumVO.setMxmmInqireBbsId(resultVO.getMxmmInqireBbsId());
 			} else {
 				sumVO.setMxmmInqireBbsId("");
 			}
-            // 2-5. 최소조회게시물ID
-        	resultVO = (StatsVO)selectOne("BbsStatsDAO.selectBbsMummInqireBbsId", parVO);
-        	if (resultVO != null && resultVO.getMummInqireBbsId() != null) {
+			// 2-5. 최소조회게시물ID
+			resultVO = bbsStatsMapper.selectBbsMummInqireBbsId(parVO);
+			if (resultVO != null && resultVO.getMummInqireBbsId() != null) {
 				sumVO.setMummInqireBbsId(resultVO.getMummInqireBbsId());
 			} else {
 				sumVO.setMummInqireBbsId("");
 			}
-            // 2-6. 최고게시자ID
-        	resultVO = (StatsVO)selectOne("BbsStatsDAO.selectBbsTopNtcepersonId", parVO);
-        	if (resultVO != null && resultVO.getTopNtcepersonId() != null) {
+			// 2-6. 최고게시자ID
+			resultVO = bbsStatsMapper.selectBbsTopNtcepersonId(parVO);
+			if (resultVO != null && resultVO.getTopNtcepersonId() != null) {
 				sumVO.setTopNtcepersonId(resultVO.getTopNtcepersonId());
 			} else {
 				sumVO.setTopNtcepersonId("");
 			}
 
-        	// 2-7. 집계 등록
-        	insert("BbsStatsDAO.summaryBbsStats", sumVO);
-    	}
+			// 2-7. 집계 등록
+			bbsStatsMapper.summaryBbsStats(sumVO);
+		}
 
-    	// 3. 방명록
-    	sumVO = new StatsVO();
-    	sumVO.setStatsKind("COM101");
-    	sumVO.setDetailStatsKind("BBST03");
-    	parVO.setStatsKind("COM101");
-    	parVO.setDetailStatsKind("BBST03");
-    	// 3-0. 집계 여부 조회
-    	resultVO = (StatsVO)selectOne("BbsStatsDAO.selectBbsSummary", parVO);
-    	if (resultVO == null || resultVO.getStatsKind() == null || "".equals(resultVO.getStatsKind())) {
-    		// 3-1. 생성글수
-        	resultVO = (StatsVO)selectOne("BbsStatsDAO.selectBbsCreatCo", parVO);
-            if (resultVO != null) {
+		// 3. 방명록
+		sumVO = new StatsVO();
+		sumVO.setStatsKind("COM101");
+		sumVO.setDetailStatsKind("BBST03");
+		parVO.setStatsKind("COM101");
+		parVO.setDetailStatsKind("BBST03");
+		// 3-0. 집계 여부 조회
+		resultVO = bbsStatsMapper.selectBbsSummary(parVO);
+		if (resultVO == null || resultVO.getStatsKind() == null || "".equals(resultVO.getStatsKind())) {
+			// 3-1. 생성글수
+			resultVO = bbsStatsMapper.selectBbsCreatCo(parVO);
+			if (resultVO != null) {
 				sumVO.setCreatCo(resultVO.getCreatCo());
 			} else {
 				sumVO.setCreatCo(0);
 			}
-            // 3-2. 총조회수
-        	resultVO = (StatsVO)selectOne("BbsStatsDAO.selectBbsTotInqireCo", parVO);
-        	if (resultVO != null) {
+			// 3-2. 총조회수
+			resultVO = bbsStatsMapper.selectBbsTotInqireCo(parVO);
+			if (resultVO != null) {
 				sumVO.setTotInqireCo(resultVO.getTotInqireCo());
 			} else {
 				sumVO.setTotInqireCo(0);
 			}
-            // 3-3. 평균조회수
-        	resultVO = (StatsVO)selectOne("BbsStatsDAO.selectBbsAvrgInqireCo", parVO);
-        	if (resultVO != null) {
+			// 3-3. 평균조회수
+			resultVO = bbsStatsMapper.selectBbsAvrgInqireCo(parVO);
+			if (resultVO != null) {
 				sumVO.setAvrgInqireCo(resultVO.getAvrgInqireCo());
 			} else {
 				sumVO.setAvrgInqireCo(0);
 			}
-            // 3-4. 최고조회게시물ID
-        	resultVO = (StatsVO)selectOne("BbsStatsDAO.selectBbsMxmmInqireBbsId", parVO);
-        	if (resultVO != null && resultVO.getMxmmInqireBbsId() != null) {
+			// 3-4. 최고조회게시물ID
+			resultVO = bbsStatsMapper.selectBbsMxmmInqireBbsId(parVO);
+			if (resultVO != null && resultVO.getMxmmInqireBbsId() != null) {
 				sumVO.setMxmmInqireBbsId(resultVO.getMxmmInqireBbsId());
 			} else {
 				sumVO.setMxmmInqireBbsId("");
 			}
-            // 3-5. 최소조회게시물ID
-        	resultVO = (StatsVO)selectOne("BbsStatsDAO.selectBbsMummInqireBbsId", parVO);
-        	if (resultVO != null && resultVO.getMummInqireBbsId() != null) {
+			// 3-5. 최소조회게시물ID
+			resultVO = bbsStatsMapper.selectBbsMummInqireBbsId(parVO);
+			if (resultVO != null && resultVO.getMummInqireBbsId() != null) {
 				sumVO.setMummInqireBbsId(resultVO.getMummInqireBbsId());
 			} else {
 				sumVO.setMummInqireBbsId("");
 			}
-            // 3-6. 최고게시자ID
-        	resultVO = (StatsVO)selectOne("BbsStatsDAO.selectBbsTopNtcepersonId", parVO);
-        	if (resultVO != null && resultVO.getTopNtcepersonId() != null) {
+			// 3-6. 최고게시자ID
+			resultVO = bbsStatsMapper.selectBbsTopNtcepersonId(parVO);
+			if (resultVO != null && resultVO.getTopNtcepersonId() != null) {
 				sumVO.setTopNtcepersonId(resultVO.getTopNtcepersonId());
 			} else {
 				sumVO.setTopNtcepersonId("");
 			}
 
-        	// 3-7. 집계 등록
-        	insert("BbsStatsDAO.summaryBbsStats", sumVO);
-    	}
+			// 3-7. 집계 등록
+			bbsStatsMapper.summaryBbsStats(sumVO);
+		}
 
 
-    	// 게시판 템플릿별
-    	// 1. 게시판
-    	sumVO = new StatsVO();
-    	sumVO.setStatsKind("COM005");
-    	sumVO.setDetailStatsKind("TMPT01");
-    	parVO.setStatsKind("COM005");
-    	parVO.setDetailStatsKind("TMPT01");
-    	// 1-0. 집계 여부 조회
-    	resultVO = (StatsVO)selectOne("BbsStatsDAO.selectBbsSummary", parVO);
-    	if (resultVO == null || resultVO.getStatsKind() == null || "".equals(resultVO.getStatsKind())) {
-    		// 1-1. 생성글수
-        	resultVO = (StatsVO)selectOne("BbsStatsDAO.selectBbsCreatCo", parVO);
-            if (resultVO != null) {
+		// 게시판 템플릿별
+		// 1. 게시판
+		sumVO = new StatsVO();
+		sumVO.setStatsKind("COM005");
+		sumVO.setDetailStatsKind("TMPT01");
+		parVO.setStatsKind("COM005");
+		parVO.setDetailStatsKind("TMPT01");
+		// 1-0. 집계 여부 조회
+		resultVO = bbsStatsMapper.selectBbsSummary(parVO);
+		if (resultVO == null || resultVO.getStatsKind() == null || "".equals(resultVO.getStatsKind())) {
+			// 1-1. 생성글수
+			resultVO = bbsStatsMapper.selectBbsCreatCo(parVO);
+			if (resultVO != null) {
 				sumVO.setCreatCo(resultVO.getCreatCo());
 			} else {
 				sumVO.setCreatCo(0);
 			}
-            // 1-2. 총조회수
-        	resultVO = (StatsVO)selectOne("BbsStatsDAO.selectBbsTotInqireCo", parVO);
-        	if (resultVO != null) {
+			// 1-2. 총조회수
+			resultVO = bbsStatsMapper.selectBbsTotInqireCo(parVO);
+			if (resultVO != null) {
 				sumVO.setTotInqireCo(resultVO.getTotInqireCo());
 			} else {
 				sumVO.setTotInqireCo(0);
 			}
-            // 1-3. 평균조회수
-        	resultVO = (StatsVO)selectOne("BbsStatsDAO.selectBbsAvrgInqireCo", parVO);
-        	if (resultVO != null) {
+			// 1-3. 평균조회수
+			resultVO = bbsStatsMapper.selectBbsAvrgInqireCo(parVO);
+			if (resultVO != null) {
 				sumVO.setAvrgInqireCo(resultVO.getAvrgInqireCo());
 			} else {
 				sumVO.setAvrgInqireCo(0);
 			}
-            // 1-4. 최고조회게시물ID
-        	resultVO = (StatsVO)selectOne("BbsStatsDAO.selectBbsMxmmInqireBbsId", parVO);
-        	if (resultVO != null && resultVO.getMxmmInqireBbsId() != null) {
+			// 1-4. 최고조회게시물ID
+			resultVO = bbsStatsMapper.selectBbsMxmmInqireBbsId(parVO);
+			if (resultVO != null && resultVO.getMxmmInqireBbsId() != null) {
 				sumVO.setMxmmInqireBbsId(resultVO.getMxmmInqireBbsId());
 			} else {
 				sumVO.setMxmmInqireBbsId("");
 			}
-            // 1-5. 최소조회게시물ID
-        	resultVO = (StatsVO)selectOne("BbsStatsDAO.selectBbsMummInqireBbsId", parVO);
-        	if (resultVO != null && resultVO.getMummInqireBbsId() != null) {
+			// 1-5. 최소조회게시물ID
+			resultVO = bbsStatsMapper.selectBbsMummInqireBbsId(parVO);
+			if (resultVO != null && resultVO.getMummInqireBbsId() != null) {
 				sumVO.setMummInqireBbsId(resultVO.getMummInqireBbsId());
 			} else {
 				sumVO.setMummInqireBbsId("");
 			}
-            // 1-6. 최고게시자ID
-        	resultVO = (StatsVO)selectOne("BbsStatsDAO.selectBbsTopNtcepersonId", parVO);
-        	if (resultVO != null && resultVO.getTopNtcepersonId() != null) {
+			// 1-6. 최고게시자ID
+			resultVO = bbsStatsMapper.selectBbsTopNtcepersonId(parVO);
+			if (resultVO != null && resultVO.getTopNtcepersonId() != null) {
 				sumVO.setTopNtcepersonId(resultVO.getTopNtcepersonId());
 			} else {
 				sumVO.setTopNtcepersonId("");
 			}
 
-        	// 1-7. 집계 등록
-        	insert("BbsStatsDAO.summaryBbsStats", sumVO);
-    	}
+			// 1-7. 집계 등록
+			bbsStatsMapper.summaryBbsStats(sumVO);
+		}
 
-    	// 2. 커뮤니티
-    	sumVO = new StatsVO();
-    	sumVO.setStatsKind("COM005");
-    	sumVO.setDetailStatsKind("TMPT02");
-    	parVO.setStatsKind("COM005");
-    	parVO.setDetailStatsKind("TMPT02");
-    	// 2-0. 집계 여부 조회
-    	resultVO = (StatsVO)selectOne("BbsStatsDAO.selectBbsSummary", parVO);
-    	if (resultVO == null || resultVO.getStatsKind() == null || "".equals(resultVO.getStatsKind())) {
-    		// 2-1. 생성글수
-        	resultVO = (StatsVO)selectOne("BbsStatsDAO.selectBbsCreatCo", parVO);
-            if (resultVO != null) {
+		// 2. 커뮤니티
+		sumVO = new StatsVO();
+		sumVO.setStatsKind("COM005");
+		sumVO.setDetailStatsKind("TMPT02");
+		parVO.setStatsKind("COM005");
+		parVO.setDetailStatsKind("TMPT02");
+		// 2-0. 집계 여부 조회
+		resultVO = bbsStatsMapper.selectBbsSummary(parVO);
+		if (resultVO == null || resultVO.getStatsKind() == null || "".equals(resultVO.getStatsKind())) {
+			// 2-1. 생성글수
+			resultVO = bbsStatsMapper.selectBbsCreatCo(parVO);
+			if (resultVO != null) {
 				sumVO.setCreatCo(resultVO.getCreatCo());
 			} else {
 				sumVO.setCreatCo(0);
 			}
-            // 2-2. 총조회수
-        	resultVO = (StatsVO)selectOne("BbsStatsDAO.selectBbsTotInqireCo", parVO);
-        	if (resultVO != null) {
+			// 2-2. 총조회수
+			resultVO = bbsStatsMapper.selectBbsTotInqireCo(parVO);
+			if (resultVO != null) {
 				sumVO.setTotInqireCo(resultVO.getTotInqireCo());
 			} else {
 				sumVO.setTotInqireCo(0);
 			}
-            // 2-3. 평균조회수
-        	resultVO = (StatsVO)selectOne("BbsStatsDAO.selectBbsAvrgInqireCo", parVO);
-        	if (resultVO != null) {
+			// 2-3. 평균조회수
+			resultVO = bbsStatsMapper.selectBbsAvrgInqireCo(parVO);
+			if (resultVO != null) {
 				sumVO.setAvrgInqireCo(resultVO.getAvrgInqireCo());
 			} else {
 				sumVO.setAvrgInqireCo(0);
 			}
-            // 2-4. 최고조회게시물ID
-        	resultVO = (StatsVO)selectOne("BbsStatsDAO.selectBbsMxmmInqireBbsId", parVO);
-        	if (resultVO != null && resultVO.getMxmmInqireBbsId() != null) {
+			// 2-4. 최고조회게시물ID
+			resultVO = bbsStatsMapper.selectBbsMxmmInqireBbsId(parVO);
+			if (resultVO != null && resultVO.getMxmmInqireBbsId() != null) {
 				sumVO.setMxmmInqireBbsId(resultVO.getMxmmInqireBbsId());
 			} else {
 				sumVO.setMxmmInqireBbsId("");
 			}
-            // 2-5. 최소조회게시물ID
-        	resultVO = (StatsVO)selectOne("BbsStatsDAO.selectBbsMummInqireBbsId", parVO);
-        	if (resultVO != null && resultVO.getMummInqireBbsId() != null) {
+			// 2-5. 최소조회게시물ID
+			resultVO = bbsStatsMapper.selectBbsMummInqireBbsId(parVO);
+			if (resultVO != null && resultVO.getMummInqireBbsId() != null) {
 				sumVO.setMummInqireBbsId(resultVO.getMummInqireBbsId());
 			} else {
 				sumVO.setMummInqireBbsId("");
 			}
-            // 2-6. 최고게시자ID
-        	resultVO = (StatsVO)selectOne("BbsStatsDAO.selectBbsTopNtcepersonId", parVO);
-        	if (resultVO != null && resultVO.getTopNtcepersonId() != null) {
+			// 2-6. 최고게시자ID
+			resultVO = bbsStatsMapper.selectBbsTopNtcepersonId(parVO);
+			if (resultVO != null && resultVO.getTopNtcepersonId() != null) {
 				sumVO.setTopNtcepersonId(resultVO.getTopNtcepersonId());
 			} else {
 				sumVO.setTopNtcepersonId("");
 			}
 
-        	// 2-7. 집계 등록
-        	insert("BbsStatsDAO.summaryBbsStats", sumVO);
-    	}
+			// 2-7. 집계 등록
+			bbsStatsMapper.summaryBbsStats(sumVO);
+		}
 
-    	// 3. 동호회
-    	sumVO = new StatsVO();
-    	sumVO.setStatsKind("COM005");
-    	sumVO.setDetailStatsKind("TMPT03");
-    	parVO.setStatsKind("COM005");
-    	parVO.setDetailStatsKind("TMPT03");
-    	// 3-0. 집계 여부 조회
-    	resultVO = (StatsVO)selectOne("BbsStatsDAO.selectBbsSummary", parVO);
-    	if (resultVO == null || resultVO.getStatsKind() == null || "".equals(resultVO.getStatsKind())) {
-    		// 3-1. 생성글수
-        	resultVO = (StatsVO)selectOne("BbsStatsDAO.selectBbsCreatCo", parVO);
-            if (resultVO != null) {
+		// 3. 동호회
+		sumVO = new StatsVO();
+		sumVO.setStatsKind("COM005");
+		sumVO.setDetailStatsKind("TMPT03");
+		parVO.setStatsKind("COM005");
+		parVO.setDetailStatsKind("TMPT03");
+		// 3-0. 집계 여부 조회
+		resultVO = bbsStatsMapper.selectBbsSummary(parVO);
+		if (resultVO == null || resultVO.getStatsKind() == null || "".equals(resultVO.getStatsKind())) {
+			// 3-1. 생성글수
+			resultVO = bbsStatsMapper.selectBbsCreatCo(parVO);
+			if (resultVO != null) {
 				sumVO.setCreatCo(resultVO.getCreatCo());
 			} else {
 				sumVO.setCreatCo(0);
 			}
-            // 3-2. 총조회수
-        	resultVO = (StatsVO)selectOne("BbsStatsDAO.selectBbsTotInqireCo", parVO);
-        	if (resultVO != null) {
+			// 3-2. 총조회수
+			resultVO = bbsStatsMapper.selectBbsTotInqireCo(parVO);
+			if (resultVO != null) {
 				sumVO.setTotInqireCo(resultVO.getTotInqireCo());
 			} else {
 				sumVO.setTotInqireCo(0);
 			}
-            // 3-3. 평균조회수
-        	resultVO = (StatsVO)selectOne("BbsStatsDAO.selectBbsAvrgInqireCo", parVO);
-        	if (resultVO != null) {
+			// 3-3. 평균조회수
+			resultVO = bbsStatsMapper.selectBbsAvrgInqireCo(parVO);
+			if (resultVO != null) {
 				sumVO.setAvrgInqireCo(resultVO.getAvrgInqireCo());
 			} else {
 				sumVO.setAvrgInqireCo(0);
 			}
-            // 3-4. 최고조회게시물ID
-        	resultVO = (StatsVO)selectOne("BbsStatsDAO.selectBbsMxmmInqireBbsId", parVO);
-        	if (resultVO != null && resultVO.getMxmmInqireBbsId() != null) {
+			// 3-4. 최고조회게시물ID
+			resultVO = bbsStatsMapper.selectBbsMxmmInqireBbsId(parVO);
+			if (resultVO != null && resultVO.getMxmmInqireBbsId() != null) {
 				sumVO.setMxmmInqireBbsId(resultVO.getMxmmInqireBbsId());
 			} else {
 				sumVO.setMxmmInqireBbsId("");
 			}
-            // 3-5. 최소조회게시물ID
-        	resultVO = (StatsVO)selectOne("BbsStatsDAO.selectBbsMummInqireBbsId", parVO);
-        	if (resultVO != null && resultVO.getMummInqireBbsId() != null) {
+			// 3-5. 최소조회게시물ID
+			resultVO = bbsStatsMapper.selectBbsMummInqireBbsId(parVO);
+			if (resultVO != null && resultVO.getMummInqireBbsId() != null) {
 				sumVO.setMummInqireBbsId(resultVO.getMummInqireBbsId());
 			} else {
 				sumVO.setMummInqireBbsId("");
 			}
-            // 3-6. 최고게시자ID
-        	resultVO = (StatsVO)selectOne("BbsStatsDAO.selectBbsTopNtcepersonId", parVO);
-        	if (resultVO != null && resultVO.getTopNtcepersonId() != null) {
+			// 3-6. 최고게시자ID
+			resultVO = bbsStatsMapper.selectBbsTopNtcepersonId(parVO);
+			if (resultVO != null && resultVO.getTopNtcepersonId() != null) {
 				sumVO.setTopNtcepersonId(resultVO.getTopNtcepersonId());
 			} else {
 				sumVO.setTopNtcepersonId("");
 			}
 
-        	// 3-7. 집계 등록
-        	insert("BbsStatsDAO.summaryBbsStats", sumVO);
-    	}
-    }
+			// 3-7. 집계 등록
+			bbsStatsMapper.summaryBbsStats(sumVO);
+		}
+	}
 }

--- a/src/main/java/egovframework/com/sts/bst/service/impl/BbsStatsMapper.java
+++ b/src/main/java/egovframework/com/sts/bst/service/impl/BbsStatsMapper.java
@@ -1,0 +1,123 @@
+package egovframework.com.sts.bst.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.sts.com.StatsVO;
+
+/**
+ * 게시물 통계 Mapper 인터페이스
+ * @author 공통서비스 개발팀 박지욱
+ * @since 2009.03.19
+ * @version 1.0
+ * <pre>
+ * 개정이력(Modification Information)
+ *
+ *   수정일      수정자          수정내용
+ *  -------    --------    ---------------------------
+ *  2009.03.19  박지욱          최초 생성
+ *  2011.06.30  이기하          패키지 분리(sts -> sts.bst)
+ * </pre>
+ */
+@EgovMapper("bbsStatsMapper")
+public interface BbsStatsMapper {
+
+	/**
+	 * 게시물 생성글수 통계를 조회한다
+	 * @param vo StatsVO
+	 * @return List
+	 */
+	List<StatsVO> selectBbsCretCntStats(StatsVO vo);
+
+	/**
+	 * 게시물 총조회수 통계를 조회한다
+	 * @param vo StatsVO
+	 * @return List
+	 */
+	List<StatsVO> selectBbsTotCntStats(StatsVO vo);
+
+	/**
+	 * 게시물 평균조회수 통계를 조회한다
+	 * @param vo StatsVO
+	 * @return List
+	 */
+	List<StatsVO> selectBbsAvgCntStats(StatsVO vo);
+
+	/**
+	 * 최고조회 게시물 통계정보를 조회한다
+	 * @param vo StatsVO
+	 * @return List
+	 */
+	List<StatsVO> selectBbsMaxCntStats(StatsVO vo);
+
+	/**
+	 * 최소조회 게시물 통계정보를 조회한다
+	 * @param vo StatsVO
+	 * @return List
+	 */
+	List<StatsVO> selectBbsMinCntStats(StatsVO vo);
+
+	/**
+	 * 게시물 최고게시자 통계를 조회한다
+	 * @param vo StatsVO
+	 * @return List
+	 */
+	List<StatsVO> selectBbsMaxUserStats(StatsVO vo);
+
+	/**
+	 * 게시물 통계를 위한 집계 여부를 조회한다
+	 * @param vo StatsVO
+	 * @return StatsVO
+	 */
+	StatsVO selectBbsSummary(StatsVO vo);
+
+	/**
+	 * 게시판 생성글수를 조회한다
+	 * @param vo StatsVO
+	 * @return StatsVO
+	 */
+	StatsVO selectBbsCreatCo(StatsVO vo);
+
+	/**
+	 * 게시판 총조회수를 조회한다
+	 * @param vo StatsVO
+	 * @return StatsVO
+	 */
+	StatsVO selectBbsTotInqireCo(StatsVO vo);
+
+	/**
+	 * 게시판 평균조회수를 조회한다
+	 * @param vo StatsVO
+	 * @return StatsVO
+	 */
+	StatsVO selectBbsAvrgInqireCo(StatsVO vo);
+
+	/**
+	 * 최고조회 게시물ID를 조회한다
+	 * @param vo StatsVO
+	 * @return StatsVO
+	 */
+	StatsVO selectBbsMxmmInqireBbsId(StatsVO vo);
+
+	/**
+	 * 최소조회 게시물ID를 조회한다
+	 * @param vo StatsVO
+	 * @return StatsVO
+	 */
+	StatsVO selectBbsMummInqireBbsId(StatsVO vo);
+
+	/**
+	 * 최고게시자ID를 조회한다
+	 * @param vo StatsVO
+	 * @return StatsVO
+	 */
+	StatsVO selectBbsTopNtcepersonId(StatsVO vo);
+
+	/**
+	 * 게시물 통계 집계를 등록한다
+	 * @param vo StatsVO
+	 */
+	void summaryBbsStats(StatsVO vo);
+
+}

--- a/src/main/java/egovframework/com/sts/dst/service/impl/DtaUseStatsDAO.java
+++ b/src/main/java/egovframework/com/sts/dst/service/impl/DtaUseStatsDAO.java
@@ -1,7 +1,7 @@
 /**
  * 개요
  * - 자료이용현황 통계에 대한 DAO 클래스를 정의한다.
- * 
+ *
  * 상세내용
  * - 자료이용현황 통계에 대한 등록, 조회 기능을 제공한다.
  * - 자료이용현황 통계의 조회기능은 목록조회, 상세조회로 구분된다.
@@ -14,14 +14,18 @@ package egovframework.com.sts.dst.service.impl;
 
 import java.util.List;
 
+import jakarta.annotation.Resource;
+
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.sts.dst.service.DtaUseStats;
 import egovframework.com.sts.dst.service.DtaUseStatsVO;
 
 @Repository("dtaUseStatsDAO")
-public class DtaUseStatsDAO extends EgovComAbstractDAO {
+public class DtaUseStatsDAO {
+
+	@Resource(name = "dtaUseStatsMapper")
+	private DtaUseStatsMapper dtaUseStatsMapper;
 
 	/**
 	 * 자료이용현황 통계정보의 대상목록을 조회한다.
@@ -29,7 +33,7 @@ public class DtaUseStatsDAO extends EgovComAbstractDAO {
 	 * @return List - 자료이용현황 목록
 	 */
 	public List<DtaUseStatsVO> selectDtaUseStatsList(DtaUseStatsVO dtaUseStatsVO) throws Exception {
-		return selectList("dtaUseStatsDAO.selectDtaUseStatsList", dtaUseStatsVO);
+		return dtaUseStatsMapper.selectDtaUseStatsList(dtaUseStatsVO);
 	}
 
 	/**
@@ -38,25 +42,25 @@ public class DtaUseStatsDAO extends EgovComAbstractDAO {
 	 * @return int
 	 */
 	public int selectDtaUseStatsListTotCnt(DtaUseStatsVO dtaUseStatsVO) throws Exception {
-		return (Integer)selectOne("dtaUseStatsDAO.selectDtaUseStatsListTotCnt", dtaUseStatsVO);
-	}	
-		
+		return dtaUseStatsMapper.selectDtaUseStatsListTotCnt(dtaUseStatsVO);
+	}
+
 	/**
 	 * 자료이용현황 통계정보의 전체 카운트를 조회한다.
 	 * @param dtaUseStatsVO - 자료이용현황 VO
 	 * @return int
 	 */
 	public int selectDtaUseStatsListBarTotCnt(DtaUseStatsVO dtaUseStatsVO) throws Exception {
-		return (Integer)selectOne("dtaUseStatsDAO.selectDtaUseStatsListBarTotCnt", dtaUseStatsVO);
-	}		
-	
+		return dtaUseStatsMapper.selectDtaUseStatsListBarTotCnt(dtaUseStatsVO);
+	}
+
 	/**
 	 * 자료이용현황 통계의 상세정보를 조회한다.
 	 * @param dtaUseStatsVO - 자료이용현황 VO
 	 * @return reprtStatsVO - 자료이용현황 VO
 	 */
 	public List<DtaUseStatsVO> selectDtaUseStats(DtaUseStatsVO dtaUseStatsVO) throws Exception {
-		return selectList("dtaUseStatsDAO.selectDtaUseStats", dtaUseStatsVO);
+		return dtaUseStatsMapper.selectDtaUseStats(dtaUseStatsVO);
 	}
 
 	/**
@@ -65,26 +69,25 @@ public class DtaUseStatsDAO extends EgovComAbstractDAO {
 	 * @return int
 	 */
 	public int selectDtaUseStatsTotCnt(DtaUseStatsVO dtaUseStatsVO) throws Exception {
-		return (Integer)selectOne("dtaUseStatsDAO.selectDtaUseStatsTotCnt", dtaUseStatsVO);
-	}	
-	
-    /**
+		return dtaUseStatsMapper.selectDtaUseStatsTotCnt(dtaUseStatsVO);
+	}
+
+	/**
 	 * 자료이용현황 정보를 등록을 위한 다운로드 첨부화일 정보를 조회한다.
 	 * @param dtaUseStats DtaUseStats
 	 * @return DtaUseStats
 	 * @exception Exception
 	 */
-    public DtaUseStats selectInsertDtaUseStats(DtaUseStats dtaUseStats) throws Exception {
-        return (DtaUseStats) selectOne("dtaUseStatsDAO.selectInsertDtaUseStats", dtaUseStats);
-    }	
-	
+	public DtaUseStats selectInsertDtaUseStats(DtaUseStats dtaUseStats) throws Exception {
+		return dtaUseStatsMapper.selectInsertDtaUseStats(dtaUseStats);
+	}
+
 	/**
 	 * 자료이용현황 정보를 등록한다.
 	 * @param dtaUseStats - 자료이용현황 model
 	 */
 	public void insertDtaUseStats(DtaUseStats dtaUseStats) throws Exception {
-
-		insert("dtaUseStatsDAO.insertDtaUseStats", dtaUseStats);
+		dtaUseStatsMapper.insertDtaUseStats(dtaUseStats);
 	}
 
 	/**
@@ -93,6 +96,6 @@ public class DtaUseStatsDAO extends EgovComAbstractDAO {
 	 * @return List - 등록일자별 자료이용현황 목록
 	 */
 	public List<DtaUseStatsVO> selectDtaUseStatsBarList(DtaUseStatsVO dtaUseStatsVO) throws Exception {
-		return selectList("dtaUseStatsDAO.selectDtaUseStatsBarList", dtaUseStatsVO);
+		return dtaUseStatsMapper.selectDtaUseStatsBarList(dtaUseStatsVO);
 	}
 }

--- a/src/main/java/egovframework/com/sts/dst/service/impl/DtaUseStatsMapper.java
+++ b/src/main/java/egovframework/com/sts/dst/service/impl/DtaUseStatsMapper.java
@@ -1,0 +1,81 @@
+package egovframework.com.sts.dst.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.sts.dst.service.DtaUseStats;
+import egovframework.com.sts.dst.service.DtaUseStatsVO;
+
+/**
+ * 자료이용현황 통계에 대한 Mapper 인터페이스
+ * @author lee.m.j
+ * @version 1.0
+ * @since 2009.09.08
+ * <pre>
+ * 개정이력(Modification Information)
+ *
+ *   수정일      수정자          수정내용
+ *  -------    --------    ---------------------------
+ *  2009.09.08  lee.m.j          최초 생성
+ * </pre>
+ */
+@EgovMapper("dtaUseStatsMapper")
+public interface DtaUseStatsMapper {
+
+	/**
+	 * 자료이용현황 통계정보의 대상목록을 조회한다.
+	 * @param dtaUseStatsVO 자료이용현황 VO
+	 * @return List 자료이용현황 목록
+	 */
+	List<DtaUseStatsVO> selectDtaUseStatsList(DtaUseStatsVO dtaUseStatsVO);
+
+	/**
+	 * 자료이용현황 통계정보의 대상목록 카운트를 조회한다.
+	 * @param dtaUseStatsVO 자료이용현황 VO
+	 * @return int
+	 */
+	int selectDtaUseStatsListTotCnt(DtaUseStatsVO dtaUseStatsVO);
+
+	/**
+	 * 자료이용현황 통계정보의 전체 카운트를 조회한다.
+	 * @param dtaUseStatsVO 자료이용현황 VO
+	 * @return int
+	 */
+	int selectDtaUseStatsListBarTotCnt(DtaUseStatsVO dtaUseStatsVO);
+
+	/**
+	 * 자료이용현황 통계의 상세정보를 조회한다.
+	 * @param dtaUseStatsVO 자료이용현황 VO
+	 * @return List 자료이용현황 상세 목록
+	 */
+	List<DtaUseStatsVO> selectDtaUseStats(DtaUseStatsVO dtaUseStatsVO);
+
+	/**
+	 * 자료이용현황 통계정보의 상세정보목록 카운트를 조회한다.
+	 * @param dtaUseStatsVO 자료이용현황 VO
+	 * @return int
+	 */
+	int selectDtaUseStatsTotCnt(DtaUseStatsVO dtaUseStatsVO);
+
+	/**
+	 * 자료이용현황 정보를 등록을 위한 다운로드 첨부화일 정보를 조회한다.
+	 * @param dtaUseStats DtaUseStats
+	 * @return DtaUseStats
+	 */
+	DtaUseStats selectInsertDtaUseStats(DtaUseStats dtaUseStats);
+
+	/**
+	 * 자료이용현황 정보를 등록한다.
+	 * @param dtaUseStats 자료이용현황 model
+	 */
+	void insertDtaUseStats(DtaUseStats dtaUseStats);
+
+	/**
+	 * 등록일자별 통계정보를 그래프로 표현한다.
+	 * @param dtaUseStatsVO 자료이용현황 VO
+	 * @return List 등록일자별 자료이용현황 목록
+	 */
+	List<DtaUseStatsVO> selectDtaUseStatsBarList(DtaUseStatsVO dtaUseStatsVO);
+
+}

--- a/src/main/java/egovframework/com/sts/rst/service/impl/ReprtStatsDAO.java
+++ b/src/main/java/egovframework/com/sts/rst/service/impl/ReprtStatsDAO.java
@@ -1,7 +1,7 @@
 /**
  * 개요
  * - 보고서통계에 대한 DAO 클래스를 정의한다.
- * 
+ *
  * 상세내용
  * - 보고서통계에 대한 등록, 조회 기능을 제공한다.
  * - 보고서통계의 조회기능은 목록조회, 상세조회로 구분된다.
@@ -13,7 +13,7 @@
  *
  *   수정일      수정자          수정내용
  *  -------    --------    ---------------------------
- *  2009.8.3   lee.m.j          최초 생성 *  
+ *  2009.8.3   lee.m.j          최초 생성 *
  *  2011.8.26	정진오			IncludedInfo annotation 추가
  *
  *  </pre>
@@ -23,14 +23,18 @@ package egovframework.com.sts.rst.service.impl;
 
 import java.util.List;
 
+import jakarta.annotation.Resource;
+
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.sts.rst.service.ReprtStats;
 import egovframework.com.sts.rst.service.ReprtStatsVO;
 
 @Repository("reprtStatsDAO")
-public class ReprtStatsDAO extends EgovComAbstractDAO {
+public class ReprtStatsDAO {
+
+	@Resource(name = "reprtStatsMapper")
+	private ReprtStatsMapper reprtStatsMapper;
 
 	/**
 	 * 보고서 통계정보의 대상목록을 조회한다.
@@ -38,34 +42,34 @@ public class ReprtStatsDAO extends EgovComAbstractDAO {
 	 * @return List - 보고서통계 목록
 	 */
 	public List<ReprtStatsVO> selectReprtStatsList(ReprtStatsVO reprtStatsVO) throws Exception {
-		return selectList("reprtStatsDAO.selectReprtStatsList", reprtStatsVO);
+		return reprtStatsMapper.selectReprtStatsList(reprtStatsVO);
 	}
 
-    /**
+	/**
 	 * 보고서통계목록 페이징 총 개수를 조회한다.
 	 * @param reprtStatsVO - 보고서통계 VO
 	 * @return int
 	 */
-    public int selectReprtStatsListTotCnt(ReprtStatsVO reprtStatsVO) throws Exception {
-        return (Integer)selectOne("reprtStatsDAO.selectReprtStatsListTotCnt", reprtStatsVO);
-    }
-    
-    /**
+	public int selectReprtStatsListTotCnt(ReprtStatsVO reprtStatsVO) throws Exception {
+		return reprtStatsMapper.selectReprtStatsListTotCnt(reprtStatsVO);
+	}
+
+	/**
 	 * 보고서통계목록 총 개수를 조회한다.
 	 * @param reprtStatsVO - 보고서통계 VO
 	 * @return int
 	 */
-    public int selectReprtStatsListBarTotCnt(ReprtStatsVO reprtStatsVO) throws Exception {
-        return (Integer)selectOne("reprtStatsDAO.selectReprtStatsListBarTotCnt", reprtStatsVO);
-    }    
-    
+	public int selectReprtStatsListBarTotCnt(ReprtStatsVO reprtStatsVO) throws Exception {
+		return reprtStatsMapper.selectReprtStatsListBarTotCnt(reprtStatsVO);
+	}
+
 	/**
 	 * 보고서 통계정보의 상세정보를 조회한다.
 	 * @param reprtStatsVO - 보고서통계 VO
 	 * @return ReprtStatsVO - 보고서통계 VO
 	 */
 	public List<ReprtStatsVO> selectReprtStats(ReprtStatsVO reprtStatsVO) throws Exception {
-		return selectList("reprtStatsDAO.selectReprtStats", reprtStatsVO);
+		return reprtStatsMapper.selectReprtStats(reprtStatsVO);
 	}
 
 	/**
@@ -73,7 +77,7 @@ public class ReprtStatsDAO extends EgovComAbstractDAO {
 	 * @param reprtStats - 보고서통계 model
 	 */
 	public void insertReprtStats(ReprtStats reprtStats) throws Exception {
-		insert("reprtStatsDAO.insertReprtStats", reprtStats);
+		reprtStatsMapper.insertReprtStats(reprtStats);
 	}
 
 	/**
@@ -82,8 +86,8 @@ public class ReprtStatsDAO extends EgovComAbstractDAO {
 	 * @return List - 보고서통계 목록
 	 */
 	public List<ReprtStatsVO> selectReprtStatsBarList(ReprtStatsVO reprtStatsVO) throws Exception {
-		return selectList("reprtStatsDAO.selectReprtStatsBarList", reprtStatsVO);
-	}	
+		return reprtStatsMapper.selectReprtStatsBarList(reprtStatsVO);
+	}
 
 	/**
 	 * 보고서유형별 통계정보를 그래프로 표현한다.
@@ -91,15 +95,15 @@ public class ReprtStatsDAO extends EgovComAbstractDAO {
 	 * @return List - 보고서통계 목록
 	 */
 	public List<ReprtStatsVO> selectReprtStatsByReprtTyList(ReprtStatsVO reprtStatsVO) throws Exception {
-		return selectList("reprtStatsDAO.selectReprtStatsByReprtTyList", reprtStatsVO);
-	}	
-	
+		return reprtStatsMapper.selectReprtStatsByReprtTyList(reprtStatsVO);
+	}
+
 	/**
 	 * 진행상태별 통계정보를 그래프로 표현한다.
 	 * @param reprtStatsVO - 보고서통계 VO
 	 * @return List - 보고서통계 목록
 	 */
 	public List<ReprtStatsVO> selectReprtStatsByReprtSttusList(ReprtStatsVO reprtStatsVO) throws Exception {
-		return selectList("reprtStatsDAO.selectReprtStatsByReprtSttusList", reprtStatsVO);
-	}		
+		return reprtStatsMapper.selectReprtStatsByReprtSttusList(reprtStatsVO);
+	}
 }

--- a/src/main/java/egovframework/com/sts/rst/service/impl/ReprtStatsMapper.java
+++ b/src/main/java/egovframework/com/sts/rst/service/impl/ReprtStatsMapper.java
@@ -1,0 +1,81 @@
+package egovframework.com.sts.rst.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.sts.rst.service.ReprtStats;
+import egovframework.com.sts.rst.service.ReprtStatsVO;
+
+/**
+ * 보고서통계에 대한 Mapper 인터페이스
+ * @author lee.m.j
+ * @version 1.0
+ * @since 2009.08.03
+ * <pre>
+ * 개정이력(Modification Information)
+ *
+ *   수정일      수정자          수정내용
+ *  -------    --------    ---------------------------
+ *  2009.08.03  lee.m.j          최초 생성
+ * </pre>
+ */
+@EgovMapper("reprtStatsMapper")
+public interface ReprtStatsMapper {
+
+	/**
+	 * 보고서 통계정보의 대상목록을 조회한다.
+	 * @param reprtStatsVO 보고서통계 VO
+	 * @return List 보고서통계 목록
+	 */
+	List<ReprtStatsVO> selectReprtStatsList(ReprtStatsVO reprtStatsVO);
+
+	/**
+	 * 보고서통계목록 페이징 총 개수를 조회한다.
+	 * @param reprtStatsVO 보고서통계 VO
+	 * @return int
+	 */
+	int selectReprtStatsListTotCnt(ReprtStatsVO reprtStatsVO);
+
+	/**
+	 * 보고서통계목록 총 개수를 조회한다.
+	 * @param reprtStatsVO 보고서통계 VO
+	 * @return int
+	 */
+	int selectReprtStatsListBarTotCnt(ReprtStatsVO reprtStatsVO);
+
+	/**
+	 * 보고서 통계정보의 상세정보를 조회한다.
+	 * @param reprtStatsVO 보고서통계 VO
+	 * @return List 보고서통계 목록
+	 */
+	List<ReprtStatsVO> selectReprtStats(ReprtStatsVO reprtStatsVO);
+
+	/**
+	 * 보고서 통계정보를 생성한 뒤 저장한다.
+	 * @param reprtStats 보고서통계 model
+	 */
+	void insertReprtStats(ReprtStats reprtStats);
+
+	/**
+	 * 등록일자별 통계정보를 그래프로 표현한다.
+	 * @param reprtStatsVO 보고서통계 VO
+	 * @return List 보고서통계 목록
+	 */
+	List<ReprtStatsVO> selectReprtStatsBarList(ReprtStatsVO reprtStatsVO);
+
+	/**
+	 * 보고서유형별 통계정보를 그래프로 표현한다.
+	 * @param reprtStatsVO 보고서통계 VO
+	 * @return List 보고서통계 목록
+	 */
+	List<ReprtStatsVO> selectReprtStatsByReprtTyList(ReprtStatsVO reprtStatsVO);
+
+	/**
+	 * 진행상태별 통계정보를 그래프로 표현한다.
+	 * @param reprtStatsVO 보고서통계 VO
+	 * @return List 보고서통계 목록
+	 */
+	List<ReprtStatsVO> selectReprtStatsByReprtSttusList(ReprtStatsVO reprtStatsVO);
+
+}

--- a/src/main/resources/egovframework/mapper/com/sts/bst/EgovBbsStats_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/sts/bst/EgovBbsStats_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BbsStatsDAO">
+<mapper namespace="egovframework.com.sts.bst.service.impl.BbsStatsMapper">
 	
 	<!-- 게시물 생성글수 조회 -->
 	<select id="selectBbsCretCntStats" parameterType="egovframework.com.sts.com.StatsVO" resultType="egovframework.com.sts.com.StatsVO">

--- a/src/main/resources/egovframework/mapper/com/sts/bst/EgovBbsStats_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/sts/bst/EgovBbsStats_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BbsStatsDAO">
+<mapper namespace="egovframework.com.sts.bst.service.impl.BbsStatsMapper">
 	
 	<!-- 게시물 생성글수 조회 -->
 	<select id="selectBbsCretCntStats" parameterType="egovframework.com.sts.com.StatsVO" resultType="egovframework.com.sts.com.StatsVO">

--- a/src/main/resources/egovframework/mapper/com/sts/bst/EgovBbsStats_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/sts/bst/EgovBbsStats_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BbsStatsDAO">
+<mapper namespace="egovframework.com.sts.bst.service.impl.BbsStatsMapper">
 	
 	<!-- 게시물 생성글수 조회 -->
 	<select id="selectBbsCretCntStats" parameterType="egovframework.com.sts.com.StatsVO" resultType="egovframework.com.sts.com.StatsVO">

--- a/src/main/resources/egovframework/mapper/com/sts/bst/EgovBbsStats_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/sts/bst/EgovBbsStats_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BbsStatsDAO">
+<mapper namespace="egovframework.com.sts.bst.service.impl.BbsStatsMapper">
 
 	<!-- 게시물 생성글수 조회 -->
 	<select id="selectBbsCretCntStats" parameterType="egovframework.com.sts.com.StatsVO" resultType="egovframework.com.sts.com.StatsVO">

--- a/src/main/resources/egovframework/mapper/com/sts/bst/EgovBbsStats_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/sts/bst/EgovBbsStats_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BbsStatsDAO">
+<mapper namespace="egovframework.com.sts.bst.service.impl.BbsStatsMapper">
 
 	<!-- 게시물 생성글수 조회 -->
 	<select id="selectBbsCretCntStats" parameterType="egovframework.com.sts.com.StatsVO" resultType="egovframework.com.sts.com.StatsVO">

--- a/src/main/resources/egovframework/mapper/com/sts/bst/EgovBbsStats_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/sts/bst/EgovBbsStats_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BbsStatsDAO">
+<mapper namespace="egovframework.com.sts.bst.service.impl.BbsStatsMapper">
 	
 	<!-- 게시물 생성글수 조회 -->
 	<select id="selectBbsCretCntStats" parameterType="egovframework.com.sts.com.StatsVO" resultType="egovframework.com.sts.com.StatsVO">

--- a/src/main/resources/egovframework/mapper/com/sts/bst/EgovBbsStats_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/sts/bst/EgovBbsStats_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BbsStatsDAO">
+<mapper namespace="egovframework.com.sts.bst.service.impl.BbsStatsMapper">
 
 	<!-- 게시물 생성글수 조회 -->
 	<select id="selectBbsCretCntStats" parameterType="egovframework.com.sts.com.StatsVO" resultType="egovframework.com.sts.com.StatsVO">

--- a/src/main/resources/egovframework/mapper/com/sts/bst/EgovBbsStats_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/sts/bst/EgovBbsStats_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BbsStatsDAO">
+<mapper namespace="egovframework.com.sts.bst.service.impl.BbsStatsMapper">
 	
 	<!-- 게시물 생성글수 조회 -->
 	<select id="selectBbsCretCntStats" parameterType="egovframework.com.sts.com.StatsVO" resultType="egovframework.com.sts.com.StatsVO">

--- a/src/main/resources/egovframework/mapper/com/sts/dst/EgovDtaUseStats_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/sts/dst/EgovDtaUseStats_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="dtaUseStatsDAO">
+<mapper namespace="egovframework.com.sts.dst.service.impl.DtaUseStatsMapper">
 
     <resultMap id="dtaUseStatsList" type="egovframework.com.sts.dst.service.DtaUseStatsVO">
         <result property="bbsId" column="BBS_ID"/>

--- a/src/main/resources/egovframework/mapper/com/sts/dst/EgovDtaUseStats_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/sts/dst/EgovDtaUseStats_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="dtaUseStatsDAO">
+<mapper namespace="egovframework.com.sts.dst.service.impl.DtaUseStatsMapper">
 
     <resultMap id="dtaUseStatsList" type="egovframework.com.sts.dst.service.DtaUseStatsVO">
         <result property="bbsId" column="BBS_ID"/>

--- a/src/main/resources/egovframework/mapper/com/sts/dst/EgovDtaUseStats_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/sts/dst/EgovDtaUseStats_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="dtaUseStatsDAO">
+<mapper namespace="egovframework.com.sts.dst.service.impl.DtaUseStatsMapper">
 
     <resultMap id="dtaUseStatsList" type="egovframework.com.sts.dst.service.DtaUseStatsVO">
         <result property="bbsId" column="BBS_ID"/>

--- a/src/main/resources/egovframework/mapper/com/sts/dst/EgovDtaUseStats_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/sts/dst/EgovDtaUseStats_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="dtaUseStatsDAO">
+<mapper namespace="egovframework.com.sts.dst.service.impl.DtaUseStatsMapper">
 
     <resultMap id="dtaUseStatsList" type="egovframework.com.sts.dst.service.DtaUseStatsVO">
         <result property="bbsId" column="BBS_ID"/>

--- a/src/main/resources/egovframework/mapper/com/sts/dst/EgovDtaUseStats_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/sts/dst/EgovDtaUseStats_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="dtaUseStatsDAO">
+<mapper namespace="egovframework.com.sts.dst.service.impl.DtaUseStatsMapper">
 
     <resultMap id="dtaUseStatsList" type="egovframework.com.sts.dst.service.DtaUseStatsVO">
         <result property="bbsId" column="BBS_ID"/>

--- a/src/main/resources/egovframework/mapper/com/sts/dst/EgovDtaUseStats_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/sts/dst/EgovDtaUseStats_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="dtaUseStatsDAO">
+<mapper namespace="egovframework.com.sts.dst.service.impl.DtaUseStatsMapper">
 
     <resultMap id="dtaUseStatsList" type="egovframework.com.sts.dst.service.DtaUseStatsVO">
         <result property="bbsId" column="BBS_ID"/>

--- a/src/main/resources/egovframework/mapper/com/sts/dst/EgovDtaUseStats_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/sts/dst/EgovDtaUseStats_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="dtaUseStatsDAO">
+<mapper namespace="egovframework.com.sts.dst.service.impl.DtaUseStatsMapper">
 
     <resultMap id="dtaUseStatsList" type="egovframework.com.sts.dst.service.DtaUseStatsVO">
         <result property="bbsId" column="BBS_ID"/>

--- a/src/main/resources/egovframework/mapper/com/sts/dst/EgovDtaUseStats_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/sts/dst/EgovDtaUseStats_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="dtaUseStatsDAO">
+<mapper namespace="egovframework.com.sts.dst.service.impl.DtaUseStatsMapper">
 
     <resultMap id="dtaUseStatsList" type="egovframework.com.sts.dst.service.DtaUseStatsVO">
         <result property="bbsId" column="BBS_ID"/>

--- a/src/main/resources/egovframework/mapper/com/sts/rst/EgovReprtStats_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/sts/rst/EgovReprtStats_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="reprtStatsDAO">
+<mapper namespace="egovframework.com.sts.rst.service.impl.ReprtStatsMapper">
 
     <resultMap id="reprtStatsList" type="egovframework.com.sts.rst.service.ReprtStatsVO">
         <result property="reprtTy" column="REPRT_TY"/>

--- a/src/main/resources/egovframework/mapper/com/sts/rst/EgovReprtStats_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/sts/rst/EgovReprtStats_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="reprtStatsDAO">
+<mapper namespace="egovframework.com.sts.rst.service.impl.ReprtStatsMapper">
 
    
     <resultMap id="reprtStatsList" type="egovframework.com.sts.rst.service.ReprtStatsVO">

--- a/src/main/resources/egovframework/mapper/com/sts/rst/EgovReprtStats_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/sts/rst/EgovReprtStats_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="reprtStatsDAO">
+<mapper namespace="egovframework.com.sts.rst.service.impl.ReprtStatsMapper">
 
     <resultMap id="reprtStatsList" type="egovframework.com.sts.rst.service.ReprtStatsVO">
         <result property="reprtTy" column="REPRT_TY"/>

--- a/src/main/resources/egovframework/mapper/com/sts/rst/EgovReprtStats_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/sts/rst/EgovReprtStats_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="reprtStatsDAO">
+<mapper namespace="egovframework.com.sts.rst.service.impl.ReprtStatsMapper">
 
     <resultMap id="reprtStatsList" type="egovframework.com.sts.rst.service.ReprtStatsVO">
         <result property="reprtTy" column="REPRT_TY"/>

--- a/src/main/resources/egovframework/mapper/com/sts/rst/EgovReprtStats_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/sts/rst/EgovReprtStats_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="reprtStatsDAO">
+<mapper namespace="egovframework.com.sts.rst.service.impl.ReprtStatsMapper">
 
     <resultMap id="reprtStatsList" type="egovframework.com.sts.rst.service.ReprtStatsVO">
         <result property="reprtTy" column="REPRT_TY"/>

--- a/src/main/resources/egovframework/mapper/com/sts/rst/EgovReprtStats_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/sts/rst/EgovReprtStats_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="reprtStatsDAO">
+<mapper namespace="egovframework.com.sts.rst.service.impl.ReprtStatsMapper">
 
     <resultMap id="reprtStatsList" type="egovframework.com.sts.rst.service.ReprtStatsVO">
         <result property="reprtTy" column="REPRT_TY"/>

--- a/src/main/resources/egovframework/mapper/com/sts/rst/EgovReprtStats_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/sts/rst/EgovReprtStats_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="reprtStatsDAO">
+<mapper namespace="egovframework.com.sts.rst.service.impl.ReprtStatsMapper">
 
     <resultMap id="reprtStatsList" type="egovframework.com.sts.rst.service.ReprtStatsVO">
         <result property="reprtTy" column="REPRT_TY"/>

--- a/src/main/resources/egovframework/mapper/com/sts/rst/EgovReprtStats_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/sts/rst/EgovReprtStats_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="reprtStatsDAO">
+<mapper namespace="egovframework.com.sts.rst.service.impl.ReprtStatsMapper">
 
     <resultMap id="reprtStatsList" type="egovframework.com.sts.rst.service.ReprtStatsVO">
         <result property="reprtTy" column="REPRT_TY"/>

--- a/src/main/resources/egovframework/spring/com/context-mapper.xml
+++ b/src/main/resources/egovframework/spring/com/context-mapper.xml
@@ -21,5 +21,12 @@
 	<bean id="egov.sqlSessionTemplate" class="org.mybatis.spring.SqlSessionTemplate">
 		<constructor-arg ref="egov.sqlSession"/>
 	</bean>
-	
+
+	<!-- @EgovMapper 인터페이스 자동 스캔 -->
+	<bean class="org.mybatis.spring.mapper.MapperScannerConfigurer">
+		<property name="basePackage" value="egovframework.com"/>
+		<property name="annotationClass" value="org.egovframe.rte.psl.dataaccess.mapper.EgovMapper"/>
+		<property name="sqlSessionFactoryBeanName" value="egov.sqlSession"/>
+	</bean>
+
 </beans>


### PR DESCRIPTION
## 변경 사유
기존 XML namespace 기반 DAO를 5.0 신규 @EgovMapper 인터페이스 방식으로 전환 (#832 sts/cst·sst·ust 후속)

## 변경 내용
- ReprtStatsMapper, DtaUseStatsMapper, BbsStatsMapper 인터페이스 신규 추가
- sts/rst·sts/dst·sts/bst 3개 DAO를 mapper 위임 구조로 리팩토링
- XML namespace를 mapper FQN으로 변경
- context-mapper.xml에 MapperScannerConfigurer 추가

## 영향 범위
- sts 통계 3개 서브 모듈 (rst, dst, bst)
- DAO bean name 유지

## 체크리스트
- [x] 단일 주제만 다룸
- [x] 기존 동작 호환
- [x] 5.x 다른 브랜치용 PR이 필요한 경우 후속 PR 링크 명시
- [x] 의존성 추가가 필요한 경우 선행 PR 링크 명시
