### PR TITLE
[refactor][5.0.x][공통컴포넌트] sym/log/lgm SysLogDAO @EgovMapper 인터페이스 방식으로 전환

### DIFF
--- a/src/main/java/egovframework/com/sym/log/lgm/service/impl/SysLogDAO.java
+++ b/src/main/java/egovframework/com/sym/log/lgm/service/impl/SysLogDAO.java
@@ -4,8 +4,8 @@ import java.util.List;
 
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.sym.log.lgm.service.SysLog;
+import jakarta.annotation.Resource;
 
 /**
 * @Class Name : SysLogDAO.java
@@ -16,6 +16,7 @@ import egovframework.com.sym.log.lgm.service.SysLog;
 *    -------        -------     -------------------
 *    2009. 3. 11.   이삼섭         최초생성
 *    2011. 7. 01.   이기하         패키지 분리(sym.log -> sym.log.lgm)
+*    2026. 5. 28.   dasomel        SysLogMapper 위임으로 전환
 *
 * @author 공통 서비스 개발팀 이삼섭
 * @since 2009. 3. 11.
@@ -24,52 +25,46 @@ import egovframework.com.sym.log.lgm.service.SysLog;
 *
 */
 @Repository("SysLogDAO")
-public class SysLogDAO extends EgovComAbstractDAO{
+public class SysLogDAO {
+
+	@Resource(name = "sysLogMapper")
+	private SysLogMapper sysLogMapper;
 
 	/**
 	 * 시스템 로그정보를 생성한다.
 	 *
-	 * @param SysLog
-	 * @return
-	 * @throws Exception
+	 * @param sysLog
 	 */
 	public void logInsertSysLog(SysLog sysLog) {
-		insert("SysLog.logInsertSysLog", sysLog);
-		
+		sysLogMapper.logInsertSysLog(sysLog);
 	}
 
 	/**
 	 * 시스템 로그정보를 요약한다.
-	 *
-	 * @param
-	 * @return
-	 * @throws Exception
 	 */
 	public void logInsertSysLogSummary() {
-		insert("SysLog.logInsertSysLogSummary", null);
-		delete("SysLog.logDeleteSysLogSummary", null);
-		
+		sysLogMapper.logInsertSysLogSummary();
+		sysLogMapper.logDeleteSysLogSummary();
 	}
 
 	/**
 	 * 시스템 로그목록을 조회한다.
 	 *
 	 * @param sysLog
-	 * @return sysLog
-	 * @throws Exception
+	 * @return sysLog 목록
 	 */
 	public List<SysLog> selectSysLogInf(SysLog sysLog) {
-		return selectList("SysLog.selectSysLogInf", sysLog);
+		return sysLogMapper.selectSysLogInf(sysLog);
 	}
 
 	/**
 	 * 시스템 로그정보 목록의 숫자를 조회한다.
+	 *
 	 * @param sysLog
-	 * @return
-	 * @throws Exception
+	 * @return 건수
 	 */
 	public int selectSysLogInfCnt(SysLog sysLog) {
-		return (Integer)selectOne("SysLog.selectSysLogInfCnt", sysLog);
+		return sysLogMapper.selectSysLogInfCnt(sysLog);
 	}
 
 	/**
@@ -77,9 +72,8 @@ public class SysLogDAO extends EgovComAbstractDAO{
 	 *
 	 * @param sysLog
 	 * @return sysLog
-	 * @throws Exception
 	 */
 	public SysLog selectSysLog(SysLog sysLog) {
-		return (SysLog) selectOne("SysLog.selectSysLog", sysLog);
+		return sysLogMapper.selectSysLog(sysLog);
 	}
 }

--- a/src/main/java/egovframework/com/sym/log/lgm/service/impl/SysLogMapper.java
+++ b/src/main/java/egovframework/com/sym/log/lgm/service/impl/SysLogMapper.java
@@ -1,0 +1,71 @@
+package egovframework.com.sym.log.lgm.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.sym.log.lgm.service.SysLog;
+
+/**
+ * 로그관리(시스템)를 위한 Mapper 인터페이스
+ *
+ * @author 공통 서비스 개발팀 이삼섭
+ * @since 2009. 3. 11.
+ * @version
+ * @see
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *    수정일         수정자         수정내용
+ *    -------        -------     -------------------
+ *    2009. 3. 11.   이삼섭         최초생성
+ *    2011. 7. 01.   이기하         패키지 분리(sym.log -> sym.log.lgm)
+ *    2026. 5. 28.   dasomel        XML 기반 DAO → @EgovMapper 인터페이스로 전환
+ * </pre>
+ */
+@EgovMapper("SysLogDAO")
+public interface SysLogMapper {
+
+	/**
+	 * 시스템 로그정보를 생성한다.
+	 *
+	 * @param sysLog
+	 */
+	void logInsertSysLog(SysLog sysLog);
+
+	/**
+	 * 시스템 로그 전날 요약 정보를 등록한다.
+	 */
+	void logInsertSysLogSummary();
+
+	/**
+	 * 시스템 로그 6개월 이전 로그를 삭제한다.
+	 */
+	void logDeleteSysLogSummary();
+
+	/**
+	 * 시스템 로그목록을 조회한다.
+	 *
+	 * @param sysLog
+	 * @return sysLog 목록
+	 */
+	List<SysLog> selectSysLogInf(SysLog sysLog);
+
+	/**
+	 * 시스템 로그정보 목록의 숫자를 조회한다.
+	 *
+	 * @param sysLog
+	 * @return 건수
+	 */
+	int selectSysLogInfCnt(SysLog sysLog);
+
+	/**
+	 * 시스템 로그 상세정보를 조회한다.
+	 *
+	 * @param sysLog
+	 * @return sysLog
+	 */
+	SysLog selectSysLog(SysLog sysLog);
+
+}

--- a/src/main/resources/egovframework/mapper/com/sym/log/lgm/EgovSysLog_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/log/lgm/EgovSysLog_SQL_altibase.xml
@@ -7,7 +7,7 @@
 --><!--Converted at: Wed May 11 15:50:41 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="SysLog">
+<mapper namespace="egovframework.com.sym.log.lgm.service.impl.SysLogMapper">
 
 	<!-- 시스템로그 맵 -->
 	<resultMap id="SysLogVO" type="egovframework.com.sym.log.lgm.service.SysLog">

--- a/src/main/resources/egovframework/mapper/com/sym/log/lgm/EgovSysLog_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/log/lgm/EgovSysLog_SQL_cubrid.xml
@@ -6,7 +6,7 @@
 --><!--Converted at: Wed May 11 15:50:41 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="SysLog">
+<mapper namespace="egovframework.com.sym.log.lgm.service.impl.SysLogMapper">
 
 	<!-- 시스템로그 맵 -->
 	<resultMap id="SysLogVO" type="egovframework.com.sym.log.lgm.service.SysLog">

--- a/src/main/resources/egovframework/mapper/com/sym/log/lgm/EgovSysLog_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/log/lgm/EgovSysLog_SQL_goldilocks.xml
@@ -7,7 +7,7 @@
 --><!--Converted at: Wed May 11 15:50:41 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="SysLog">
+<mapper namespace="egovframework.com.sym.log.lgm.service.impl.SysLogMapper">
 
 	<!-- 시스템로그 맵 -->
 	<resultMap id="SysLogVO" type="egovframework.com.sym.log.lgm.service.SysLog">

--- a/src/main/resources/egovframework/mapper/com/sym/log/lgm/EgovSysLog_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/log/lgm/EgovSysLog_SQL_maria.xml
@@ -5,7 +5,7 @@
   -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="SysLog">
+<mapper namespace="egovframework.com.sym.log.lgm.service.impl.SysLogMapper">
 
 	<!-- 시스템로그 맵 -->
 	<resultMap id="SysLogVO" type="egovframework.com.sym.log.lgm.service.SysLog">
@@ -163,7 +163,7 @@
 	
 
 <!--  	시스템 로그 6개월전 로그 삭제 -->
-	<delete id="SysLog.logDeleteSysLogSummary">
+	<delete id="logDeleteSysLogSummary">
 	<![CDATA[ 
 		
 			DELETE FROM COMTNSYSLOG

--- a/src/main/resources/egovframework/mapper/com/sym/log/lgm/EgovSysLog_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/log/lgm/EgovSysLog_SQL_mysql.xml
@@ -5,7 +5,7 @@
   -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="SysLog">
+<mapper namespace="egovframework.com.sym.log.lgm.service.impl.SysLogMapper">
 
 	<!-- 시스템로그 맵 -->
 	<resultMap id="SysLogVO" type="egovframework.com.sym.log.lgm.service.SysLog">
@@ -163,7 +163,7 @@
 	
 
 <!--  	시스템 로그 6개월전 로그 삭제 -->
-	<delete id="SysLog.logDeleteSysLogSummary">
+	<delete id="logDeleteSysLogSummary">
 	<![CDATA[ 
 		
 			DELETE FROM COMTNSYSLOG

--- a/src/main/resources/egovframework/mapper/com/sym/log/lgm/EgovSysLog_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/log/lgm/EgovSysLog_SQL_oracle.xml
@@ -7,7 +7,7 @@
 --><!--Converted at: Wed May 11 15:50:41 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="SysLog">
+<mapper namespace="egovframework.com.sym.log.lgm.service.impl.SysLogMapper">
 
 	<!-- 시스템로그 맵 -->
 	<resultMap id="SysLogVO" type="egovframework.com.sym.log.lgm.service.SysLog">

--- a/src/main/resources/egovframework/mapper/com/sym/log/lgm/EgovSysLog_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/log/lgm/EgovSysLog_SQL_postgres.xml
@@ -5,7 +5,7 @@
   -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="SysLog">
+<mapper namespace="egovframework.com.sym.log.lgm.service.impl.SysLogMapper">
 
 	<!-- 시스템로그 맵 -->
 	<resultMap id="SysLogVO" type="egovframework.com.sym.log.lgm.service.SysLog">
@@ -162,7 +162,7 @@
 	
 
 <!--  	시스템 로그 6개월전 로그 삭제 -->
-	<delete id="SysLog.logDeleteSysLogSummary">
+	<delete id="logDeleteSysLogSummary">
 	<![CDATA[ 
 		
 			DELETE FROM COMTNSYSLOG

--- a/src/main/resources/egovframework/mapper/com/sym/log/lgm/EgovSysLog_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/log/lgm/EgovSysLog_SQL_tibero.xml
@@ -7,7 +7,7 @@
 --><!--Converted at: Wed May 11 15:50:41 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="SysLog">
+<mapper namespace="egovframework.com.sym.log.lgm.service.impl.SysLogMapper">
 
 	<!-- 시스템로그 맵 -->
 	<resultMap id="SysLogVO" type="egovframework.com.sym.log.lgm.service.SysLog">


### PR DESCRIPTION
sym/log/lgm 모듈의 SysLogDAO를 @EgovMapper 인터페이스 방식으로 전환합니다.

## 변경 내용

- `SysLogMapper` 인터페이스 신규 생성 (`@EgovMapper("SysLogDAO")`)
- `SysLogDAO`가 `EgovComAbstractDAO`를 상속하는 대신 `SysLogMapper`에 위임하도록 변경
- `logInsertSysLogSummary()` 내부에서 직접 호출하던 delete 쿼리를 `logDeleteSysLogSummary()` 메서드로 분리
- 8개 DB 방언별 XML 매퍼 namespace를 `SysLog` → FQN(`egovframework.com.sym.log.lgm.service.impl.SysLogMapper`)으로 수정
- mysql/maria/postgres XML의 `id="SysLog.logDeleteSysLogSummary"` 오류를 `id="logDeleteSysLogSummary"`로 정정

## 영향 범위

- `EgovSysLogServiceImpl`의 `SysLogDAO` 주입 방식 및 메서드 호출 변경 없음
- 기존 동작 동일하게 유지

## 체크리스트

- [x] 단일 주제만 다룸 (다른 변경 없음)
- [x] 기존 동작에 영향 없음
- [x] 컴파일 오류 없음 확인
