### PR TITLE
[refactor][5.0.x][공통컴포넌트] cop/ems 메일발송 3개 DAO @EgovMapper 인터페이스 방식으로 전환

### DIFF
--- a/src/main/java/egovframework/com/cop/ems/service/impl/SndngMailDetailDAO.java
+++ b/src/main/java/egovframework/com/cop/ems/service/impl/SndngMailDetailDAO.java
@@ -2,12 +2,13 @@ package egovframework.com.cop.ems.service.impl;
 
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.cop.ems.service.SndngMailVO;
+
+import jakarta.annotation.Resource;
 
 /**
  * 발송메일을 상세 조회하는 DAO 클래스
- * 
+ *
  * @author 공통서비스 개발팀 박지욱
  * @since 2009.03.12
  * @version 1.0
@@ -23,27 +24,30 @@ import egovframework.com.cop.ems.service.SndngMailVO;
  *      </pre>
  */
 @Repository("sndngMailDetailDAO")
-public class SndngMailDetailDAO extends EgovComAbstractDAO {
+public class SndngMailDetailDAO {
+
+	@Resource(name = "sndngMailDetailMapper")
+	private SndngMailDetailMapper sndngMailDetailMapper;
 
 	/**
 	 * 발송메일을 상세 조회한다.
-	 * 
+	 *
 	 * @param vo SndngMailVO
 	 * @return SndngMailVO
 	 * @exception Exception
 	 */
 	public SndngMailVO selectSndngMail(SndngMailVO vo) throws Exception {
-		return (SndngMailVO) selectOne("sndngMailDetailDAO.selectSndngMail", vo);
+		return sndngMailDetailMapper.selectSndngMail(vo);
 	}
 
 	/**
 	 * 발송메일을 삭제한다.
-	 * 
+	 *
 	 * @param vo SndngMailVO
 	 * @exception
 	 */
 	public int deleteSndngMail(SndngMailVO vo) throws Exception {
-        return delete("sndngMailDetailDAO.deleteSndngMail", vo);
-    }
+		return sndngMailDetailMapper.deleteSndngMail(vo);
+	}
 
 }

--- a/src/main/java/egovframework/com/cop/ems/service/impl/SndngMailDetailMapper.java
+++ b/src/main/java/egovframework/com/cop/ems/service/impl/SndngMailDetailMapper.java
@@ -1,0 +1,40 @@
+package egovframework.com.cop.ems.service.impl;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.cop.ems.service.SndngMailVO;
+
+/**
+ * 발송메일을 상세 조회하기 위한 Mapper 인터페이스
+ *
+ * @author 공통서비스 개발팀 박지욱
+ * @since 2009.03.12
+ * @version 1.0
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일         수정자       수정내용
+ *  ----------    --------    ---------------------------
+ *   2009.03.12    박지욱       최초 생성
+ *
+ * </pre>
+ */
+@EgovMapper
+public interface SndngMailDetailMapper {
+
+	/**
+	 * 발송메일을 상세 조회한다.
+	 * @param vo SndngMailVO
+	 * @return SndngMailVO
+	 */
+	SndngMailVO selectSndngMail(SndngMailVO vo);
+
+	/**
+	 * 발송메일을 삭제한다.
+	 * @param vo SndngMailVO
+	 * @return int
+	 */
+	int deleteSndngMail(SndngMailVO vo);
+
+}

--- a/src/main/java/egovframework/com/cop/ems/service/impl/SndngMailDtlsDAO.java
+++ b/src/main/java/egovframework/com/cop/ems/service/impl/SndngMailDtlsDAO.java
@@ -5,12 +5,13 @@ import java.util.List;
 import org.springframework.stereotype.Repository;
 
 import egovframework.com.cmm.ComDefaultVO;
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.cop.ems.service.SndngMailVO;
+
+import jakarta.annotation.Resource;
 
 /**
  * 발송메일 내역을 조회하는 DAO 클래스
- * 
+ *
  * @author 공통서비스 개발팀 박지욱
  * @since 2009.03.12
  * @version 1.0
@@ -26,27 +27,30 @@ import egovframework.com.cop.ems.service.SndngMailVO;
  *      </pre>
  */
 @Repository("sndngMailDtlsDAO")
-public class SndngMailDtlsDAO extends EgovComAbstractDAO {
+public class SndngMailDtlsDAO {
+
+	@Resource(name = "sndngMailDtlsMapper")
+	private SndngMailDtlsMapper sndngMailDtlsMapper;
 
 	/**
 	 * 발송메일 목록을 조회한다.
-	 * 
+	 *
 	 * @param vo ComDefaultVO
 	 * @return List
 	 * @exception Exception
 	 */
 	public List<SndngMailVO> selectSndngMailList(ComDefaultVO vo) throws Exception {
-		return selectList("SndngMailDtlsDAO.selectSndngMailList_D", vo);
+		return sndngMailDtlsMapper.selectSndngMailList_D(vo);
 	}
 
 	/**
 	 * 발송메일 총건수를 조회한다.
-	 * 
+	 *
 	 * @param vo ComDefaultVO
 	 * @return int
 	 * @exception
 	 */
 	public int selectSndngMailListTotCnt(ComDefaultVO vo) {
-		return (Integer) selectOne("SndngMailDtlsDAO.selectSndngMailListTotCnt_S", vo);
+		return sndngMailDtlsMapper.selectSndngMailListTotCnt_S(vo);
 	}
 }

--- a/src/main/java/egovframework/com/cop/ems/service/impl/SndngMailDtlsMapper.java
+++ b/src/main/java/egovframework/com/cop/ems/service/impl/SndngMailDtlsMapper.java
@@ -1,0 +1,43 @@
+package egovframework.com.cop.ems.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.cmm.ComDefaultVO;
+import egovframework.com.cop.ems.service.SndngMailVO;
+
+/**
+ * 발송메일 내역을 조회하기 위한 Mapper 인터페이스
+ *
+ * @author 공통서비스 개발팀 박지욱
+ * @since 2009.03.12
+ * @version 1.0
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일         수정자       수정내용
+ *  ----------    --------    ---------------------------
+ *   2009.03.12    박지욱       최초 생성
+ *
+ * </pre>
+ */
+@EgovMapper
+public interface SndngMailDtlsMapper {
+
+	/**
+	 * 발송메일 목록을 조회한다.
+	 * @param vo ComDefaultVO
+	 * @return List
+	 */
+	List<SndngMailVO> selectSndngMailList_D(ComDefaultVO vo);
+
+	/**
+	 * 발송메일 총건수를 조회한다.
+	 * @param vo ComDefaultVO
+	 * @return int
+	 */
+	int selectSndngMailListTotCnt_S(ComDefaultVO vo);
+
+}

--- a/src/main/java/egovframework/com/cop/ems/service/impl/SndngMailRegistDAO.java
+++ b/src/main/java/egovframework/com/cop/ems/service/impl/SndngMailRegistDAO.java
@@ -4,9 +4,10 @@ import java.util.List;
 
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.cop.ems.service.AtchmnFileVO;
 import egovframework.com.cop.ems.service.SndngMailVO;
+
+import jakarta.annotation.Resource;
 
 /**
  * 발송메일을 등록하는 DAO 클래스
@@ -25,7 +26,10 @@ import egovframework.com.cop.ems.service.SndngMailVO;
  *  </pre>
  */
 @Repository("sndngMailRegistDAO")
-public class SndngMailRegistDAO extends EgovComAbstractDAO {
+public class SndngMailRegistDAO {
+
+	@Resource(name = "sndngMailRegistMapper")
+	private SndngMailRegistMapper sndngMailRegistMapper;
 
 	/**
 	 * 발송할 메일을 등록한다
@@ -34,8 +38,8 @@ public class SndngMailRegistDAO extends EgovComAbstractDAO {
 	 * @exception Exception
 	 */
 	public SndngMailVO insertSndngMail(SndngMailVO vo) throws Exception {
-		insert("sndngMailRegistDAO.insertSndngMail", vo);
-		return new SndngMailVO() ;
+		sndngMailRegistMapper.insertSndngMail(vo);
+		return new SndngMailVO();
 	}
 
 	/**
@@ -45,7 +49,7 @@ public class SndngMailRegistDAO extends EgovComAbstractDAO {
 	 * @exception Exception
 	 */
 	public List<AtchmnFileVO> selectAtchmnFileList(SndngMailVO vo) throws Exception {
-		return selectList("sndngMailRegistDAO.selectAtchmnFileList", vo);
+		return sndngMailRegistMapper.selectAtchmnFileList(vo);
 	}
 
 	/**
@@ -55,7 +59,7 @@ public class SndngMailRegistDAO extends EgovComAbstractDAO {
 	 * @exception Exception
 	 */
 	public SndngMailVO updateSndngMail(SndngMailVO vo) throws Exception {
-		update("sndngMailRegistDAO.updateSndngMail", vo);
+		sndngMailRegistMapper.updateSndngMail(vo);
 		return new SndngMailVO();
 	}
 }

--- a/src/main/java/egovframework/com/cop/ems/service/impl/SndngMailRegistMapper.java
+++ b/src/main/java/egovframework/com/cop/ems/service/impl/SndngMailRegistMapper.java
@@ -1,0 +1,47 @@
+package egovframework.com.cop.ems.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.cop.ems.service.AtchmnFileVO;
+import egovframework.com.cop.ems.service.SndngMailVO;
+
+/**
+ * 발송메일을 등록하기 위한 Mapper 인터페이스
+ * @author 공통서비스 개발팀 박지욱
+ * @since 2009.03.12
+ * @version 1.0
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일         수정자       수정내용
+ *  ----------    --------    ---------------------------
+ *   2009.03.12    박지욱       최초 생성
+ *
+ * </pre>
+ */
+@EgovMapper
+public interface SndngMailRegistMapper {
+
+	/**
+	 * 발송할 메일을 등록한다.
+	 * @param vo SndngMailVO
+	 */
+	void insertSndngMail(SndngMailVO vo);
+
+	/**
+	 * 발송할 메일에 있는 첨부파일 목록을 조회한다.
+	 * @param vo SndngMailVO
+	 * @return List
+	 */
+	List<AtchmnFileVO> selectAtchmnFileList(SndngMailVO vo);
+
+	/**
+	 * 발송결과를 수정한다.
+	 * @param vo SndngMailVO
+	 */
+	void updateSndngMail(SndngMailVO vo);
+
+}

--- a/src/main/resources/egovframework/mapper/com/cop/ems/EgovSndngMailDetail_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/ems/EgovSndngMailDetail_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:49:51 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="sndngMailDetailDAO">
+<mapper namespace="egovframework.com.cop.ems.service.impl.SndngMailDetailMapper">
 
 	<!-- 발송메일을 위한 resultMap -->
 	<resultMap id="sndngMail" type="egovframework.com.cop.ems.service.SndngMailVO">

--- a/src/main/resources/egovframework/mapper/com/cop/ems/EgovSndngMailDetail_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/ems/EgovSndngMailDetail_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:49:51 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="sndngMailDetailDAO">
+<mapper namespace="egovframework.com.cop.ems.service.impl.SndngMailDetailMapper">
 
 	<!-- 발송메일을 위한 resultMap -->
 	<resultMap id="sndngMail" type="egovframework.com.cop.ems.service.SndngMailVO">

--- a/src/main/resources/egovframework/mapper/com/cop/ems/EgovSndngMailDetail_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/ems/EgovSndngMailDetail_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:49:51 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="sndngMailDetailDAO">
+<mapper namespace="egovframework.com.cop.ems.service.impl.SndngMailDetailMapper">
 
 	<!-- 발송메일을 위한 resultMap -->
 	<resultMap id="sndngMail" type="egovframework.com.cop.ems.service.SndngMailVO">

--- a/src/main/resources/egovframework/mapper/com/cop/ems/EgovSndngMailDetail_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/ems/EgovSndngMailDetail_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:49:52 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="sndngMailDetailDAO">
+<mapper namespace="egovframework.com.cop.ems.service.impl.SndngMailDetailMapper">
 
 	<!-- 발송메일을 위한 resultMap -->
 	<resultMap id="sndngMail" type="egovframework.com.cop.ems.service.SndngMailVO">

--- a/src/main/resources/egovframework/mapper/com/cop/ems/EgovSndngMailDetail_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/ems/EgovSndngMailDetail_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:49:52 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="sndngMailDetailDAO">
+<mapper namespace="egovframework.com.cop.ems.service.impl.SndngMailDetailMapper">
 
 	<!-- 발송메일을 위한 resultMap -->
 	<resultMap id="sndngMail" type="egovframework.com.cop.ems.service.SndngMailVO">

--- a/src/main/resources/egovframework/mapper/com/cop/ems/EgovSndngMailDetail_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/ems/EgovSndngMailDetail_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:49:52 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="sndngMailDetailDAO">
+<mapper namespace="egovframework.com.cop.ems.service.impl.SndngMailDetailMapper">
 
 	<!-- 발송메일을 위한 resultMap -->
 	<resultMap id="sndngMail" type="egovframework.com.cop.ems.service.SndngMailVO">

--- a/src/main/resources/egovframework/mapper/com/cop/ems/EgovSndngMailDetail_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/ems/EgovSndngMailDetail_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:49:52 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="sndngMailDetailDAO">
+<mapper namespace="egovframework.com.cop.ems.service.impl.SndngMailDetailMapper">
 
 	<!-- 발송메일을 위한 resultMap -->
 	<resultMap id="sndngMail" type="egovframework.com.cop.ems.service.SndngMailVO">

--- a/src/main/resources/egovframework/mapper/com/cop/ems/EgovSndngMailDetail_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/ems/EgovSndngMailDetail_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:49:52 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="sndngMailDetailDAO">
+<mapper namespace="egovframework.com.cop.ems.service.impl.SndngMailDetailMapper">
 
 	<!-- 발송메일을 위한 resultMap -->
 	<resultMap id="sndngMail" type="egovframework.com.cop.ems.service.SndngMailVO">

--- a/src/main/resources/egovframework/mapper/com/cop/ems/EgovSndngMailDtls_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/ems/EgovSndngMailDtls_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:49:52 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="SndngMailDtlsDAO">
+<mapper namespace="egovframework.com.cop.ems.service.impl.SndngMailDtlsMapper">
 
 	<!-- 발송메일 내역 조회를 위한 resultMap -->
 	<resultMap id="sndngMail" type="egovframework.com.cop.ems.service.SndngMailVO">

--- a/src/main/resources/egovframework/mapper/com/cop/ems/EgovSndngMailDtls_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/ems/EgovSndngMailDtls_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:49:52 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="SndngMailDtlsDAO">
+<mapper namespace="egovframework.com.cop.ems.service.impl.SndngMailDtlsMapper">
 	
 	<!-- 발송메일 내역 조회를 위한 resultMap -->
 	<resultMap id="sndngMail" type="egovframework.com.cop.ems.service.SndngMailVO">

--- a/src/main/resources/egovframework/mapper/com/cop/ems/EgovSndngMailDtls_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/ems/EgovSndngMailDtls_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:49:52 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="SndngMailDtlsDAO">
+<mapper namespace="egovframework.com.cop.ems.service.impl.SndngMailDtlsMapper">
 
 	<!-- 발송메일 내역 조회를 위한 resultMap -->
 	<resultMap id="sndngMail" type="egovframework.com.cop.ems.service.SndngMailVO">

--- a/src/main/resources/egovframework/mapper/com/cop/ems/EgovSndngMailDtls_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/ems/EgovSndngMailDtls_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:49:52 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="SndngMailDtlsDAO">
+<mapper namespace="egovframework.com.cop.ems.service.impl.SndngMailDtlsMapper">
 	
 	<!-- 발송메일 내역 조회를 위한 resultMap -->
 	<resultMap id="sndngMail" type="egovframework.com.cop.ems.service.SndngMailVO">

--- a/src/main/resources/egovframework/mapper/com/cop/ems/EgovSndngMailDtls_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/ems/EgovSndngMailDtls_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:49:52 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="SndngMailDtlsDAO">
+<mapper namespace="egovframework.com.cop.ems.service.impl.SndngMailDtlsMapper">
 	
 	<!-- 발송메일 내역 조회를 위한 resultMap -->
 	<resultMap id="sndngMail" type="egovframework.com.cop.ems.service.SndngMailVO">

--- a/src/main/resources/egovframework/mapper/com/cop/ems/EgovSndngMailDtls_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/ems/EgovSndngMailDtls_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:49:53 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="SndngMailDtlsDAO">
+<mapper namespace="egovframework.com.cop.ems.service.impl.SndngMailDtlsMapper">
 	
 	<!-- 발송메일 내역 조회를 위한 resultMap -->
 	<resultMap id="sndngMail" type="egovframework.com.cop.ems.service.SndngMailVO">

--- a/src/main/resources/egovframework/mapper/com/cop/ems/EgovSndngMailDtls_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/ems/EgovSndngMailDtls_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:49:52 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="SndngMailDtlsDAO">
+<mapper namespace="egovframework.com.cop.ems.service.impl.SndngMailDtlsMapper">
 	
 	<!-- 발송메일 내역 조회를 위한 resultMap -->
 	<resultMap id="sndngMail" type="egovframework.com.cop.ems.service.SndngMailVO">

--- a/src/main/resources/egovframework/mapper/com/cop/ems/EgovSndngMailDtls_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/ems/EgovSndngMailDtls_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:49:53 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="SndngMailDtlsDAO">
+<mapper namespace="egovframework.com.cop.ems.service.impl.SndngMailDtlsMapper">
 	
 	<!-- 발송메일 내역 조회를 위한 resultMap -->
 	<resultMap id="sndngMail" type="egovframework.com.cop.ems.service.SndngMailVO">

--- a/src/main/resources/egovframework/mapper/com/cop/ems/EgovSndngMailRegist_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/ems/EgovSndngMailRegist_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:49:53 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="sndngMailRegistDAO">
+<mapper namespace="egovframework.com.cop.ems.service.impl.SndngMailRegistMapper">
 
 
 	<resultMap id="atchmnFileVO" type="egovframework.com.cop.ems.service.AtchmnFileVO">

--- a/src/main/resources/egovframework/mapper/com/cop/ems/EgovSndngMailRegist_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/ems/EgovSndngMailRegist_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:49:53 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="sndngMailRegistDAO">
+<mapper namespace="egovframework.com.cop.ems.service.impl.SndngMailRegistMapper">
 	
 	<resultMap id="atchmnFileVO" type="egovframework.com.cop.ems.service.AtchmnFileVO">
 		<result property="atchFileId" column="atchFileId"/>

--- a/src/main/resources/egovframework/mapper/com/cop/ems/EgovSndngMailRegist_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/ems/EgovSndngMailRegist_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:49:53 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="sndngMailRegistDAO">
+<mapper namespace="egovframework.com.cop.ems.service.impl.SndngMailRegistMapper">
 
 
 	<resultMap id="atchmnFileVO" type="egovframework.com.cop.ems.service.AtchmnFileVO">

--- a/src/main/resources/egovframework/mapper/com/cop/ems/EgovSndngMailRegist_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/ems/EgovSndngMailRegist_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:49:53 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="sndngMailRegistDAO">
+<mapper namespace="egovframework.com.cop.ems.service.impl.SndngMailRegistMapper">
 
 	<resultMap id="atchmnFileVO" type="egovframework.com.cop.ems.service.AtchmnFileVO">
 		<result property="atchFileId" column="atchFileId"/>

--- a/src/main/resources/egovframework/mapper/com/cop/ems/EgovSndngMailRegist_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/ems/EgovSndngMailRegist_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:49:53 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="sndngMailRegistDAO">
+<mapper namespace="egovframework.com.cop.ems.service.impl.SndngMailRegistMapper">
 
 	<resultMap id="atchmnFileVO" type="egovframework.com.cop.ems.service.AtchmnFileVO">
 		<result property="atchFileId" column="atchFileId"/>

--- a/src/main/resources/egovframework/mapper/com/cop/ems/EgovSndngMailRegist_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/ems/EgovSndngMailRegist_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:49:53 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="sndngMailRegistDAO">
+<mapper namespace="egovframework.com.cop.ems.service.impl.SndngMailRegistMapper">
 
 	<resultMap id="atchmnFileVO" type="egovframework.com.cop.ems.service.AtchmnFileVO">
 		<result property="atchFileId" column="atchFileId"/>

--- a/src/main/resources/egovframework/mapper/com/cop/ems/EgovSndngMailRegist_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/ems/EgovSndngMailRegist_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:49:53 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="sndngMailRegistDAO">
+<mapper namespace="egovframework.com.cop.ems.service.impl.SndngMailRegistMapper">
 
 	<resultMap id="atchmnFileVO" type="egovframework.com.cop.ems.service.AtchmnFileVO">
 		<result property="atchFileId" column="atchFileId"/>

--- a/src/main/resources/egovframework/mapper/com/cop/ems/EgovSndngMailRegist_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/ems/EgovSndngMailRegist_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:49:54 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="sndngMailRegistDAO">
+<mapper namespace="egovframework.com.cop.ems.service.impl.SndngMailRegistMapper">
 
 	<resultMap id="atchmnFileVO" type="egovframework.com.cop.ems.service.AtchmnFileVO">
 		<result property="atchFileId" column="atchFileId"/>

--- a/src/main/resources/egovframework/spring/com/context-mapper.xml
+++ b/src/main/resources/egovframework/spring/com/context-mapper.xml
@@ -21,5 +21,11 @@
 	<bean id="egov.sqlSessionTemplate" class="org.mybatis.spring.SqlSessionTemplate">
 		<constructor-arg ref="egov.sqlSession"/>
 	</bean>
-	
+
+	<!-- @EgovMapper 어노테이션 기반 Mapper 인터페이스 자동 등록 -->
+	<bean class="org.mybatis.spring.mapper.MapperScannerConfigurer">
+		<property name="basePackage" value="egovframework.com"/>
+		<property name="annotationClass" value="org.egovframe.rte.psl.dataaccess.mapper.EgovMapper"/>
+	</bean>
+
 </beans>


### PR DESCRIPTION
## 변경 사유
기존 XML namespace 기반 DAO를 5.0 신규 @EgovMapper 인터페이스 방식으로 전환

## 변경 내용
- SndngMailRegistMapper, SndngMailDtlsMapper, SndngMailDetailMapper 인터페이스 신규 추가
- cop/ems 3개 DAO를 mapper 위임 구조로 리팩토링 (EgovComAbstractDAO 상속 제거)
- XML namespace를 mapper FQN으로 변경 (8개 DBMS)
- context-mapper.xml MapperScannerConfigurer 추가

## 영향 범위
- cop/ems 메일발송 모듈만 영향
- DAO bean name 유지

## 체크리스트
- [x] 단일 주제만 다룸
- [x] 기존 동작 호환
