### PR TITLE
[refactor][5.0.x][공통컴포넌트] uss/ion 5개 DAO @EgovMapper 인터페이스 방식으로 전환

### DIFF
--- a/src/main/java/egovframework/com/uss/ion/ans/service/impl/AnnvrsryManageDAO.java
+++ b/src/main/java/egovframework/com/uss/ion/ans/service/impl/AnnvrsryManageDAO.java
@@ -2,15 +2,14 @@ package egovframework.com.uss.ion.ans.service.impl;
 
 import java.util.List;
 
-import org.springframework.stereotype.Repository;
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.uss.ion.ans.service.AnnvrsryManage;
 import egovframework.com.uss.ion.ans.service.AnnvrsryManageVO;
 
 /**
  * 개요
- * - 기념일관리에 대한 DAO 클래스를 정의한다.
+ * - 기념일관리에 대한 DAO 인터페이스를 정의한다.
  *
  * 상세내용
  * - 기념일관리에 대한 등록, 수정, 삭제, 조회, 반영확인 기능을 제공한다.
@@ -18,89 +17,78 @@ import egovframework.com.uss.ion.ans.service.AnnvrsryManageVO;
  * @author 이용
  * @version 1.0
  * @created 06-15-2010 오후 2:08:56
+ *
+ * <pre>
+ *  == 개정이력(Modification Information) ==
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2010.06.15  이용           최초 생성
+ *   2026.05.28  dasomel        @EgovMapper 인터페이스 방식으로 전환
+ *
+ * </pre>
  */
-
-@Repository("annvrsryManageDAO")
-public class AnnvrsryManageDAO extends EgovComAbstractDAO {
+@EgovMapper("annvrsryManageDAO")
+public interface AnnvrsryManageDAO {
 
 	/**
 	 * 기념일관리정보를 관리하기 위해 등록된 기념일관리 목록을 조회한다.
 	 * @param annvrsryManageVO - 기념일관리 VO
 	 * @return List - 기념일관리 목록
-	 */	
-	public List<AnnvrsryManageVO> selectAnnvrsryManageList(AnnvrsryManageVO annvrsryManageVO) throws Exception {
-		return selectList("annvrsryManageDAO.selectAnnvrsryManageList", annvrsryManageVO);
-	}
+	 */
+	List<AnnvrsryManageVO> selectAnnvrsryManageList(AnnvrsryManageVO annvrsryManageVO);
 
-    /**
+	/**
 	 * 기념일관리목록 총 개수를 조회한다.
 	 * @param annvrsryManageVO - 기념일관리 VO
 	 * @return int
-	 * @exception Exception
 	 */
-    public int selectAnnvrsryManageListTotCnt(AnnvrsryManageVO annvrsryManageVO) throws Exception {
-        return (Integer)selectOne("annvrsryManageDAO.selectAnnvrsryManageListTotCnt", annvrsryManageVO);
-    }
+	int selectAnnvrsryManageListTotCnt(AnnvrsryManageVO annvrsryManageVO);
 
 	/**
 	 * 등록된 기념일관리의 상세정보를 조회한다.
 	 * @param annvrsryManageVO - 기념일관리 VO
 	 * @return AnnvrsryManageVO - 기념일관리 VO
 	 */
-	public AnnvrsryManageVO selectAnnvrsryManage(AnnvrsryManageVO annvrsryManageVO)  throws Exception {
-		return (AnnvrsryManageVO) selectOne("annvrsryManageDAO.selectAnnvrsryManage", annvrsryManageVO);
-	}
+	AnnvrsryManageVO selectAnnvrsryManage(AnnvrsryManageVO annvrsryManageVO);
 
 	/**
 	 * 기념일관리정보를 신규로 등록한다.
 	 * @param annvrsryManage - 기념일관리 model
 	 */
-	public void insertAnnvrsryManage(AnnvrsryManage annvrsryManage) throws Exception {
-		insert("annvrsryManageDAO.insertAnnvrsryManage", annvrsryManage);
-	}
+	void insertAnnvrsryManage(AnnvrsryManage annvrsryManage);
 
 	/**
 	 * 기 등록된 기념일관리정보를 수정한다.
 	 * @param annvrsryManage - 기념일관리 model
 	 */
-	public void updateAnnvrsryManage(AnnvrsryManage annvrsryManage) throws Exception {
-		update("annvrsryManageDAO.updateAnnvrsryManage", annvrsryManage);
-	}
+	void updateAnnvrsryManage(AnnvrsryManage annvrsryManage);
 
 	/**
 	 * 기 등록된 기념일관리정보를 삭제한다.
 	 * @param annvrsryManage - 기념일관리 model
 	 */
-	public void deleteAnnvrsryManage(AnnvrsryManage annvrsryManage) throws Exception {
-        delete("annvrsryManageDAO.deleteAnnvrsryManage",annvrsryManage);
-	}
+	void deleteAnnvrsryManage(AnnvrsryManage annvrsryManage);
 
 	/**
 	 * 등록된 기념일관리의 상세정보를 조회한다.
 	 * @param annvrsryManageVO - 기념일관리 VO
-	 * @return AnnvrsryManageVO - 기념일관리 VO
-	 */	
-	public List<AnnvrsryManageVO> selectAnnvrsryGdcc(AnnvrsryManageVO annvrsryManageVO)  throws Exception {
-		return selectList("annvrsryManageDAO.selectAnnvrsryGdcc", annvrsryManageVO);
-	}
+	 * @return List - 기념일관리 VO
+	 */
+	List<AnnvrsryManageVO> selectAnnvrsryGdcc(AnnvrsryManageVO annvrsryManageVO);
 
-    /**
+	/**
 	 * 기념일관리 등록시 중복여부를 조회한다.
 	 * @param annvrsryManage - 기념일관리 VO
 	 * @return int
-	 * @exception Exception
 	 */
-    public int selectAnnvrsryManageDplctAt(AnnvrsryManage annvrsryManage) throws Exception {
-        return (Integer)selectOne("annvrsryManageDAO.selectAnnvrsryManageDplctAt", annvrsryManage);
-    }
+	int selectAnnvrsryManageDplctAt(AnnvrsryManage annvrsryManage);
 
 	/**
 	 * 등록된 기념일관리의 상세정보를 조회한다.
 	 * @param annvrsryManageVO - 기념일관리 VO
 	 * @return AnnvrsryManageVO - 기념일관리 VO
 	 */
-	public AnnvrsryManageVO selectAnnvrsryManageBnde(AnnvrsryManageVO annvrsryManageVO)  throws Exception {
-		return (AnnvrsryManageVO) selectOne("annvrsryManageDAO.selectAnnvrsryManageBnde", annvrsryManageVO);
-	}
+	AnnvrsryManageVO selectAnnvrsryManageBnde(AnnvrsryManageVO annvrsryManageVO);
 
 }

--- a/src/main/java/egovframework/com/uss/ion/bnt/service/impl/BndtManageDAO.java
+++ b/src/main/java/egovframework/com/uss/ion/bnt/service/impl/BndtManageDAO.java
@@ -2,208 +2,165 @@ package egovframework.com.uss.ion.bnt.service.impl;
 
 import java.util.List;
 
-import org.springframework.stereotype.Repository;
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.uss.ion.bnt.service.BndtCeckManageVO;
 import egovframework.com.uss.ion.bnt.service.BndtDiaryVO;
 import egovframework.com.uss.ion.bnt.service.BndtManageVO;
 
 /**
  * 개요
- * - 당직관리에 대한 DAO 클래스를 정의한다.
- * 
+ * - 당직관리에 대한 DAO 인터페이스를 정의한다.
+ *
  * 상세내용
  * - 당직관리에 대한 등록, 수정, 삭제, 조회, 반영확인 기능을 제공한다.
  * - 당직관리의 조회기능은 목록조회, 상세조회로 구분된다.
  * @author 이용
  * @version 1.0
  * @created 06-15-2010 오후 2:08:56
+ *
+ * <pre>
+ *  == 개정이력(Modification Information) ==
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2010.06.15  이용           최초 생성
+ *   2026.05.28  dasomel        @EgovMapper 인터페이스 방식으로 전환
+ *
+ * </pre>
  */
-
-@Repository("bndtManageDAO")
-public class BndtManageDAO extends EgovComAbstractDAO {
+@EgovMapper("bndtManageDAO")
+public interface BndtManageDAO {
 
 	/**
 	 * 당직관리정보를 관리하기 위해 등록된 당직관리 목록을 조회한다.
 	 * @param bndtManageVO - 당직관리 VO
 	 * @return List - 당직관리 목록
 	 */
-	
-	public List<BndtManageVO> selectBndtManageList(BndtManageVO bndtManageVO) throws Exception {
-		return  selectList("bndtManageDAO.selectBndtManageList", bndtManageVO);
-	}
+	List<BndtManageVO> selectBndtManageList(BndtManageVO bndtManageVO);
 
-    /**
+	/**
 	 * 당직관리목록 총 개수를 조회한다.
 	 * @param bndtManageVO - 당직관리 VO
 	 * @return int
-	 * @exception Exception
 	 */
-    public int selectBndtManageListTotCnt(BndtManageVO bndtManageVO) throws Exception {
-        return (Integer)selectOne("bndtManageDAO.selectBndtManageListTotCnt", bndtManageVO);
-    }
+	int selectBndtManageListTotCnt(BndtManageVO bndtManageVO);
 
 	/**
 	 * 등록된 당직관리의 상세정보를 조회한다.
 	 * @param bndtManageVO - 당직관리 VO
 	 * @return BndtManageVO - 당직관리 VO
 	 */
-	public BndtManageVO selectBndtManage(BndtManageVO bndtManageVO)  throws Exception {
-		return (BndtManageVO) selectOne("bndtManageDAO.selectBndtManage", bndtManageVO);
-	}
+	BndtManageVO selectBndtManage(BndtManageVO bndtManageVO);
 
 	/**
 	 * 당직관리정보를 신규로 등록한다.
 	 * @param bndtManageVO - 당직관리 VO
 	 */
-	public void insertBndtManage(BndtManageVO bndtManageVO) throws Exception {
-		insert("bndtManageDAO.insertBndtManage", bndtManageVO);
-	}
+	void insertBndtManage(BndtManageVO bndtManageVO);
 
 	/**
 	 * 기 등록된 당직관리정보를 수정한다.
 	 * @param bndtManageVO - 당직관리 VO
 	 */
-	public void updtBndtManage(BndtManageVO bndtManageVO) throws Exception {
-		update("bndtManageDAO.updtBndtManage", bndtManageVO);
-	}
+	void updtBndtManage(BndtManageVO bndtManageVO);
 
 	/**
 	 * 기 등록된 당직관리정보를 삭제한다.
 	 * @param bndtManageVO - 당직관리 VO
 	 */
-	public void deleteBndtManage(BndtManageVO bndtManageVO) throws Exception {
-        delete("bndtManageDAO.deleteBndtManage",bndtManageVO);
-	}
+	void deleteBndtManage(BndtManageVO bndtManageVO);
 
-    /**
+	/**
 	 * 당직일지 개수를 조회한다.
 	 * @param bndtManageVO - 당직관리 VO
 	 * @return int
-	 * @exception Exception
 	 */
-    public int selectBndtDiaryTotCnt(BndtManageVO bndtManageVO) throws Exception {
-        return (Integer)selectOne("bndtManageDAO.selectBndtDiaryTotCnt", bndtManageVO);
-    }
-	
-    /***** 당직 체크관리 *****/	
+	int selectBndtDiaryTotCnt(BndtManageVO bndtManageVO);
 
 	/**
 	 * 당직체크관리정보를 관리하기 위해 등록된 당직체크관리 목록을 조회한다.
 	 * @param bndtCeckManageVO - 당직체크관리 VO
 	 * @return List - 당직체크관리 목록
 	 */
-	public List<BndtCeckManageVO> selectBndtCeckManageList(BndtCeckManageVO bndtCeckManageVO) throws Exception {
-		return selectList("bndtManageDAO.selectBndtCeckManageList", bndtCeckManageVO);
-	}
+	List<BndtCeckManageVO> selectBndtCeckManageList(BndtCeckManageVO bndtCeckManageVO);
 
-    /**
+	/**
 	 * 당직체크관리목록 총 개수를 조회한다.
 	 * @param bndtCeckManageVO - 당직체크관리 VO
 	 * @return int
-	 * @exception Exception
 	 */
-    public int selectBndtCeckManageListTotCnt(BndtCeckManageVO bndtCeckManageVO) throws Exception {
-        return (Integer)selectOne("bndtManageDAO.selectBndtCeckManageListTotCnt", bndtCeckManageVO);
-    }
+	int selectBndtCeckManageListTotCnt(BndtCeckManageVO bndtCeckManageVO);
 
 	/**
 	 * 등록된 당직체크관리의 상세정보를 조회한다.
 	 * @param bndtCeckManageVO - 당직체크관리 VO
 	 * @return BndtCeckManageVO - 당직체크관리 VO
 	 */
-	public BndtCeckManageVO selectBndtCeckManage(BndtCeckManageVO bndtCeckManageVO)  throws Exception {
-		return (BndtCeckManageVO) selectOne("bndtManageDAO.selectBndtCeckManage", bndtCeckManageVO);
-	}
+	BndtCeckManageVO selectBndtCeckManage(BndtCeckManageVO bndtCeckManageVO);
 
 	/**
 	 * 당직체크관리정보를 신규로 등록한다.
 	 * @param bndtCeckManageVO - 당직체크관리 VO
 	 */
-	public void insertBndtCeckManage(BndtCeckManageVO bndtCeckManageVO) throws Exception {
-		insert("bndtManageDAO.insertBndtCeckManage", bndtCeckManageVO);
-	}
+	void insertBndtCeckManage(BndtCeckManageVO bndtCeckManageVO);
 
 	/**
 	 * 기 등록된 당직체크관리정보를 수정한다.
 	 * @param bndtCeckManageVO - 당직체크관리 VO
 	 */
-	public void updtBndtCeckManage(BndtCeckManageVO bndtCeckManageVO) throws Exception {
-		update("bndtManageDAO.updtBndtCeckManage", bndtCeckManageVO);
-	}
+	void updtBndtCeckManage(BndtCeckManageVO bndtCeckManageVO);
 
 	/**
 	 * 기 등록된 당직체크관리정보를 삭제한다.
 	 * @param bndtCeckManageVO - 당직체크관리 VO
 	 */
-	public void deleteBndtCeckManage(BndtCeckManageVO bndtCeckManageVO) throws Exception {
-        delete("bndtManageDAO.deleteBndtCeckManage",bndtCeckManageVO);
-	}
+	void deleteBndtCeckManage(BndtCeckManageVO bndtCeckManageVO);
 
-    /**
+	/**
 	 * 당직체크 중복여부 조회한다.
 	 * @param bndtCeckManageVO - 당직체크관리 VO
 	 * @return int
-	 * @exception Exception
 	 */
-    public int selectBndtCeckManageDplctAt(BndtCeckManageVO bndtCeckManageVO) throws Exception {
-        return (Integer)selectOne("bndtManageDAO.selectBndtCeckManageDplctAt", bndtCeckManageVO);
-    }
-	
-    /***** 당직 일지 *****/
+	int selectBndtCeckManageDplctAt(BndtCeckManageVO bndtCeckManageVO);
 
 	/**
 	 * 등록된 당직일지관리의 상세정보를 조회한다.
 	 * @param bndtDiaryVO - 당직일지관리 VO
 	 * @return List - 당직일지관리 VO
 	 */
-	public List<BndtDiaryVO> selectBndtDiary(BndtDiaryVO bndtDiaryVO) throws Exception {
-		return selectList("bndtManageDAO.selectBndtDiary", bndtDiaryVO);
-	}
-	
+	List<BndtDiaryVO> selectBndtDiary(BndtDiaryVO bndtDiaryVO);
+
 	/**
 	 * 당직일지관리정보를 신규로 등록한다.
 	 * @param bndtDiaryVO - 당직일지관리 VO
 	 */
-	public void insertBndtDiary(BndtDiaryVO bndtDiaryVO) throws Exception {
-
-		insert("bndtManageDAO.insertBndtDiary", bndtDiaryVO);
-	}
+	void insertBndtDiary(BndtDiaryVO bndtDiaryVO);
 
 	/**
 	 * 기 등록된 당직일지관리정보를 수정한다.
 	 * @param bndtDiaryVO - 당직일지관리 VO
 	 */
-	public void updtBndtDiary(BndtDiaryVO bndtDiaryVO) throws Exception {
-		update("bndtManageDAO.updtBndtDiary", bndtDiaryVO);
-	}
+	void updtBndtDiary(BndtDiaryVO bndtDiaryVO);
 
 	/**
 	 * 기 등록된 당직일지관리정보를 삭제한다.
 	 * @param bndtDiaryVO - 당직일지관리 VO
 	 */
-	public void deleteBndtDiary(BndtDiaryVO bndtDiaryVO) throws Exception {
-        delete("bndtManageDAO.deleteBndtDiary",bndtDiaryVO);
-	}
+	void deleteBndtDiary(BndtDiaryVO bndtDiaryVO);
 
-	
 	/**
 	 * 등록된 당직관리의 상세정보를 조회한다.
 	 * @param bndtManageVO - 당직관리 VO
 	 * @return BndtManageVO - 당직관리 VO
 	 */
-	public BndtManageVO selectBndtManageBnde(BndtManageVO bndtManageVO)  throws Exception {
-		return (BndtManageVO) selectOne("bndtManageDAO.selectBndtManageBnde", bndtManageVO);
-	}
-	
-    /**
+	BndtManageVO selectBndtManageBnde(BndtManageVO bndtManageVO);
+
+	/**
 	 * 당직관리 등록건수 조회한다.
 	 * @param bndtManageVO - 당직관리 VO
 	 * @return int
-	 * @exception Exception
 	 */
-    public int selectBndtManageMonthCnt(BndtManageVO bndtManageVO) throws Exception {
-        return (Integer)selectOne("bndtManageDAO.selectBndtManageMonthCnt", bndtManageVO);
-    }
+	int selectBndtManageMonthCnt(BndtManageVO bndtManageVO);
+
 }

--- a/src/main/java/egovframework/com/uss/ion/ecc/service/impl/EgovEventCmpgnDAO.java
+++ b/src/main/java/egovframework/com/uss/ion/ecc/service/impl/EgovEventCmpgnDAO.java
@@ -2,65 +2,52 @@ package egovframework.com.uss.ion.ecc.service.impl;
 
 import java.util.List;
 
-import org.springframework.stereotype.Repository;
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.uss.ion.ecc.service.EventCmpgnVO;
 import egovframework.com.uss.ion.ecc.service.TnextrlHrVO;
 
-@Repository("EgovEventCmpgnDAO")
-public class EgovEventCmpgnDAO extends EgovComAbstractDAO {
+/**
+ * 개요
+ * - 행사캠페인에 대한 DAO 인터페이스를 정의한다.
+ *
+ * <pre>
+ *  == 개정이력(Modification Information) ==
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2010.xx.xx  최초 생성
+ *   2026.05.28  dasomel        @EgovMapper 인터페이스 방식으로 전환
+ *
+ * </pre>
+ */
+@EgovMapper("EgovEventCmpgnDAO")
+public interface EgovEventCmpgnDAO {
 
-	public List<EventCmpgnVO> selectEventCmpgnList(EventCmpgnVO eventCmpgnVO) {
-		return selectList("EventCmpgn.selectEventCmpgnList", eventCmpgnVO);
-	}
+	List<EventCmpgnVO> selectEventCmpgnList(EventCmpgnVO eventCmpgnVO);
 
-	public int selectEventCmpgnListCnt(EventCmpgnVO eventCmpgnVO) {
-		return (Integer) selectOne("EventCmpgn.selectEventCmpgnListCnt", eventCmpgnVO);
-	}
+	int selectEventCmpgnListCnt(EventCmpgnVO eventCmpgnVO);
 
-	public void insertEventCmpgn(EventCmpgnVO eventCmpgnVO) {
-		insert("EventCmpgn.insertEventCmpgn", eventCmpgnVO);
-	}
+	void insertEventCmpgn(EventCmpgnVO eventCmpgnVO);
 
-	public EventCmpgnVO selectEventCmpgnDetail(EventCmpgnVO eventCmpgnVO) {
-		return (EventCmpgnVO) selectOne("EventCmpgn.selectEventCmpgnDetail", eventCmpgnVO);
-	}
+	EventCmpgnVO selectEventCmpgnDetail(EventCmpgnVO eventCmpgnVO);
 
-	public void updateEventCmpgn(EventCmpgnVO eventCmpgnVO) {
-		update("EventCmpgn.updateEventCmpgn", eventCmpgnVO);
-	}
+	void updateEventCmpgn(EventCmpgnVO eventCmpgnVO);
 
-	public void deleteEventCmpgn(EventCmpgnVO eventCmpgnVO) {
-		delete("EventCmpgn.deleteEventCmpgn", eventCmpgnVO);
-	}
+	void deleteEventCmpgn(EventCmpgnVO eventCmpgnVO);
 
-	public List<TnextrlHrVO> selectTnextrlHrList(TnextrlHrVO tnextrlHrVO) {
-		return selectList("EventCmpgn.selectTnextrlHrList", tnextrlHrVO);
-	}
+	List<TnextrlHrVO> selectTnextrlHrList(TnextrlHrVO tnextrlHrVO);
 
-	public int selectTnextrlHrListCnt(TnextrlHrVO tnextrlHrVO) {
-		return (Integer) selectOne("EventCmpgn.selectTnextrlHrListCnt", tnextrlHrVO);
-	}
+	int selectTnextrlHrListCnt(TnextrlHrVO tnextrlHrVO);
 
-	public void insertTnextrlHr(TnextrlHrVO tnextrlHrVO) {
-		insert("EventCmpgn.insertTnextrlHr", tnextrlHrVO);
-	}
+	void insertTnextrlHr(TnextrlHrVO tnextrlHrVO);
 
-	public TnextrlHrVO selectTnextrlHrDetail(TnextrlHrVO tnextrlHrVO) {
-		return (TnextrlHrVO) selectOne("EventCmpgn.selectTnextrlHrDetail", tnextrlHrVO);
-	}
+	TnextrlHrVO selectTnextrlHrDetail(TnextrlHrVO tnextrlHrVO);
 
-	public void updateTnextrlHr(TnextrlHrVO tnextrlHrVO) {
-		update("EventCmpgn.updateTnextrlHr", tnextrlHrVO);
-	}
+	void updateTnextrlHr(TnextrlHrVO tnextrlHrVO);
 
-	public void deleteTnextrlHr(TnextrlHrVO tnextrlHrVO) {
-		delete("EventCmpgn.deleteTnextrlHr", tnextrlHrVO);
-	}
+	void deleteTnextrlHr(TnextrlHrVO tnextrlHrVO);
 
-	public void deleteEventCmpgnTnextrlHr(EventCmpgnVO eventCmpgnVO) {
-		delete("EventCmpgn.deleteEventCmpgnTnextrlHr", eventCmpgnVO);
-	}
+	void deleteEventCmpgnTnextrlHr(EventCmpgnVO eventCmpgnVO);
 
 }

--- a/src/main/java/egovframework/com/uss/ion/ism/service/impl/InfrmlSanctnDAO.java
+++ b/src/main/java/egovframework/com/uss/ion/ism/service/impl/InfrmlSanctnDAO.java
@@ -1,99 +1,79 @@
 package egovframework.com.uss.ion.ism.service.impl;
+
 import java.util.List;
 
-import org.springframework.stereotype.Repository;
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.uss.ion.ism.service.InfrmlSanctn;
 import egovframework.com.uss.ion.ism.service.SanctnerVO;
 
 /**
  * 개요
- * - 약식결재관리에 대한 DAO 클래스를 정의한다.
- * 
+ * - 약식결재관리에 대한 DAO 인터페이스를 정의한다.
+ *
  * 상세내용
  * - 약식결재관리에 대한 등록, 수정, 삭제기능을 제공한다.
  * - 결재자에 대한 목록조회기능을 제공한다.
  * @author 장철호
  * @version 1.0
  * @created 28-6-2010 오전 11:29:26
+ *
+ * <pre>
+ *  == 개정이력(Modification Information) ==
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2010.06.28  장철호           최초 생성
+ *   2026.05.28  dasomel        @EgovMapper 인터페이스 방식으로 전환
+ *
+ * </pre>
  */
-@Repository("InfrmlSanctnDAO")
-public class InfrmlSanctnDAO extends EgovComAbstractDAO {
+@EgovMapper("InfrmlSanctnDAO")
+public interface InfrmlSanctnDAO {
 
-	
 	/**
 	 * 주어진 조건에 맞는 결재자를 불러온다.
-	 * @param SanctnerVO
-	 * @return List
-	 * 
 	 * @param sanctnerVO
-	 */	
-	public List<SanctnerVO> selectSanctnerList(SanctnerVO sanctnerVO) throws Exception{
-		return selectList("InfrmlSanctnDAO.selectSanctnerList", sanctnerVO);
-	}
-	
+	 * @return List
+	 */
+	List<SanctnerVO> selectSanctnerList(SanctnerVO sanctnerVO);
+
 	/**
 	 * 결재자 목록에 대한 전체 건수를 조회한다.
-	 * @param SanctnerVO
-	 * @return int
-	 * 
 	 * @param sanctnerVO
+	 * @return int
 	 */
-	public int selectSanctnerListCnt(SanctnerVO sanctnerVO) throws Exception{
-		return (Integer)selectOne("InfrmlSanctnDAO.selectSanctnerListCnt", sanctnerVO);
-	}
-	
+	int selectSanctnerListCnt(SanctnerVO sanctnerVO);
+
 	/**
 	 * 주어진 조건에 맞는 약식결재정보를 불러온다.
-	 * @param InfrmlSanctn
-	 * @return InfrmlSanctn
-	 * 
 	 * @param infrmlSanctn
+	 * @return InfrmlSanctn
 	 */
-	public InfrmlSanctn selectInfrmlSanctn(InfrmlSanctn infrmlSanctn) throws Exception{
-		return (InfrmlSanctn)selectOne("InfrmlSanctnDAO.selectInfrmlSanctn", infrmlSanctn);
-	}
-	
+	InfrmlSanctn selectInfrmlSanctn(InfrmlSanctn infrmlSanctn);
 
 	/**
 	 * 약식결재관리 정보를 수정한다.
-	 * @param InfrmlSanctn
-	 * 
 	 * @param infrmlSanctn
 	 */
-	public void updateInfrmlSanctn(InfrmlSanctn infrmlSanctn) throws Exception{
-		update("InfrmlSanctnDAO.updateInfrmlSanctn", infrmlSanctn);
-	}
-	
+	void updateInfrmlSanctn(InfrmlSanctn infrmlSanctn);
+
 	/**
 	 * 약식결재관리 정보를 승인 또는 반려한다.
-	 * @param InfrmlSanctn
-	 * 
 	 * @param infrmlSanctn
 	 */
-	public void updateInfrmlSanctnConfm(InfrmlSanctn infrmlSanctn) throws Exception{
-		update("InfrmlSanctnDAO.updateInfrmlSanctnConfm", infrmlSanctn);
-	}
+	void updateInfrmlSanctnConfm(InfrmlSanctn infrmlSanctn);
 
 	/**
 	 * 약식결재관리 정보를 등록한다.
-	 * @param InfrmlSanctn
-	 * 
 	 * @param infrmlSanctn
 	 */
-	public void insertInfrmlSanctn(InfrmlSanctn infrmlSanctn) throws Exception{
-		insert("InfrmlSanctnDAO.insertInfrmlSanctn", infrmlSanctn);
-	}
+	void insertInfrmlSanctn(InfrmlSanctn infrmlSanctn);
 
 	/**
 	 * 약식결재관리 정보를 삭제한다.
-	 * @param InfrmlSanctn
-	 * 
 	 * @param infrmlSanctn
 	 */
-	public void deleteInfrmlSanctn(InfrmlSanctn infrmlSanctn) throws Exception{
-		delete("InfrmlSanctnDAO.deleteInfrmlSanctn", infrmlSanctn);
-	}
+	void deleteInfrmlSanctn(InfrmlSanctn infrmlSanctn);
 
 }

--- a/src/main/java/egovframework/com/uss/ion/mtg/service/impl/MtgPlaceManageDAO.java
+++ b/src/main/java/egovframework/com/uss/ion/mtg/service/impl/MtgPlaceManageDAO.java
@@ -1,144 +1,126 @@
+package egovframework.com.uss.ion.mtg.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.uss.ion.mtg.service.MtgPlaceManageVO;
+import egovframework.com.uss.ion.mtg.service.MtgPlaceResveVO;
+
 /**
  * 개요
- * - 회의실관리에 대한 DAO 클래스를 정의한다.
- * 
+ * - 회의실관리에 대한 DAO 인터페이스를 정의한다.
+ *
  * 상세내용
  * - 회의실관리에 대한 등록, 수정, 삭제, 조회, 반영확인 기능을 제공한다.
  * - 회의실관리의 조회기능은 목록조회, 상세조회로 구분된다.
  * @author 이용
  * @version 1.0
  * @created 06-15-2010 오후 2:08:56
+ *
+ * <pre>
+ *  == 개정이력(Modification Information) ==
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2010.06.15  이용           최초 생성
+ *   2026.05.28  dasomel        @EgovMapper 인터페이스 방식으로 전환
+ *
+ * </pre>
  */
-
-package egovframework.com.uss.ion.mtg.service.impl;
-
-import java.util.List;
-
-import org.springframework.stereotype.Repository;
-
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
-import egovframework.com.uss.ion.mtg.service.MtgPlaceManageVO;
-import egovframework.com.uss.ion.mtg.service.MtgPlaceResveVO;
-
-@Repository("mtgPlaceManageDAO")
-public class MtgPlaceManageDAO extends EgovComAbstractDAO {
+@EgovMapper("mtgPlaceManageDAO")
+public interface MtgPlaceManageDAO {
 
 	/**
 	 * 회의실관리정보를 관리하기 위해 등록된 회의실관리 목록을 조회한다.
 	 * @param mtgPlaceManageVO - 회의실관리 VO
 	 * @return List - 회의실관리 목록
 	 */
-	public List<MtgPlaceManageVO> selectMtgPlaceManageList(MtgPlaceManageVO mtgPlaceManageVO) throws Exception {
-		return selectList("mtgPlaceManageDAO.selectMtgPlaceManageList", mtgPlaceManageVO);
-	}
+	List<MtgPlaceManageVO> selectMtgPlaceManageList(MtgPlaceManageVO mtgPlaceManageVO);
 
-    /**
+	/**
 	 * 회의실관리목록 총 개수를 조회한다.
 	 * @param mtgPlaceManageVO - 회의실관리 VO
 	 * @return int
-	 * @exception Exception
 	 */
-    public int selectMtgPlaceManageListTotCnt(MtgPlaceManageVO mtgPlaceManageVO) throws Exception {
-        return (Integer)selectOne("mtgPlaceManageDAO.selectMtgPlaceManageListTotCnt", mtgPlaceManageVO);
-    }
+	int selectMtgPlaceManageListTotCnt(MtgPlaceManageVO mtgPlaceManageVO);
 
 	/**
 	 * 등록된 회의실관리의 상세정보를 조회한다.
 	 * @param mtgPlaceManageVO - 회의실관리 VO
 	 * @return MtgPlaceManageVO - 회의실관리 VO
 	 */
-	public MtgPlaceManageVO selectMtgPlaceManage(MtgPlaceManageVO mtgPlaceManageVO)  throws Exception {
-		return (MtgPlaceManageVO) selectOne("mtgPlaceManageDAO.selectMtgPlaceManage", mtgPlaceManageVO);
-	}
+	MtgPlaceManageVO selectMtgPlaceManage(MtgPlaceManageVO mtgPlaceManageVO);
 
 	/**
 	 * 회의실관리정보를 신규로 등록한다.
+	 * @param mtgPlaceManageVO - 회의실관리 VO
 	 */
-	public void insertMtgPlaceManage(MtgPlaceManageVO mtgPlaceManageVO) throws Exception {
-		insert("mtgPlaceManageDAO.insertMtgPlaceManage", mtgPlaceManageVO);
-	}
+	void insertMtgPlaceManage(MtgPlaceManageVO mtgPlaceManageVO);
 
 	/**
 	 * 기 등록된 회의실관리정보를 수정한다.
+	 * @param mtgPlaceManageVO - 회의실관리 VO
 	 */
-	public void updtMtgPlaceManage(MtgPlaceManageVO mtgPlaceManageVO) throws Exception {
-		update("mtgPlaceManageDAO.updtMtgPlaceManage", mtgPlaceManageVO);
-	}
+	void updtMtgPlaceManage(MtgPlaceManageVO mtgPlaceManageVO);
 
 	/**
 	 * 기 등록된 회의실관리정보를 삭제한다.
+	 * @param mtgPlaceManageVO - 회의실관리 VO
 	 */
-	public void deleteMtgPlaceManage(MtgPlaceManageVO mtgPlaceManageVO) throws Exception {
-		delete("mtgPlaceManageDAO.deleteMtgPlaceManage", mtgPlaceManageVO);
-	}
+	void deleteMtgPlaceManage(MtgPlaceManageVO mtgPlaceManageVO);
 
-	/******** 회의실 예약 관리 *************/
-
-	/** 
+	/**
 	 * 회의실 ID 정보 목록을 조회한다.
 	 * @param mtgPlaceManageVO - 회의실관리 VO
 	 * @return List - 회의실관리 목록
 	 */
-	public List<MtgPlaceManageVO> selectMtgPlaceIDList(MtgPlaceManageVO mtgPlaceManageVO) throws Exception {
-		return selectList("mtgPlaceManageDAO.selectMtgPlaceIDList", mtgPlaceManageVO);
-	}
-	
-	/** 
+	List<MtgPlaceManageVO> selectMtgPlaceIDList(MtgPlaceManageVO mtgPlaceManageVO);
+
+	/**
 	 * 회의실 예약정보를 관리하기 위해 등록된 회의실예약을 조회한다.
 	 * @param mtgPlaceManageVO - 회의실관리 VO
 	 * @return MtgPlaceManageVO - 회의실관리 목록
 	 */
-	public MtgPlaceManageVO selectMtgPlaceResveManageList(MtgPlaceManageVO mtgPlaceManageVO) throws Exception {
-		return (MtgPlaceManageVO) selectOne("mtgPlaceManageDAO.selectMtgPlaceResveManageList", mtgPlaceManageVO);
-	}
-	
+	MtgPlaceManageVO selectMtgPlaceResveManageList(MtgPlaceManageVO mtgPlaceManageVO);
+
 	/**
 	 * 회의실예약 신청화면을 조회한다.
 	 * @param mtgPlaceManageVO - 회의실관리 VO
 	 * @return MtgPlaceManageVO - 회의실관리 VO
 	 */
-	public MtgPlaceManageVO selectMtgPlaceResve(MtgPlaceManageVO mtgPlaceManageVO)  throws Exception {
-		return (MtgPlaceManageVO) selectOne("mtgPlaceManageDAO.selectMtgPlaceResve", mtgPlaceManageVO);
-	}
+	MtgPlaceManageVO selectMtgPlaceResve(MtgPlaceManageVO mtgPlaceManageVO);
 
 	/**
 	 * 등록된 회의실예약 상세정보를 조회한다.
 	 * @param mtgPlaceManageVO - 회의실관리 VO
 	 * @return MtgPlaceManageVO - 회의실관리 VO
 	 */
-	public MtgPlaceManageVO selectMtgPlaceResveDetail(MtgPlaceManageVO mtgPlaceManageVO)  throws Exception {
-		return (MtgPlaceManageVO) selectOne("mtgPlaceManageDAO.selectMtgPlaceResveDetail", mtgPlaceManageVO);
-	}
-	
+	MtgPlaceManageVO selectMtgPlaceResveDetail(MtgPlaceManageVO mtgPlaceManageVO);
+
 	/**
 	 * 회의실예약 정보를 신규로 등록한다.
+	 * @param mtgPlaceResveVO - 회의실예약 VO
 	 */
-	public void insertMtgPlaceResve(MtgPlaceResveVO mtgPlaceResveVO) throws Exception {
-		insert("mtgPlaceManageDAO.insertMtgPlaceResve", mtgPlaceResveVO);
-	}
+	void insertMtgPlaceResve(MtgPlaceResveVO mtgPlaceResveVO);
 
 	/**
 	 * 기 등록된 회의실예약 정보를 수정한다.
+	 * @param mtgPlaceResveVO - 회의실예약 VO
 	 */
-	public void updtMtgPlaceResve(MtgPlaceResveVO mtgPlaceResveVO) throws Exception {
-		update("mtgPlaceManageDAO.updtMtgPlaceResve", mtgPlaceResveVO);
-	}
+	void updtMtgPlaceResve(MtgPlaceResveVO mtgPlaceResveVO);
 
 	/**
 	 * 기 등록된 회의실예약 정보를 삭제한다.
+	 * @param mtgPlaceResveVO - 회의실예약 VO
 	 */
-	public void deleteMtgPlaceResve(MtgPlaceResveVO mtgPlaceResveVO) throws Exception {
-		delete("mtgPlaceManageDAO.deleteMtgPlaceResve", mtgPlaceResveVO);
-	}	
-	
-	
+	void deleteMtgPlaceResve(MtgPlaceResveVO mtgPlaceResveVO);
+
 	/**
 	 * 회의실 중복여부 체크.
 	 * @param mtgPlaceManageVO - 회의실관리 VO
 	 * @return int - 중복건수
 	 */
-	public int mtgPlaceResveDplactCeck(MtgPlaceManageVO mtgPlaceManageVO) throws Exception {
-		return (Integer)selectOne("mtgPlaceManageDAO.mtgPlaceResveDplactCeck", mtgPlaceManageVO);
-	}
-	
+	int mtgPlaceResveDplactCeck(MtgPlaceManageVO mtgPlaceManageVO);
+
 }

--- a/src/main/resources/egovframework/mapper/com/uss/ion/ans/EgovAnnvrsryManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/ans/EgovAnnvrsryManage_SQL_altibase.xml
@@ -12,7 +12,7 @@
  --><!--Converted at: Wed May 11 15:51:01 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="annvrsryManageDAO">
+<mapper namespace="egovframework.com.uss.ion.ans.service.impl.AnnvrsryManageDAO">
 
     <resultMap id="annvrsryManage" type="egovframework.com.uss.ion.ans.service.AnnvrsryManageVO">
         <result property="usid" column="USER_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/ans/EgovAnnvrsryManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/ans/EgovAnnvrsryManage_SQL_cubrid.xml
@@ -12,7 +12,7 @@
  --><!--Converted at: Wed May 11 15:51:01 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="annvrsryManageDAO">
+<mapper namespace="egovframework.com.uss.ion.ans.service.impl.AnnvrsryManageDAO">
 
     <resultMap id="annvrsryManage" type="egovframework.com.uss.ion.ans.service.AnnvrsryManageVO">
         <result property="usid" column="USER_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/ans/EgovAnnvrsryManage_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/ans/EgovAnnvrsryManage_SQL_goldilocks.xml
@@ -12,7 +12,7 @@
  --><!--Converted at: Wed May 11 15:51:01 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="annvrsryManageDAO">
+<mapper namespace="egovframework.com.uss.ion.ans.service.impl.AnnvrsryManageDAO">
 
     <resultMap id="annvrsryManage" type="egovframework.com.uss.ion.ans.service.AnnvrsryManageVO">
         <result property="usid" column="USER_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/ans/EgovAnnvrsryManage_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/ans/EgovAnnvrsryManage_SQL_maria.xml
@@ -12,7 +12,7 @@
  --><!--Converted at: Wed May 11 15:51:01 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="annvrsryManageDAO">
+<mapper namespace="egovframework.com.uss.ion.ans.service.impl.AnnvrsryManageDAO">
 
     <resultMap id="annvrsryManage" type="egovframework.com.uss.ion.ans.service.AnnvrsryManageVO">
         <result property="usid" column="USER_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/ans/EgovAnnvrsryManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/ans/EgovAnnvrsryManage_SQL_mysql.xml
@@ -12,7 +12,7 @@
  --><!--Converted at: Wed May 11 15:51:01 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="annvrsryManageDAO">
+<mapper namespace="egovframework.com.uss.ion.ans.service.impl.AnnvrsryManageDAO">
 
     <resultMap id="annvrsryManage" type="egovframework.com.uss.ion.ans.service.AnnvrsryManageVO">
         <result property="usid" column="USER_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/ans/EgovAnnvrsryManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/ans/EgovAnnvrsryManage_SQL_oracle.xml
@@ -12,7 +12,7 @@
  --><!--Converted at: Wed May 11 15:51:01 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="annvrsryManageDAO">
+<mapper namespace="egovframework.com.uss.ion.ans.service.impl.AnnvrsryManageDAO">
 
     <resultMap id="annvrsryManage" type="egovframework.com.uss.ion.ans.service.AnnvrsryManageVO">
         <result property="usid" column="USER_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/ans/EgovAnnvrsryManage_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/ans/EgovAnnvrsryManage_SQL_postgres.xml
@@ -12,7 +12,7 @@
  --><!--Converted at: Wed May 11 15:51:01 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="annvrsryManageDAO">
+<mapper namespace="egovframework.com.uss.ion.ans.service.impl.AnnvrsryManageDAO">
 
     <resultMap id="annvrsryManage" type="egovframework.com.uss.ion.ans.service.AnnvrsryManageVO">
         <result property="usid" column="USER_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/ans/EgovAnnvrsryManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/ans/EgovAnnvrsryManage_SQL_tibero.xml
@@ -12,7 +12,7 @@
  --><!--Converted at: Wed May 11 15:51:02 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="annvrsryManageDAO">
+<mapper namespace="egovframework.com.uss.ion.ans.service.impl.AnnvrsryManageDAO">
 
     <resultMap id="annvrsryManage" type="egovframework.com.uss.ion.ans.service.AnnvrsryManageVO">
         <result property="usid" column="USER_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/bnt/EgovBndtManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/bnt/EgovBndtManage_SQL_altibase.xml
@@ -7,7 +7,7 @@
 --><!--Converted at: Wed May 11 15:51:03 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="bndtManageDAO">
+<mapper namespace="egovframework.com.uss.ion.bnt.service.impl.BndtManageDAO">
 
 
     <resultMap id="bndtManage" type="egovframework.com.uss.ion.bnt.service.BndtManageVO">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/bnt/EgovBndtManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/bnt/EgovBndtManage_SQL_cubrid.xml
@@ -7,7 +7,7 @@
 --><!--Converted at: Wed May 11 15:51:03 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="bndtManageDAO">
+<mapper namespace="egovframework.com.uss.ion.bnt.service.impl.BndtManageDAO">
 
 
     <resultMap id="bndtManage" type="egovframework.com.uss.ion.bnt.service.BndtManageVO">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/bnt/EgovBndtManage_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/bnt/EgovBndtManage_SQL_goldilocks.xml
@@ -7,7 +7,7 @@
 --><!--Converted at: Wed May 11 15:51:03 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="bndtManageDAO">
+<mapper namespace="egovframework.com.uss.ion.bnt.service.impl.BndtManageDAO">
 
 
     <resultMap id="bndtManage" type="egovframework.com.uss.ion.bnt.service.BndtManageVO">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/bnt/EgovBndtManage_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/bnt/EgovBndtManage_SQL_maria.xml
@@ -7,7 +7,7 @@
 --><!--Converted at: Wed May 11 15:51:03 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="bndtManageDAO">
+<mapper namespace="egovframework.com.uss.ion.bnt.service.impl.BndtManageDAO">
 
 
     <resultMap id="bndtManage" type="egovframework.com.uss.ion.bnt.service.BndtManageVO">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/bnt/EgovBndtManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/bnt/EgovBndtManage_SQL_mysql.xml
@@ -7,7 +7,7 @@
 --><!--Converted at: Wed May 11 15:51:03 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="bndtManageDAO">
+<mapper namespace="egovframework.com.uss.ion.bnt.service.impl.BndtManageDAO">
 
 
     <resultMap id="bndtManage" type="egovframework.com.uss.ion.bnt.service.BndtManageVO">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/bnt/EgovBndtManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/bnt/EgovBndtManage_SQL_oracle.xml
@@ -7,7 +7,7 @@
 --><!--Converted at: Wed May 11 15:51:03 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="bndtManageDAO">
+<mapper namespace="egovframework.com.uss.ion.bnt.service.impl.BndtManageDAO">
 
 
     <resultMap id="bndtManage" type="egovframework.com.uss.ion.bnt.service.BndtManageVO">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/bnt/EgovBndtManage_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/bnt/EgovBndtManage_SQL_postgres.xml
@@ -7,7 +7,7 @@
 --><!--Converted at: Wed May 11 15:51:03 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="bndtManageDAO">
+<mapper namespace="egovframework.com.uss.ion.bnt.service.impl.BndtManageDAO">
 
 
     <resultMap id="bndtManage" type="egovframework.com.uss.ion.bnt.service.BndtManageVO">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/bnt/EgovBndtManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/bnt/EgovBndtManage_SQL_tibero.xml
@@ -7,7 +7,7 @@
 --><!--Converted at: Wed May 11 15:51:03 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="bndtManageDAO">
+<mapper namespace="egovframework.com.uss.ion.bnt.service.impl.BndtManageDAO">
 
 
     <resultMap id="bndtManage" type="egovframework.com.uss.ion.bnt.service.BndtManageVO">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/ecc/EgovEventCmpgn_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/ecc/EgovEventCmpgn_SQL_altibase.xml
@@ -9,7 +9,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="EventCmpgn">
+<mapper namespace="egovframework.com.uss.ion.ecc.service.impl.EgovEventCmpgnDAO">
 
 	<resultMap id="EventCmpgnListMap" type="egovframework.com.uss.ion.ecc.service.EventCmpgnVO">
 		<result property="eventId" column="EVENT_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/ecc/EgovEventCmpgn_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/ecc/EgovEventCmpgn_SQL_cubrid.xml
@@ -9,7 +9,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="EventCmpgn">
+<mapper namespace="egovframework.com.uss.ion.ecc.service.impl.EgovEventCmpgnDAO">
 
 	<resultMap id="EventCmpgnListMap" type="egovframework.com.uss.ion.ecc.service.EventCmpgnVO">
 		<result property="eventId" column="EVENT_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/ecc/EgovEventCmpgn_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/ecc/EgovEventCmpgn_SQL_goldilocks.xml
@@ -9,7 +9,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="EventCmpgn">
+<mapper namespace="egovframework.com.uss.ion.ecc.service.impl.EgovEventCmpgnDAO">
 
 	<resultMap id="EventCmpgnListMap" type="egovframework.com.uss.ion.ecc.service.EventCmpgnVO">
 		<result property="eventId" column="EVENT_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/ecc/EgovEventCmpgn_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/ecc/EgovEventCmpgn_SQL_maria.xml
@@ -9,7 +9,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="EventCmpgn">
+<mapper namespace="egovframework.com.uss.ion.ecc.service.impl.EgovEventCmpgnDAO">
 
 	<resultMap id="EventCmpgnListMap" type="egovframework.com.uss.ion.ecc.service.EventCmpgnVO">
 		<result property="eventId" column="EVENT_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/ecc/EgovEventCmpgn_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/ecc/EgovEventCmpgn_SQL_mysql.xml
@@ -9,7 +9,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="EventCmpgn">
+<mapper namespace="egovframework.com.uss.ion.ecc.service.impl.EgovEventCmpgnDAO">
 
 	<resultMap id="EventCmpgnListMap" type="egovframework.com.uss.ion.ecc.service.EventCmpgnVO">
 		<result property="eventId" column="EVENT_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/ecc/EgovEventCmpgn_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/ecc/EgovEventCmpgn_SQL_oracle.xml
@@ -9,7 +9,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="EventCmpgn">
+<mapper namespace="egovframework.com.uss.ion.ecc.service.impl.EgovEventCmpgnDAO">
 
 	<resultMap id="EventCmpgnListMap" type="egovframework.com.uss.ion.ecc.service.EventCmpgnVO">
 		<result property="eventId" column="EVENT_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/ecc/EgovEventCmpgn_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/ecc/EgovEventCmpgn_SQL_postgres.xml
@@ -9,7 +9,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="EventCmpgn">
+<mapper namespace="egovframework.com.uss.ion.ecc.service.impl.EgovEventCmpgnDAO">
 
 	<resultMap id="EventCmpgnListMap" type="egovframework.com.uss.ion.ecc.service.EventCmpgnVO">
 		<result property="eventId" column="EVENT_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/ecc/EgovEventCmpgn_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/ecc/EgovEventCmpgn_SQL_tibero.xml
@@ -9,7 +9,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="EventCmpgn">
+<mapper namespace="egovframework.com.uss.ion.ecc.service.impl.EgovEventCmpgnDAO">
 
 	<resultMap id="EventCmpgnListMap" type="egovframework.com.uss.ion.ecc.service.EventCmpgnVO">
 		<result property="eventId" column="EVENT_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/ism/EgovInfrmlSanctn_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/ism/EgovInfrmlSanctn_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:51:07 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="InfrmlSanctnDAO">
+<mapper namespace="egovframework.com.uss.ion.ism.service.impl.InfrmlSanctnDAO">
 
 	<resultMap id="sanctnerList" type="egovframework.com.uss.ion.ism.service.SanctnerVO">
 		<result property="orgnztNm" column="ORGNZT_NM"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/ism/EgovInfrmlSanctn_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/ism/EgovInfrmlSanctn_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:51:07 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="InfrmlSanctnDAO">
+<mapper namespace="egovframework.com.uss.ion.ism.service.impl.InfrmlSanctnDAO">
 
 	<resultMap id="sanctnerList" type="egovframework.com.uss.ion.ism.service.SanctnerVO">
 		<result property="orgnztNm" column="ORGNZT_NM"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/ism/EgovInfrmlSanctn_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/ism/EgovInfrmlSanctn_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:51:07 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="InfrmlSanctnDAO">
+<mapper namespace="egovframework.com.uss.ion.ism.service.impl.InfrmlSanctnDAO">
 
 	<resultMap id="sanctnerList" type="egovframework.com.uss.ion.ism.service.SanctnerVO">
 		<result property="orgnztNm" column="ORGNZT_NM"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/ism/EgovInfrmlSanctn_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/ism/EgovInfrmlSanctn_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:51:07 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="InfrmlSanctnDAO">
+<mapper namespace="egovframework.com.uss.ion.ism.service.impl.InfrmlSanctnDAO">
 
 	<resultMap id="sanctnerList" type="egovframework.com.uss.ion.ism.service.SanctnerVO">
 		<result property="orgnztNm" column="ORGNZT_NM"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/ism/EgovInfrmlSanctn_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/ism/EgovInfrmlSanctn_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:51:07 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="InfrmlSanctnDAO">
+<mapper namespace="egovframework.com.uss.ion.ism.service.impl.InfrmlSanctnDAO">
 
 	<resultMap id="sanctnerList" type="egovframework.com.uss.ion.ism.service.SanctnerVO">
 		<result property="orgnztNm" column="ORGNZT_NM"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/ism/EgovInfrmlSanctn_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/ism/EgovInfrmlSanctn_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:51:07 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="InfrmlSanctnDAO">
+<mapper namespace="egovframework.com.uss.ion.ism.service.impl.InfrmlSanctnDAO">
 
 	<resultMap id="sanctnerList" type="egovframework.com.uss.ion.ism.service.SanctnerVO">
 		<result property="orgnztNm" column="ORGNZT_NM"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/ism/EgovInfrmlSanctn_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/ism/EgovInfrmlSanctn_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:51:07 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="InfrmlSanctnDAO">
+<mapper namespace="egovframework.com.uss.ion.ism.service.impl.InfrmlSanctnDAO">
 
 	<resultMap id="sanctnerList" type="egovframework.com.uss.ion.ism.service.SanctnerVO">
 		<result property="orgnztNm" column="ORGNZT_NM"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/ism/EgovInfrmlSanctn_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/ism/EgovInfrmlSanctn_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:51:08 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="InfrmlSanctnDAO">
+<mapper namespace="egovframework.com.uss.ion.ism.service.impl.InfrmlSanctnDAO">
 
 	<resultMap id="sanctnerList" type="egovframework.com.uss.ion.ism.service.SanctnerVO">
 		<result property="orgnztNm" column="ORGNZT_NM"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/mtg/EgovMtgPlaceManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/mtg/EgovMtgPlaceManage_SQL_altibase.xml
@@ -12,7 +12,7 @@
 --><!--Converted at: Wed May 11 15:51:10 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="mtgPlaceManageDAO">
+<mapper namespace="egovframework.com.uss.ion.mtg.service.impl.MtgPlaceManageDAO">
 
    <resultMap id="mtgPlaceManage" type="egovframework.com.uss.ion.mtg.service.MtgPlaceManageVO">
        <result property="mtgPlaceId" column="MTGRUM_ID"/>            

--- a/src/main/resources/egovframework/mapper/com/uss/ion/mtg/EgovMtgPlaceManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/mtg/EgovMtgPlaceManage_SQL_cubrid.xml
@@ -12,7 +12,7 @@
 --><!--Converted at: Wed May 11 15:51:10 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="mtgPlaceManageDAO">
+<mapper namespace="egovframework.com.uss.ion.mtg.service.impl.MtgPlaceManageDAO">
 
    <resultMap id="mtgPlaceManage" type="egovframework.com.uss.ion.mtg.service.MtgPlaceManageVO">
        <result property="mtgPlaceId" column="MTGRUM_ID"/>            

--- a/src/main/resources/egovframework/mapper/com/uss/ion/mtg/EgovMtgPlaceManage_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/mtg/EgovMtgPlaceManage_SQL_goldilocks.xml
@@ -12,7 +12,7 @@
 --><!--Converted at: Wed May 11 15:51:10 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="mtgPlaceManageDAO">
+<mapper namespace="egovframework.com.uss.ion.mtg.service.impl.MtgPlaceManageDAO">
 
    <resultMap id="mtgPlaceManage" type="egovframework.com.uss.ion.mtg.service.MtgPlaceManageVO">
        <result property="mtgPlaceId" column="MTGRUM_ID"/>            

--- a/src/main/resources/egovframework/mapper/com/uss/ion/mtg/EgovMtgPlaceManage_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/mtg/EgovMtgPlaceManage_SQL_maria.xml
@@ -13,7 +13,7 @@
 --><!--Converted at: Wed May 11 15:51:10 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="mtgPlaceManageDAO">
+<mapper namespace="egovframework.com.uss.ion.mtg.service.impl.MtgPlaceManageDAO">
 
    <resultMap id="mtgPlaceManage" type="egovframework.com.uss.ion.mtg.service.MtgPlaceManageVO">
        <result property="mtgPlaceId" column="MTGRUM_ID"/>            

--- a/src/main/resources/egovframework/mapper/com/uss/ion/mtg/EgovMtgPlaceManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/mtg/EgovMtgPlaceManage_SQL_mysql.xml
@@ -13,7 +13,7 @@
 --><!--Converted at: Wed May 11 15:51:10 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="mtgPlaceManageDAO">
+<mapper namespace="egovframework.com.uss.ion.mtg.service.impl.MtgPlaceManageDAO">
 
    <resultMap id="mtgPlaceManage" type="egovframework.com.uss.ion.mtg.service.MtgPlaceManageVO">
        <result property="mtgPlaceId" column="MTGRUM_ID"/>            

--- a/src/main/resources/egovframework/mapper/com/uss/ion/mtg/EgovMtgPlaceManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/mtg/EgovMtgPlaceManage_SQL_oracle.xml
@@ -12,7 +12,7 @@
 --><!--Converted at: Wed May 11 15:51:10 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="mtgPlaceManageDAO">
+<mapper namespace="egovframework.com.uss.ion.mtg.service.impl.MtgPlaceManageDAO">
 
    <resultMap id="mtgPlaceManage" type="egovframework.com.uss.ion.mtg.service.MtgPlaceManageVO">
        <result property="mtgPlaceId" column="MTGRUM_ID"/>            

--- a/src/main/resources/egovframework/mapper/com/uss/ion/mtg/EgovMtgPlaceManage_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/mtg/EgovMtgPlaceManage_SQL_postgres.xml
@@ -12,7 +12,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="mtgPlaceManageDAO">
+<mapper namespace="egovframework.com.uss.ion.mtg.service.impl.MtgPlaceManageDAO">
 
    <resultMap id="mtgPlaceManage" type="egovframework.com.uss.ion.mtg.service.MtgPlaceManageVO">
        <result property="mtgPlaceId" column="MTGRUM_ID"/>            

--- a/src/main/resources/egovframework/mapper/com/uss/ion/mtg/EgovMtgPlaceManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/mtg/EgovMtgPlaceManage_SQL_tibero.xml
@@ -12,7 +12,7 @@
 --><!--Converted at: Wed May 11 15:51:11 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="mtgPlaceManageDAO">
+<mapper namespace="egovframework.com.uss.ion.mtg.service.impl.MtgPlaceManageDAO">
 
    <resultMap id="mtgPlaceManage" type="egovframework.com.uss.ion.mtg.service.MtgPlaceManageVO">
        <result property="mtgPlaceId" column="MTGRUM_ID"/>            

--- a/src/main/resources/egovframework/spring/com/context-mapper.xml
+++ b/src/main/resources/egovframework/spring/com/context-mapper.xml
@@ -21,5 +21,12 @@
 	<bean id="egov.sqlSessionTemplate" class="org.mybatis.spring.SqlSessionTemplate">
 		<constructor-arg ref="egov.sqlSession"/>
 	</bean>
-	
+
+	<!-- @EgovMapper 어노테이션이 붙은 인터페이스를 자동으로 스캔하여 빈으로 등록 -->
+	<bean class="org.mybatis.spring.mapper.MapperScannerConfigurer">
+		<property name="basePackage" value="egovframework.com"/>
+		<property name="annotationClass" value="org.egovframe.rte.psl.dataaccess.mapper.EgovMapper"/>
+		<property name="sqlSessionFactoryBeanName" value="egov.sqlSession"/>
+	</bean>
+
 </beans>


### PR DESCRIPTION
## 변경 사유

eGovFrame 5.0에서 도입된 @EgovMapper 어노테이션 방식을 uss/ion 하위 5개 컴포넌트에 적용한다.
기존 EgovComAbstractDAO 상속 방식은 sqlSession을 직접 다루는 레거시 패턴으로,
인터페이스 기반 @EgovMapper 방식이 더 명확하고 유지보수성이 높다.

## 변경 내용

- AnnvrsryManageDAO (기념일관리): @Repository 클래스 → @EgovMapper 인터페이스로 전환
- EgovEventCmpgnDAO (행사캠페인): @Repository 클래스 → @EgovMapper 인터페이스로 전환
- InfrmlSanctnDAO (약식결재): @Repository 클래스 → @EgovMapper 인터페이스로 전환
- MtgPlaceManageDAO (회의실관리): @Repository 클래스 → @EgovMapper 인터페이스로 전환
- BndtManageDAO (당직관리): @Repository 클래스 → @EgovMapper 인터페이스로 전환
- 5개 모듈 x 8개 DB 방언 XML namespace를 인터페이스 FQN으로 변경 (SQL 내용 변경 없음)
- context-mapper.xml: MapperScannerConfigurer 빈 추가 (basePackage=egovframework.com)

## 영향 범위

- uss/ion 5개 서브 모듈 (ans, ecc, ism, mtg, bnt)
- DAO bean name 유지로 기존 ServiceImpl @Resource 주입 호환 유지

## 체크리스트

- [x] 단일 주제만 다룸 (다른 변경 없음)
- [x] 기존 동작 호환 (bean name 유지, SQL 변경 없음)
- [x] 5.x 다른 브랜치용 후속 PR 필요
