### PR TITLE
[refactor][5.0.x][공통컴포넌트] uss/sam/cpy CpyrhtPrtcPolicyDAO @EgovMapper 인터페이스 방식으로 전환

### DIFF
--- a/src/main/java/egovframework/com/uss/sam/cpy/service/impl/CpyrhtPrtcPolicyDAO.java
+++ b/src/main/java/egovframework/com/uss/sam/cpy/service/impl/CpyrhtPrtcPolicyDAO.java
@@ -5,9 +5,10 @@ import java.util.List;
 import org.egovframe.rte.psl.dataaccess.util.EgovMap;
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.uss.sam.cpy.service.CpyrhtPrtcPolicyDefaultVO;
 import egovframework.com.uss.sam.cpy.service.CpyrhtPrtcPolicyVO;
+
+import jakarta.annotation.Resource;
 
 /**
  *
@@ -28,80 +29,65 @@ import egovframework.com.uss.sam.cpy.service.CpyrhtPrtcPolicyVO;
  *      </pre>
  */
 @Repository("CpyrhtPrtcPolicyDAO")
-public class CpyrhtPrtcPolicyDAO extends EgovComAbstractDAO {
+public class CpyrhtPrtcPolicyDAO {
 
-	/**
-	 * 저작권보호정책 글 목록에 대한 상세내용을 조회한다.
-	 * 
-	 * @param vo
-	 * @return 조회한 글
-	 * @exception Exception
-	 */
-	public CpyrhtPrtcPolicyVO selectCpyrhtPrtcPolicyDetail(CpyrhtPrtcPolicyVO vo) throws Exception {
+    @Resource(name = "CpyrhtPrtcPolicyMapper")
+    private CpyrhtPrtcPolicyMapper cpyrhtPrtcPolicyMapper;
 
-		return (CpyrhtPrtcPolicyVO) selectOne("CpyrhtPrtcPolicyDAO.selectCpyrhtPrtcPolicyDetail", vo);
+    /**
+     * 저작권보호정책 글 목록에 대한 상세내용을 조회한다.
+     * @param vo
+     * @return 조회한 글
+     * @exception Exception
+     */
+    public CpyrhtPrtcPolicyVO selectCpyrhtPrtcPolicyDetail(CpyrhtPrtcPolicyVO vo) throws Exception {
+        return cpyrhtPrtcPolicyMapper.selectCpyrhtPrtcPolicyDetail(vo);
+    }
 
-	}
+    /**
+     * 저작권보호정책 글 목록을 조회한다.
+     * @param searchVO
+     * @return 글 목록
+     * @exception Exception
+     */
+    public List<EgovMap> selectCpyrhtPrtcPolicyList(CpyrhtPrtcPolicyDefaultVO searchVO) throws Exception {
+        return cpyrhtPrtcPolicyMapper.selectCpyrhtPrtcPolicyList(searchVO);
+    }
 
-	/**
-	 * 저작권보호정책 글 목록을 조회한다.
-	 * 
-	 * @param searchVO
-	 * @return 글 목록
-	 * @exception Exception
-	 */
-	public List<EgovMap> selectCpyrhtPrtcPolicyList(CpyrhtPrtcPolicyDefaultVO searchVO) throws Exception {
+    /**
+     * 저작권보호정책 글 총 개수를 조회한다.
+     * @param searchVO
+     * @return 글 총 개수
+     */
+    public int selectCpyrhtPrtcPolicyListTotCnt(CpyrhtPrtcPolicyDefaultVO searchVO) {
+        return cpyrhtPrtcPolicyMapper.selectCpyrhtPrtcPolicyListTotCnt(searchVO);
+    }
 
-		return selectList("CpyrhtPrtcPolicyDAO.selectCpyrhtPrtcPolicyList", searchVO);
+    /**
+     * 저작권보호정책 글을 등록한다.
+     * @param vo
+     * @exception Exception
+     */
+    public void insertCpyrhtPrtcPolicyCn(CpyrhtPrtcPolicyVO vo) throws Exception {
+        cpyrhtPrtcPolicyMapper.insertCpyrhtPrtcPolicyCn(vo);
+    }
 
-	}
+    /**
+     * 저작권보호정책 글을 수정한다.
+     * @param vo
+     * @exception Exception
+     */
+    public void updateCpyrhtPrtcPolicyCn(CpyrhtPrtcPolicyVO vo) throws Exception {
+        cpyrhtPrtcPolicyMapper.updateCpyrhtPrtcPolicyCn(vo);
+    }
 
-	/**
-	 * 저작권보호정책 글 총 개수를 조회한다.
-	 * 
-	 * @param searchVO
-	 * @return 글 총 개수
-	 */
-	public int selectCpyrhtPrtcPolicyListTotCnt(CpyrhtPrtcPolicyDefaultVO searchVO) {
-
-		return (Integer) selectOne("CpyrhtPrtcPolicyDAO.selectCpyrhtPrtcPolicyListTotCnt", searchVO);
-
-	}
-
-	/**
-	 * 저작권보호정책 글을 등록한다.
-	 * 
-	 * @param vo
-	 * @exception Exception
-	 */
-	public void insertCpyrhtPrtcPolicyCn(CpyrhtPrtcPolicyVO vo) throws Exception {
-
-		insert("CpyrhtPrtcPolicyDAO.insertCpyrhtPrtcPolicyCn", vo);
-
-	}
-
-	/**
-	 * 저작권보호정책 글을 수정한다.
-	 * 
-	 * @param vo
-	 * @exception Exception
-	 */
-	public void updateCpyrhtPrtcPolicyCn(CpyrhtPrtcPolicyVO vo) throws Exception {
-
-		update("CpyrhtPrtcPolicyDAO.updateCpyrhtPrtcPolicyCn", vo);
-
-	}
-
-	/**
-	 * 저작권보호정책 글을 삭제한다.
-	 * 
-	 * @param vo
-	 * @exception Exception
-	 */
-	public void deleteCpyrhtPrtcPolicyCn(CpyrhtPrtcPolicyVO vo) throws Exception {
-
-		delete("CpyrhtPrtcPolicyDAO.deleteCpyrhtPrtcPolicyCn", vo);
-
-	}
+    /**
+     * 저작권보호정책 글을 삭제한다.
+     * @param vo
+     * @exception Exception
+     */
+    public void deleteCpyrhtPrtcPolicyCn(CpyrhtPrtcPolicyVO vo) throws Exception {
+        cpyrhtPrtcPolicyMapper.deleteCpyrhtPrtcPolicyCn(vo);
+    }
 
 }

--- a/src/main/java/egovframework/com/uss/sam/cpy/service/impl/CpyrhtPrtcPolicyMapper.java
+++ b/src/main/java/egovframework/com/uss/sam/cpy/service/impl/CpyrhtPrtcPolicyMapper.java
@@ -1,0 +1,68 @@
+package egovframework.com.uss.sam.cpy.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+import org.egovframe.rte.psl.dataaccess.util.EgovMap;
+
+import egovframework.com.uss.sam.cpy.service.CpyrhtPrtcPolicyDefaultVO;
+import egovframework.com.uss.sam.cpy.service.CpyrhtPrtcPolicyVO;
+
+/**
+ * 저작권보호정책을 관리하기 위한 Mapper 인터페이스
+ * @author 공통서비스 개발팀 박정규
+ * @since 2009.04.01
+ * @version 1.0
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일         수정자       수정내용
+ *  ----------    --------    ---------------------------
+ *   2009.04.01    박정규       최초 생성
+ *
+ * </pre>
+ */
+@EgovMapper
+public interface CpyrhtPrtcPolicyMapper {
+
+    /**
+     * 저작권보호정책 글 목록에 대한 상세내용을 조회한다.
+     * @param vo - 저작권보호정책 VO
+     * @return 저작권보호정책 상세정보
+     */
+    CpyrhtPrtcPolicyVO selectCpyrhtPrtcPolicyDetail(CpyrhtPrtcPolicyVO vo);
+
+    /**
+     * 저작권보호정책 글 목록을 조회한다.
+     * @param searchVO - 검색 VO
+     * @return 글 목록
+     */
+    List<EgovMap> selectCpyrhtPrtcPolicyList(CpyrhtPrtcPolicyDefaultVO searchVO);
+
+    /**
+     * 저작권보호정책 글 총 개수를 조회한다.
+     * @param searchVO - 검색 VO
+     * @return 글 총 개수
+     */
+    int selectCpyrhtPrtcPolicyListTotCnt(CpyrhtPrtcPolicyDefaultVO searchVO);
+
+    /**
+     * 저작권보호정책 글을 등록한다.
+     * @param vo - 저작권보호정책 VO
+     */
+    void insertCpyrhtPrtcPolicyCn(CpyrhtPrtcPolicyVO vo);
+
+    /**
+     * 저작권보호정책 글을 수정한다.
+     * @param vo - 저작권보호정책 VO
+     */
+    void updateCpyrhtPrtcPolicyCn(CpyrhtPrtcPolicyVO vo);
+
+    /**
+     * 저작권보호정책 글을 삭제한다.
+     * @param vo - 저작권보호정책 VO
+     */
+    void deleteCpyrhtPrtcPolicyCn(CpyrhtPrtcPolicyVO vo);
+
+}

--- a/src/main/resources/egovframework/mapper/com/uss/sam/cpy/EgovCpyrhtPrtcPolicy_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/sam/cpy/EgovCpyrhtPrtcPolicy_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CpyrhtPrtcPolicyDAO">
+<mapper namespace="egovframework.com.uss.sam.cpy.service.impl.CpyrhtPrtcPolicyMapper">
 
 	<resultMap id="CpyrhtPrtcPolicy" type="egovframework.com.uss.sam.cpy.service.CpyrhtPrtcPolicyVO">
 		<result property="cpyrhtId" column="CPYRHT_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/sam/cpy/EgovCpyrhtPrtcPolicy_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/sam/cpy/EgovCpyrhtPrtcPolicy_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CpyrhtPrtcPolicyDAO">
+<mapper namespace="egovframework.com.uss.sam.cpy.service.impl.CpyrhtPrtcPolicyMapper">
 
 	<resultMap id="CpyrhtPrtcPolicy" type="egovframework.com.uss.sam.cpy.service.CpyrhtPrtcPolicyVO">
 		<result property="cpyrhtId" column="CPYRHT_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/sam/cpy/EgovCpyrhtPrtcPolicy_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/sam/cpy/EgovCpyrhtPrtcPolicy_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CpyrhtPrtcPolicyDAO">
+<mapper namespace="egovframework.com.uss.sam.cpy.service.impl.CpyrhtPrtcPolicyMapper">
 
 	<resultMap id="CpyrhtPrtcPolicy" type="egovframework.com.uss.sam.cpy.service.CpyrhtPrtcPolicyVO">
 		<result property="cpyrhtId" column="CPYRHT_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/sam/cpy/EgovCpyrhtPrtcPolicy_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/sam/cpy/EgovCpyrhtPrtcPolicy_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CpyrhtPrtcPolicyDAO">
+<mapper namespace="egovframework.com.uss.sam.cpy.service.impl.CpyrhtPrtcPolicyMapper">
 
 	<resultMap id="CpyrhtPrtcPolicy" type="egovframework.com.uss.sam.cpy.service.CpyrhtPrtcPolicyVO">
 		<result property="cpyrhtId" column="CPYRHT_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/sam/cpy/EgovCpyrhtPrtcPolicy_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/sam/cpy/EgovCpyrhtPrtcPolicy_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CpyrhtPrtcPolicyDAO">
+<mapper namespace="egovframework.com.uss.sam.cpy.service.impl.CpyrhtPrtcPolicyMapper">
 
 	<resultMap id="CpyrhtPrtcPolicy" type="egovframework.com.uss.sam.cpy.service.CpyrhtPrtcPolicyVO">
 		<result property="cpyrhtId" column="CPYRHT_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/sam/cpy/EgovCpyrhtPrtcPolicy_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/sam/cpy/EgovCpyrhtPrtcPolicy_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CpyrhtPrtcPolicyDAO">
+<mapper namespace="egovframework.com.uss.sam.cpy.service.impl.CpyrhtPrtcPolicyMapper">
 
 
 	<resultMap id="CpyrhtPrtcPolicy" type="egovframework.com.uss.sam.cpy.service.CpyrhtPrtcPolicyVO">

--- a/src/main/resources/egovframework/mapper/com/uss/sam/cpy/EgovCpyrhtPrtcPolicy_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/sam/cpy/EgovCpyrhtPrtcPolicy_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CpyrhtPrtcPolicyDAO">
+<mapper namespace="egovframework.com.uss.sam.cpy.service.impl.CpyrhtPrtcPolicyMapper">
 
 	<resultMap id="CpyrhtPrtcPolicy" type="egovframework.com.uss.sam.cpy.service.CpyrhtPrtcPolicyVO">
 		<result property="cpyrhtId" column="CPYRHT_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/sam/cpy/EgovCpyrhtPrtcPolicy_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/sam/cpy/EgovCpyrhtPrtcPolicy_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CpyrhtPrtcPolicyDAO">
+<mapper namespace="egovframework.com.uss.sam.cpy.service.impl.CpyrhtPrtcPolicyMapper">
 
 
 	<resultMap id="CpyrhtPrtcPolicy" type="egovframework.com.uss.sam.cpy.service.CpyrhtPrtcPolicyVO">

--- a/src/main/resources/egovframework/spring/com/context-mapper.xml
+++ b/src/main/resources/egovframework/spring/com/context-mapper.xml
@@ -21,5 +21,11 @@
 	<bean id="egov.sqlSessionTemplate" class="org.mybatis.spring.SqlSessionTemplate">
 		<constructor-arg ref="egov.sqlSession"/>
 	</bean>
-	
+
+	<!-- @EgovMapper 어노테이션 기반 Mapper 인터페이스 자동 등록 -->
+	<bean class="org.mybatis.spring.mapper.MapperScannerConfigurer">
+		<property name="basePackage" value="egovframework.com"/>
+		<property name="annotationClass" value="org.egovframe.rte.psl.dataaccess.mapper.EgovMapper"/>
+	</bean>
+
 </beans>


### PR DESCRIPTION
## 변경 사유
기존 XML namespace 기반 DAO를 5.0 신규 @EgovMapper 인터페이스 방식으로 전환

## 변경 내용
- CpyrhtPrtcPolicyMapper 인터페이스 신규 추가
- uss/sam/cpy CpyrhtPrtcPolicyDAO를 mapper 위임 구조로 리팩토링 (EgovComAbstractDAO 상속 제거)
- XML namespace를 mapper FQN으로 변경 (8개 DBMS)
- context-mapper.xml MapperScannerConfigurer 추가

## 영향 범위
- uss/sam/cpy 저작권보호정책 관리 모듈만 영향
- DAO bean name 유지

## 체크리스트
- [x] 단일 주제만 다룸
- [x] 기존 동작 호환
