### PR TITLE
[refactor][5.0.x][공통컴포넌트] cop/smt 일정관리 5개 DAO @EgovMapper 인터페이스 방식으로 전환

### DIFF
--- a/src/main/java/egovframework/com/cop/smt/mtm/service/impl/MemoTodoDAO.java
+++ b/src/main/java/egovframework/com/cop/smt/mtm/service/impl/MemoTodoDAO.java
@@ -1,16 +1,17 @@
 package egovframework.com.cop.smt.mtm.service.impl;
+
 import java.util.List;
 
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.cop.smt.mtm.service.MemoTodo;
 import egovframework.com.cop.smt.mtm.service.MemoTodoVO;
+import jakarta.annotation.Resource;
 
 /**
  * 개요
  * - 메모할일에 대한 DAO 클래스를 정의한다.
- * 
+ *
  * 상세내용
  * - 메모할일에 대한 등록, 수정, 삭제, 조회기능을 제공한다.
  * - 메모할일의 조회기능은 목록조회, 상세조회로 구분된다.
@@ -19,32 +20,34 @@ import egovframework.com.cop.smt.mtm.service.MemoTodoVO;
  * @created 19-7-2010 오전 10:12:47
  *   <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
- *   2010.7.19	장철호          최초 생성
+ *   2010.7.19   장철호          최초 생성
+ *   2026.05.28  dasomel         @EgovMapper 인터페이스 위임 방식으로 전환
  *
  * </pre>
  */
 @Repository("MemoTodoDAO")
-public class MemoTodoDAO extends EgovComAbstractDAO {
+public class MemoTodoDAO {
+
+	@Resource(name = "memoTodoMapper")
+	private MemoTodoMapper mapper;
 
 	/**
 	 * 주어진 조건에 맞는 메모할일 목록을 불러온다.
-	 * @param MemoTodoVO - 메모할일 VO
+	 * @param memoTodoVO - 메모할일 VO
 	 * @return List<MemoTodoVO> - 메모할일 List
-	 * 
-	 * @param memoTodoVO
-	 */	
-	public List<MemoTodoVO> selectMemoTodoList(MemoTodoVO memoTodoVO) throws Exception{
-		List<MemoTodoVO> resultList = selectList("MemoTodoDAO.selectMemoTodoList", memoTodoVO);
-		for(int i=0; i < resultList.size(); i++){
+	 */
+	public List<MemoTodoVO> selectMemoTodoList(MemoTodoVO memoTodoVO) throws Exception {
+		List<MemoTodoVO> resultList = mapper.selectMemoTodoList(memoTodoVO);
+		for (int i = 0; i < resultList.size(); i++) {
 			MemoTodoVO resultVO = resultList.get(i);
-			resultVO.setTodoDe(resultVO.getTodoBeginTime().substring(0,10));
-			resultVO.setTodoBeginHour(resultVO.getTodoBeginTime().substring(10,12));
-			resultVO.setTodoBeginMin(resultVO.getTodoBeginTime().substring(12,14));
-			resultVO.setTodoEndHour(resultVO.getTodoEndTime().substring(10,12));
-			resultVO.setTodoEndMin(resultVO.getTodoEndTime().substring(12,14));
+			resultVO.setTodoDe(resultVO.getTodoBeginTime().substring(0, 10));
+			resultVO.setTodoBeginHour(resultVO.getTodoBeginTime().substring(10, 12));
+			resultVO.setTodoBeginMin(resultVO.getTodoBeginTime().substring(12, 14));
+			resultVO.setTodoEndHour(resultVO.getTodoEndTime().substring(10, 12));
+			resultVO.setTodoEndMin(resultVO.getTodoEndTime().substring(12, 14));
 			resultList.set(i, resultVO);
 		}
 		return resultList;
@@ -52,79 +55,66 @@ public class MemoTodoDAO extends EgovComAbstractDAO {
 
 	/**
 	 * 주어진 조건에 맞는 메모할일을 불러온다.
-	 * @param MemoTodoVO - 메모할일 VO
+	 * @param memoTodoVO - 메모할일 VO
 	 * @return MemoTodoVO - 메모할일 VO
-	 * 
-	 * @param memoTodoVO
 	 */
-	public MemoTodoVO selectMemoTodo(MemoTodoVO memoTodoVO) throws Exception{
-		MemoTodoVO resultVO = (MemoTodoVO)selectOne("MemoTodoDAO.selectMemoTodo", memoTodoVO);
-		resultVO.setTodoDe(resultVO.getTodoBeginTime().substring(0,10));
-		resultVO.setTodoBeginHour(resultVO.getTodoBeginTime().substring(10,12));
-		resultVO.setTodoBeginMin(resultVO.getTodoBeginTime().substring(12,14));
-		resultVO.setTodoEndHour(resultVO.getTodoEndTime().substring(10,12));
-		resultVO.setTodoEndMin(resultVO.getTodoEndTime().substring(12,14));
-		
+	public MemoTodoVO selectMemoTodo(MemoTodoVO memoTodoVO) throws Exception {
+		MemoTodoVO resultVO = mapper.selectMemoTodo(memoTodoVO);
+		resultVO.setTodoDe(resultVO.getTodoBeginTime().substring(0, 10));
+		resultVO.setTodoBeginHour(resultVO.getTodoBeginTime().substring(10, 12));
+		resultVO.setTodoBeginMin(resultVO.getTodoBeginTime().substring(12, 14));
+		resultVO.setTodoEndHour(resultVO.getTodoEndTime().substring(10, 12));
+		resultVO.setTodoEndMin(resultVO.getTodoEndTime().substring(12, 14));
 		return resultVO;
 	}
 
 	/**
 	 * 메모할일 정보를 수정한다.
-	 * @param MemoTodo - 메모할일 model
-	 * 
-	 * @param memoTodo
+	 * @param memoTodo - 메모할일 model
 	 */
-	public void updateMemoTodo(MemoTodo memoTodo) throws Exception{
-		update("MemoTodoDAO.updateMemoTodo", memoTodo);
+	public void updateMemoTodo(MemoTodo memoTodo) throws Exception {
+		mapper.updateMemoTodo(memoTodo);
 	}
 
 	/**
 	 * 메모할일 정보를 등록한다.
-	 * @param MemoTodo - 메모할일 model
-	 * 
-	 * @param memoTodo
+	 * @param memoTodo - 메모할일 model
 	 */
-	public void insertMemoTodo(MemoTodo memoTodo) throws Exception{
-		insert("MemoTodoDAO.insertMemoTodo", memoTodo);
+	public void insertMemoTodo(MemoTodo memoTodo) throws Exception {
+		mapper.insertMemoTodo(memoTodo);
 	}
 
 	/**
 	 * 메모할일 정보를 삭제한다.
-	 * @param MemoTodo - 메모할일 model
-	 * 
-	 * @param memoTodo
+	 * @param memoTodo - 메모할일 model
 	 */
-	public void deleteMemoTodo(MemoTodo memoTodo) throws Exception{
-		delete("MemoTodoDAO.deleteMemoTodo", memoTodo);
+	public void deleteMemoTodo(MemoTodo memoTodo) throws Exception {
+		mapper.deleteMemoTodo(memoTodo);
 	}
 
 	/**
 	 * 메모할일 목록에 대한 전체 건수를 조회한다.
-	 * @param MemoTodoVO - 메모할일 VO
+	 * @param memoTodoVO - 메모할일 VO
 	 * @return int - 메모할일 목록 개수
-	 * 
-	 * @param memoTodoVO
 	 */
-	public int selectMemoTodoListCnt(MemoTodoVO memoTodoVO) throws Exception{
-		return (Integer)selectOne("MemoTodoDAO.selectMemoTodoListCnt", memoTodoVO);
+	public int selectMemoTodoListCnt(MemoTodoVO memoTodoVO) throws Exception {
+		return mapper.selectMemoTodoListCnt(memoTodoVO);
 	}
-	
+
 	/**
 	 * 메모할일 목록 중 오늘의 할일을 조회한다.
-	 * @param MemoTodoVO - 메모할일 VO
-	 * @return  List - 메모할일 List
-	 * 
-	 * @param memoTodoVO
+	 * @param memoTodoVO - 메모할일 VO
+	 * @return List - 메모할일 List
 	 */
-	public List<MemoTodoVO> selectMemoTodoListToday(MemoTodoVO memoTodoVO) throws Exception{
-		List<MemoTodoVO> resultList = selectList("MemoTodoDAO.selectMemoTodoListToday", memoTodoVO);
-		for(int i=0; i < resultList.size(); i++){
+	public List<MemoTodoVO> selectMemoTodoListToday(MemoTodoVO memoTodoVO) throws Exception {
+		List<MemoTodoVO> resultList = mapper.selectMemoTodoListToday(memoTodoVO);
+		for (int i = 0; i < resultList.size(); i++) {
 			MemoTodoVO resultVO = resultList.get(i);
-			resultVO.setTodoDe(resultVO.getTodoBeginTime().substring(0,10));
-			resultVO.setTodoBeginHour(resultVO.getTodoBeginTime().substring(10,12));
-			resultVO.setTodoBeginMin(resultVO.getTodoBeginTime().substring(12,14));
-			resultVO.setTodoEndHour(resultVO.getTodoEndTime().substring(10,12));
-			resultVO.setTodoEndMin(resultVO.getTodoEndTime().substring(12,14));
+			resultVO.setTodoDe(resultVO.getTodoBeginTime().substring(0, 10));
+			resultVO.setTodoBeginHour(resultVO.getTodoBeginTime().substring(10, 12));
+			resultVO.setTodoBeginMin(resultVO.getTodoBeginTime().substring(12, 14));
+			resultVO.setTodoEndHour(resultVO.getTodoEndTime().substring(10, 12));
+			resultVO.setTodoEndMin(resultVO.getTodoEndTime().substring(12, 14));
 			resultList.set(i, resultVO);
 		}
 		return resultList;

--- a/src/main/java/egovframework/com/cop/smt/mtm/service/impl/MemoTodoMapper.java
+++ b/src/main/java/egovframework/com/cop/smt/mtm/service/impl/MemoTodoMapper.java
@@ -1,0 +1,44 @@
+package egovframework.com.cop.smt.mtm.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.cop.smt.mtm.service.MemoTodo;
+import egovframework.com.cop.smt.mtm.service.MemoTodoVO;
+
+/**
+ * 메모할일을 위한 Mapper 인터페이스
+ * @author 장철호
+ * @since 2010.07.19
+ * @version 1.0
+ * @see
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2010.07.19  장철호          최초 생성
+ *   2026.05.28  dasomel         XML 기반 DAO → @EgovMapper 인터페이스로 전환
+ *
+ * </pre>
+ */
+@EgovMapper("memoTodoMapper")
+public interface MemoTodoMapper {
+
+	List<MemoTodoVO> selectMemoTodoList(MemoTodoVO memoTodoVO);
+
+	MemoTodoVO selectMemoTodo(MemoTodoVO memoTodoVO);
+
+	int updateMemoTodo(MemoTodo memoTodo);
+
+	int insertMemoTodo(MemoTodo memoTodo);
+
+	int deleteMemoTodo(MemoTodo memoTodo);
+
+	int selectMemoTodoListCnt(MemoTodoVO memoTodoVO);
+
+	List<MemoTodoVO> selectMemoTodoListToday(MemoTodoVO memoTodoVO);
+
+}

--- a/src/main/java/egovframework/com/cop/smt/sam/service/impl/AllSchdulManageDao.java
+++ b/src/main/java/egovframework/com/cop/smt/sam/service/impl/AllSchdulManageDao.java
@@ -6,7 +6,8 @@ import org.egovframe.rte.psl.dataaccess.util.EgovMap;
 import org.springframework.stereotype.Repository;
 
 import egovframework.com.cmm.ComDefaultVO;
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
+import jakarta.annotation.Resource;
+
 /**
  * 전체일정을 처리하는 Dao Class 구현
  * @author 공통서비스 장동한
@@ -16,35 +17,38 @@ import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.04.10  장동한         최초 생성
  *   2016.08.01  장동한         표준프레임워크 v3.6 개선
+ *   2026.05.28  dasomel        @EgovMapper 인터페이스 위임 방식으로 전환
  *
  * </pre>
  */
 @Repository("allSchdulManageDao")
-public class AllSchdulManageDao extends EgovComAbstractDAO {
-	
-    /**
-	 * 전체일정 목록을 조회한다. 
+public class AllSchdulManageDao {
+
+	@Resource(name = "allSchdulManageMapper")
+	private AllSchdulManageMapper mapper;
+
+	/**
+	 * 전체일정 목록을 조회한다.
 	 * @param searchVO - 조회할 정보가 담긴 VO
 	 * @return List
 	 * @throws Exception
 	 */
-	public List<EgovMap> selectAllSchdulManageeList(ComDefaultVO searchVO) throws Exception{
-		return selectList("AllSchdulManage.selectIndvdlSchdulManage", searchVO);
+	public List<EgovMap> selectAllSchdulManageeList(ComDefaultVO searchVO) throws Exception {
+		return mapper.selectIndvdlSchdulManage(searchVO);
 	}
-	
 
-    /**
+	/**
 	 * 전체일정를(을) 목록 전체 건수를(을) 조회한다.
 	 * @param searchVO - 조회할 정보가 담긴 VO
 	 * @return int
 	 * @throws Exception
 	 */
-	public int selectAllSchdulManageListCnt(ComDefaultVO searchVO) throws Exception{
-		return (Integer)selectOne("AllSchdulManage.selectIndvdlSchdulManageCnt", searchVO);
+	public int selectAllSchdulManageListCnt(ComDefaultVO searchVO) throws Exception {
+		return mapper.selectIndvdlSchdulManageCnt(searchVO);
 	}
 }

--- a/src/main/java/egovframework/com/cop/smt/sam/service/impl/AllSchdulManageMapper.java
+++ b/src/main/java/egovframework/com/cop/smt/sam/service/impl/AllSchdulManageMapper.java
@@ -1,0 +1,34 @@
+package egovframework.com.cop.smt.sam.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+import org.egovframe.rte.psl.dataaccess.util.EgovMap;
+
+import egovframework.com.cmm.ComDefaultVO;
+
+/**
+ * 전체일정을 위한 Mapper 인터페이스
+ * @author 공통서비스 장동한
+ * @since 2009.04.10
+ * @version 1.0
+ * @see
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2009.04.10  장동한          최초 생성
+ *   2026.05.28  dasomel         XML 기반 DAO → @EgovMapper 인터페이스로 전환
+ *
+ * </pre>
+ */
+@EgovMapper("allSchdulManageMapper")
+public interface AllSchdulManageMapper {
+
+	List<EgovMap> selectIndvdlSchdulManage(ComDefaultVO searchVO);
+
+	int selectIndvdlSchdulManageCnt(ComDefaultVO searchVO);
+
+}

--- a/src/main/java/egovframework/com/cop/smt/sdm/service/impl/DeptSchdulManageDao.java
+++ b/src/main/java/egovframework/com/cop/smt/sdm/service/impl/DeptSchdulManageDao.java
@@ -7,8 +7,9 @@ import org.egovframe.rte.psl.dataaccess.util.EgovMap;
 import org.springframework.stereotype.Repository;
 
 import egovframework.com.cmm.ComDefaultVO;
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.cop.smt.sdm.service.DeptSchdulManageVO;
+import jakarta.annotation.Resource;
+
 /**
  * 부서일정관리를 처리하는 Dao Class 구현
  * @author 공통서비스 장동한
@@ -18,125 +19,126 @@ import egovframework.com.cop.smt.sdm.service.DeptSchdulManageVO;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.04.10  장동한          최초 생성
  *   2016.08.01  장동한          표준프레임워크 v3.6 개선
+ *   2026.05.28  dasomel         @EgovMapper 인터페이스 위임 방식으로 전환
  *
  * </pre>
  */
 @Repository("deptSchdulManageDao")
-public class DeptSchdulManageDao extends EgovComAbstractDAO {
-	
-    /**
+public class DeptSchdulManageDao {
+
+	@Resource(name = "deptSchdulManageMapper")
+	private DeptSchdulManageMapper mapper;
+
+	/**
 	 * 부서 목록을 조회한다.
 	 * @param searchVO - 조회할 정보가 담긴 VO
 	 * @return List
-	 * @throws Exception
 	 */
-	public List<EgovMap> selectDeptSchdulManageAuthorGroupPopup(ComDefaultVO searchVO){
-		return selectList("DeptSchdulManage.selectDeptSchdulAuthorGroupPopup", searchVO);
+	public List<EgovMap> selectDeptSchdulManageAuthorGroupPopup(ComDefaultVO searchVO) {
+		return mapper.selectDeptSchdulAuthorGroupPopup(searchVO);
 	}
 
-    /**
+	/**
 	 * 아이디 목록을 조회한다.
 	 * @param searchVO - 조회할 정보가 담긴 VO
 	 * @return List
+	 */
+	public List<EgovMap> selectDeptSchdulManageEmpLyrPopup(ComDefaultVO searchVO) {
+		return mapper.selectDeptSchdulEmpLyrPopup(searchVO);
+	}
+
+	/**
+	 * 부서일정 목록을 Map(map)형식으로 조회한다.
+	 * @param map - 조회할 정보가 담긴 Map
+	 * @return List
 	 * @throws Exception
 	 */
-	public List<EgovMap> selectDeptSchdulManageEmpLyrPopup(ComDefaultVO searchVO){
-		return selectList("DeptSchdulManage.selectDeptSchdulEmpLyrPopup", searchVO);
+	public List<EgovMap> selectDeptSchdulManageMainList(Map<String, String> map) throws Exception {
+		return mapper.selectDeptSchdulManageMainList(map);
 	}
-	
-    /**
-	 * 부서일정 목록을 Map(map)형식으로 조회한다. 
-	 * @param Map(map) - 조회할 정보가 담긴 VO
+
+	/**
+	 * 부서일정 목록을 Map(map)형식으로 조회한다.
+	 * @param map - 조회할 정보가 담긴 Map
 	 * @return List
-	 * @exception Exception
+	 * @throws Exception
 	 */
-	public List<EgovMap> selectDeptSchdulManageMainList(Map<String, String> map) throws Exception{
-		 return selectList("DeptSchdulManage.selectDeptSchdulManageMainList", map);
+	public List<EgovMap> selectDeptSchdulManageRetrieve(Map<String, String> map) throws Exception {
+		return mapper.selectDeptSchdulManageRetrieve(map);
 	}
-	
-    /**
-	 * 부서일정 목록을 Map(map)형식으로 조회한다. 
-	 * @param Map(map) - 조회할 정보가 담긴 VO
-	 * @return List
-	 * @exception Exception
-	 */
-	public List<EgovMap> selectDeptSchdulManageRetrieve(Map<String, String> map) throws Exception{
-		 return selectList("DeptSchdulManage.selectDeptSchdulManageRetrieve", map);
-	}
-	
-	
-    /**
-	 * 부서일정 목록을 VO(model)형식으로 조회한다. 
+
+	/**
+	 * 부서일정 목록을 VO(model)형식으로 조회한다.
 	 * @param deptSchdulManageVO - 조회할 정보가 담긴 VO
 	 * @return DeptSchdulManageVO
-	 * @exception Exception
+	 * @throws Exception
 	 */
-	public DeptSchdulManageVO selectDeptSchdulManageDetailVO(DeptSchdulManageVO deptSchdulManageVO) throws Exception{
-		return (DeptSchdulManageVO)selectOne("DeptSchdulManage.selectDeptSchdulManageDetailVO", deptSchdulManageVO);
+	public DeptSchdulManageVO selectDeptSchdulManageDetailVO(DeptSchdulManageVO deptSchdulManageVO) throws Exception {
+		return mapper.selectDeptSchdulManageDetailVO(deptSchdulManageVO);
 	}
-	
-    /**
-	 * 부서일정 목록을 조회한다. 
+
+	/**
+	 * 부서일정 목록을 조회한다.
 	 * @param searchVO - 조회할 정보가 담긴 VO
 	 * @return List
-	 * @exception Exception
+	 * @throws Exception
 	 */
-	public List<EgovMap> selectDeptSchdulManageList(ComDefaultVO searchVO) throws Exception{
-		return selectList("DeptSchdulManage.selectDeptSchdulManage", searchVO);
+	public List<EgovMap> selectDeptSchdulManageList(ComDefaultVO searchVO) throws Exception {
+		return mapper.selectDeptSchdulManage(searchVO);
 	}
-	
-    /**
+
+	/**
 	 * 부서일정를(을) 상세조회 한다.
 	 * @param deptSchdulManageVO - 부서일정 정보 담김 VO
 	 * @return List
-	 * @exception Exception
+	 * @throws Exception
 	 */
-	public List<EgovMap> selectDeptSchdulManageDetail(DeptSchdulManageVO deptSchdulManageVO) throws Exception{
-		return selectList("DeptSchdulManage.selectDeptSchdulManageDetail", deptSchdulManageVO);
+	public List<EgovMap> selectDeptSchdulManageDetail(DeptSchdulManageVO deptSchdulManageVO) throws Exception {
+		return mapper.selectDeptSchdulManageDetail(deptSchdulManageVO);
 	}
 
-    /**
+	/**
 	 * 부서일정를(을) 목록 전체 건수를(을) 조회한다.
 	 * @param searchVO - 조회할 정보가 담긴 VO
 	 * @return int
-	 * @exception Exception
+	 * @throws Exception
 	 */
-	public int selectDeptSchdulManageListCnt(ComDefaultVO searchVO) throws Exception{
-		return (Integer)selectOne("DeptSchdulManage.selectDeptSchdulManageCnt", searchVO);
-	}
-	
-    /**
-	 * 부서일정를(을) 등록한다.
-	 * @param qdeptSchdulManageVO - 부서일정 정보 담김 VO
-	 * @exception Exception
-	 */
-	public void insertDeptSchdulManage(DeptSchdulManageVO deptSchdulManageVO) throws Exception{
-		insert("DeptSchdulManage.insertDeptSchdulManage", deptSchdulManageVO);
+	public int selectDeptSchdulManageListCnt(ComDefaultVO searchVO) throws Exception {
+		return mapper.selectDeptSchdulManageCnt(searchVO);
 	}
 
-    /**
+	/**
+	 * 부서일정를(을) 등록한다.
+	 * @param deptSchdulManageVO - 부서일정 정보 담김 VO
+	 * @throws Exception
+	 */
+	public void insertDeptSchdulManage(DeptSchdulManageVO deptSchdulManageVO) throws Exception {
+		mapper.insertDeptSchdulManage(deptSchdulManageVO);
+	}
+
+	/**
 	 * 부서일정를(을) 수정한다.
 	 * @param deptSchdulManageVO - 부서일정 정보 담김 VO
-	 * @exception Exception
+	 * @throws Exception
 	 */
-	public void updateDeptSchdulManage(DeptSchdulManageVO deptSchdulManageVO) throws Exception{
-		insert("DeptSchdulManage.updateDeptSchdulManage", deptSchdulManageVO);
+	public void updateDeptSchdulManage(DeptSchdulManageVO deptSchdulManageVO) throws Exception {
+		mapper.updateDeptSchdulManage(deptSchdulManageVO);
 	}
-	
-    /**
+
+	/**
 	 * 부서일정를(을) 삭제한다.
 	 * @param deptSchdulManageVO - 부서일정 정보 담김 VO
-	 * @exception Exception
+	 * @throws Exception
 	 */
-	public void deleteDeptSchdulManage(DeptSchdulManageVO deptSchdulManageVO) throws Exception{
+	public void deleteDeptSchdulManage(DeptSchdulManageVO deptSchdulManageVO) throws Exception {
 		// 일지 삭제
-		delete("DeptSchdulManage.deleteDiaryManage", deptSchdulManageVO);
+		mapper.deleteDiaryManage(deptSchdulManageVO);
 		// 부서일정 삭제
-		delete("DeptSchdulManage.deleteDeptSchdulManage", deptSchdulManageVO);
+		mapper.deleteDeptSchdulManage(deptSchdulManageVO);
 	}
 }

--- a/src/main/java/egovframework/com/cop/smt/sdm/service/impl/DeptSchdulManageMapper.java
+++ b/src/main/java/egovframework/com/cop/smt/sdm/service/impl/DeptSchdulManageMapper.java
@@ -1,0 +1,57 @@
+package egovframework.com.cop.smt.sdm.service.impl;
+
+import java.util.List;
+import java.util.Map;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+import org.egovframe.rte.psl.dataaccess.util.EgovMap;
+
+import egovframework.com.cmm.ComDefaultVO;
+import egovframework.com.cop.smt.sdm.service.DeptSchdulManageVO;
+
+/**
+ * 부서일정관리를 위한 Mapper 인터페이스
+ * @author 공통서비스 장동한
+ * @since 2009.04.10
+ * @version 1.0
+ * @see
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2009.04.10  장동한          최초 생성
+ *   2016.08.01  장동한          표준프레임워크 v3.6 개선
+ *   2026.05.28  dasomel         XML 기반 DAO → @EgovMapper 인터페이스로 전환
+ *
+ * </pre>
+ */
+@EgovMapper("deptSchdulManageMapper")
+public interface DeptSchdulManageMapper {
+
+	List<EgovMap> selectDeptSchdulAuthorGroupPopup(ComDefaultVO searchVO);
+
+	List<EgovMap> selectDeptSchdulEmpLyrPopup(ComDefaultVO searchVO);
+
+	List<EgovMap> selectDeptSchdulManageMainList(Map<String, String> map);
+
+	List<EgovMap> selectDeptSchdulManageRetrieve(Map<String, String> map);
+
+	DeptSchdulManageVO selectDeptSchdulManageDetailVO(DeptSchdulManageVO deptSchdulManageVO);
+
+	List<EgovMap> selectDeptSchdulManage(ComDefaultVO searchVO);
+
+	List<EgovMap> selectDeptSchdulManageDetail(DeptSchdulManageVO deptSchdulManageVO);
+
+	int selectDeptSchdulManageCnt(ComDefaultVO searchVO);
+
+	int insertDeptSchdulManage(DeptSchdulManageVO deptSchdulManageVO);
+
+	int updateDeptSchdulManage(DeptSchdulManageVO deptSchdulManageVO);
+
+	int deleteDiaryManage(DeptSchdulManageVO deptSchdulManageVO);
+
+	int deleteDeptSchdulManage(DeptSchdulManageVO deptSchdulManageVO);
+
+}

--- a/src/main/java/egovframework/com/cop/smt/sim/service/impl/IndvdlSchdulManageDao.java
+++ b/src/main/java/egovframework/com/cop/smt/sim/service/impl/IndvdlSchdulManageDao.java
@@ -7,8 +7,9 @@ import org.egovframe.rte.psl.dataaccess.util.EgovMap;
 import org.springframework.stereotype.Repository;
 
 import egovframework.com.cmm.ComDefaultVO;
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.cop.smt.sim.service.IndvdlSchdulManageVO;
+import jakarta.annotation.Resource;
+
 /**
  * 일정관리를 처리하는 Dao Class 구현
  * @author 공통서비스 장동한
@@ -23,101 +24,103 @@ import egovframework.com.cop.smt.sim.service.IndvdlSchdulManageVO;
  *  -------    --------    ---------------------------
  *   2009.04.10  장동한          최초 생성
  *   2016.08.01  장동한          표준프레임워크 v3.6 개선
+ *   2026.05.28  dasomel         @EgovMapper 인터페이스 위임 방식으로 전환
  *
  * </pre>
  */
 @Repository("indvdlSchdulManageDao")
-public class IndvdlSchdulManageDao extends EgovComAbstractDAO {
+public class IndvdlSchdulManageDao {
 
+	@Resource(name = "indvdlSchdulManageMapper")
+	private IndvdlSchdulManageMapper mapper;
 
-    /**
+	/**
 	 * 메인페이지/일정관리조회 목록을 Map(map)형식으로 조회한다.
-	 * @param Map(map) - 조회할 정보가 담긴 VO
+	 * @param map - 조회할 정보가 담긴 Map
 	 * @return List
 	 * @throws Exception
 	 */
-	public List<EgovMap> selectIndvdlSchdulManageMainList(Map<String, String> map) throws Exception{
-		 return selectList("IndvdlSchdulManage.selectIndvdlSchdulManageMainList", map);
+	public List<EgovMap> selectIndvdlSchdulManageMainList(Map<String, String> map) throws Exception {
+		return mapper.selectIndvdlSchdulManageMainList(map);
 	}
 
-    /**
+	/**
 	 * 일정 목록을 Map(map)형식으로 조회한다.
-	 * @param Map(map) - 조회할 정보가 담긴 VO
+	 * @param map - 조회할 정보가 담긴 Map
 	 * @return List
 	 * @throws Exception
 	 */
-	public List<EgovMap> selectIndvdlSchdulManageRetrieve(Map<String, String> map) throws Exception{
-		 return selectList("IndvdlSchdulManage.selectIndvdlSchdulManageRetrieve", map);
+	public List<EgovMap> selectIndvdlSchdulManageRetrieve(Map<String, String> map) throws Exception {
+		return mapper.selectIndvdlSchdulManageRetrieve(map);
 	}
 
-
-    /**
+	/**
 	 * 일정 목록을 VO(model)형식으로 조회한다.
 	 * @param indvdlSchdulManageVO - 조회할 정보가 담긴 VO
 	 * @return IndvdlSchdulManageVO
 	 * @throws Exception
 	 */
-	public IndvdlSchdulManageVO selectIndvdlSchdulManageDetailVO(IndvdlSchdulManageVO indvdlSchdulManageVO) throws Exception{
-		return (IndvdlSchdulManageVO)selectOne("IndvdlSchdulManage.selectIndvdlSchdulManageDetailVO", indvdlSchdulManageVO);
+	public IndvdlSchdulManageVO selectIndvdlSchdulManageDetailVO(IndvdlSchdulManageVO indvdlSchdulManageVO) throws Exception {
+		return mapper.selectIndvdlSchdulManageDetailVO(indvdlSchdulManageVO);
 	}
 
-    /**
+	/**
 	 * 일정 목록을 조회한다.
 	 * @param searchVO - 조회할 정보가 담긴 VO
 	 * @return List
 	 * @throws Exception
 	 */
-	public List<IndvdlSchdulManageVO> selectIndvdlSchdulManageList(ComDefaultVO searchVO) throws Exception{
-		return selectList("IndvdlSchdulManage.selectIndvdlSchdulManage", searchVO);
+	public List<IndvdlSchdulManageVO> selectIndvdlSchdulManageList(ComDefaultVO searchVO) throws Exception {
+		return mapper.selectIndvdlSchdulManage(searchVO);
 	}
 
-    /**
+	/**
 	 * 일정를(을) 상세조회 한다.
 	 * @param indvdlSchdulManageVO - 일정 정보 담김 VO
 	 * @return List
 	 * @throws Exception
 	 */
-	public List<IndvdlSchdulManageVO> selectIndvdlSchdulManageDetail(IndvdlSchdulManageVO indvdlSchdulManageVO) throws Exception{
-		return selectList("IndvdlSchdulManage.selectIndvdlSchdulManageDetail", indvdlSchdulManageVO);
+	public List<IndvdlSchdulManageVO> selectIndvdlSchdulManageDetail(IndvdlSchdulManageVO indvdlSchdulManageVO) throws Exception {
+		return mapper.selectIndvdlSchdulManageDetail(indvdlSchdulManageVO);
 	}
 
-    /**
+	/**
 	 * 일정를(을) 목록 전체 건수를(을) 조회한다.
 	 * @param searchVO - 조회할 정보가 담긴 VO
 	 * @return int
 	 * @throws Exception
 	 */
-	public int selectIndvdlSchdulManageListCnt(ComDefaultVO searchVO) throws Exception{
-		return (Integer)selectOne("IndvdlSchdulManage.selectIndvdlSchdulManageCnt", searchVO);
+	public int selectIndvdlSchdulManageListCnt(ComDefaultVO searchVO) throws Exception {
+		return mapper.selectIndvdlSchdulManageCnt(searchVO);
 	}
 
-    /**
+	/**
 	 * 일정를(을) 등록한다.
-	 * @param qindvdlSchdulManageVO - 일정 정보 담김 VO
+	 * @param indvdlSchdulManageVO - 일정 정보 담김 VO
 	 * @throws Exception
 	 */
-	public void insertIndvdlSchdulManage(IndvdlSchdulManageVO indvdlSchdulManageVO) throws Exception{
-		insert("IndvdlSchdulManage.insertIndvdlSchdulManage", indvdlSchdulManageVO);
+	public void insertIndvdlSchdulManage(IndvdlSchdulManageVO indvdlSchdulManageVO) throws Exception {
+		mapper.insertIndvdlSchdulManage(indvdlSchdulManageVO);
 	}
 
-    /**
+	/**
 	 * 일정를(을) 수정한다.
 	 * @param indvdlSchdulManageVO - 일정 정보 담김 VO
 	 * @throws Exception
 	 */
-	public void updateIndvdlSchdulManage(IndvdlSchdulManageVO indvdlSchdulManageVO) throws Exception{
-		insert("IndvdlSchdulManage.updateIndvdlSchdulManage", indvdlSchdulManageVO);
+	public void updateIndvdlSchdulManage(IndvdlSchdulManageVO indvdlSchdulManageVO) throws Exception {
+		mapper.updateIndvdlSchdulManage(indvdlSchdulManageVO);
 	}
 
-    /**
+	/**
 	 * 일정를(을) 삭제한다.
 	 * @param indvdlSchdulManageVO - 일정 정보 담김 VO
 	 * @throws Exception
 	 */
-	public void deleteIndvdlSchdulManage(IndvdlSchdulManageVO indvdlSchdulManageVO) throws Exception{
+	public void deleteIndvdlSchdulManage(IndvdlSchdulManageVO indvdlSchdulManageVO) throws Exception {
 		// 일지 삭제
-		delete("IndvdlSchdulManage.deleteDiaryManage", indvdlSchdulManageVO);
+		mapper.deleteDiaryManage(indvdlSchdulManageVO);
 		// 일정관리 삭제
-		delete("IndvdlSchdulManage.deleteIndvdlSchdulManage", indvdlSchdulManageVO);
+		mapper.deleteIndvdlSchdulManage(indvdlSchdulManageVO);
 	}
 }

--- a/src/main/java/egovframework/com/cop/smt/sim/service/impl/IndvdlSchdulManageMapper.java
+++ b/src/main/java/egovframework/com/cop/smt/sim/service/impl/IndvdlSchdulManageMapper.java
@@ -1,0 +1,53 @@
+package egovframework.com.cop.smt.sim.service.impl;
+
+import java.util.List;
+import java.util.Map;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+import org.egovframe.rte.psl.dataaccess.util.EgovMap;
+
+import egovframework.com.cmm.ComDefaultVO;
+import egovframework.com.cop.smt.sim.service.IndvdlSchdulManageVO;
+
+/**
+ * 일정관리를 위한 Mapper 인터페이스
+ * @author 공통서비스 장동한
+ * @since 2009.04.10
+ * @version 1.0
+ * @see
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2009.04.10  장동한          최초 생성
+ *   2016.08.01  장동한          표준프레임워크 v3.6 개선
+ *   2026.05.28  dasomel         XML 기반 DAO → @EgovMapper 인터페이스로 전환
+ *
+ * </pre>
+ */
+@EgovMapper("indvdlSchdulManageMapper")
+public interface IndvdlSchdulManageMapper {
+
+	List<EgovMap> selectIndvdlSchdulManageMainList(Map<String, String> map);
+
+	List<EgovMap> selectIndvdlSchdulManageRetrieve(Map<String, String> map);
+
+	IndvdlSchdulManageVO selectIndvdlSchdulManageDetailVO(IndvdlSchdulManageVO indvdlSchdulManageVO);
+
+	List<IndvdlSchdulManageVO> selectIndvdlSchdulManage(ComDefaultVO searchVO);
+
+	List<IndvdlSchdulManageVO> selectIndvdlSchdulManageDetail(IndvdlSchdulManageVO indvdlSchdulManageVO);
+
+	int selectIndvdlSchdulManageCnt(ComDefaultVO searchVO);
+
+	int insertIndvdlSchdulManage(IndvdlSchdulManageVO indvdlSchdulManageVO);
+
+	int updateIndvdlSchdulManage(IndvdlSchdulManageVO indvdlSchdulManageVO);
+
+	int deleteDiaryManage(IndvdlSchdulManageVO indvdlSchdulManageVO);
+
+	int deleteIndvdlSchdulManage(IndvdlSchdulManageVO indvdlSchdulManageVO);
+
+}

--- a/src/main/java/egovframework/com/cop/smt/wmr/service/impl/WikMnthngReprtDAO.java
+++ b/src/main/java/egovframework/com/cop/smt/wmr/service/impl/WikMnthngReprtDAO.java
@@ -1,19 +1,20 @@
 package egovframework.com.cop.smt.wmr.service.impl;
+
 import java.util.List;
 
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.cop.smt.wmr.service.ReportrVO;
 import egovframework.com.cop.smt.wmr.service.WikMnthngReprt;
 import egovframework.com.cop.smt.wmr.service.WikMnthngReprtVO;
 import egovframework.com.utl.fcc.service.EgovDateUtil;
 import egovframework.com.utl.fcc.service.EgovStringUtil;
+import jakarta.annotation.Resource;
 
 /**
  * 개요
  * - 주간월간보고에 대한 DAO 클래스를 정의한다.
- * 
+ *
  * 상세내용
  * - 주간월간보고에 대한 등록, 수정, 삭제, 조회기능을 제공한다.
  * - 주간월간보고의 조회기능은 목록조회, 상세조회로 구분된다.
@@ -25,60 +26,56 @@ import egovframework.com.utl.fcc.service.EgovStringUtil;
  *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
- *   2010.7.19	장철호          최초 생성
+ *   2010.7.19   장철호          최초 생성
+ *   2026.05.28  dasomel         @EgovMapper 인터페이스 위임 방식으로 전환
  *
  * </pre>
  */
 @Repository("WikMnthngReprtDAO")
-public class WikMnthngReprtDAO extends EgovComAbstractDAO {
-	
+public class WikMnthngReprtDAO {
+
+	@Resource(name = "wikMnthngReprtMapper")
+	private WikMnthngReprtMapper mapper;
+
 	/**
 	 * 주어진 조건에 맞는 보고자를 불러온다.
-	 * @param ReportrVO
-	 * @return List
-	 * 
 	 * @param reportrVO
-	 */	
-	public List<ReportrVO> selectReportrList(ReportrVO reportrVO) throws Exception{
-		return selectList("WikMnthngReprtDAO.selectReportrList", reportrVO);
+	 * @return List
+	 */
+	public List<ReportrVO> selectReportrList(ReportrVO reportrVO) throws Exception {
+		return mapper.selectReportrList(reportrVO);
 	}
-	
+
 	/**
 	 * 보고자 목록에 대한 전체 건수를 조회한다.
-	 * @param ReportrVO
-	 * @return int
-	 * 
 	 * @param reportrVO
+	 * @return int
 	 */
-	public int selectReportrListCnt(ReportrVO reportrVO) throws Exception{
-		return (Integer)selectOne("WikMnthngReprtDAO.selectReportrListCnt", reportrVO);
+	public int selectReportrListCnt(ReportrVO reportrVO) throws Exception {
+		return mapper.selectReportrListCnt(reportrVO);
 	}
-	
+
 	/**
 	 * 주어진 조건에 맞는 직위명을 불러온다.
-	 * @param DeptVO
+	 * @param wrterId
 	 * @return String
-	 * 
-	 * @param DeptVO
 	 */
-	public String selectWrterClsfNm(String wrterId) throws Exception{
-		return (String)selectOne("WikMnthngReprtDAO.selectWrterClsfNm", wrterId);
+	public String selectWrterClsfNm(String wrterId) throws Exception {
+		return mapper.selectWrterClsfNm(wrterId);
 	}
-	
+
 	/**
 	 * 주어진 조건에 맞는 주간월간보고를 불러온다.
-	 * @param WikMnthngReprtVO - 주간월간보고 VO
+	 * @param wikMnthngReprtVO - 주간월간보고 VO
 	 * @return List<WikMnthngReprtVO> - 주간월간보고 List
-	 * 
-	 * @param wikMnthngReprtVO
 	 */
-	public List<WikMnthngReprtVO> selectWikMnthngReprtList(WikMnthngReprtVO wikMnthngReprtVO) throws Exception{
+	public List<WikMnthngReprtVO> selectWikMnthngReprtList(WikMnthngReprtVO wikMnthngReprtVO) throws Exception {
 		//날짜관련
 		wikMnthngReprtVO.setSearchBgnDe(wikMnthngReprtVO.getSearchBgnDe().replaceAll("-", ""));
 		wikMnthngReprtVO.setSearchEndDe(wikMnthngReprtVO.getSearchEndDe().replaceAll("-", ""));
-		
-		List<WikMnthngReprtVO> resultList = selectList("WikMnthngReprtDAO.selectWikMnthngReprtList", wikMnthngReprtVO);
-		for(int i=0; i < resultList.size(); i++){
+
+		List<WikMnthngReprtVO> resultList = mapper.selectWikMnthngReprtList(wikMnthngReprtVO);
+		for (int i = 0; i < resultList.size(); i++) {
 			WikMnthngReprtVO resultVO = resultList.get(i);
 			resultVO.setReprtDe(EgovDateUtil.convertDate(resultVO.getReprtDe(), "0000", "yyyy-MM-dd"));
 			resultVO.setReprtBgnDe(EgovDateUtil.convertDate(resultVO.getReprtBgnDe(), "0000", "yyyy-MM-dd"));
@@ -90,13 +87,11 @@ public class WikMnthngReprtDAO extends EgovComAbstractDAO {
 
 	/**
 	 * 주어진 조건에 맞는 주간월간보고 목록을 불러온다.
-	 * @param WikMnthngReprtVO - 주간월간보고 VO
+	 * @param wikMnthngReprtVO - 주간월간보고 VO
 	 * @return WikMnthngReprtVO - 주간월간보고 VO
-	 * 
-	 * @param wikMnthngReprtVO
 	 */
-	public WikMnthngReprtVO selectWikMnthngReprt(WikMnthngReprtVO wikMnthngReprtVO) throws Exception{
-		WikMnthngReprtVO resultVO = (WikMnthngReprtVO)selectOne("WikMnthngReprtDAO.selectWikMnthngReprt", wikMnthngReprtVO);
+	public WikMnthngReprtVO selectWikMnthngReprt(WikMnthngReprtVO wikMnthngReprtVO) throws Exception {
+		WikMnthngReprtVO resultVO = mapper.selectWikMnthngReprt(wikMnthngReprtVO);
 		resultVO.setReprtDe(EgovDateUtil.convertDate(resultVO.getReprtDe(), "0000", "yyyy-MM-dd"));
 		resultVO.setReprtBgnDe(EgovDateUtil.convertDate(resultVO.getReprtBgnDe(), "0000", "yyyy-MM-dd"));
 		resultVO.setReprtEndDe(EgovDateUtil.convertDate(resultVO.getReprtEndDe(), "0000", "yyyy-MM-dd"));
@@ -105,68 +100,57 @@ public class WikMnthngReprtDAO extends EgovComAbstractDAO {
 
 	/**
 	 * 주간월간보고 정보를 수정한다.
-	 * @param WikMnthngReprt - 주간월간보고 model
-	 * 
-	 * @param wikMnthngReprt
+	 * @param wikMnthngReprt - 주간월간보고 model
 	 */
-	public void updateWikMnthngReprt(WikMnthngReprt wikMnthngReprt) throws Exception{
+	public void updateWikMnthngReprt(WikMnthngReprt wikMnthngReprt) throws Exception {
 		//날짜관련
 		//KISA 보안약점 조치 (2018-10-29, 윤창원)
 		wikMnthngReprt.setReprtDe(EgovStringUtil.isNullToString(wikMnthngReprt.getReprtDe()).replaceAll("-", ""));
 		wikMnthngReprt.setReprtBgnDe(EgovStringUtil.isNullToString(wikMnthngReprt.getReprtBgnDe()).replaceAll("-", ""));
 		wikMnthngReprt.setReprtEndDe(EgovStringUtil.isNullToString(wikMnthngReprt.getReprtEndDe()).replaceAll("-", ""));
-		update("WikMnthngReprtDAO.updateWikMnthngReprt", wikMnthngReprt);
+		mapper.updateWikMnthngReprt(wikMnthngReprt);
 	}
 
 	/**
 	 * 주간월간보고 정보를 등록한다.
-	 * @param WikMnthngReprt - 주간월간보고 model
-	 * 
-	 * @param wikMnthngReprt
+	 * @param wikMnthngReprt - 주간월간보고 model
 	 */
-	public void insertWikMnthngReprt(WikMnthngReprt wikMnthngReprt) throws Exception{
+	public void insertWikMnthngReprt(WikMnthngReprt wikMnthngReprt) throws Exception {
 		//날짜관련
 		//KISA 보안약점 조치 (2018-10-29, 윤창원)
 		wikMnthngReprt.setReprtDe(EgovStringUtil.isNullToString(wikMnthngReprt.getReprtDe()).replaceAll("-", ""));
 		wikMnthngReprt.setReprtBgnDe(EgovStringUtil.isNullToString(wikMnthngReprt.getReprtBgnDe()).replaceAll("-", ""));
 		wikMnthngReprt.setReprtEndDe(EgovStringUtil.isNullToString(wikMnthngReprt.getReprtEndDe()).replaceAll("-", ""));
-		insert("WikMnthngReprtDAO.insertWikMnthngReprt", wikMnthngReprt);
+		mapper.insertWikMnthngReprt(wikMnthngReprt);
 	}
 
 	/**
 	 * 주간월간보고 정보를 삭제한다.
-	 * @param WikMnthngReprt - 주간월간보고 model
-	 * 
-	 * @param wikMnthngReprt
+	 * @param wikMnthngReprt - 주간월간보고 model
 	 */
-	public void deleteWikMnthngReprt(WikMnthngReprt wikMnthngReprt) throws Exception{
-		delete("WikMnthngReprtDAO.deleteWikMnthngReprt", wikMnthngReprt);
+	public void deleteWikMnthngReprt(WikMnthngReprt wikMnthngReprt) throws Exception {
+		mapper.deleteWikMnthngReprt(wikMnthngReprt);
 	}
 
 	/**
 	 * 주간월간보고 정보를 승인한다.
-	 * @param WikMnthngReprt - 주간월간보고 model
-	 * 
-	 * @param wikMnthngReprt
+	 * @param wikMnthngReprt - 주간월간보고 model
 	 */
-	public void confirmWikMnthngReprt(WikMnthngReprt wikMnthngReprt) throws Exception{
-		update("WikMnthngReprtDAO.confirmWikMnthngReprt", wikMnthngReprt);
+	public void confirmWikMnthngReprt(WikMnthngReprt wikMnthngReprt) throws Exception {
+		mapper.confirmWikMnthngReprt(wikMnthngReprt);
 	}
 
 	/**
 	 * 주간월간보고 목록에 대한 전체 건수를 조회한다.
-	 * @param WikMnthngReprtVO - 주간월간보고 VO
+	 * @param wikMnthngReprtVO - 주간월간보고 VO
 	 * @return int - 주간월간보고 목록 개수
-	 * 
-	 * @param wikMnthngReprtVO
 	 */
-	public int selectWikMnthngReprtListCnt(WikMnthngReprtVO wikMnthngReprtVO) throws Exception{
+	public int selectWikMnthngReprtListCnt(WikMnthngReprtVO wikMnthngReprtVO) throws Exception {
 		//날짜관련
 		//KISA 보안약점 조치 (2018-10-29, 윤창원)
 		wikMnthngReprtVO.setSearchBgnDe(EgovStringUtil.isNullToString(wikMnthngReprtVO.getSearchBgnDe()).replaceAll("-", ""));
 		wikMnthngReprtVO.setSearchEndDe(EgovStringUtil.isNullToString(wikMnthngReprtVO.getSearchEndDe()).replaceAll("-", ""));
-		
-		return (Integer)selectOne("WikMnthngReprtDAO.selectWikMnthngReprtListCnt", wikMnthngReprtVO);
+		return mapper.selectWikMnthngReprtListCnt(wikMnthngReprtVO);
 	}
 
 }

--- a/src/main/java/egovframework/com/cop/smt/wmr/service/impl/WikMnthngReprtMapper.java
+++ b/src/main/java/egovframework/com/cop/smt/wmr/service/impl/WikMnthngReprtMapper.java
@@ -1,0 +1,51 @@
+package egovframework.com.cop.smt.wmr.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.cop.smt.wmr.service.ReportrVO;
+import egovframework.com.cop.smt.wmr.service.WikMnthngReprt;
+import egovframework.com.cop.smt.wmr.service.WikMnthngReprtVO;
+
+/**
+ * 주간월간보고를 위한 Mapper 인터페이스
+ * @author 장철호
+ * @since 2010.07.19
+ * @version 1.0
+ * @see
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2010.07.19  장철호          최초 생성
+ *   2026.05.28  dasomel         XML 기반 DAO → @EgovMapper 인터페이스로 전환
+ *
+ * </pre>
+ */
+@EgovMapper("wikMnthngReprtMapper")
+public interface WikMnthngReprtMapper {
+
+	List<ReportrVO> selectReportrList(ReportrVO reportrVO);
+
+	int selectReportrListCnt(ReportrVO reportrVO);
+
+	String selectWrterClsfNm(String wrterId);
+
+	List<WikMnthngReprtVO> selectWikMnthngReprtList(WikMnthngReprtVO wikMnthngReprtVO);
+
+	WikMnthngReprtVO selectWikMnthngReprt(WikMnthngReprtVO wikMnthngReprtVO);
+
+	int updateWikMnthngReprt(WikMnthngReprt wikMnthngReprt);
+
+	int insertWikMnthngReprt(WikMnthngReprt wikMnthngReprt);
+
+	int deleteWikMnthngReprt(WikMnthngReprt wikMnthngReprt);
+
+	int confirmWikMnthngReprt(WikMnthngReprt wikMnthngReprt);
+
+	int selectWikMnthngReprtListCnt(WikMnthngReprtVO wikMnthngReprtVO);
+
+}

--- a/src/main/resources/egovframework/mapper/com/cop/smt/mtm/EgovMemoTodo_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/smt/mtm/EgovMemoTodo_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="MemoTodoDAO">
+<mapper namespace="egovframework.com.cop.smt.mtm.service.impl.MemoTodoMapper">
 	
 	<resultMap id="MemoTodoList" type="egovframework.com.cop.smt.mtm.service.MemoTodoVO">
 		<result property="todoId" column="TODO_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/smt/mtm/EgovMemoTodo_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/smt/mtm/EgovMemoTodo_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="MemoTodoDAO">
+<mapper namespace="egovframework.com.cop.smt.mtm.service.impl.MemoTodoMapper">
 	
 	<resultMap id="MemoTodoList" type="egovframework.com.cop.smt.mtm.service.MemoTodoVO">
 		<result property="todoId" column="TODO_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/smt/mtm/EgovMemoTodo_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/smt/mtm/EgovMemoTodo_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="MemoTodoDAO">
+<mapper namespace="egovframework.com.cop.smt.mtm.service.impl.MemoTodoMapper">
 	
 	<resultMap id="MemoTodoList" type="egovframework.com.cop.smt.mtm.service.MemoTodoVO">
 		<result property="todoId" column="TODO_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/smt/mtm/EgovMemoTodo_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/smt/mtm/EgovMemoTodo_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="MemoTodoDAO">
+<mapper namespace="egovframework.com.cop.smt.mtm.service.impl.MemoTodoMapper">
 	
 	<resultMap id="MemoTodoList" type="egovframework.com.cop.smt.mtm.service.MemoTodoVO">
 		<result property="todoId" column="TODO_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/smt/mtm/EgovMemoTodo_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/smt/mtm/EgovMemoTodo_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="MemoTodoDAO">
+<mapper namespace="egovframework.com.cop.smt.mtm.service.impl.MemoTodoMapper">
 	
 	<resultMap id="MemoTodoList" type="egovframework.com.cop.smt.mtm.service.MemoTodoVO">
 		<result property="todoId" column="TODO_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/smt/mtm/EgovMemoTodo_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/smt/mtm/EgovMemoTodo_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="MemoTodoDAO">
+<mapper namespace="egovframework.com.cop.smt.mtm.service.impl.MemoTodoMapper">
 	
 	<resultMap id="MemoTodoList" type="egovframework.com.cop.smt.mtm.service.MemoTodoVO">
 		<result property="todoId" column="TODO_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/smt/mtm/EgovMemoTodo_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/smt/mtm/EgovMemoTodo_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="MemoTodoDAO">
+<mapper namespace="egovframework.com.cop.smt.mtm.service.impl.MemoTodoMapper">
 	
 	<resultMap id="MemoTodoList" type="egovframework.com.cop.smt.mtm.service.MemoTodoVO">
 		<result property="todoId" column="TODO_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/smt/mtm/EgovMemoTodo_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/smt/mtm/EgovMemoTodo_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="MemoTodoDAO">
+<mapper namespace="egovframework.com.cop.smt.mtm.service.impl.MemoTodoMapper">
 	
 	<resultMap id="MemoTodoList" type="egovframework.com.cop.smt.mtm.service.MemoTodoVO">
 		<result property="todoId" column="TODO_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/smt/sam/EgovAllSchdulManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/smt/sam/EgovAllSchdulManage_SQL_altibase.xml
@@ -9,7 +9,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="AllSchdulManage">
+<mapper namespace="egovframework.com.cop.smt.sam.service.impl.AllSchdulManageMapper">
 
 	<!-- 전제일정::목록조회_게시물정보 -->
 	<select id="selectIndvdlSchdulManage" parameterType="comDefaultVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/com/cop/smt/sam/EgovAllSchdulManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/smt/sam/EgovAllSchdulManage_SQL_cubrid.xml
@@ -9,7 +9,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="AllSchdulManage">
+<mapper namespace="egovframework.com.cop.smt.sam.service.impl.AllSchdulManageMapper">
 
 	<!-- 전제일정::목록조회_게시물정보 -->
 	<select id="selectIndvdlSchdulManage" parameterType="comDefaultVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/com/cop/smt/sam/EgovAllSchdulManage_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/smt/sam/EgovAllSchdulManage_SQL_goldilocks.xml
@@ -9,7 +9,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="AllSchdulManage">
+<mapper namespace="egovframework.com.cop.smt.sam.service.impl.AllSchdulManageMapper">
 
 	<!-- 전제일정::목록조회_게시물정보 -->
 	<select id="selectIndvdlSchdulManage" parameterType="comDefaultVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/com/cop/smt/sam/EgovAllSchdulManage_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/smt/sam/EgovAllSchdulManage_SQL_maria.xml
@@ -7,7 +7,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="AllSchdulManage">
+<mapper namespace="egovframework.com.cop.smt.sam.service.impl.AllSchdulManageMapper">
 
 	<!-- 전제일정::목록조회_게시물정보 -->
 	<select id="selectIndvdlSchdulManage" parameterType="comDefaultVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/com/cop/smt/sam/EgovAllSchdulManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/smt/sam/EgovAllSchdulManage_SQL_mysql.xml
@@ -7,7 +7,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="AllSchdulManage">
+<mapper namespace="egovframework.com.cop.smt.sam.service.impl.AllSchdulManageMapper">
 
 	<!-- 전제일정::목록조회_게시물정보 -->
 	<select id="selectIndvdlSchdulManage" parameterType="comDefaultVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/com/cop/smt/sam/EgovAllSchdulManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/smt/sam/EgovAllSchdulManage_SQL_oracle.xml
@@ -9,7 +9,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="AllSchdulManage">
+<mapper namespace="egovframework.com.cop.smt.sam.service.impl.AllSchdulManageMapper">
 
 	<!-- 전제일정::목록조회_게시물정보 -->
 	<select id="selectIndvdlSchdulManage" parameterType="comDefaultVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/com/cop/smt/sam/EgovAllSchdulManage_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/smt/sam/EgovAllSchdulManage_SQL_postgres.xml
@@ -7,7 +7,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="AllSchdulManage">
+<mapper namespace="egovframework.com.cop.smt.sam.service.impl.AllSchdulManageMapper">
 
 	<!-- 전제일정::목록조회_게시물정보 -->
 	<select id="selectIndvdlSchdulManage" parameterType="comDefaultVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/com/cop/smt/sam/EgovAllSchdulManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/smt/sam/EgovAllSchdulManage_SQL_tibero.xml
@@ -9,7 +9,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="AllSchdulManage">
+<mapper namespace="egovframework.com.cop.smt.sam.service.impl.AllSchdulManageMapper">
 
 	<!-- 전제일정::목록조회_게시물정보 -->
 	<select id="selectIndvdlSchdulManage" parameterType="comDefaultVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/com/cop/smt/sdm/EgovDeptSchdulManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/smt/sdm/EgovDeptSchdulManage_SQL_altibase.xml
@@ -11,7 +11,7 @@
 --><!--Converted at: Wed May 11 15:50:02 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="DeptSchdulManage">
+<mapper namespace="egovframework.com.cop.smt.sdm.service.impl.DeptSchdulManageMapper">
 
 	<resultMap id="DeptSchdulManage" type="egovframework.com.cop.smt.sdm.service.DeptSchdulManageVO">
 		<result property="schdulId" column="SCHDUL_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/smt/sdm/EgovDeptSchdulManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/smt/sdm/EgovDeptSchdulManage_SQL_cubrid.xml
@@ -10,7 +10,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="DeptSchdulManage">
+<mapper namespace="egovframework.com.cop.smt.sdm.service.impl.DeptSchdulManageMapper">
 
 	<resultMap id="DeptSchdulManage" type="egovframework.com.cop.smt.sdm.service.DeptSchdulManageVO">
 		<result property="schdulId" column="SCHDUL_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/smt/sdm/EgovDeptSchdulManage_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/smt/sdm/EgovDeptSchdulManage_SQL_goldilocks.xml
@@ -11,7 +11,7 @@
 --><!--Converted at: Wed May 11 15:50:02 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="DeptSchdulManage">
+<mapper namespace="egovframework.com.cop.smt.sdm.service.impl.DeptSchdulManageMapper">
 
 	<resultMap id="DeptSchdulManage" type="egovframework.com.cop.smt.sdm.service.DeptSchdulManageVO">
 		<result property="schdulId" column="SCHDUL_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/smt/sdm/EgovDeptSchdulManage_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/smt/sdm/EgovDeptSchdulManage_SQL_maria.xml
@@ -10,7 +10,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="DeptSchdulManage">
+<mapper namespace="egovframework.com.cop.smt.sdm.service.impl.DeptSchdulManageMapper">
 
 	<resultMap id="DeptSchdulManage" type="egovframework.com.cop.smt.sdm.service.DeptSchdulManageVO">
 		<result property="schdulId" column="SCHDUL_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/smt/sdm/EgovDeptSchdulManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/smt/sdm/EgovDeptSchdulManage_SQL_mysql.xml
@@ -10,7 +10,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="DeptSchdulManage">
+<mapper namespace="egovframework.com.cop.smt.sdm.service.impl.DeptSchdulManageMapper">
 
 	<resultMap id="DeptSchdulManage" type="egovframework.com.cop.smt.sdm.service.DeptSchdulManageVO">
 		<result property="schdulId" column="SCHDUL_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/smt/sdm/EgovDeptSchdulManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/smt/sdm/EgovDeptSchdulManage_SQL_oracle.xml
@@ -11,7 +11,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="DeptSchdulManage">
+<mapper namespace="egovframework.com.cop.smt.sdm.service.impl.DeptSchdulManageMapper">
 
 
 	<resultMap id="DeptSchdulManage" type="egovframework.com.cop.smt.sdm.service.DeptSchdulManageVO">

--- a/src/main/resources/egovframework/mapper/com/cop/smt/sdm/EgovDeptSchdulManage_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/smt/sdm/EgovDeptSchdulManage_SQL_postgres.xml
@@ -10,7 +10,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="DeptSchdulManage">
+<mapper namespace="egovframework.com.cop.smt.sdm.service.impl.DeptSchdulManageMapper">
 
 	<resultMap id="DeptSchdulManage" type="egovframework.com.cop.smt.sdm.service.DeptSchdulManageVO">
 		<result property="schdulId" column="SCHDUL_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/smt/sdm/EgovDeptSchdulManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/smt/sdm/EgovDeptSchdulManage_SQL_tibero.xml
@@ -10,7 +10,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="DeptSchdulManage">
+<mapper namespace="egovframework.com.cop.smt.sdm.service.impl.DeptSchdulManageMapper">
 
 	<resultMap id="DeptSchdulManage" type="egovframework.com.cop.smt.sdm.service.DeptSchdulManageVO">
 		<result property="schdulId" column="SCHDUL_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/smt/sim/EgovIndvdlSchdulManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/smt/sim/EgovIndvdlSchdulManage_SQL_altibase.xml
@@ -10,7 +10,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="IndvdlSchdulManage">
+<mapper namespace="egovframework.com.cop.smt.sim.service.impl.IndvdlSchdulManageMapper">
 
 	<resultMap id="IndvdlSchdulManage" type="egovframework.com.cop.smt.sim.service.IndvdlSchdulManageVO">
 		<result property="schdulId" column="SCHDUL_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/smt/sim/EgovIndvdlSchdulManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/smt/sim/EgovIndvdlSchdulManage_SQL_cubrid.xml
@@ -11,7 +11,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="IndvdlSchdulManage">
+<mapper namespace="egovframework.com.cop.smt.sim.service.impl.IndvdlSchdulManageMapper">
 
 	<resultMap id="IndvdlSchdulManage" type="egovframework.com.cop.smt.sim.service.IndvdlSchdulManageVO">
 		<result property="schdulId" column="SCHDUL_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/smt/sim/EgovIndvdlSchdulManage_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/smt/sim/EgovIndvdlSchdulManage_SQL_goldilocks.xml
@@ -10,7 +10,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="IndvdlSchdulManage">
+<mapper namespace="egovframework.com.cop.smt.sim.service.impl.IndvdlSchdulManageMapper">
 
 	<resultMap id="IndvdlSchdulManage" type="egovframework.com.cop.smt.sim.service.IndvdlSchdulManageVO">
 		<result property="schdulId" column="SCHDUL_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/smt/sim/EgovIndvdlSchdulManage_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/smt/sim/EgovIndvdlSchdulManage_SQL_maria.xml
@@ -10,7 +10,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="IndvdlSchdulManage">
+<mapper namespace="egovframework.com.cop.smt.sim.service.impl.IndvdlSchdulManageMapper">
 
 	<resultMap id="IndvdlSchdulManage" type="egovframework.com.cop.smt.sim.service.IndvdlSchdulManageVO">
 		<result property="schdulId" column="SCHDUL_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/smt/sim/EgovIndvdlSchdulManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/smt/sim/EgovIndvdlSchdulManage_SQL_mysql.xml
@@ -10,7 +10,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="IndvdlSchdulManage">
+<mapper namespace="egovframework.com.cop.smt.sim.service.impl.IndvdlSchdulManageMapper">
 
 	<resultMap id="IndvdlSchdulManage" type="egovframework.com.cop.smt.sim.service.IndvdlSchdulManageVO">
 		<result property="schdulId" column="SCHDUL_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/smt/sim/EgovIndvdlSchdulManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/smt/sim/EgovIndvdlSchdulManage_SQL_oracle.xml
@@ -11,7 +11,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="IndvdlSchdulManage">
+<mapper namespace="egovframework.com.cop.smt.sim.service.impl.IndvdlSchdulManageMapper">
 
 	<resultMap id="IndvdlSchdulManage" type="egovframework.com.cop.smt.sim.service.IndvdlSchdulManageVO">
 		<result property="schdulId" column="SCHDUL_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/smt/sim/EgovIndvdlSchdulManage_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/smt/sim/EgovIndvdlSchdulManage_SQL_postgres.xml
@@ -10,7 +10,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="IndvdlSchdulManage">
+<mapper namespace="egovframework.com.cop.smt.sim.service.impl.IndvdlSchdulManageMapper">
 
 	<resultMap id="IndvdlSchdulManage" type="egovframework.com.cop.smt.sim.service.IndvdlSchdulManageVO">
 		<result property="schdulId" column="SCHDUL_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/smt/sim/EgovIndvdlSchdulManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/smt/sim/EgovIndvdlSchdulManage_SQL_tibero.xml
@@ -10,7 +10,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="IndvdlSchdulManage">
+<mapper namespace="egovframework.com.cop.smt.sim.service.impl.IndvdlSchdulManageMapper">
 
 
 	<resultMap id="IndvdlSchdulManage" type="egovframework.com.cop.smt.sim.service.IndvdlSchdulManageVO">

--- a/src/main/resources/egovframework/mapper/com/cop/smt/wmr/EgovWikMnthngReprt_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/smt/wmr/EgovWikMnthngReprt_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="WikMnthngReprtDAO">
+<mapper namespace="egovframework.com.cop.smt.wmr.service.impl.WikMnthngReprtMapper">
 	
 	<resultMap id="wikMnthngReportrList" type="egovframework.com.cop.smt.wmr.service.ReportrVO">
 		<result property="orgnztNm" column="ORGNZT_NM"/>

--- a/src/main/resources/egovframework/mapper/com/cop/smt/wmr/EgovWikMnthngReprt_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/smt/wmr/EgovWikMnthngReprt_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="WikMnthngReprtDAO">
+<mapper namespace="egovframework.com.cop.smt.wmr.service.impl.WikMnthngReprtMapper">
 	
 	<resultMap id="wikMnthngReportrList" type="egovframework.com.cop.smt.wmr.service.ReportrVO">
 		<result property="orgnztNm" column="ORGNZT_NM"/>

--- a/src/main/resources/egovframework/mapper/com/cop/smt/wmr/EgovWikMnthngReprt_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/smt/wmr/EgovWikMnthngReprt_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="WikMnthngReprtDAO">
+<mapper namespace="egovframework.com.cop.smt.wmr.service.impl.WikMnthngReprtMapper">
 	
 	<resultMap id="wikMnthngReportrList" type="egovframework.com.cop.smt.wmr.service.ReportrVO">
 		<result property="orgnztNm" column="ORGNZT_NM"/>

--- a/src/main/resources/egovframework/mapper/com/cop/smt/wmr/EgovWikMnthngReprt_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/smt/wmr/EgovWikMnthngReprt_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="WikMnthngReprtDAO">
+<mapper namespace="egovframework.com.cop.smt.wmr.service.impl.WikMnthngReprtMapper">
 	
 	<resultMap id="wikMnthngReportrList" type="egovframework.com.cop.smt.wmr.service.ReportrVO">
 		<result property="orgnztNm" column="ORGNZT_NM"/>

--- a/src/main/resources/egovframework/mapper/com/cop/smt/wmr/EgovWikMnthngReprt_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/smt/wmr/EgovWikMnthngReprt_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="WikMnthngReprtDAO">
+<mapper namespace="egovframework.com.cop.smt.wmr.service.impl.WikMnthngReprtMapper">
 	
 	<resultMap id="wikMnthngReportrList" type="egovframework.com.cop.smt.wmr.service.ReportrVO">
 		<result property="orgnztNm" column="ORGNZT_NM"/>

--- a/src/main/resources/egovframework/mapper/com/cop/smt/wmr/EgovWikMnthngReprt_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/smt/wmr/EgovWikMnthngReprt_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="WikMnthngReprtDAO">
+<mapper namespace="egovframework.com.cop.smt.wmr.service.impl.WikMnthngReprtMapper">
 	
 	<resultMap id="wikMnthngReportrList" type="egovframework.com.cop.smt.wmr.service.ReportrVO">
 		<result property="orgnztNm" column="ORGNZT_NM"/>

--- a/src/main/resources/egovframework/mapper/com/cop/smt/wmr/EgovWikMnthngReprt_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/smt/wmr/EgovWikMnthngReprt_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="WikMnthngReprtDAO">
+<mapper namespace="egovframework.com.cop.smt.wmr.service.impl.WikMnthngReprtMapper">
 	
 	<resultMap id="wikMnthngReportrList" type="egovframework.com.cop.smt.wmr.service.ReportrVO">
 		<result property="orgnztNm" column="ORGNZT_NM"/>

--- a/src/main/resources/egovframework/mapper/com/cop/smt/wmr/EgovWikMnthngReprt_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/smt/wmr/EgovWikMnthngReprt_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="WikMnthngReprtDAO">
+<mapper namespace="egovframework.com.cop.smt.wmr.service.impl.WikMnthngReprtMapper">
 	
 	<resultMap id="wikMnthngReportrList" type="egovframework.com.cop.smt.wmr.service.ReportrVO">
 		<result property="orgnztNm" column="ORGNZT_NM"/>

--- a/src/main/resources/egovframework/spring/com/context-mapper.xml
+++ b/src/main/resources/egovframework/spring/com/context-mapper.xml
@@ -21,5 +21,11 @@
 	<bean id="egov.sqlSessionTemplate" class="org.mybatis.spring.SqlSessionTemplate">
 		<constructor-arg ref="egov.sqlSession"/>
 	</bean>
-	
+
+	<!-- @EgovMapper 어노테이션 기반 Mapper 인터페이스 자동 등록 -->
+	<bean class="org.mybatis.spring.mapper.MapperScannerConfigurer">
+		<property name="basePackage" value="egovframework.com" />
+		<property name="annotationClass" value="org.egovframe.rte.psl.dataaccess.mapper.EgovMapper" />
+	</bean>
+
 </beans>


### PR DESCRIPTION
## 변경 사유
기존 XML namespace 기반 DAO를 5.0 신규 @EgovMapper 인터페이스 방식으로 전환

## 변경 내용
- AllSchdulManageMapper, MemoTodoMapper, IndvdlSchdulManageMapper, WikMnthngReprtMapper, DeptSchdulManageMapper 인터페이스 신규 추가
- cop/smt 하위 5개 DAO를 mapper 위임 구조로 리팩토링
- XML namespace를 mapper FQN으로 변경
- context-mapper.xml MapperScannerConfigurer 추가

## 영향 범위
- cop/smt 일정관리 5개 서브 모듈
- DAO bean name 유지

## 체크리스트
- [x] 단일 주제만 다룸
- [x] 기존 동작 호환
