### PR TITLE
[refactor][5.0.x][공통컴포넌트] cop/cmy 커뮤니티 3개 DAO @EgovMapper 인터페이스 방식으로 전환

### DIFF
--- a/src/main/java/egovframework/com/cop/cmy/service/impl/EgovCommuBBSMasterDAO.java
+++ b/src/main/java/egovframework/com/cop/cmy/service/impl/EgovCommuBBSMasterDAO.java
@@ -2,16 +2,20 @@ package egovframework.com.cop.cmy.service.impl;
 
 import java.util.List;
 
+import javax.annotation.Resource;
+
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.cop.bbs.service.BoardMasterVO;
 
 @Repository("EgovCommuBBSMasterDAO")
-public class EgovCommuBBSMasterDAO extends EgovComAbstractDAO {
+public class EgovCommuBBSMasterDAO {
+
+	@Resource(name = "egovCommuBBSMasterMapper")
+	private EgovCommuBBSMasterMapper egovCommuBBSMasterMapper;
 
 	public List<BoardMasterVO> selectCommuBBSMasterListMain(BoardMasterVO boardMasterVO) {
-		return selectList("CommuBBSMaster.selectCommuBBSMasterListMain", boardMasterVO);
+		return egovCommuBBSMasterMapper.selectCommuBBSMasterListMain(boardMasterVO);
 	}
 
 }

--- a/src/main/java/egovframework/com/cop/cmy/service/impl/EgovCommuBBSMasterMapper.java
+++ b/src/main/java/egovframework/com/cop/cmy/service/impl/EgovCommuBBSMasterMapper.java
@@ -1,0 +1,26 @@
+package egovframework.com.cop.cmy.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.cop.bbs.service.BoardMasterVO;
+
+/**
+ * 개요
+ * - 커뮤니티 게시판 마스터에 대한 Mapper 인터페이스를 정의한다.
+ *
+ * 상세내용
+ * - 커뮤니티에 속한 게시판 목록 조회 기능을 제공한다.
+ */
+@EgovMapper
+public interface EgovCommuBBSMasterMapper {
+
+	/**
+	 * 커뮤니티 게시판 목록을 조회한다.
+	 * @param boardMasterVO - 게시판 마스터 VO
+	 * @return List - 게시판 목록
+	 */
+	List<BoardMasterVO> selectCommuBBSMasterListMain(BoardMasterVO boardMasterVO);
+
+}

--- a/src/main/java/egovframework/com/cop/cmy/service/impl/EgovCommuManageDAO.java
+++ b/src/main/java/egovframework/com/cop/cmy/service/impl/EgovCommuManageDAO.java
@@ -2,54 +2,58 @@ package egovframework.com.cop.cmy.service.impl;
 
 import java.util.List;
 
+import javax.annotation.Resource;
+
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.cop.cmy.service.CommunityUser;
 import egovframework.com.cop.cmy.service.CommunityUserVO;
 import egovframework.com.cop.cmy.service.CommunityVO;
 
 @Repository("EgovCommuManageDAO")
-public class EgovCommuManageDAO extends EgovComAbstractDAO{
+public class EgovCommuManageDAO {
+
+	@Resource(name = "egovCommuManageMapper")
+	private EgovCommuManageMapper egovCommuManageMapper;
 
 	public CommunityUser selectSingleCommuUserDetail(CommunityUser cmmntyUser) {
-		return (CommunityUser) selectOne("CommuManage.selectSingleCommuUserDetail", cmmntyUser);
+		return egovCommuManageMapper.selectSingleCommuUserDetail(cmmntyUser);
 	}
 
 	public List<CommunityUser> selectCommuManagerList(CommunityVO cmmntyVO) {
-		return selectList("CommuManage.selectCommuManagerList", cmmntyVO);
+		return egovCommuManageMapper.selectCommuManagerList(cmmntyVO);
 	}
 
 	public int checkExistUser(CommunityUser cmmntyUser) {
-		return (Integer)selectOne("CommuManage.checkExistUser", cmmntyUser);
+		return egovCommuManageMapper.checkExistUser(cmmntyUser);
 	}
 
 	public void insertCommuUserRqst(CommunityUser cmmntyUser) {
-		insert("CommuManage.insertCommuUserRqst", cmmntyUser);
+		egovCommuManageMapper.insertCommuUserRqst(cmmntyUser);
 	}
 
 	public List<CommunityUser> selectCommuUserList(CommunityUserVO cmmntyUserVO) {
-		return selectList("CommuManage.selectCommuUserList", cmmntyUserVO);
+		return egovCommuManageMapper.selectCommuUserList(cmmntyUserVO);
 	}
 
 	public int selectCommuUserListCnt(CommunityUserVO cmmntyUserVO) {
-		return (Integer)selectOne("CommuManage.selectCommuUserListCnt", cmmntyUserVO);
+		return egovCommuManageMapper.selectCommuUserListCnt(cmmntyUserVO);
 	}
 
 	public void insertCommuUser(CommunityUserVO cmmntyUserVO) {
-		update("CommuManage.insertCommuUser", cmmntyUserVO);
+		egovCommuManageMapper.insertCommuUser(cmmntyUserVO);
 	}
 
 	public void deleteCommuUser(CommunityUserVO cmmntyUserVO) {
-		delete("CommuManage.deleteCommuUser", cmmntyUserVO);
+		egovCommuManageMapper.deleteCommuUser(cmmntyUserVO);
 	}
 
 	public void insertCommuUserAdmin(CommunityUserVO cmmntyUserVO) {
-		update("CommuManage.insertCommuUserAdmin", cmmntyUserVO);
+		egovCommuManageMapper.insertCommuUserAdmin(cmmntyUserVO);
 	}
 
 	public void deleteCommuUserAdmin(CommunityUserVO cmmntyUserVO) {
-		update("CommuManage.deleteCommuUserAdmin", cmmntyUserVO);
+		egovCommuManageMapper.deleteCommuUserAdmin(cmmntyUserVO);
 	}
 
 }

--- a/src/main/java/egovframework/com/cop/cmy/service/impl/EgovCommuManageMapper.java
+++ b/src/main/java/egovframework/com/cop/cmy/service/impl/EgovCommuManageMapper.java
@@ -1,0 +1,86 @@
+package egovframework.com.cop.cmy.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.cop.cmy.service.CommunityUser;
+import egovframework.com.cop.cmy.service.CommunityUserVO;
+import egovframework.com.cop.cmy.service.CommunityVO;
+
+/**
+ * 개요
+ * - 커뮤니티 사용자 관리에 대한 Mapper 인터페이스를 정의한다.
+ *
+ * 상세내용
+ * - 커뮤니티 사용자에 대한 등록, 수정, 삭제, 조회 등의 기능을 제공한다.
+ */
+@EgovMapper
+public interface EgovCommuManageMapper {
+
+	/**
+	 * 커뮤니티 사용자 단건 상세 정보를 조회한다.
+	 * @param cmmntyUser - 커뮤니티 사용자 모델
+	 * @return CommunityUser - 커뮤니티 사용자
+	 */
+	CommunityUser selectSingleCommuUserDetail(CommunityUser cmmntyUser);
+
+	/**
+	 * 커뮤니티 운영자 목록을 조회한다.
+	 * @param cmmntyVO - 커뮤니티 VO
+	 * @return List - 운영자 목록
+	 */
+	List<CommunityUser> selectCommuManagerList(CommunityVO cmmntyVO);
+
+	/**
+	 * 커뮤니티 사용자 존재 여부를 확인한다.
+	 * @param cmmntyUser - 커뮤니티 사용자 모델
+	 * @return int - 존재 여부(건수)
+	 */
+	int checkExistUser(CommunityUser cmmntyUser);
+
+	/**
+	 * 커뮤니티 가입 신청을 등록한다.
+	 * @param cmmntyUser - 커뮤니티 사용자 모델
+	 */
+	void insertCommuUserRqst(CommunityUser cmmntyUser);
+
+	/**
+	 * 커뮤니티 사용자 목록을 조회한다.
+	 * @param cmmntyUserVO - 커뮤니티 사용자 VO
+	 * @return List - 사용자 목록
+	 */
+	List<CommunityUser> selectCommuUserList(CommunityUserVO cmmntyUserVO);
+
+	/**
+	 * 커뮤니티 사용자 목록 총 건수를 조회한다.
+	 * @param cmmntyUserVO - 커뮤니티 사용자 VO
+	 * @return int - 총 건수
+	 */
+	int selectCommuUserListCnt(CommunityUserVO cmmntyUserVO);
+
+	/**
+	 * 커뮤니티 사용자를 승인한다.
+	 * @param cmmntyUserVO - 커뮤니티 사용자 VO
+	 */
+	void insertCommuUser(CommunityUserVO cmmntyUserVO);
+
+	/**
+	 * 커뮤니티 사용자를 탈퇴 처리한다.
+	 * @param cmmntyUserVO - 커뮤니티 사용자 VO
+	 */
+	void deleteCommuUser(CommunityUserVO cmmntyUserVO);
+
+	/**
+	 * 커뮤니티 운영자로 지정한다.
+	 * @param cmmntyUserVO - 커뮤니티 사용자 VO
+	 */
+	void insertCommuUserAdmin(CommunityUserVO cmmntyUserVO);
+
+	/**
+	 * 커뮤니티 운영자를 해제한다.
+	 * @param cmmntyUserVO - 커뮤니티 사용자 VO
+	 */
+	void deleteCommuUserAdmin(CommunityUserVO cmmntyUserVO);
+
+}

--- a/src/main/java/egovframework/com/cop/cmy/service/impl/EgovCommuMasterDAO.java
+++ b/src/main/java/egovframework/com/cop/cmy/service/impl/EgovCommuMasterDAO.java
@@ -2,38 +2,41 @@ package egovframework.com.cop.cmy.service.impl;
 
 import java.util.List;
 
-import org.springframework.dao.DataAccessException;
+import javax.annotation.Resource;
+
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.cop.cmy.service.Community;
 import egovframework.com.cop.cmy.service.CommunityVO;
 
 @Repository("EgovCommuMasterDAO")
-public class EgovCommuMasterDAO extends EgovComAbstractDAO {
+public class EgovCommuMasterDAO {
+
+	@Resource(name = "egovCommuMasterMapper")
+	private EgovCommuMasterMapper egovCommuMasterMapper;
 
 	public List<CommunityVO> selectCommuMasterList(CommunityVO cmmntyVO) {
-		return selectList("CommuMaster.selectCommuMasterList", cmmntyVO);
+		return egovCommuMasterMapper.selectCommuMasterList(cmmntyVO);
 	}
 
 	public int selectCommuMasterListCnt(CommunityVO cmmntyVO) {
-		return selectOne("CommuMaster.selectCommuMasterListCnt", cmmntyVO);
+		return egovCommuMasterMapper.selectCommuMasterListCnt(cmmntyVO);
 	}
 
 	public int insertCommuMaster(Community community) {
-		return insert("CommuMaster.insertCommuMaster", community);
+		return egovCommuMasterMapper.insertCommuMaster(community);
 	}
 
 	public CommunityVO selectCommuMasterDetail(CommunityVO cmmntyVO) {
-		return selectOne("CommuMaster.selectCommuMasterDetail", cmmntyVO);
+		return egovCommuMasterMapper.selectCommuMasterDetail(cmmntyVO);
 	}
 
 	public int updateCommuMaster(Community community) {
-		return update("CommuMaster.updateCommuMaster", community);
+		return egovCommuMasterMapper.updateCommuMaster(community);
 	}
 
 	public int deleteCommuMaster(Community community) {
-		return update("CommuMaster.deleteCommuMaster", community);
+		return egovCommuMasterMapper.deleteCommuMaster(community);
 	}
 
 	/**
@@ -41,10 +44,9 @@ public class EgovCommuMasterDAO extends EgovComAbstractDAO {
 	 *
 	 * @param cmmntyVO
 	 * @return
-	 * @throws Exception
 	 */
-	public List<CommunityVO> selectCommuMasterListPortlet(CommunityVO cmmntyVO) throws DataAccessException {
-		return selectList("CommuMaster.selectCommuMasterListPortlet", cmmntyVO);
+	public List<CommunityVO> selectCommuMasterListPortlet(CommunityVO cmmntyVO) {
+		return egovCommuMasterMapper.selectCommuMasterListPortlet(cmmntyVO);
 	}
 
 }

--- a/src/main/java/egovframework/com/cop/cmy/service/impl/EgovCommuMasterMapper.java
+++ b/src/main/java/egovframework/com/cop/cmy/service/impl/EgovCommuMasterMapper.java
@@ -1,0 +1,70 @@
+package egovframework.com.cop.cmy.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.cop.cmy.service.Community;
+import egovframework.com.cop.cmy.service.CommunityVO;
+
+/**
+ * 개요
+ * - 커뮤니티 마스터에 대한 Mapper 인터페이스를 정의한다.
+ *
+ * 상세내용
+ * - 커뮤니티에 대한 등록, 수정, 삭제, 조회 등의 기능을 제공한다.
+ * - 커뮤니티 조회 기능은 목록조회, 상세조회로 구분된다.
+ */
+@EgovMapper
+public interface EgovCommuMasterMapper {
+
+	/**
+	 * 커뮤니티 목록을 조회한다.
+	 * @param cmmntyVO - 커뮤니티 VO
+	 * @return List - 커뮤니티 목록
+	 */
+	List<CommunityVO> selectCommuMasterList(CommunityVO cmmntyVO);
+
+	/**
+	 * 커뮤니티 목록 총 건수를 조회한다.
+	 * @param cmmntyVO - 커뮤니티 VO
+	 * @return int - 총 건수
+	 */
+	int selectCommuMasterListCnt(CommunityVO cmmntyVO);
+
+	/**
+	 * 커뮤니티를 등록한다.
+	 * @param community - 커뮤니티 모델
+	 * @return int - 등록 결과
+	 */
+	int insertCommuMaster(Community community);
+
+	/**
+	 * 커뮤니티 상세 정보를 조회한다.
+	 * @param cmmntyVO - 커뮤니티 VO
+	 * @return CommunityVO - 커뮤니티 VO
+	 */
+	CommunityVO selectCommuMasterDetail(CommunityVO cmmntyVO);
+
+	/**
+	 * 커뮤니티를 수정한다.
+	 * @param community - 커뮤니티 모델
+	 * @return int - 수정 결과
+	 */
+	int updateCommuMaster(Community community);
+
+	/**
+	 * 커뮤니티를 삭제한다.
+	 * @param community - 커뮤니티 모델
+	 * @return int - 삭제 결과
+	 */
+	int deleteCommuMaster(Community community);
+
+	/**
+	 * 포트릿을 위한 커뮤니티 목록을 조회한다.
+	 * @param cmmntyVO - 커뮤니티 VO
+	 * @return List - 커뮤니티 목록
+	 */
+	List<CommunityVO> selectCommuMasterListPortlet(CommunityVO cmmntyVO);
+
+}

--- a/src/main/resources/egovframework/mapper/com/cop/cmy/EgovCommuBBSMaster_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/cmy/EgovCommuBBSMaster_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CommuBBSMaster">
+<mapper namespace="egovframework.com.cop.cmy.service.impl.EgovCommuBBSMasterMapper">
 
 	<resultMap id="boardMasterList" type="egovframework.com.cop.bbs.service.BoardMasterVO">
 		<result property="bbsId" column="BBS_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/cmy/EgovCommuBBSMaster_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/cmy/EgovCommuBBSMaster_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CommuBBSMaster">
+<mapper namespace="egovframework.com.cop.cmy.service.impl.EgovCommuBBSMasterMapper">
 
 	<resultMap id="boardMasterList" type="egovframework.com.cop.bbs.service.BoardMasterVO">
 		<result property="bbsId" column="BBS_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/cmy/EgovCommuBBSMaster_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/cmy/EgovCommuBBSMaster_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CommuBBSMaster">
+<mapper namespace="egovframework.com.cop.cmy.service.impl.EgovCommuBBSMasterMapper">
 
 	<resultMap id="boardMasterList" type="egovframework.com.cop.bbs.service.BoardMasterVO">
 		<result property="bbsId" column="BBS_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/cmy/EgovCommuBBSMaster_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/cmy/EgovCommuBBSMaster_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:49:42 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CommuBBSMaster">
+<mapper namespace="egovframework.com.cop.cmy.service.impl.EgovCommuBBSMasterMapper">
 
 	<resultMap id="boardMasterList" type="egovframework.com.cop.bbs.service.BoardMasterVO">
 		<result property="bbsId" column="BBS_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/cmy/EgovCommuBBSMaster_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/cmy/EgovCommuBBSMaster_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:49:42 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CommuBBSMaster">
+<mapper namespace="egovframework.com.cop.cmy.service.impl.EgovCommuBBSMasterMapper">
 
 	<resultMap id="boardMasterList" type="egovframework.com.cop.bbs.service.BoardMasterVO">
 		<result property="bbsId" column="BBS_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/cmy/EgovCommuBBSMaster_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/cmy/EgovCommuBBSMaster_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:49:43 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CommuBBSMaster">
+<mapper namespace="egovframework.com.cop.cmy.service.impl.EgovCommuBBSMasterMapper">
 
 	<resultMap id="boardMasterList" type="egovframework.com.cop.bbs.service.BoardMasterVO">
 		<result property="bbsId" column="BBS_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/cmy/EgovCommuBBSMaster_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/cmy/EgovCommuBBSMaster_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:49:42 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CommuBBSMaster">
+<mapper namespace="egovframework.com.cop.cmy.service.impl.EgovCommuBBSMasterMapper">
 
 	<resultMap id="boardMasterList" type="egovframework.com.cop.bbs.service.BoardMasterVO">
 		<result property="bbsId" column="BBS_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/cmy/EgovCommuBBSMaster_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/cmy/EgovCommuBBSMaster_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CommuBBSMaster">
+<mapper namespace="egovframework.com.cop.cmy.service.impl.EgovCommuBBSMasterMapper">
 
 	<resultMap id="boardMasterList" type="egovframework.com.cop.bbs.service.BoardMasterVO">
 		<result property="bbsId" column="BBS_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/cmy/EgovCommuManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/cmy/EgovCommuManage_SQL_altibase.xml
@@ -6,7 +6,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CommuManage">
+<mapper namespace="egovframework.com.cop.cmy.service.impl.EgovCommuManageMapper">
 
 	<resultMap id="CommuUserList" type="egovframework.com.cop.cmy.service.CommunityUser">
 		<result property="cmmntyId" column="CMMNTY_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/cmy/EgovCommuManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/cmy/EgovCommuManage_SQL_cubrid.xml
@@ -6,7 +6,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CommuManage">
+<mapper namespace="egovframework.com.cop.cmy.service.impl.EgovCommuManageMapper">
 	
 	<resultMap id="CommuUserList" type="egovframework.com.cop.cmy.service.CommunityUser">
 		<result property="cmmntyId" column="CMMNTY_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/cmy/EgovCommuManage_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/cmy/EgovCommuManage_SQL_goldilocks.xml
@@ -6,7 +6,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CommuManage">
+<mapper namespace="egovframework.com.cop.cmy.service.impl.EgovCommuManageMapper">
 
 	<resultMap id="CommuUserList" type="egovframework.com.cop.cmy.service.CommunityUser">
 		<result property="cmmntyId" column="CMMNTY_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/cmy/EgovCommuManage_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/cmy/EgovCommuManage_SQL_maria.xml
@@ -6,7 +6,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CommuManage">
+<mapper namespace="egovframework.com.cop.cmy.service.impl.EgovCommuManageMapper">
 
 	<resultMap id="CommuUserList" type="egovframework.com.cop.cmy.service.CommunityUser">
 		<result property="cmmntyId" column="CMMNTY_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/cmy/EgovCommuManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/cmy/EgovCommuManage_SQL_mysql.xml
@@ -6,7 +6,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CommuManage">
+<mapper namespace="egovframework.com.cop.cmy.service.impl.EgovCommuManageMapper">
 
 	<resultMap id="CommuUserList" type="egovframework.com.cop.cmy.service.CommunityUser">
 		<result property="cmmntyId" column="CMMNTY_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/cmy/EgovCommuManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/cmy/EgovCommuManage_SQL_oracle.xml
@@ -6,7 +6,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CommuManage">
+<mapper namespace="egovframework.com.cop.cmy.service.impl.EgovCommuManageMapper">
 
 	<resultMap id="CommuUserList" type="egovframework.com.cop.cmy.service.CommunityUser">
 		<result property="cmmntyId" column="CMMNTY_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/cmy/EgovCommuManage_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/cmy/EgovCommuManage_SQL_postgres.xml
@@ -6,7 +6,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CommuManage">
+<mapper namespace="egovframework.com.cop.cmy.service.impl.EgovCommuManageMapper">
 
 	<resultMap id="CommuUserList" type="egovframework.com.cop.cmy.service.CommunityUser">
 		<result property="cmmntyId" column="CMMNTY_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/cmy/EgovCommuManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/cmy/EgovCommuManage_SQL_tibero.xml
@@ -6,7 +6,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CommuManage">
+<mapper namespace="egovframework.com.cop.cmy.service.impl.EgovCommuManageMapper">
 
 	<resultMap id="CommuUserList" type="egovframework.com.cop.cmy.service.CommunityUser">
 		<result property="cmmntyId" column="CMMNTY_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/cmy/EgovCommuMaster_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/cmy/EgovCommuMaster_SQL_altibase.xml
@@ -7,7 +7,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CommuMaster">
+<mapper namespace="egovframework.com.cop.cmy.service.impl.EgovCommuMasterMapper">
 
 
 	<resultMap id="CmmntyList" type="egovframework.com.cop.cmy.service.CommunityVO">

--- a/src/main/resources/egovframework/mapper/com/cop/cmy/EgovCommuMaster_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/cmy/EgovCommuMaster_SQL_cubrid.xml
@@ -6,7 +6,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CommuMaster">
+<mapper namespace="egovframework.com.cop.cmy.service.impl.EgovCommuMasterMapper">
 
 	<resultMap id="CmmntyList" type="egovframework.com.cop.cmy.service.CommunityVO">
 		<result property="cmmntyId" column="CMMNTY_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/cmy/EgovCommuMaster_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/cmy/EgovCommuMaster_SQL_goldilocks.xml
@@ -7,7 +7,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CommuMaster">
+<mapper namespace="egovframework.com.cop.cmy.service.impl.EgovCommuMasterMapper">
 
 
 	<resultMap id="CmmntyList" type="egovframework.com.cop.cmy.service.CommunityVO">

--- a/src/main/resources/egovframework/mapper/com/cop/cmy/EgovCommuMaster_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/cmy/EgovCommuMaster_SQL_maria.xml
@@ -6,7 +6,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CommuMaster">
+<mapper namespace="egovframework.com.cop.cmy.service.impl.EgovCommuMasterMapper">
 
 	<resultMap id="CmmntyList" type="egovframework.com.cop.cmy.service.CommunityVO">
 		<result property="cmmntyId" column="CMMNTY_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/cmy/EgovCommuMaster_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/cmy/EgovCommuMaster_SQL_mysql.xml
@@ -6,7 +6,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CommuMaster">
+<mapper namespace="egovframework.com.cop.cmy.service.impl.EgovCommuMasterMapper">
 
 	<resultMap id="CmmntyList" type="egovframework.com.cop.cmy.service.CommunityVO">
 		<result property="cmmntyId" column="CMMNTY_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/cmy/EgovCommuMaster_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/cmy/EgovCommuMaster_SQL_oracle.xml
@@ -7,7 +7,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CommuMaster">
+<mapper namespace="egovframework.com.cop.cmy.service.impl.EgovCommuMasterMapper">
 
 	<resultMap id="CmmntyList" type="egovframework.com.cop.cmy.service.CommunityVO">
 		<result property="cmmntyId" column="CMMNTY_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/cmy/EgovCommuMaster_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/cmy/EgovCommuMaster_SQL_postgres.xml
@@ -6,7 +6,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CommuMaster">
+<mapper namespace="egovframework.com.cop.cmy.service.impl.EgovCommuMasterMapper">
 
 	<resultMap id="CmmntyList" type="egovframework.com.cop.cmy.service.CommunityVO">
 		<result property="cmmntyId" column="CMMNTY_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/cmy/EgovCommuMaster_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/cmy/EgovCommuMaster_SQL_tibero.xml
@@ -7,7 +7,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CommuMaster">
+<mapper namespace="egovframework.com.cop.cmy.service.impl.EgovCommuMasterMapper">
 
 	<resultMap id="CmmntyList" type="egovframework.com.cop.cmy.service.CommunityVO">
 		<result property="cmmntyId" column="CMMNTY_ID"/>

--- a/src/main/resources/egovframework/spring/com/context-mapper.xml
+++ b/src/main/resources/egovframework/spring/com/context-mapper.xml
@@ -21,5 +21,10 @@
 	<bean id="egov.sqlSessionTemplate" class="org.mybatis.spring.SqlSessionTemplate">
 		<constructor-arg ref="egov.sqlSession"/>
 	</bean>
-	
+
+	<bean class="org.mybatis.spring.mapper.MapperScannerConfigurer">
+		<property name="basePackage" value="egovframework.com" />
+		<property name="annotationClass" value="org.egovframe.rte.psl.dataaccess.mapper.EgovMapper" />
+	</bean>
+
 </beans>


### PR DESCRIPTION
## 변경 사유
기존 XML namespace 기반 DAO를 5.0 신규 @EgovMapper 인터페이스 방식으로 전환

## 변경 내용
- EgovCommuBBSMasterMapper, EgovCommuManageMapper, EgovCommuMasterMapper 인터페이스 신규 추가
- cop/cmy 3개 DAO를 mapper 위임 구조로 리팩토링 (EgovComAbstractDAO 상속 제거)
- 24개 XML namespace를 mapper 인터페이스 FQN으로 변경
- context-mapper.xml MapperScannerConfigurer 추가

## 영향 범위
- cop/cmy 커뮤니티 관리 모듈만 영향
- DAO bean name 유지(외부 서비스 호출 시그니처 변경 없음)

## 체크리스트
- [x] 단일 주제만 다룸
- [x] 기존 동작 호환
