### PR TITLE
[refactor][5.0.x][공통컴포넌트] cop/ncm NcrdManageDAO @EgovMapper 인터페이스 방식으로 전환

### DIFF
--- a/src/main/java/egovframework/com/cop/ncm/service/impl/NcrdManageDAO.java
+++ b/src/main/java/egovframework/com/cop/ncm/service/impl/NcrdManageDAO.java
@@ -4,10 +4,10 @@ import java.util.List;
 
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.cop.ncm.service.NameCard;
 import egovframework.com.cop.ncm.service.NameCardUser;
 import egovframework.com.cop.ncm.service.NameCardVO;
+import jakarta.annotation.Resource;
 
 /**
  * 명함정보를 관리하기 위한 데이터 접근 클래스
@@ -26,137 +26,132 @@ import egovframework.com.cop.ncm.service.NameCardVO;
  * </pre>
  */
 @Repository("NcrdManageDAO")
-public class NcrdManageDAO extends EgovComAbstractDAO {
+public class NcrdManageDAO {
 
-    // Logger log = Logger.getLogger(this.getClass());
+    @Resource(name = "NcrdManageMapper")
+    private NcrdManageMapper ncrdManageMapper;
+
+    /**
+     * 명함사용자 정보를 삭제한다.
+     *
+     * @param nameCardVO
+     */
+    public int deleteNcrdItemUser(NameCardVO nameCardVO) {
+        return ncrdManageMapper.deleteNcrdItemUser(nameCardVO);
+    }
 
     /**
      * 명함 정보를 삭제한다.
      *
-     * @param nameCard
-     * @throws Exception
+     * @param nameCardVO
      */
-    public int deleteNcrdItemUser(NameCardVO nameCardVO){
-        return delete("NcrdManageDAO.deleteNcrdItemUser", nameCardVO);
-    }
-
     public int deleteNcrdItem(NameCardVO nameCardVO) {
-        return delete("NcrdManageDAO.deleteNcrdItem", nameCardVO);
+        return ncrdManageMapper.deleteNcrdItem(nameCardVO);
     }
 
     /**
      * 명함 정보를 등록한다.
      *
      * @param nameCard
-     * @throws Exception
      */
     public int insertNcrdItem(NameCard nameCard) {
-        return insert("NcrdManageDAO.insertNcrdItem", nameCard);
+        return ncrdManageMapper.insertNcrdItem(nameCard);
     }
 
     /**
      * 명함사용자 정보를 등록한다.
      *
      * @param ncrdUser
-     * @throws Exception
      */
     public int insertNcrdUseInf(NameCardUser ncrdUser) {
-        return insert("NcrdManageDAO.insertNcrdUseInf", ncrdUser);
+        return ncrdManageMapper.insertNcrdUseInf(ncrdUser);
     }
 
     /**
      * 명함 정보에 대한 상세정보를 조회한다.
      *
      * @param nameCard
-     * @return
-     * @throws Exception
+     * @return 명함 상세정보 VO
      */
     public NameCardVO selectNcrdItem(NameCard nameCard) {
-        return selectOne("NcrdManageDAO.selectNcrdItem", nameCard);
+        return ncrdManageMapper.selectNcrdItem(nameCard);
     }
 
     /**
      * 명함 정보에 대한 목록을 조회한다.
      *
-     * @param nameCard
-     * @return
-     * @throws Exception
+     * @param nameCardVO
+     * @return 명함 목록
      */
     public List<NameCardVO> selectNcrdItemList(NameCardVO nameCardVO) {
-        return selectList("NcrdManageDAO.selectNcrdItemList", nameCardVO);
+        return ncrdManageMapper.selectNcrdItemList(nameCardVO);
     }
 
     /**
+     * 명함 목록 전체 건수를 조회한다.
      *
-     * @param nameCard
-     * @return
-     * @throws Exception
+     * @param nameCardVO
+     * @return 전체 건수
      */
     public int selectNcrdItemListCnt(NameCardVO nameCardVO) {
-        return selectOne("NcrdManageDAO.selectNcrdItemListCnt", nameCardVO);
+        return ncrdManageMapper.selectNcrdItemListCnt(nameCardVO);
     }
 
     /**
-     * 명함 정보에 대한 목록 전체 건수를 조회한다.
+     * 명함사용자 목록을 조회한다.
      *
      * @param nameCardUser
-     * @return
-     * @throws Exception
+     * @return 명함사용자 목록
      */
     public List<NameCardUser> selectNcrdUseInfs(NameCardUser nameCardUser) {
-        return selectList("NcrdManageDAO.selectNcrdUseInfs", nameCardUser);
+        return ncrdManageMapper.selectNcrdUseInfs(nameCardUser);
     }
 
     /**
-     * 명함사용자 정보에 대한 목록 전체 건수를 조회한다.
+     * 명함사용자 목록 전체 건수를 조회한다.
      *
-     * @param ncrdUser
-     * @return
-     * @throws Exception
+     * @param nameCardUser
+     * @return 전체 건수
      */
     public int selectNcrdUseInfsCnt(NameCardUser nameCardUser) {
-        return selectOne("NcrdManageDAO.selectNcrdUseInfsCnt", nameCardUser);
+        return ncrdManageMapper.selectNcrdUseInfsCnt(nameCardUser);
     }
 
     /**
      * 명함 정보를 수정한다.
      *
      * @param nameCard
-     * @throws Exception
      */
     public int updateNcrdItem(NameCard nameCard) {
-        return update("NcrdManageDAO.updateNcrdItem", nameCard);
+        return ncrdManageMapper.updateNcrdItem(nameCard);
     }
 
     /**
      * 명함사용자 정보를 수정한다.
      *
      * @param nameCardUser
-     * @throws Exception
      */
     public int updateNcrdUseInf(NameCardUser nameCardUser) {
-        return update("NcrdManageDAO.updateNcrdUseInf", nameCardUser);
+        return ncrdManageMapper.updateNcrdUseInf(nameCardUser);
     }
 
     /**
      * 내 명함 정보에 대한 목록을 조회한다.
      *
      * @param nameCardVO
-     * @return
-     * @throws Exception
+     * @return 내 명함 목록
      */
     public List<NameCardVO> selectMyNcrdItemList(NameCardVO nameCardVO) {
-        return selectList("NcrdManageDAO.selectMyNcrdItemList", nameCardVO);
+        return ncrdManageMapper.selectMyNcrdItemList(nameCardVO);
     }
 
     /**
-     * 내 명함 정보에 대한 목록 전체 건수를 조회한다.
+     * 내 명함 목록 전체 건수를 조회한다.
      *
      * @param nameCardVO
-     * @return
-     * @throws Exception
+     * @return 전체 건수
      */
     public int selectMyNcrdItemListCnt(NameCardVO nameCardVO) {
-        return selectOne("NcrdManageDAO.selectMyNcrdItemListCnt", nameCardVO);
+        return ncrdManageMapper.selectMyNcrdItemListCnt(nameCardVO);
     }
 }

--- a/src/main/java/egovframework/com/cop/ncm/service/impl/NcrdManageMapper.java
+++ b/src/main/java/egovframework/com/cop/ncm/service/impl/NcrdManageMapper.java
@@ -1,0 +1,119 @@
+package egovframework.com.cop.ncm.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.cop.ncm.service.NameCard;
+import egovframework.com.cop.ncm.service.NameCardUser;
+import egovframework.com.cop.ncm.service.NameCardVO;
+
+/**
+ * 명함정보를 관리하기 위한 Mapper 인터페이스
+ * @author 공통서비스개발팀 이삼섭
+ * @since 2009.06.01
+ * @version 1.0
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일         수정자       수정내용
+ *  ----------    --------    ---------------------------
+ *   2009.3.28     이삼섭       최초 생성
+ *
+ * </pre>
+ */
+@EgovMapper
+public interface NcrdManageMapper {
+
+    /**
+     * 명함사용자 정보를 삭제한다.
+     * @param nameCardVO - 명함 VO
+     * @return 삭제 건수
+     */
+    int deleteNcrdItemUser(NameCardVO nameCardVO);
+
+    /**
+     * 명함 정보를 삭제한다.
+     * @param nameCardVO - 명함 VO
+     * @return 삭제 건수
+     */
+    int deleteNcrdItem(NameCardVO nameCardVO);
+
+    /**
+     * 명함 정보를 등록한다.
+     * @param nameCard - 명함 정보
+     * @return 등록 건수
+     */
+    int insertNcrdItem(NameCard nameCard);
+
+    /**
+     * 명함사용자 정보를 등록한다.
+     * @param ncrdUser - 명함사용자 정보
+     * @return 등록 건수
+     */
+    int insertNcrdUseInf(NameCardUser ncrdUser);
+
+    /**
+     * 명함 정보에 대한 상세정보를 조회한다.
+     * @param nameCard - 명함 정보
+     * @return 명함 상세정보 VO
+     */
+    NameCardVO selectNcrdItem(NameCard nameCard);
+
+    /**
+     * 명함 정보에 대한 목록을 조회한다.
+     * @param nameCardVO - 명함 VO
+     * @return 명함 목록
+     */
+    List<NameCardVO> selectNcrdItemList(NameCardVO nameCardVO);
+
+    /**
+     * 명함 목록 전체 건수를 조회한다.
+     * @param nameCardVO - 명함 VO
+     * @return 전체 건수
+     */
+    int selectNcrdItemListCnt(NameCardVO nameCardVO);
+
+    /**
+     * 명함사용자 목록을 조회한다.
+     * @param nameCardUser - 명함사용자 정보
+     * @return 명함사용자 목록
+     */
+    List<NameCardUser> selectNcrdUseInfs(NameCardUser nameCardUser);
+
+    /**
+     * 명함사용자 목록 전체 건수를 조회한다.
+     * @param nameCardUser - 명함사용자 정보
+     * @return 전체 건수
+     */
+    int selectNcrdUseInfsCnt(NameCardUser nameCardUser);
+
+    /**
+     * 명함 정보를 수정한다.
+     * @param nameCard - 명함 정보
+     * @return 수정 건수
+     */
+    int updateNcrdItem(NameCard nameCard);
+
+    /**
+     * 명함사용자 정보를 수정한다.
+     * @param nameCardUser - 명함사용자 정보
+     * @return 수정 건수
+     */
+    int updateNcrdUseInf(NameCardUser nameCardUser);
+
+    /**
+     * 내 명함 정보에 대한 목록을 조회한다.
+     * @param nameCardVO - 명함 VO
+     * @return 내 명함 목록
+     */
+    List<NameCardVO> selectMyNcrdItemList(NameCardVO nameCardVO);
+
+    /**
+     * 내 명함 목록 전체 건수를 조회한다.
+     * @param nameCardVO - 명함 VO
+     * @return 전체 건수
+     */
+    int selectMyNcrdItemListCnt(NameCardVO nameCardVO);
+}

--- a/src/main/resources/egovframework/mapper/com/cop/ncm/EgovNcrd_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/ncm/EgovNcrd_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="NcrdManageDAO">
+<mapper namespace="egovframework.com.cop.ncm.service.impl.NcrdManageMapper">
 	
 	<resultMap id="ncrdList" type="egovframework.com.cop.ncm.service.NameCardVO">
 		<result property="ncrdId" column="NCRD_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/ncm/EgovNcrd_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/ncm/EgovNcrd_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="NcrdManageDAO">
+<mapper namespace="egovframework.com.cop.ncm.service.impl.NcrdManageMapper">
 
 	<resultMap id="ncrdList" type="egovframework.com.cop.ncm.service.NameCardVO">
 		<result property="ncrdId" column="NCRD_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/ncm/EgovNcrd_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/ncm/EgovNcrd_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="NcrdManageDAO">
+<mapper namespace="egovframework.com.cop.ncm.service.impl.NcrdManageMapper">
 	
 	<resultMap id="ncrdList" type="egovframework.com.cop.ncm.service.NameCardVO">
 		<result property="ncrdId" column="NCRD_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/ncm/EgovNcrd_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/ncm/EgovNcrd_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="NcrdManageDAO">
+<mapper namespace="egovframework.com.cop.ncm.service.impl.NcrdManageMapper">
 
 	<resultMap id="ncrdList" type="egovframework.com.cop.ncm.service.NameCardVO">
 		<result property="ncrdId" column="NCRD_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/ncm/EgovNcrd_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/ncm/EgovNcrd_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="NcrdManageDAO">
+<mapper namespace="egovframework.com.cop.ncm.service.impl.NcrdManageMapper">
 
 	<resultMap id="ncrdList" type="egovframework.com.cop.ncm.service.NameCardVO">
 		<result property="ncrdId" column="NCRD_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/ncm/EgovNcrd_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/ncm/EgovNcrd_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="NcrdManageDAO">
+<mapper namespace="egovframework.com.cop.ncm.service.impl.NcrdManageMapper">
 
 	<resultMap id="ncrdList" type="egovframework.com.cop.ncm.service.NameCardVO">
 		<result property="ncrdId" column="NCRD_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/ncm/EgovNcrd_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/ncm/EgovNcrd_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="NcrdManageDAO">
+<mapper namespace="egovframework.com.cop.ncm.service.impl.NcrdManageMapper">
 
 	<resultMap id="ncrdList" type="egovframework.com.cop.ncm.service.NameCardVO">
 		<result property="ncrdId" column="NCRD_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/ncm/EgovNcrd_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/ncm/EgovNcrd_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="NcrdManageDAO">
+<mapper namespace="egovframework.com.cop.ncm.service.impl.NcrdManageMapper">
 
 	<resultMap id="ncrdList" type="egovframework.com.cop.ncm.service.NameCardVO">
 		<result property="ncrdId" column="NCRD_ID"/>

--- a/src/main/resources/egovframework/spring/com/context-mapper.xml
+++ b/src/main/resources/egovframework/spring/com/context-mapper.xml
@@ -21,5 +21,11 @@
 	<bean id="egov.sqlSessionTemplate" class="org.mybatis.spring.SqlSessionTemplate">
 		<constructor-arg ref="egov.sqlSession"/>
 	</bean>
-	
+
+	<!-- @EgovMapper 어노테이션 기반 Mapper 인터페이스 자동 등록 -->
+	<bean class="org.mybatis.spring.mapper.MapperScannerConfigurer">
+		<property name="basePackage" value="egovframework.com"/>
+		<property name="annotationClass" value="org.egovframe.rte.psl.dataaccess.mapper.EgovMapper"/>
+	</bean>
+
 </beans>


### PR DESCRIPTION
## 변경 사유
기존 XML namespace 기반 DAO를 5.0 신규 @EgovMapper 인터페이스 방식으로 전환

## 변경 내용
- NcrdManageMapper 인터페이스 신규 추가
- cop/ncm NcrdManageDAO를 mapper 위임 구조로 리팩토링 (EgovComAbstractDAO 상속 제거)
- XML namespace를 mapper FQN으로 변경 (8개 DBMS)
- context-mapper.xml MapperScannerConfigurer 추가

## 영향 범위
- cop/ncm 명함관리 모듈만 영향
- DAO bean name 유지

## 체크리스트
- [x] 단일 주제만 다룸
- [x] 기존 동작 호환
