### PR TITLE
[refactor][5.0.x][공통컴포넌트] cop/smt 일정·다이어리 4개 DAO @EgovMapper 인터페이스 방식으로 전환

### DIFF
--- a/src/main/java/egovframework/com/cop/smt/djm/service/impl/DeptJobDAO.java
+++ b/src/main/java/egovframework/com/cop/smt/djm/service/impl/DeptJobDAO.java
@@ -4,285 +4,136 @@ import java.util.List;
 
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.cop.smt.djm.service.ChargerVO;
 import egovframework.com.cop.smt.djm.service.DeptJob;
 import egovframework.com.cop.smt.djm.service.DeptJobBx;
 import egovframework.com.cop.smt.djm.service.DeptJobBxVO;
 import egovframework.com.cop.smt.djm.service.DeptJobVO;
 import egovframework.com.cop.smt.djm.service.DeptVO;
+import jakarta.annotation.Resource;
 
 /**
  * 개요 - 부서업무에 대한 DAO 클래스를 정의한다.
- * 
+ *
  * 상세내용 - 부서업무에 대한 등록, 수정, 삭제, 조회기능을 제공한다. - 부서업무의 조회기능은 목록조회, 상세조회로 구분된다.
- * 
+ *
  * @author 장철호
  * @version 1.0
  * @created 28-6-2010 오전 10:59:05
- * 
+ *
  *          <pre>
  * << 개정이력(Modification Information) >>
  *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2010.6.28	장철호          최초 생성
- *
+ *   2026.05.28  dasomel         @EgovMapper 인터페이스 위임 방식으로 전환
  *          </pre>
  */
 @Repository("DeptJobDAO")
-public class DeptJobDAO extends EgovComAbstractDAO {
+public class DeptJobDAO {
 
-    /**
-     * 주어진 조건에 맞는 담당자를 불러온다.
-     * 
-     * @param chargerVO
-     * @return List
-     */
-    public List<ChargerVO> selectChargerList(ChargerVO chargerVO) {
-        return selectList("DeptJobDAO.selectChargerList", chargerVO);
-    }
+	@Resource(name = "deptJobMapper")
+	private DeptJobMapper mapper;
 
-    /**
-     * 담당자 목록에 대한 전체 건수를 조회한다.
-     * 
-     * @param chargerVO
-     * @return int
-     */
-    public int selectChargerListCnt(ChargerVO chargerVO) {
-        return selectOne("DeptJobDAO.selectChargerListCnt", chargerVO);
-    }
+	public List<ChargerVO> selectChargerList(ChargerVO chargerVO) {
+		return mapper.selectChargerList(chargerVO);
+	}
 
-    /**
-     * 주어진 조건에 맞는 부서를 불러온다.
-     * 
-     * @param deptVO
-     * @return List
-     */
-    public List<DeptVO> selectDeptList(DeptVO deptVO) {
-        return selectList("DeptJobDAO.selectDeptList", deptVO);
-    }
+	public int selectChargerListCnt(ChargerVO chargerVO) {
+		return mapper.selectChargerListCnt(chargerVO);
+	}
 
-    /**
-     * 부서 목록에 대한 전체 건수를 조회한다.
-     * 
-     * @param deptVO
-     * @return int
-     */
-    public int selectDeptListCnt(DeptVO deptVO) {
-        return selectOne("DeptJobDAO.selectDeptListCnt", deptVO);
-    }
+	public List<DeptVO> selectDeptList(DeptVO deptVO) {
+		return mapper.selectDeptList(deptVO);
+	}
 
-    /**
-     * 주어진 조건에 맞는 부서를 불러온다.
-     * 
-     * @param orgnztId
-     * @return String
-     */
-    public String selectDept(String orgnztId) {
-        return selectOne("DeptJobDAO.selectDept", orgnztId);
-    }
+	public int selectDeptListCnt(DeptVO deptVO) {
+		return mapper.selectDeptListCnt(deptVO);
+	}
 
-    /**
-     * 주어진 조건에 따른 부서업무함 목록을 불러온다.
-     * 
-     * @param deptJobBxVO
-     * @return List
-     */
-    public List<DeptJobBxVO> selectDeptJobBxList(DeptJobBxVO deptJobBxVO) {
-        return selectList("DeptJobDAO.selectDeptJobBxList", deptJobBxVO);
-    }
+	public String selectDept(String orgnztId) {
+		return mapper.selectDept(orgnztId);
+	}
 
-    /**
-     * 주어진 조건에 따른 부서업무함 목록 전체를 불러온다.
-     * 
-     * @return List
-     */
-    public List<DeptJobBxVO> selectDeptJobBxListAll() {
-        return selectList("DeptJobDAO.selectDeptJobBxListAll");
-    }
+	public List<DeptJobBxVO> selectDeptJobBxList(DeptJobBxVO deptJobBxVO) {
+		return mapper.selectDeptJobBxList(deptJobBxVO);
+	}
 
-    /**
-     * 부서업무함 목록에 대한 전체 건수를 조회한다.
-     * 
-     * @param DeptJobBxVO
-     * @return int
-     * 
-     * @param deptJobBxVO
-     */
-    public int selectDeptJobBxListCnt(DeptJobBxVO deptJobBxVO) {
-        return selectOne("DeptJobDAO.selectDeptJobBxListCnt", deptJobBxVO);
-    }
+	public List<DeptJobBxVO> selectDeptJobBxListAll() {
+		return mapper.selectDeptJobBxListAll();
+	}
 
-    /**
-     * 주어진 조건에 맞는 부서업무함을 불러온다.
-     * 
-     * @param deptJobBxVO
-     * @return DeptJobBxVO
-     */
-    public DeptJobBxVO selectDeptJobBx(DeptJobBxVO deptJobBxVO) {
-        return selectOne("DeptJobDAO.selectDeptJobBx", deptJobBxVO);
-    }
+	public int selectDeptJobBxListCnt(DeptJobBxVO deptJobBxVO) {
+		return mapper.selectDeptJobBxListCnt(deptJobBxVO);
+	}
 
-    /**
-     * 부서업무함 정보를 수정한다.
-     * 
-     * @param deptJobBxVO
-     * @return int
-     */
-    public int updateDeptJobBx(DeptJobBx deptJobBx) {
-        return update("DeptJobDAO.updateDeptJobBx", deptJobBx);
-    }
+	public DeptJobBxVO selectDeptJobBx(DeptJobBxVO deptJobBxVO) {
+		return mapper.selectDeptJobBx(deptJobBxVO);
+	}
 
-    /**
-     * 부서업무함의 표시순서가 중복되는지를 조회한다.
-     * 
-     * @param deptJobBxVO
-     * @return int
-     */
-    public int selectDeptJobBxOrdr(DeptJobBxVO deptJobBxVO) {
-        return selectOne("DeptJobDAO.selectDeptJobBxOrdr", deptJobBxVO);
-    }
+	public int updateDeptJobBx(DeptJobBx deptJobBx) {
+		return mapper.updateDeptJobBx(deptJobBx);
+	}
 
-    /**
-     * 부서업무함 정보의 표시순서를 수정한다. (표시순서 증가)
-     * 
-     * @param deptJobBx
-     * @return int
-     */
-    public int updateDeptJobBxOrdrUp(DeptJobBx deptJobBx) {
-        return update("DeptJobDAO.updateDeptJobBxOrdrUp", deptJobBx);
-    }
+	public int selectDeptJobBxOrdr(DeptJobBxVO deptJobBxVO) {
+		return mapper.selectDeptJobBxOrdr(deptJobBxVO);
+	}
 
-    /**
-     * 부서업무함 정보의 표시순서를 수정한다. (표시순서 감소)
-     * 
-     * @param deptJobBx
-     * @return int
-     */
-    public int updateDeptJobBxOrdrDown(DeptJobBx deptJobBx) {
-        return update("DeptJobDAO.updateDeptJobBxOrdrDown", deptJobBx);
-    }
+	public int updateDeptJobBxOrdrUp(DeptJobBx deptJobBx) {
+		return mapper.updateDeptJobBxOrdrUp(deptJobBx);
+	}
 
-    /**
-     * 부서업무함 정보의 표시순서를 수정한다.
-     * 
-     * @param deptJobBx
-     * @return int
-     */
-    public int updateDeptJobBxOrdr(DeptJobBx deptJobBx) {
-        return update("DeptJobDAO.updateDeptJobBxOrdr", deptJobBx);
-    }
+	public int updateDeptJobBxOrdrDown(DeptJobBx deptJobBx) {
+		return mapper.updateDeptJobBxOrdrDown(deptJobBx);
+	}
 
-    /**
-     * 주어진 조건에 만족하는 전체 부서업무함 정보의 표시순서를 수정한다.
-     * 
-     * @param deptJobBxVO
-     * @return int
-     */
-    public int updateDeptJobBxOrdrAll(DeptJobBxVO deptJobBxVO) {
-        return update("DeptJobDAO.updateDeptJobBxOrdrAll", deptJobBxVO);
-    }
+	public int updateDeptJobBxOrdr(DeptJobBx deptJobBx) {
+		return mapper.updateDeptJobBxOrdr(deptJobBx);
+	}
 
-    /**
-     * 등록시 부서업무함의 표시순서를 조회한다.
-     * 
-     * @param deptId
-     * @return int
-     */
-    public int selectMaxDeptJobBxOrdr(String deptId) {
-        return selectOne("DeptJobDAO.selectMaxDeptJobBxOrdr", deptId);
-    }
+	public int updateDeptJobBxOrdrAll(DeptJobBxVO deptJobBxVO) {
+		return mapper.updateDeptJobBxOrdrAll(deptJobBxVO);
+	}
 
-    /**
-     * 부서업무함 정보를 등록한다.
-     * 
-     * @param DeptJobBx
-     * 
-     * @param deptJobBx
-     */
-    public int insertDeptJobBx(DeptJobBx deptJobBx) {
-        return insert("DeptJobDAO.insertDeptJobBx", deptJobBx);
-    }
+	public int selectMaxDeptJobBxOrdr(String deptId) {
+		return mapper.selectMaxDeptJobBxOrdr(deptId);
+	}
 
-    /**
-     * 부서내 부서업무함명의 건수를 조회한다.
-     * 
-     * @param deptJobBx
-     * @return int
-     */
-    public int selectDeptJobBxCheck(DeptJobBx deptJobBx) {
-        return selectOne("DeptJobDAO.selectDeptJobBxCheck", deptJobBx);
-    }
+	public int insertDeptJobBx(DeptJobBx deptJobBx) {
+		return mapper.insertDeptJobBx(deptJobBx);
+	}
 
-    /**
-     * 부서업무함 정보를 삭제한다.
-     * 
-     * @param deptJobBx
-     * @return int
-     */
-    public int deleteDeptJobBx(DeptJobBx deptJobBx) {
-        return delete("DeptJobDAO.deleteDeptJobBx", deptJobBx);
-    }
+	public int selectDeptJobBxCheck(DeptJobBx deptJobBx) {
+		return mapper.selectDeptJobBxCheck(deptJobBx);
+	}
 
-    /**
-     * 주어진 조건에 따른 부서업무 목록을 불러온다.
-     * 
-     * @param deptJobVO
-     * @return List
-     */
-    public List<DeptJobVO> selectDeptJobList(DeptJobVO deptJobVO) {
-        return selectList("DeptJobDAO.selectDeptJobList", deptJobVO);
-    }
+	public int deleteDeptJobBx(DeptJobBx deptJobBx) {
+		return mapper.deleteDeptJobBx(deptJobBx);
+	}
 
-    /**
-     * 부서업무 목록에 대한 전체 건수를 조회한다.
-     * 
-     * @param deptJobVO
-     * @return int
-     */
-    public int selectDeptJobListCnt(DeptJobVO deptJobVO) {
-        return selectOne("DeptJobDAO.selectDeptJobListCnt", deptJobVO);
-    }
+	public List<DeptJobVO> selectDeptJobList(DeptJobVO deptJobVO) {
+		return mapper.selectDeptJobList(deptJobVO);
+	}
 
-    /**
-     * 주어진 조건에 맞는 부서업무를 불러온다.
-     * 
-     * @param deptJobVO
-     * @return DeptJobVO
-     */
-    public DeptJobVO selectDeptJob(DeptJobVO deptJobVO) {
-        return selectOne("DeptJobDAO.selectDeptJob", deptJobVO);
-    }
+	public int selectDeptJobListCnt(DeptJobVO deptJobVO) {
+		return mapper.selectDeptJobListCnt(deptJobVO);
+	}
 
-    /**
-     * 부서업무 정보를 수정한다.
-     * 
-     * @param deptJob
-     * @return int
-     */
-    public int updateDeptJob(DeptJob deptJob) {
-        return update("DeptJobDAO.updateDeptJob", deptJob);
-    }
+	public DeptJobVO selectDeptJob(DeptJobVO deptJobVO) {
+		return mapper.selectDeptJob(deptJobVO);
+	}
 
-    /**
-     * 부서업무 정보를 등록한다.
-     * 
-     * @param deptJob
-     * @return int
-     */
-    public int insertDeptJob(DeptJob deptJob) {
-        return insert("DeptJobDAO.insertDeptJob", deptJob);
-    }
+	public int updateDeptJob(DeptJob deptJob) {
+		return mapper.updateDeptJob(deptJob);
+	}
 
-    /**
-     * 부서업무 정보를 삭제한다.
-     * 
-     * @param deptJob
-     * @return int
-     */
-    public int deleteDeptJob(DeptJob deptJob) {
-        return delete("DeptJobDAO.deleteDeptJob", deptJob);
-    }
+	public int insertDeptJob(DeptJob deptJob) {
+		return mapper.insertDeptJob(deptJob);
+	}
+
+	public int deleteDeptJob(DeptJob deptJob) {
+		return mapper.deleteDeptJob(deptJob);
+	}
 
 }

--- a/src/main/java/egovframework/com/cop/smt/djm/service/impl/DeptJobMapper.java
+++ b/src/main/java/egovframework/com/cop/smt/djm/service/impl/DeptJobMapper.java
@@ -1,0 +1,78 @@
+package egovframework.com.cop.smt.djm.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.cop.smt.djm.service.ChargerVO;
+import egovframework.com.cop.smt.djm.service.DeptJob;
+import egovframework.com.cop.smt.djm.service.DeptJobBx;
+import egovframework.com.cop.smt.djm.service.DeptJobBxVO;
+import egovframework.com.cop.smt.djm.service.DeptJobVO;
+import egovframework.com.cop.smt.djm.service.DeptVO;
+
+/**
+ * 부서업무에 대한 Mapper 인터페이스
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2026.05.28  dasomel         XML 기반 DAO → @EgovMapper 인터페이스로 전환
+ * </pre>
+ */
+@EgovMapper("deptJobMapper")
+public interface DeptJobMapper {
+
+	List<ChargerVO> selectChargerList(ChargerVO chargerVO);
+
+	int selectChargerListCnt(ChargerVO chargerVO);
+
+	List<DeptVO> selectDeptList(DeptVO deptVO);
+
+	int selectDeptListCnt(DeptVO deptVO);
+
+	String selectDept(String orgnztId);
+
+	List<DeptJobBxVO> selectDeptJobBxList(DeptJobBxVO deptJobBxVO);
+
+	List<DeptJobBxVO> selectDeptJobBxListAll();
+
+	int selectDeptJobBxListCnt(DeptJobBxVO deptJobBxVO);
+
+	DeptJobBxVO selectDeptJobBx(DeptJobBxVO deptJobBxVO);
+
+	int updateDeptJobBx(DeptJobBx deptJobBx);
+
+	int selectDeptJobBxOrdr(DeptJobBxVO deptJobBxVO);
+
+	int updateDeptJobBxOrdrUp(DeptJobBx deptJobBx);
+
+	int updateDeptJobBxOrdrDown(DeptJobBx deptJobBx);
+
+	int updateDeptJobBxOrdr(DeptJobBx deptJobBx);
+
+	int updateDeptJobBxOrdrAll(DeptJobBxVO deptJobBxVO);
+
+	int selectMaxDeptJobBxOrdr(String deptId);
+
+	int insertDeptJobBx(DeptJobBx deptJobBx);
+
+	int selectDeptJobBxCheck(DeptJobBx deptJobBx);
+
+	int deleteDeptJobBx(DeptJobBx deptJobBx);
+
+	List<DeptJobVO> selectDeptJobList(DeptJobVO deptJobVO);
+
+	int selectDeptJobListCnt(DeptJobVO deptJobVO);
+
+	DeptJobVO selectDeptJob(DeptJobVO deptJobVO);
+
+	int updateDeptJob(DeptJob deptJob);
+
+	int insertDeptJob(DeptJob deptJob);
+
+	int deleteDeptJob(DeptJob deptJob);
+
+}

--- a/src/main/java/egovframework/com/cop/smt/dsm/service/impl/DiaryManageDao.java
+++ b/src/main/java/egovframework/com/cop/smt/dsm/service/impl/DiaryManageDao.java
@@ -6,8 +6,9 @@ import org.egovframe.rte.psl.dataaccess.util.EgovMap;
 import org.springframework.stereotype.Repository;
 
 import egovframework.com.cmm.ComDefaultVO;
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.cop.smt.dsm.service.DiaryManageVO;
+import jakarta.annotation.Resource;
+
 /**
  * 일지관리를 처리하는 Dao Class 구현
  * @author 공통서비스 장동한
@@ -17,71 +18,75 @@ import egovframework.com.cop.smt.dsm.service.DiaryManageVO;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.04.10  장동한          최초 생성
+ *   2026.05.28  dasomel         @EgovMapper 인터페이스 위임 방식으로 전환
  *
  * </pre>
  */
 @Repository("diaryManageDao")
-public class DiaryManageDao extends EgovComAbstractDAO {
-	
-    /**
-	 * 일지관리 목록을 조회한다. 
+public class DiaryManageDao {
+
+	@Resource(name = "diaryManageMapper")
+	private DiaryManageMapper mapper;
+
+	/**
+	 * 일지관리 목록을 조회한다.
 	 * @param searchVO - 조회할 정보가 담긴 VO
 	 * @return List
 	 * @throws Exception
 	 */
-	public List<EgovMap> selectDiaryManageList(ComDefaultVO searchVO) throws Exception{
-		return selectList("DiaryManage.selectDiaryManage", searchVO);
-	}
-	
-    /**
-	 * 일지관리를(을) 상세조회 한다.
-	 * @param diaryManageVO - 일지관리 정보 담김 VO
-	 * @return List
-	 * @throws Exception
-	 */
-	public DiaryManageVO selectDiaryManageDetail(DiaryManageVO diaryManageVO) throws Exception{
-		return (DiaryManageVO)selectOne("DiaryManage.selectDiaryManageDetail", diaryManageVO);
+	public List<EgovMap> selectDiaryManageList(ComDefaultVO searchVO) throws Exception {
+		return mapper.selectDiaryManage(searchVO);
 	}
 
-    /**
+	/**
+	 * 일지관리를(을) 상세조회 한다.
+	 * @param diaryManageVO - 일지관리 정보 담김 VO
+	 * @return DiaryManageVO
+	 * @throws Exception
+	 */
+	public DiaryManageVO selectDiaryManageDetail(DiaryManageVO diaryManageVO) throws Exception {
+		return mapper.selectDiaryManageDetail(diaryManageVO);
+	}
+
+	/**
 	 * 일지관리를(을) 목록 전체 건수를(을) 조회한다.
 	 * @param searchVO - 조회할 정보가 담긴 VO
 	 * @return int
 	 * @throws Exception
 	 */
-	public int selectDiaryManageListCnt(ComDefaultVO searchVO) throws Exception{
-		return (Integer)selectOne("DiaryManage.selectDiaryManageCnt", searchVO);
-	}
-	
-    /**
-	 * 일지관리를(을) 등록한다.
-	 * @param qdiaryManageVO - 일지관리 정보 담김 VO
-	 * @throws Exception
-	 */
-	public void insertDiaryManage(DiaryManageVO diaryManageVO) throws Exception{
-		insert("DiaryManage.insertDiaryManage", diaryManageVO);
+	public int selectDiaryManageListCnt(ComDefaultVO searchVO) throws Exception {
+		return mapper.selectDiaryManageCnt(searchVO);
 	}
 
-    /**
+	/**
+	 * 일지관리를(을) 등록한다.
+	 * @param diaryManageVO - 일지관리 정보 담김 VO
+	 * @throws Exception
+	 */
+	public void insertDiaryManage(DiaryManageVO diaryManageVO) throws Exception {
+		mapper.insertDiaryManage(diaryManageVO);
+	}
+
+	/**
 	 * 일지관리를(을) 수정한다.
 	 * @param diaryManageVO - 일지관리 정보 담김 VO
 	 * @throws Exception
 	 */
-	public void updateDiaryManage(DiaryManageVO diaryManageVO) throws Exception{
-		insert("DiaryManage.updateDiaryManage", diaryManageVO);
+	public void updateDiaryManage(DiaryManageVO diaryManageVO) throws Exception {
+		mapper.updateDiaryManage(diaryManageVO);
 	}
-	
-    /**
+
+	/**
 	 * 일지관리를(을) 삭제한다.
 	 * @param diaryManageVO - 일지관리 정보 담김 VO
-	 * @return 
 	 * @throws Exception
 	 */
-	public void deleteDiaryManage(DiaryManageVO diaryManageVO) throws Exception{
-		insert("DiaryManage.deleteDiaryManage", diaryManageVO);
+	public void deleteDiaryManage(DiaryManageVO diaryManageVO) throws Exception {
+		mapper.deleteDiaryManage(diaryManageVO);
 	}
+
 }

--- a/src/main/java/egovframework/com/cop/smt/dsm/service/impl/DiaryManageMapper.java
+++ b/src/main/java/egovframework/com/cop/smt/dsm/service/impl/DiaryManageMapper.java
@@ -1,0 +1,37 @@
+package egovframework.com.cop.smt.dsm.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+import org.egovframe.rte.psl.dataaccess.util.EgovMap;
+
+import egovframework.com.cmm.ComDefaultVO;
+import egovframework.com.cop.smt.dsm.service.DiaryManageVO;
+
+/**
+ * 일지관리에 대한 Mapper 인터페이스
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2026.05.28  dasomel         XML 기반 DAO → @EgovMapper 인터페이스로 전환
+ * </pre>
+ */
+@EgovMapper("diaryManageMapper")
+public interface DiaryManageMapper {
+
+	List<EgovMap> selectDiaryManage(ComDefaultVO searchVO);
+
+	DiaryManageVO selectDiaryManageDetail(DiaryManageVO diaryManageVO);
+
+	int selectDiaryManageCnt(ComDefaultVO searchVO);
+
+	void insertDiaryManage(DiaryManageVO diaryManageVO);
+
+	void updateDiaryManage(DiaryManageVO diaryManageVO);
+
+	void deleteDiaryManage(DiaryManageVO diaryManageVO);
+
+}

--- a/src/main/java/egovframework/com/cop/smt/lsm/service/impl/LeaderSchdulDAO.java
+++ b/src/main/java/egovframework/com/cop/smt/lsm/service/impl/LeaderSchdulDAO.java
@@ -1,196 +1,104 @@
 package egovframework.com.cop.smt.lsm.service.impl;
+
 import java.util.List;
 
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.cop.smt.lsm.service.EmplyrVO;
 import egovframework.com.cop.smt.lsm.service.LeaderSchdul;
 import egovframework.com.cop.smt.lsm.service.LeaderSchdulVO;
 import egovframework.com.cop.smt.lsm.service.LeaderSttus;
 import egovframework.com.cop.smt.lsm.service.LeaderSttusVO;
+import jakarta.annotation.Resource;
 
 /**
  * 개요
  * - 간부일정에 대한 DAO 클래스를 정의한다.
- * 
+ *
  * 상세내용
  * - 간부일정에 대한 등록, 수정, 삭제, 조회기능을 제공한다.
  * - 간부일정의 조회기능은 목록조회, 상세조회로 구분된다.
  * @author 장철호
  * @version 1.0
  * @created 28-6-2010 오전 10:59:06
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2010.6.28	장철호          최초 생성
+ *   2026.05.28  dasomel         @EgovMapper 인터페이스 위임 방식으로 전환
+ * </pre>
  */
 @Repository("LeaderSchdulDAO")
-public class LeaderSchdulDAO extends EgovComAbstractDAO {
-	
-	/**
-	 * 주어진 조건에 맞는 사용자를 불러온다.
-	 * @param EmplyrVO - 사용자 VO
-	 * @return List- 사용자 List
-	 * 
-	 * @param emplyrVO
-	 */	
-	public List<EmplyrVO> selectEmplyrList(EmplyrVO emplyrVO) throws Exception{
-		return selectList("LeaderSchdulDAO.selectEmplyrList", emplyrVO);
-	}
-	
-	/**
-	 * 사용자 목록에 대한 전체 건수를 조회한다.
-	 * @param EmplyrVO - 사용자 VO
-	 * @return int - 사용자 목록 개수
-	 * 
-	 * @param emplyrVO
-	 */
-	public int selectEmplyrListCnt(EmplyrVO emplyrVO) throws Exception{
-		return (Integer)selectOne("LeaderSchdulDAO.selectEmplyrListCnt", emplyrVO);
-	}
-	
-	/**
-	 * 주어진 조건에 따른 간부일정 목록을 월별로 불러온다.
-	 * @param LeaderSchdulVO - 간부일정 VO
-	 * @return List - 간부일정 List
-	 * 
-	 * @param leaderSchdulVO
-	 */
-	
-	public List<LeaderSchdulVO> selectLeaderSchdulList(LeaderSchdulVO leaderSchdulVO) throws Exception{
-		return selectList("LeaderSchdulDAO.selectLeaderSchdulList", leaderSchdulVO);
+public class LeaderSchdulDAO {
+
+	@Resource(name = "leaderSchdulMapper")
+	private LeaderSchdulMapper mapper;
+
+	public List<EmplyrVO> selectEmplyrList(EmplyrVO emplyrVO) throws Exception {
+		return mapper.selectEmplyrList(emplyrVO);
 	}
 
-	/**
-	 * 주어진 조건에 맞는 간부일정을 불러온다.
-	 * @param LeaderSchdulVO - 간부일정 VO
-	 * @return LeaderSchdulVO - 간부일정 VO
-	 * 
-	 * @param leaderSchdulVO
-	 */
-	public LeaderSchdulVO selectLeaderSchdul(LeaderSchdulVO leaderSchdulVO) throws Exception{
-		return (LeaderSchdulVO)selectOne("LeaderSchdulDAO.selectLeaderSchdul", leaderSchdulVO);
+	public int selectEmplyrListCnt(EmplyrVO emplyrVO) throws Exception {
+		return mapper.selectEmplyrListCnt(emplyrVO);
 	}
 
-	/**
-	 * 간부일정 정보를 수정한다.
-	 * @param LeaderSchdul - 간부일정 model
-	 * 
-	 * @param leaderSchdul
-	 */
-	public void updateLeaderSchdul(LeaderSchdul leaderSchdul) throws Exception{
-		update("LeaderSchdulDAO.updateLeaderSchdul", leaderSchdul);
+	public List<LeaderSchdulVO> selectLeaderSchdulList(LeaderSchdulVO leaderSchdulVO) throws Exception {
+		return mapper.selectLeaderSchdulList(leaderSchdulVO);
 	}
 
-	/**
-	 * 간부일정 정보를 등록한다.
-	 * @param LeaderSchdul - 간부일정 model
-	 * 
-	 * @param leaderSchdul
-	 */
-	public void insertLeaderSchdul(LeaderSchdul leaderSchdul) throws Exception{
-		insert("LeaderSchdulDAO.insertLeaderSchdul", leaderSchdul);
-	}
-	
-	/**
-	 * 간부일정 일자 정보를 등록한다.
-	 * @param LeaderSchdul - 간부일정 model
-	 * 
-	 * @param leaderSchdul
-	 */
-	public void insertLeaderSchdulDe(LeaderSchdul leaderSchdul) throws Exception{
-		insert("LeaderSchdulDAO.insertLeaderSchdulDe", leaderSchdul);
+	public LeaderSchdulVO selectLeaderSchdul(LeaderSchdulVO leaderSchdulVO) throws Exception {
+		return mapper.selectLeaderSchdul(leaderSchdulVO);
 	}
 
-	/**
-	 * 간부일정 정보를 삭제한다.
-	 * @param LeaderSchdul - 간부일정 model
-	 * 
-	 * @param leaderSchdul
-	 */
-	public void deleteLeaderSchdul(LeaderSchdul leaderSchdul) throws Exception{
-		delete("LeaderSchdulDAO.deleteLeaderSchdul", leaderSchdul);
-	}
-	
-	/**
-	 * 간부일정일자 정보를 삭제한다.
-	 * @param LeaderSchdul - 간부일정 model
-	 * 
-	 * @param leaderSchdul
-	 */
-	public void deleteLeaderSchdulDe(LeaderSchdul leaderSchdul) throws Exception{
-		delete("LeaderSchdulDAO.deleteLeaderSchdulDe", leaderSchdul);
-	}
-	
-	/**
-	 * 주어진 조건에 따른 간부상태 목록을 불러온다.
-	 * @param LeaderSttusVO - 간부상태 VO
-	 * @return List - 간부상태 List
-	 * 
-	 * @param LeaderSttusVO
-	 */
-	public List<LeaderSttusVO> selectLeaderSttusList(LeaderSttusVO leaderSttusVO) throws Exception{
-		return selectList("LeaderSchdulDAO.selectLeaderSttusList", leaderSttusVO);
-	}
-	
-	/**
-	 * 간부상태 목록에 대한 전체 건수를 조회한다.
-	 * @param LeaderSttusVO - 간부상태 VO
-	 * @return int
-	 * 
-	 * @param LeaderSttusVO
-	 */
-	public int selectLeaderSttusListCnt(LeaderSttusVO leaderSttusVO) throws Exception{
-		return (Integer)selectOne("LeaderSchdulDAO.selectLeaderSttusListCnt", leaderSttusVO);
-	}
-	
-	/**
-	 * 주어진 조건에 맞는 간부상태를 불러온다.
-	 * @param LeaderSttusVO - 간부상태 VO
-	 * @return LeaderSttusVO - 간부상태 VO
-	 * 
-	 * @param leaderSttusVO
-	 */
-	public LeaderSttusVO selectLeaderSttus(LeaderSttusVO leaderSttusVO) throws Exception{
-		return (LeaderSttusVO)selectOne("LeaderSchdulDAO.selectLeaderSttus", leaderSttusVO);
+	public void updateLeaderSchdul(LeaderSchdul leaderSchdul) throws Exception {
+		mapper.updateLeaderSchdul(leaderSchdul);
 	}
 
-	/**
-	 * 간부상태 정보를 수정한다.
-	 * @param LeaderSttus - 간부상태 model
-	 * 
-	 * @param leaderSttus
-	 */
-	public void updateLeaderSttus(LeaderSttus leaderSttus) throws Exception{
-		update("LeaderSchdulDAO.updateLeaderSttus", leaderSttus);
+	public void insertLeaderSchdul(LeaderSchdul leaderSchdul) throws Exception {
+		mapper.insertLeaderSchdul(leaderSchdul);
 	}
 
-	/**
-	 * 간부상태 정보를 등록한다.
-	 * @param LeaderSttus - 간부상태 model
-	 * 
-	 * @param leaderSttus
-	 */
-	public void insertLeaderSttus(LeaderSttus leaderSttus) throws Exception{
-		insert("LeaderSchdulDAO.insertLeaderSttus", leaderSttus);
-	}
-	
-	/**
-	 * 간부상태 등록을 위한 중복 조회를 수행한다.
-	 * @param LeaderSttus - 간부상태 model
-	 * @return int
-	 * 
-	 * @param leaderSttus
-	 */
-	public int selectLeaderSttusCheck(LeaderSttus leaderSttus) throws Exception{
-		return (Integer)selectOne("LeaderSchdulDAO.selectLeaderSttusCheck", leaderSttus);
+	public void insertLeaderSchdulDe(LeaderSchdul leaderSchdul) throws Exception {
+		mapper.insertLeaderSchdulDe(leaderSchdul);
 	}
 
-	/**
-	 * 간부상태 정보를 삭제한다.
-	 * @param LeaderSttus - 간부상태 model
-	 * 
-	 * @param leaderSttus
-	 */
-	public void deleteLeaderSttus(LeaderSttus leaderSttus) throws Exception{
-		delete("LeaderSchdulDAO.deleteLeaderSttus", leaderSttus);
+	public void deleteLeaderSchdul(LeaderSchdul leaderSchdul) throws Exception {
+		mapper.deleteLeaderSchdul(leaderSchdul);
+	}
+
+	public void deleteLeaderSchdulDe(LeaderSchdul leaderSchdul) throws Exception {
+		mapper.deleteLeaderSchdulDe(leaderSchdul);
+	}
+
+	public List<LeaderSttusVO> selectLeaderSttusList(LeaderSttusVO leaderSttusVO) throws Exception {
+		return mapper.selectLeaderSttusList(leaderSttusVO);
+	}
+
+	public int selectLeaderSttusListCnt(LeaderSttusVO leaderSttusVO) throws Exception {
+		return mapper.selectLeaderSttusListCnt(leaderSttusVO);
+	}
+
+	public LeaderSttusVO selectLeaderSttus(LeaderSttusVO leaderSttusVO) throws Exception {
+		return mapper.selectLeaderSttus(leaderSttusVO);
+	}
+
+	public void updateLeaderSttus(LeaderSttus leaderSttus) throws Exception {
+		mapper.updateLeaderSttus(leaderSttus);
+	}
+
+	public void insertLeaderSttus(LeaderSttus leaderSttus) throws Exception {
+		mapper.insertLeaderSttus(leaderSttus);
+	}
+
+	public int selectLeaderSttusCheck(LeaderSttus leaderSttus) throws Exception {
+		return mapper.selectLeaderSttusCheck(leaderSttus);
+	}
+
+	public void deleteLeaderSttus(LeaderSttus leaderSttus) throws Exception {
+		mapper.deleteLeaderSttus(leaderSttus);
 	}
 
 }

--- a/src/main/java/egovframework/com/cop/smt/lsm/service/impl/LeaderSchdulMapper.java
+++ b/src/main/java/egovframework/com/cop/smt/lsm/service/impl/LeaderSchdulMapper.java
@@ -1,0 +1,59 @@
+package egovframework.com.cop.smt.lsm.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.cop.smt.lsm.service.EmplyrVO;
+import egovframework.com.cop.smt.lsm.service.LeaderSchdul;
+import egovframework.com.cop.smt.lsm.service.LeaderSchdulVO;
+import egovframework.com.cop.smt.lsm.service.LeaderSttus;
+import egovframework.com.cop.smt.lsm.service.LeaderSttusVO;
+
+/**
+ * 간부일정에 대한 Mapper 인터페이스
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2026.05.28  dasomel         XML 기반 DAO → @EgovMapper 인터페이스로 전환
+ * </pre>
+ */
+@EgovMapper("leaderSchdulMapper")
+public interface LeaderSchdulMapper {
+
+	List<EmplyrVO> selectEmplyrList(EmplyrVO emplyrVO);
+
+	int selectEmplyrListCnt(EmplyrVO emplyrVO);
+
+	List<LeaderSchdulVO> selectLeaderSchdulList(LeaderSchdulVO leaderSchdulVO);
+
+	LeaderSchdulVO selectLeaderSchdul(LeaderSchdulVO leaderSchdulVO);
+
+	void updateLeaderSchdul(LeaderSchdul leaderSchdul);
+
+	void insertLeaderSchdul(LeaderSchdul leaderSchdul);
+
+	void insertLeaderSchdulDe(LeaderSchdul leaderSchdul);
+
+	void deleteLeaderSchdul(LeaderSchdul leaderSchdul);
+
+	void deleteLeaderSchdulDe(LeaderSchdul leaderSchdul);
+
+	List<LeaderSttusVO> selectLeaderSttusList(LeaderSttusVO leaderSttusVO);
+
+	int selectLeaderSttusListCnt(LeaderSttusVO leaderSttusVO);
+
+	LeaderSttusVO selectLeaderSttus(LeaderSttusVO leaderSttusVO);
+
+	void updateLeaderSttus(LeaderSttus leaderSttus);
+
+	void insertLeaderSttus(LeaderSttus leaderSttus);
+
+	int selectLeaderSttusCheck(LeaderSttus leaderSttus);
+
+	void deleteLeaderSttus(LeaderSttus leaderSttus);
+
+}

--- a/src/main/java/egovframework/com/cop/smt/mrm/service/impl/MemoReprtDAO.java
+++ b/src/main/java/egovframework/com/cop/smt/mrm/service/impl/MemoReprtDAO.java
@@ -1,84 +1,60 @@
 package egovframework.com.cop.smt.mrm.service.impl;
+
 import java.util.List;
 
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.cop.smt.mrm.service.MemoReprt;
 import egovframework.com.cop.smt.mrm.service.MemoReprtVO;
 import egovframework.com.cop.smt.mrm.service.ReportrVO;
 import egovframework.com.utl.fcc.service.EgovDateUtil;
 import egovframework.com.utl.fcc.service.EgovStringUtil;
+import jakarta.annotation.Resource;
 
 /**
  * 개요
  * - 메모보고에 대한 DAO 클래스를 정의한다.
- * 
+ *
  * 상세내용
  * - 메모보고에 대한 등록, 수정, 삭제, 조회기능을 제공한다.
  * - 메모보고의 조회기능은 목록조회, 상세조회로 구분된다.
  * @author 장철호
  * @version 1.0
  * @created 19-7-2010 오전 10:14:53
- *  <pre>
+ *
+ * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2010.7.19	장철호          최초 생성
- *
+ *   2026.05.28  dasomel         @EgovMapper 인터페이스 위임 방식으로 전환
  * </pre>
  */
 @Repository("MemoReprtDAO")
-public class MemoReprtDAO extends EgovComAbstractDAO {
-	
-	/**
-	 * 주어진 조건에 맞는 보고자를 불러온다.
-	 * @param ReportrVO
-	 * @return List
-	 * 
-	 * @param reportrVO
-	 */
-	public List<ReportrVO> selectReportrList(ReportrVO reportrVO) throws Exception{
-		return selectList("MemoReprtDAO.selectReportrList", reportrVO);
+public class MemoReprtDAO {
+
+	@Resource(name = "memoReprtMapper")
+	private MemoReprtMapper mapper;
+
+	public List<ReportrVO> selectReportrList(ReportrVO reportrVO) throws Exception {
+		return mapper.selectReportrList(reportrVO);
 	}
-	
-	/**
-	 * 보고자 목록에 대한 전체 건수를 조회한다.
-	 * @param ReportrVO
-	 * @return int
-	 * 
-	 * @param reportrVO
-	 */
-	public int selectReportrListCnt(ReportrVO reportrVO) throws Exception{
-		return (Integer)selectOne("MemoReprtDAO.selectReportrListCnt", reportrVO);
+
+	public int selectReportrListCnt(ReportrVO reportrVO) throws Exception {
+		return mapper.selectReportrListCnt(reportrVO);
 	}
-	
-	/**
-	 * 주어진 조건에 맞는 직위명을 불러온다.
-	 * @param DeptVO
-	 * @return String
-	 * 
-	 * @param DeptVO
-	 */
-	public String selectWrterClsfNm(String wrterId) throws Exception{
-		return (String)selectOne("MemoReprtDAO.selectWrterClsfNm", wrterId);
+
+	public String selectWrterClsfNm(String wrterId) throws Exception {
+		return mapper.selectWrterClsfNm(wrterId);
 	}
-	
-	/**
-	 * 주어진 조건에 따른 메모보고 목록을 불러온다.
-	 * @param MemoReprtVO - 메모보고 VO
-	 * @return List<MemoReprtVO> - 메모보고 List
-	 * 
-	 * @param memoReprtVO
-	 */
-	public List<MemoReprtVO> selectMemoReprtList(MemoReprtVO memoReprtVO) throws Exception{
-		//날짜관련
+
+	public List<MemoReprtVO> selectMemoReprtList(MemoReprtVO memoReprtVO) throws Exception {
 		memoReprtVO.setSearchBgnDe(memoReprtVO.getSearchBgnDe().replaceAll("-", ""));
 		memoReprtVO.setSearchEndDe(memoReprtVO.getSearchEndDe().replaceAll("-", ""));
-		
-		List<MemoReprtVO> resultList = selectList("MemoReprtDAO.selectMemoReprtList", memoReprtVO);
-		for(int i=0; i < resultList.size(); i++){
+
+		List<MemoReprtVO> resultList = mapper.selectMemoReprtList(memoReprtVO);
+		for (int i = 0; i < resultList.size(); i++) {
 			MemoReprtVO resultVO = resultList.get(i);
 			resultVO.setReprtDe(EgovDateUtil.convertDate(resultVO.getReprtDe(), "0000", "yyyy-MM-dd"));
 			resultList.set(i, resultVO);
@@ -86,86 +62,38 @@ public class MemoReprtDAO extends EgovComAbstractDAO {
 		return resultList;
 	}
 
-	/**
-	 * 주어진 조건에 맞는 메모보고를 불러온다.
-	 * @param MemoReprtVO - 메모보고 VO
-	 * @return MemoReprtVO - 메모보고 VO
-	 * 
-	 * @param memoReprtVO
-	 */
-	public MemoReprtVO selectMemoReprt(MemoReprtVO memoReprtVO) throws Exception{
-		MemoReprtVO resultVO = (MemoReprtVO)selectOne("MemoReprtDAO.selectMemoReprt", memoReprtVO);
+	public MemoReprtVO selectMemoReprt(MemoReprtVO memoReprtVO) throws Exception {
+		MemoReprtVO resultVO = mapper.selectMemoReprt(memoReprtVO);
 		resultVO.setReprtDe(EgovDateUtil.convertDate(resultVO.getReprtDe(), "0000", "yyyy-MM-dd"));
 		return resultVO;
 	}
 
-	/**
-	 * 메모보고 정보의 보고자 조회일시를 수정한다.
-	 * @param MemoReprt - 메모보고 model
-	 * 
-	 * @param memoReprt
-	 */
-	public void readMemoReprt(MemoReprt memoReprt) throws Exception{
-		update("MemoReprtDAO.readMemoReprt", memoReprt);
+	public void readMemoReprt(MemoReprt memoReprt) throws Exception {
+		mapper.readMemoReprt(memoReprt);
 	}
 
-	/**
-	 * 메모보고 정보를 수정한다.
-	 * @param MemoReprt - 메모보고 model
-	 * 
-	 * @param memoReprt
-	 */
-	public void updateMemoReprt(MemoReprt memoReprt) throws Exception{
-		//날짜관련
+	public void updateMemoReprt(MemoReprt memoReprt) throws Exception {
 		memoReprt.setReprtDe(EgovStringUtil.isNullToString(memoReprt.getReprtDe()).replaceAll("-", ""));//KISA 보안약점 조치 (2018-10-29, 윤창원)
-		update("MemoReprtDAO.updateMemoReprt", memoReprt);
+		mapper.updateMemoReprt(memoReprt);
 	}
 
-	/**
-	 * 메모보고 정보의 지시사항을 등록한다.
-	 * @param MemoReprt - 메모보고 model
-	 * 
-	 * @param memoReprt
-	 */
-	public void updateMemoReprtDrctMatter(MemoReprt memoReprt) throws Exception{
-		update("MemoReprtDAO.updateMemoReprtDrctMatter", memoReprt);
+	public void updateMemoReprtDrctMatter(MemoReprt memoReprt) throws Exception {
+		mapper.updateMemoReprtDrctMatter(memoReprt);
 	}
 
-	/**
-	 * 메모보고 정보를 등록한다.
-	 * @param MemoReprt - 메모보고 model
-	 * 
-	 * @param memoReprt
-	 */
-	public void insertMemoReprt(MemoReprt memoReprt) throws Exception{
-		//날짜관련
+	public void insertMemoReprt(MemoReprt memoReprt) throws Exception {
 		memoReprt.setReprtDe(EgovStringUtil.isNullToString(memoReprt.getReprtDe()).replaceAll("-", ""));//KISA 보안약점 조치 (2018-10-29, 윤창원)
-		insert("MemoReprtDAO.insertMemoReprt", memoReprt);
+		mapper.insertMemoReprt(memoReprt);
 	}
 
-	/**
-	 * 메모보고 정보를 삭제한다.
-	 * @param MemoReprt - 메모보고 model
-	 * 
-	 * @param memoReprt
-	 */
-	public void deleteMemoReprt(MemoReprtVO memoReprtVO) throws Exception{
-		delete("MemoReprtDAO.deleteMemoReprt", memoReprtVO);
+	public void deleteMemoReprt(MemoReprtVO memoReprtVO) throws Exception {
+		mapper.deleteMemoReprt(memoReprtVO);
 	}
 
-	/**
-	 * 메모보고 목록에 대한 전체 건수를 조회한다.
-	 * @param MemoReprtVO - 메모보고 VO
-	 * @return int - 메모보고 목록 개수
-	 * 
-	 * @param memoReprtVO
-	 */
-	public int selectMemoReprtListCnt(MemoReprtVO memoReprtVO) throws Exception{
-		//날짜관련
+	public int selectMemoReprtListCnt(MemoReprtVO memoReprtVO) throws Exception {
 		memoReprtVO.setSearchBgnDe(memoReprtVO.getSearchBgnDe().replaceAll("-", ""));
 		memoReprtVO.setSearchEndDe(memoReprtVO.getSearchEndDe().replaceAll("-", ""));
-		
-		return (Integer)selectOne("MemoReprtDAO.selectMemoReprtListCnt", memoReprtVO);
+		return mapper.selectMemoReprtListCnt(memoReprtVO);
 	}
 
 }

--- a/src/main/java/egovframework/com/cop/smt/mrm/service/impl/MemoReprtMapper.java
+++ b/src/main/java/egovframework/com/cop/smt/mrm/service/impl/MemoReprtMapper.java
@@ -1,0 +1,47 @@
+package egovframework.com.cop.smt.mrm.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.cop.smt.mrm.service.MemoReprt;
+import egovframework.com.cop.smt.mrm.service.MemoReprtVO;
+import egovframework.com.cop.smt.mrm.service.ReportrVO;
+
+/**
+ * 메모보고에 대한 Mapper 인터페이스
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2026.05.28  dasomel         XML 기반 DAO → @EgovMapper 인터페이스로 전환
+ * </pre>
+ */
+@EgovMapper("memoReprtMapper")
+public interface MemoReprtMapper {
+
+	List<ReportrVO> selectReportrList(ReportrVO reportrVO);
+
+	int selectReportrListCnt(ReportrVO reportrVO);
+
+	String selectWrterClsfNm(String wrterId);
+
+	List<MemoReprtVO> selectMemoReprtList(MemoReprtVO memoReprtVO);
+
+	int selectMemoReprtListCnt(MemoReprtVO memoReprtVO);
+
+	MemoReprtVO selectMemoReprt(MemoReprtVO memoReprtVO);
+
+	void updateMemoReprt(MemoReprt memoReprt);
+
+	void readMemoReprt(MemoReprt memoReprt);
+
+	void updateMemoReprtDrctMatter(MemoReprt memoReprt);
+
+	void deleteMemoReprt(MemoReprtVO memoReprtVO);
+
+	void insertMemoReprt(MemoReprt memoReprt);
+
+}

--- a/src/main/resources/egovframework/mapper/com/cop/smt/djm/EgovDeptJob_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/smt/djm/EgovDeptJob_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="DeptJobDAO">
+<mapper namespace="egovframework.com.cop.smt.djm.service.impl.DeptJobMapper">
 
 	
 	<resultMap id="chargerList" type="egovframework.com.cop.smt.djm.service.ChargerVO">

--- a/src/main/resources/egovframework/mapper/com/cop/smt/djm/EgovDeptJob_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/smt/djm/EgovDeptJob_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="DeptJobDAO">
+<mapper namespace="egovframework.com.cop.smt.djm.service.impl.DeptJobMapper">
 
 	
 	<resultMap id="chargerList" type="egovframework.com.cop.smt.djm.service.ChargerVO">

--- a/src/main/resources/egovframework/mapper/com/cop/smt/djm/EgovDeptJob_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/smt/djm/EgovDeptJob_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="DeptJobDAO">
+<mapper namespace="egovframework.com.cop.smt.djm.service.impl.DeptJobMapper">
 
 	
 	<resultMap id="chargerList" type="egovframework.com.cop.smt.djm.service.ChargerVO">

--- a/src/main/resources/egovframework/mapper/com/cop/smt/djm/EgovDeptJob_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/smt/djm/EgovDeptJob_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="DeptJobDAO">
+<mapper namespace="egovframework.com.cop.smt.djm.service.impl.DeptJobMapper">
 
 	
 	<resultMap id="chargerList" type="egovframework.com.cop.smt.djm.service.ChargerVO">

--- a/src/main/resources/egovframework/mapper/com/cop/smt/djm/EgovDeptJob_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/smt/djm/EgovDeptJob_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="DeptJobDAO">
+<mapper namespace="egovframework.com.cop.smt.djm.service.impl.DeptJobMapper">
 
 	
 	<resultMap id="chargerList" type="egovframework.com.cop.smt.djm.service.ChargerVO">

--- a/src/main/resources/egovframework/mapper/com/cop/smt/djm/EgovDeptJob_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/smt/djm/EgovDeptJob_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="DeptJobDAO">
+<mapper namespace="egovframework.com.cop.smt.djm.service.impl.DeptJobMapper">
 
 	
 	<resultMap id="chargerList" type="egovframework.com.cop.smt.djm.service.ChargerVO">

--- a/src/main/resources/egovframework/mapper/com/cop/smt/djm/EgovDeptJob_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/smt/djm/EgovDeptJob_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="DeptJobDAO">
+<mapper namespace="egovframework.com.cop.smt.djm.service.impl.DeptJobMapper">
 
 	
 	<resultMap id="chargerList" type="egovframework.com.cop.smt.djm.service.ChargerVO">

--- a/src/main/resources/egovframework/mapper/com/cop/smt/djm/EgovDeptJob_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/smt/djm/EgovDeptJob_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="DeptJobDAO">
+<mapper namespace="egovframework.com.cop.smt.djm.service.impl.DeptJobMapper">
 
 	
 	<resultMap id="chargerList" type="egovframework.com.cop.smt.djm.service.ChargerVO">

--- a/src/main/resources/egovframework/mapper/com/cop/smt/dsm/EgovDiaryManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/smt/dsm/EgovDiaryManage_SQL_altibase.xml
@@ -7,7 +7,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="DiaryManage">
+<mapper namespace="egovframework.com.cop.smt.dsm.service.impl.DiaryManageMapper">
 
 	<resultMap id="DiaryManage" type="egovframework.com.cop.smt.dsm.service.DiaryManageVO">
 	<result property="diaryId" column="DIARY_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/smt/dsm/EgovDiaryManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/smt/dsm/EgovDiaryManage_SQL_cubrid.xml
@@ -7,7 +7,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="DiaryManage">
+<mapper namespace="egovframework.com.cop.smt.dsm.service.impl.DiaryManageMapper">
 
 	<resultMap id="DiaryManage" type="egovframework.com.cop.smt.dsm.service.DiaryManageVO">
 	<result property="diaryId" column="DIARY_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/smt/dsm/EgovDiaryManage_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/smt/dsm/EgovDiaryManage_SQL_goldilocks.xml
@@ -7,7 +7,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="DiaryManage">
+<mapper namespace="egovframework.com.cop.smt.dsm.service.impl.DiaryManageMapper">
 
 	<resultMap id="DiaryManage" type="egovframework.com.cop.smt.dsm.service.DiaryManageVO">
 	<result property="diaryId" column="DIARY_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/smt/dsm/EgovDiaryManage_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/smt/dsm/EgovDiaryManage_SQL_maria.xml
@@ -5,7 +5,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="DiaryManage">
+<mapper namespace="egovframework.com.cop.smt.dsm.service.impl.DiaryManageMapper">
 
 	<resultMap id="DiaryManage" type="egovframework.com.cop.smt.dsm.service.DiaryManageVO">
 		<result property="diaryId" column="DIARY_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/smt/dsm/EgovDiaryManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/smt/dsm/EgovDiaryManage_SQL_mysql.xml
@@ -5,7 +5,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="DiaryManage">
+<mapper namespace="egovframework.com.cop.smt.dsm.service.impl.DiaryManageMapper">
 
 	<resultMap id="DiaryManage" type="egovframework.com.cop.smt.dsm.service.DiaryManageVO">
 		<result property="diaryId" column="DIARY_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/smt/dsm/EgovDiaryManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/smt/dsm/EgovDiaryManage_SQL_oracle.xml
@@ -7,7 +7,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="DiaryManage">
+<mapper namespace="egovframework.com.cop.smt.dsm.service.impl.DiaryManageMapper">
 
 	<resultMap id="DiaryManage" type="egovframework.com.cop.smt.dsm.service.DiaryManageVO">
 	<result property="diaryId" column="DIARY_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/smt/dsm/EgovDiaryManage_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/smt/dsm/EgovDiaryManage_SQL_postgres.xml
@@ -5,7 +5,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="DiaryManage">
+<mapper namespace="egovframework.com.cop.smt.dsm.service.impl.DiaryManageMapper">
 
 	<resultMap id="DiaryManage" type="egovframework.com.cop.smt.dsm.service.DiaryManageVO">
 		<result property="diaryId" column="DIARY_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/smt/dsm/EgovDiaryManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/smt/dsm/EgovDiaryManage_SQL_tibero.xml
@@ -7,7 +7,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="DiaryManage">
+<mapper namespace="egovframework.com.cop.smt.dsm.service.impl.DiaryManageMapper">
 
 	<resultMap id="DiaryManage" type="egovframework.com.cop.smt.dsm.service.DiaryManageVO">
 	<result property="diaryId" column="DIARY_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/smt/lsm/EgovLeaderSchdul_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/smt/lsm/EgovLeaderSchdul_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="LeaderSchdulDAO">
+<mapper namespace="egovframework.com.cop.smt.lsm.service.impl.LeaderSchdulMapper">
 	
 	<resultMap id="emplyrList" type="egovframework.com.cop.smt.lsm.service.EmplyrVO">
 		<result property="orgnztNm" column="ORGNZT_NM"/>

--- a/src/main/resources/egovframework/mapper/com/cop/smt/lsm/EgovLeaderSchdul_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/smt/lsm/EgovLeaderSchdul_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="LeaderSchdulDAO">
+<mapper namespace="egovframework.com.cop.smt.lsm.service.impl.LeaderSchdulMapper">
 	
 	<resultMap id="emplyrList" type="egovframework.com.cop.smt.lsm.service.EmplyrVO">
 		<result property="orgnztNm" column="ORGNZT_NM"/>

--- a/src/main/resources/egovframework/mapper/com/cop/smt/lsm/EgovLeaderSchdul_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/smt/lsm/EgovLeaderSchdul_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="LeaderSchdulDAO">
+<mapper namespace="egovframework.com.cop.smt.lsm.service.impl.LeaderSchdulMapper">
 	
 	<resultMap id="emplyrList" type="egovframework.com.cop.smt.lsm.service.EmplyrVO">
 		<result property="orgnztNm" column="ORGNZT_NM"/>

--- a/src/main/resources/egovframework/mapper/com/cop/smt/lsm/EgovLeaderSchdul_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/smt/lsm/EgovLeaderSchdul_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="LeaderSchdulDAO">
+<mapper namespace="egovframework.com.cop.smt.lsm.service.impl.LeaderSchdulMapper">
 	
 	<resultMap id="emplyrList" type="egovframework.com.cop.smt.lsm.service.EmplyrVO">
 		<result property="orgnztNm" column="ORGNZT_NM"/>

--- a/src/main/resources/egovframework/mapper/com/cop/smt/lsm/EgovLeaderSchdul_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/smt/lsm/EgovLeaderSchdul_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="LeaderSchdulDAO">
+<mapper namespace="egovframework.com.cop.smt.lsm.service.impl.LeaderSchdulMapper">
 	
 	<resultMap id="emplyrList" type="egovframework.com.cop.smt.lsm.service.EmplyrVO">
 		<result property="orgnztNm" column="ORGNZT_NM"/>

--- a/src/main/resources/egovframework/mapper/com/cop/smt/lsm/EgovLeaderSchdul_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/smt/lsm/EgovLeaderSchdul_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="LeaderSchdulDAO">
+<mapper namespace="egovframework.com.cop.smt.lsm.service.impl.LeaderSchdulMapper">
 	
 	<resultMap id="emplyrList" type="egovframework.com.cop.smt.lsm.service.EmplyrVO">
 		<result property="orgnztNm" column="ORGNZT_NM"/>

--- a/src/main/resources/egovframework/mapper/com/cop/smt/lsm/EgovLeaderSchdul_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/smt/lsm/EgovLeaderSchdul_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="LeaderSchdulDAO">
+<mapper namespace="egovframework.com.cop.smt.lsm.service.impl.LeaderSchdulMapper">
 	
 	<resultMap id="emplyrList" type="egovframework.com.cop.smt.lsm.service.EmplyrVO">
 		<result property="orgnztNm" column="ORGNZT_NM"/>

--- a/src/main/resources/egovframework/mapper/com/cop/smt/lsm/EgovLeaderSchdul_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/smt/lsm/EgovLeaderSchdul_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="LeaderSchdulDAO">
+<mapper namespace="egovframework.com.cop.smt.lsm.service.impl.LeaderSchdulMapper">
 	
 	<resultMap id="emplyrList" type="egovframework.com.cop.smt.lsm.service.EmplyrVO">
 		<result property="orgnztNm" column="ORGNZT_NM"/>

--- a/src/main/resources/egovframework/mapper/com/cop/smt/mrm/EgovMemoReprt_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/smt/mrm/EgovMemoReprt_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="MemoReprtDAO">
+<mapper namespace="egovframework.com.cop.smt.mrm.service.impl.MemoReprtMapper">
 
 	<resultMap id="memoReportrList" type="egovframework.com.cop.smt.mrm.service.ReportrVO">
 		<result property="orgnztNm" column="ORGNZT_NM"/>

--- a/src/main/resources/egovframework/mapper/com/cop/smt/mrm/EgovMemoReprt_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/smt/mrm/EgovMemoReprt_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="MemoReprtDAO">
+<mapper namespace="egovframework.com.cop.smt.mrm.service.impl.MemoReprtMapper">
 	
 	<resultMap id="memoReportrList" type="egovframework.com.cop.smt.mrm.service.ReportrVO">
 		<result property="orgnztNm" column="ORGNZT_NM"/>

--- a/src/main/resources/egovframework/mapper/com/cop/smt/mrm/EgovMemoReprt_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/smt/mrm/EgovMemoReprt_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="MemoReprtDAO">
+<mapper namespace="egovframework.com.cop.smt.mrm.service.impl.MemoReprtMapper">
 
 	<resultMap id="memoReportrList" type="egovframework.com.cop.smt.mrm.service.ReportrVO">
 		<result property="orgnztNm" column="ORGNZT_NM"/>

--- a/src/main/resources/egovframework/mapper/com/cop/smt/mrm/EgovMemoReprt_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/smt/mrm/EgovMemoReprt_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="MemoReprtDAO">
+<mapper namespace="egovframework.com.cop.smt.mrm.service.impl.MemoReprtMapper">
 
 	<resultMap id="memoReportrList" type="egovframework.com.cop.smt.mrm.service.ReportrVO">
 		<result property="orgnztNm" column="ORGNZT_NM"/>

--- a/src/main/resources/egovframework/mapper/com/cop/smt/mrm/EgovMemoReprt_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/smt/mrm/EgovMemoReprt_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="MemoReprtDAO">
+<mapper namespace="egovframework.com.cop.smt.mrm.service.impl.MemoReprtMapper">
 
 	<resultMap id="memoReportrList" type="egovframework.com.cop.smt.mrm.service.ReportrVO">
 		<result property="orgnztNm" column="ORGNZT_NM"/>

--- a/src/main/resources/egovframework/mapper/com/cop/smt/mrm/EgovMemoReprt_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/smt/mrm/EgovMemoReprt_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="MemoReprtDAO">
+<mapper namespace="egovframework.com.cop.smt.mrm.service.impl.MemoReprtMapper">
 	
 	<resultMap id="memoReportrList" type="egovframework.com.cop.smt.mrm.service.ReportrVO">
 		<result property="orgnztNm" column="ORGNZT_NM"/>

--- a/src/main/resources/egovframework/mapper/com/cop/smt/mrm/EgovMemoReprt_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/smt/mrm/EgovMemoReprt_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="MemoReprtDAO">
+<mapper namespace="egovframework.com.cop.smt.mrm.service.impl.MemoReprtMapper">
 
 	<resultMap id="memoReportrList" type="egovframework.com.cop.smt.mrm.service.ReportrVO">
 		<result property="orgnztNm" column="ORGNZT_NM"/>

--- a/src/main/resources/egovframework/mapper/com/cop/smt/mrm/EgovMemoReprt_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/smt/mrm/EgovMemoReprt_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="MemoReprtDAO">
+<mapper namespace="egovframework.com.cop.smt.mrm.service.impl.MemoReprtMapper">
 	
 	<resultMap id="memoReportrList" type="egovframework.com.cop.smt.mrm.service.ReportrVO">
 		<result property="orgnztNm" column="ORGNZT_NM"/>


### PR DESCRIPTION
## 변경 사유
기존 XML namespace 기반 DAO를 5.0 신규 @EgovMapper 인터페이스 방식으로 전환

## 변경 내용
- DiaryManageMapper, DeptJobMapper, LeaderSchdulMapper, MemoReprtMapper 인터페이스 신규 추가
- cop/smt 하위 4개 DAO를 mapper 위임 구조로 리팩토링
- XML namespace를 mapper FQN으로 변경

## 영향 범위
- cop/smt 일정·다이어리 4개 서브 모듈 (dsm, djm, lsm, mrm)
- DAO bean name 유지

## 체크리스트
- [x] 단일 주제만 다룸 (다른 변경 없음)
- [x] 기존 동작 호환
- [x] 테스트 통과 확인