### PR TITLE
[refactor][5.0.x][공통컴포넌트] cop/sms SmsDAO @EgovMapper 인터페이스 방식으로 전환

### DIFF
--- a/src/main/java/egovframework/com/cop/sms/service/impl/SmsDAO.java
+++ b/src/main/java/egovframework/com/cop/sms/service/impl/SmsDAO.java
@@ -1,13 +1,13 @@
- package egovframework.com.cop.sms.service.impl;
+package egovframework.com.cop.sms.service.impl;
 
 import java.util.List;
 
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.cop.sms.service.Sms;
 import egovframework.com.cop.sms.service.SmsRecptn;
 import egovframework.com.cop.sms.service.SmsVO;
+import jakarta.annotation.Resource;
 
 /**
  * 문자메시지를 위한 데이터 접근 클래스
@@ -18,83 +18,88 @@ import egovframework.com.cop.sms.service.SmsVO;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.06.18  한성곤          최초 생성
+ *   2026.05.28  dasomel         @EgovMapper 인터페이스 위임 방식으로 전환
  *
  * </pre>
  */
 @Repository("SmsDAO")
-public class SmsDAO extends EgovComAbstractDAO {
-	
+public class SmsDAO {
+
+	@Resource(name = "smsMapper")
+	private SmsMapper mapper;
+
     /**
      * 문자메시지 목록을 조회한다.
-     * 
-     * @param SmsVO
+     *
+     * @param smsVO
      * @return List<SmsVO>
      */
 	public List<SmsVO> selectSmsInfs(SmsVO smsVO) {
-        return selectList("SmsDAO.selectSmsInfs", smsVO);
-    }
+		return mapper.selectSmsInfs(smsVO);
+	}
 
     /**
      * 문자메시지 목록 숫자를 조회한다
-     * 
-     * @param SmsVO
+     *
+     * @param smsVO
      * @return int
      */
 	public int selectSmsInfsCnt(SmsVO smsVO) {
-        return selectOne("SmsDAO.selectSmsInfsCnt", smsVO);
-    }
-    
+		return mapper.selectSmsInfsCnt(smsVO);
+	}
+
     /**
      * 문자메시지 정보를 등록한다.
-     * 
+     *
      * @param sms
      * @return int
      */
 	public int insertSmsInf(Sms sms) {
-        return insert("SmsDAO.insertSmsInf", sms);
-    }
-    
+		return mapper.insertSmsInf(sms);
+	}
+
     /**
      * 문자메시지 수신정보 및 결과 정보를 등록한다.
+     *
      * @param smsRecptn
      * @return int
      */
 	public int insertSmsRecptnInf(SmsRecptn smsRecptn) {
-        return insert("SmsDAO.insertSmsRecptnInf", smsRecptn);
-    }
-    
+		return mapper.insertSmsRecptnInf(smsRecptn);
+	}
+
     /**
      * 문자메시지에 대한 상세정보를 조회한다.
-     * 
+     *
      * @param smsVO
-     * @return
+     * @return SmsVO
      */
 	public SmsVO selectSmsInf(SmsVO smsVO) {
-        return selectOne("SmsDAO.selectSmsInf", smsVO);
-    }
-    
+		return mapper.selectSmsInf(smsVO);
+	}
+
     /**
      * 문자메시지 수신 및 결과 목록을 조회한다.
-     * 
-     * @param SmsRecptn
-     * @return
-     * @throws Exception
+     *
+     * @param smsRecptn
+     * @return List<SmsRecptn>
      */
 	public List<SmsRecptn> selectSmsRecptnInfs(SmsRecptn smsRecptn) {
-        return selectList("SmsDAO.selectSmsRecptnInfs", smsRecptn);
-    }
-    
+		return mapper.selectSmsRecptnInfs(smsRecptn);
+	}
+
     /**
      * 문자메시지 전송 결과 수신을 처리한다. EgovSmsInfoReceiver(Schedule job)에 의해 호출된다.
-     * 
+     *
      * @param smsRecptn
      * @return int
      */
 	public int updateSmsRecptnInf(SmsRecptn smsRecptn) {
-        return update("SmsDAO.updateSmsRecptnInf", smsRecptn);
-    }
+		return mapper.updateSmsRecptnInf(smsRecptn);
+	}
+
 }

--- a/src/main/java/egovframework/com/cop/sms/service/impl/SmsMapper.java
+++ b/src/main/java/egovframework/com/cop/sms/service/impl/SmsMapper.java
@@ -1,0 +1,45 @@
+package egovframework.com.cop.sms.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.cop.sms.service.Sms;
+import egovframework.com.cop.sms.service.SmsRecptn;
+import egovframework.com.cop.sms.service.SmsVO;
+
+/**
+ * 문자메시지를 위한 Mapper 인터페이스
+ * @author 공통컴포넌트개발팀 한성곤
+ * @since 2009.06.18
+ * @version 1.0
+ * @see
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2009.06.18  한성곤          최초 생성
+ *   2026.05.28  dasomel         XML 기반 DAO → @EgovMapper 인터페이스로 전환
+ *
+ * </pre>
+ */
+@EgovMapper("smsMapper")
+public interface SmsMapper {
+
+	List<SmsVO> selectSmsInfs(SmsVO smsVO);
+
+	int selectSmsInfsCnt(SmsVO smsVO);
+
+	int insertSmsInf(Sms sms);
+
+	int insertSmsRecptnInf(SmsRecptn smsRecptn);
+
+	SmsVO selectSmsInf(SmsVO smsVO);
+
+	List<SmsRecptn> selectSmsRecptnInfs(SmsRecptn smsRecptn);
+
+	int updateSmsRecptnInf(SmsRecptn smsRecptn);
+
+}

--- a/src/main/resources/egovframework/mapper/com/cop/sms/EgovSms_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/sms/EgovSms_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="SmsDAO">
+<mapper namespace="egovframework.com.cop.sms.service.impl.SmsMapper">
 
 	<resultMap id="smsList" type="egovframework.com.cop.sms.service.SmsVO">
 		<result property="smsId" column="SMS_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/sms/EgovSms_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/sms/EgovSms_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="SmsDAO">
+<mapper namespace="egovframework.com.cop.sms.service.impl.SmsMapper">
 
 	<resultMap id="smsList" type="egovframework.com.cop.sms.service.SmsVO">
 		<result property="smsId" column="SMS_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/sms/EgovSms_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/sms/EgovSms_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="SmsDAO">
+<mapper namespace="egovframework.com.cop.sms.service.impl.SmsMapper">
 
 	<resultMap id="smsList" type="egovframework.com.cop.sms.service.SmsVO">
 		<result property="smsId" column="SMS_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/sms/EgovSms_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/sms/EgovSms_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="SmsDAO">
+<mapper namespace="egovframework.com.cop.sms.service.impl.SmsMapper">
 
 	<resultMap id="smsList" type="egovframework.com.cop.sms.service.SmsVO">
 		<result property="smsId" column="SMS_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/sms/EgovSms_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/sms/EgovSms_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="SmsDAO">
+<mapper namespace="egovframework.com.cop.sms.service.impl.SmsMapper">
 
 	<resultMap id="smsList" type="egovframework.com.cop.sms.service.SmsVO">
 		<result property="smsId" column="SMS_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/sms/EgovSms_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/sms/EgovSms_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="SmsDAO">
+<mapper namespace="egovframework.com.cop.sms.service.impl.SmsMapper">
 
 	<resultMap id="smsList" type="egovframework.com.cop.sms.service.SmsVO">
 		<result property="smsId" column="SMS_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/sms/EgovSms_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/sms/EgovSms_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="SmsDAO">
+<mapper namespace="egovframework.com.cop.sms.service.impl.SmsMapper">
 
 	<resultMap id="smsList" type="egovframework.com.cop.sms.service.SmsVO">
 		<result property="smsId" column="SMS_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/sms/EgovSms_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/sms/EgovSms_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="SmsDAO">
+<mapper namespace="egovframework.com.cop.sms.service.impl.SmsMapper">
 
 	<resultMap id="smsList" type="egovframework.com.cop.sms.service.SmsVO">
 		<result property="smsId" column="SMS_ID"/>

--- a/src/main/resources/egovframework/spring/com/context-mapper.xml
+++ b/src/main/resources/egovframework/spring/com/context-mapper.xml
@@ -21,5 +21,11 @@
 	<bean id="egov.sqlSessionTemplate" class="org.mybatis.spring.SqlSessionTemplate">
 		<constructor-arg ref="egov.sqlSession"/>
 	</bean>
-	
+
+	<!-- @EgovMapper 어노테이션 기반 Mapper 인터페이스 자동 등록 -->
+	<bean class="org.mybatis.spring.mapper.MapperScannerConfigurer">
+		<property name="basePackage" value="egovframework.com" />
+		<property name="annotationClass" value="org.egovframe.rte.psl.dataaccess.mapper.EgovMapper" />
+	</bean>
+
 </beans>


### PR DESCRIPTION
## 변경 사유
기존 XML namespace 기반 DAO를 5.0 신규 @EgovMapper 인터페이스 방식으로 전환

## 변경 내용
- SmsMapper 인터페이스 신규 추가
- cop/sms SmsDAO를 mapper 위임 구조로 리팩토링
- XML namespace를 mapper FQN으로 변경
- context-mapper.xml MapperScannerConfigurer 추가

## 영향 범위
- cop/sms SMS 발송 모듈만 영향
- DAO bean name 유지

## 체크리스트
- [x] 단일 주제만 다룸
- [x] 기존 동작 호환
