### PR TITLE
[refactor][5.0.x][공통컴포넌트] uss/ion bnr·ctn·lsi·nws·sit 5개 DAO @EgovMapper 인터페이스 방식으로 전환

### DIFF
--- a/src/main/java/egovframework/com/uss/ion/bnr/service/impl/BannerDAO.java
+++ b/src/main/java/egovframework/com/uss/ion/bnr/service/impl/BannerDAO.java
@@ -1,7 +1,7 @@
 /**
  * 개요
  * - 배너에 대한 DAO 클래스를 정의한다.
- * 
+ *
  * 상세내용
  * - 배너에 대한 등록, 수정, 삭제, 조회, 반영확인 기능을 제공한다.
  * - 배너의 조회기능은 목록조회, 상세조회로 구분된다.
@@ -17,85 +17,68 @@ import java.util.List;
 import org.springframework.stereotype.Repository;
 
 import egovframework.com.cmm.service.FileVO;
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.uss.ion.bnr.service.BannerVO;
+import jakarta.annotation.Resource;
 
 @Repository("bannerDAO")
-public class BannerDAO extends EgovComAbstractDAO {
-	
+public class BannerDAO {
+
+	@Resource(name = "bannerMapper")
+	private BannerMapper bannerMapper;
+
 	/**
 	 * 배너를 관리하기 위해 등록된 배너목록을 조회한다.
-	 * @param bannerVO - 배너 Vo
-	 * @return List - 배너 목록
-	 * @exception Exception
-	 */	
+	 */
 	public List<BannerVO> selectBannerList(BannerVO bannerVO) throws Exception {
-		return selectList("bannerDAO.selectBannerList", bannerVO);
+		return bannerMapper.selectBannerList(bannerVO);
 	}
 
-    /**
+	/**
 	 * 배너목록 총 개수를 조회한다.
-	 * @param bannerVO BannerVO
-	 * @return int
-	 * @exception Exception
 	 */
-    public int selectBannerListTotCnt(BannerVO bannerVO) throws Exception {
-        return (Integer)selectOne("bannerDAO.selectBannerListTotCnt", bannerVO);
-    }
+	public int selectBannerListTotCnt(BannerVO bannerVO) throws Exception {
+		return bannerMapper.selectBannerListTotCnt(bannerVO);
+	}
 
 	/**
 	 * 등록된 배너의 상세정보를 조회한다.
-	 * @param bannerVO - 배너 Vo
-	 * @return BannerVO - 배너 Vo
-	 * 
-	 * @param bannerVO
 	 */
 	public BannerVO selectBanner(BannerVO bannerVO) throws Exception {
-		return (BannerVO) selectOne("bannerDAO.selectBanner", bannerVO);
+		return bannerMapper.selectBanner(bannerVO);
 	}
 
 	/**
 	 * 배너정보를 신규로 등록한다.
-	 * @param bannerVO - 배너 VO
 	 */
 	public void insertBanner(BannerVO bannerVO) throws Exception {
-		insert("bannerDAO.insertBanner", bannerVO);
+		bannerMapper.insertBanner(bannerVO);
 	}
 
 	/**
 	 * 기 등록된 배너정보를 수정한다.
-	 * @param bannerVO - 배너 VO
 	 */
 	public void updateBanner(BannerVO bannerVO) throws Exception {
-        update("bannerDAO.updateBanner", bannerVO);
+		bannerMapper.updateBanner(bannerVO);
 	}
 
 	/**
 	 * 기 등록된 배너정보를 삭제한다.
-	 * @param bannerVO - 배너 VO
 	 */
 	public void deleteBanner(BannerVO bannerVO) throws Exception {
-		delete("bannerDAO.deleteBanner", bannerVO);
+		bannerMapper.deleteBanner(bannerVO);
 	}
 
 	/**
 	 * 기 등록된 배너정보의 이미지파일을 삭제하기 위해 파일정보를 조회한다.
-	 * @param bannerVO - 배너 VO
-	 * @return FileVO - 파일 VO
 	 */
 	public FileVO selectBannerFile(BannerVO bannerVO) throws Exception {
-		return (FileVO) selectOne("bannerDAO.selectBannerFile", bannerVO);
+		return bannerMapper.selectBannerFile(bannerVO);
 	}
 
 	/**
 	 * 배너가 특정화면에 반영된 결과를 조회한다.
-	 * @param bannerVO - 배너 VO
-	 * @return BannerVO - 배너 VO
-	 * @exception Exception
 	 */
-	
 	public List<BannerVO> selectBannerResult(BannerVO bannerVO) throws Exception {
-		return selectList("bannerDAO.selectBannerResult", bannerVO);
+		return bannerMapper.selectBannerResult(bannerVO);
 	}
-
 }

--- a/src/main/java/egovframework/com/uss/ion/bnr/service/impl/BannerMapper.java
+++ b/src/main/java/egovframework/com/uss/ion/bnr/service/impl/BannerMapper.java
@@ -1,0 +1,57 @@
+package egovframework.com.uss.ion.bnr.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.EgovMapper;
+
+import egovframework.com.cmm.service.FileVO;
+import egovframework.com.uss.ion.bnr.service.BannerVO;
+
+/**
+ * 배너 관리에 대한 Mapper 인터페이스
+ * @author 이문준
+ * @version 1.0
+ */
+@EgovMapper("bannerMapper")
+public interface BannerMapper {
+
+	/**
+	 * 배너 목록을 조회한다.
+	 */
+	List<BannerVO> selectBannerList(BannerVO bannerVO);
+
+	/**
+	 * 배너 목록 총 개수를 조회한다.
+	 */
+	int selectBannerListTotCnt(BannerVO bannerVO);
+
+	/**
+	 * 배너 상세정보를 조회한다.
+	 */
+	BannerVO selectBanner(BannerVO bannerVO);
+
+	/**
+	 * 배너를 등록한다.
+	 */
+	void insertBanner(BannerVO bannerVO);
+
+	/**
+	 * 배너를 수정한다.
+	 */
+	void updateBanner(BannerVO bannerVO);
+
+	/**
+	 * 배너를 삭제한다.
+	 */
+	void deleteBanner(BannerVO bannerVO);
+
+	/**
+	 * 배너 파일정보를 조회한다.
+	 */
+	FileVO selectBannerFile(BannerVO bannerVO);
+
+	/**
+	 * 배너 반영 결과를 조회한다.
+	 */
+	List<BannerVO> selectBannerResult(BannerVO bannerVO);
+}

--- a/src/main/java/egovframework/com/uss/ion/ctn/service/impl/CtsnnManageDAO.java
+++ b/src/main/java/egovframework/com/uss/ion/ctn/service/impl/CtsnnManageDAO.java
@@ -4,8 +4,8 @@ import java.util.List;
 
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.uss.ion.ctn.service.CtsnnManageVO;
+import jakarta.annotation.Resource;
 
 /**
  * 개요
@@ -20,85 +20,71 @@ import egovframework.com.uss.ion.ctn.service.CtsnnManageVO;
  */
 
 @Repository("ctsnnManageDAO")
-public class CtsnnManageDAO extends EgovComAbstractDAO {
+public class CtsnnManageDAO {
+
+	@Resource(name = "ctsnnManageMapper")
+	private CtsnnManageMapper ctsnnManageMapper;
 
 	/**
-	 * 경조관리정보를 관리하기 위해 등록된 경조관리 목록을 조회한다.
-	 * @param ctsnnManageVO - 경조관리 VO
-	 * @return List - 경조관리 목록
+	 * 경조관리 목록을 조회한다.
 	 */
 	public List<CtsnnManageVO> selectCtsnnManageList(CtsnnManageVO ctsnnManageVO) throws Exception {
-		return selectList("ctsnnManageDAO.selectCtsnnManageList", ctsnnManageVO);
+		return ctsnnManageMapper.selectCtsnnManageList(ctsnnManageVO);
 	}
 
-    /**
+	/**
 	 * 경조관리목록 총 개수를 조회한다.
-	 * @param ctsnnManageVO - 경조관리 VO
-	 * @return int
-	 * @exception Exception
 	 */
-    public int selectCtsnnManageListTotCnt(CtsnnManageVO ctsnnManageVO) throws Exception {
-        return (Integer)selectOne("ctsnnManageDAO.selectCtsnnManageListTotCnt", ctsnnManageVO);
-    }
+	public int selectCtsnnManageListTotCnt(CtsnnManageVO ctsnnManageVO) throws Exception {
+		return ctsnnManageMapper.selectCtsnnManageListTotCnt(ctsnnManageVO);
+	}
 
 	/**
-	 * 등록된 경조관리의 상세정보를 조회한다.
-	 * @param ctsnnManageVO - 경조관리 VO
-	 * @return CtsnnManageVO - 경조관리 VO
+	 * 경조관리 상세정보를 조회한다.
 	 */
-	public CtsnnManageVO selectCtsnnManage(CtsnnManageVO ctsnnManageVO)  throws Exception {
-		return (CtsnnManageVO) selectOne("ctsnnManageDAO.selectCtsnnManage", ctsnnManageVO);
+	public CtsnnManageVO selectCtsnnManage(CtsnnManageVO ctsnnManageVO) throws Exception {
+		return ctsnnManageMapper.selectCtsnnManage(ctsnnManageVO);
 	}
 
 	/**
 	 * 경조관리정보를 신규로 등록한다.
-	 * @param ctsnnManage - 경조관리 model
 	 */
 	public void insertCtsnnManage(CtsnnManageVO ctsnnManageVO) throws Exception {
-		insert("ctsnnManageDAO.insertCtsnnManage", ctsnnManageVO);
+		ctsnnManageMapper.insertCtsnnManage(ctsnnManageVO);
 	}
 
 	/**
 	 * 기 등록된 경조관리정보를 수정한다.
-	 * @param ctsnnManage - 경조관리 model
 	 */
 	public void updtCtsnnManage(CtsnnManageVO ctsnnManageVO) throws Exception {
-		update("ctsnnManageDAO.updateCtsnnManage", ctsnnManageVO);
+		ctsnnManageMapper.updateCtsnnManage(ctsnnManageVO);
 	}
 
 	/**
 	 * 기 등록된 경조관리정보를 삭제한다.
-	 * @param ctsnnManage - 경조관리 model
 	 */
 	public void deleteCtsnnManage(CtsnnManageVO ctsnnManageVO) throws Exception {
-        delete("ctsnnManageDAO.deleteCtsnnManage", ctsnnManageVO);
+		ctsnnManageMapper.deleteCtsnnManage(ctsnnManageVO);
 	}
 
-    /*** 승인처리관련 ***/
 	/**
 	 * 경조관리정보 승인 처리를 위해 신청된 경조관리 목록을 조회한다.
-	 * @param ctsnnManageVO - 경조관리 VO
-	 * @return List - 경조관리 목록
 	 */
 	public List<CtsnnManageVO> selectCtsnnManageConfmList(CtsnnManageVO ctsnnManageVO) throws Exception {
-		return selectList("ctsnnManageDAO.selectCtsnnManageConfmList", ctsnnManageVO);
+		return ctsnnManageMapper.selectCtsnnManageConfmList(ctsnnManageVO);
 	}
 
-    /**
+	/**
 	 * 경조관리정보 승인 처리를 위해 신청된 경조관리 목록 총 개수를 조회한다.
-	 * @param ctsnnManageVO - 경조관리 VO
-	 * @return int
-	 * @exception Exception
 	 */
-    public int selectCtsnnManageConfmListTotCnt(CtsnnManageVO ctsnnManageVO) throws Exception {
-        return (Integer)selectOne("ctsnnManageDAO.selectCtsnnManageConfmListTotCnt", ctsnnManageVO);
-    }
+	public int selectCtsnnManageConfmListTotCnt(CtsnnManageVO ctsnnManageVO) throws Exception {
+		return ctsnnManageMapper.selectCtsnnManageConfmListTotCnt(ctsnnManageVO);
+	}
 
 	/**
-	 *경조정보를 승인처리 한다.
-	 * @param ctsnnManage - 경조관리 model
+	 * 경조정보를 승인처리 한다.
 	 */
 	public void updtCtsnnManageConfm(CtsnnManageVO ctsnnManageVO) throws Exception {
-		update("ctsnnManageDAO.updtCtsnnManageConfm", ctsnnManageVO);
+		ctsnnManageMapper.updtCtsnnManageConfm(ctsnnManageVO);
 	}
 }

--- a/src/main/java/egovframework/com/uss/ion/ctn/service/impl/CtsnnManageMapper.java
+++ b/src/main/java/egovframework/com/uss/ion/ctn/service/impl/CtsnnManageMapper.java
@@ -1,0 +1,34 @@
+package egovframework.com.uss.ion.ctn.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.EgovMapper;
+
+import egovframework.com.uss.ion.ctn.service.CtsnnManageVO;
+
+/**
+ * 경조관리에 대한 Mapper 인터페이스
+ * @author 이용
+ * @version 1.0
+ */
+@EgovMapper("ctsnnManageMapper")
+public interface CtsnnManageMapper {
+
+	List<CtsnnManageVO> selectCtsnnManageList(CtsnnManageVO ctsnnManageVO);
+
+	int selectCtsnnManageListTotCnt(CtsnnManageVO ctsnnManageVO);
+
+	CtsnnManageVO selectCtsnnManage(CtsnnManageVO ctsnnManageVO);
+
+	void insertCtsnnManage(CtsnnManageVO ctsnnManageVO);
+
+	void updateCtsnnManage(CtsnnManageVO ctsnnManageVO);
+
+	void deleteCtsnnManage(CtsnnManageVO ctsnnManageVO);
+
+	List<CtsnnManageVO> selectCtsnnManageConfmList(CtsnnManageVO ctsnnManageVO);
+
+	int selectCtsnnManageConfmListTotCnt(CtsnnManageVO ctsnnManageVO);
+
+	void updtCtsnnManageConfm(CtsnnManageVO ctsnnManageVO);
+}

--- a/src/main/java/egovframework/com/uss/ion/lsi/service/impl/LoginScrinImageDAO.java
+++ b/src/main/java/egovframework/com/uss/ion/lsi/service/impl/LoginScrinImageDAO.java
@@ -1,7 +1,7 @@
 /**
  * 개요
  * - 로그인화면이미지에 대한 DAO 클래스를 정의한다.
- * 
+ *
  * 상세내용
  * - 로그인화면이미지에 대한 등록, 수정, 삭제, 조회, 반영확인 기능을 제공한다.
  * - 로그인화면이미지의 조회기능은 목록조회, 상세조회로 구분된다.
@@ -17,19 +17,22 @@ import java.util.List;
 import org.springframework.stereotype.Repository;
 
 import egovframework.com.cmm.service.FileVO;
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.uss.ion.lsi.service.LoginScrinImageVO;
+import jakarta.annotation.Resource;
 
 @Repository("loginScrinImageDAO")
-public class LoginScrinImageDAO extends EgovComAbstractDAO {
+public class LoginScrinImageDAO {
+
+	@Resource(name = "loginScrinImageMapper")
+	private LoginScrinImageMapper loginScrinImageMapper;
 
 	/**
 	 * 로그인화면이미지정보를 관리하기 위해 등록된 로그인화면이미지 목록을 조회한다.
 	 * @param loginScrinImageVO - 로그인화면이미지 VO
 	 * @return List - 로그인화면이미지 목록
-	 */	
+	 */
 	public List<LoginScrinImageVO> selectLoginScrinImageList(LoginScrinImageVO loginScrinImageVO) throws Exception {
-		return selectList("loginScrinImageDAO.selectLoginScrinImageList", loginScrinImageVO);
+		return loginScrinImageMapper.selectLoginScrinImageList(loginScrinImageVO);
 	}
 
     /**
@@ -39,7 +42,7 @@ public class LoginScrinImageDAO extends EgovComAbstractDAO {
 	 * @exception Exception
 	 */
     public int selectLoginScrinImageListTotCnt(LoginScrinImageVO loginScrinImageVO) throws Exception {
-        return (Integer)selectOne("loginScrinImageDAO.selectLoginScrinImageListTotCnt", loginScrinImageVO);
+        return loginScrinImageMapper.selectLoginScrinImageListTotCnt(loginScrinImageVO);
     }
 
 	/**
@@ -47,8 +50,8 @@ public class LoginScrinImageDAO extends EgovComAbstractDAO {
 	 * @param loginScrinImageVO - 로그인화면이미지 VO
 	 * @return LoginScrinImageVO - 로그인화면이미지 VO
 	 */
-	public LoginScrinImageVO selectLoginScrinImage(LoginScrinImageVO loginScrinImageVO)  throws Exception {
-		return (LoginScrinImageVO) selectOne("loginScrinImageDAO.selectLoginScrinImage", loginScrinImageVO);
+	public LoginScrinImageVO selectLoginScrinImage(LoginScrinImageVO loginScrinImageVO) throws Exception {
+		return loginScrinImageMapper.selectLoginScrinImage(loginScrinImageVO);
 	}
 
 	/**
@@ -56,7 +59,7 @@ public class LoginScrinImageDAO extends EgovComAbstractDAO {
 	 * @param loginScrinImageVO - 로그인화면이미지 VO
 	 */
 	public void insertLoginScrinImage(LoginScrinImageVO loginScrinImageVO) throws Exception {
-		insert("loginScrinImageDAO.insertLoginScrinImage", loginScrinImageVO);
+		loginScrinImageMapper.insertLoginScrinImage(loginScrinImageVO);
 	}
 
 	/**
@@ -64,7 +67,7 @@ public class LoginScrinImageDAO extends EgovComAbstractDAO {
 	 * @param loginScrinImageVO - 로그인화면이미지 VO
 	 */
 	public void updateLoginScrinImage(LoginScrinImageVO loginScrinImageVO) throws Exception {
-		update("loginScrinImageDAO.updateLoginScrinImage", loginScrinImageVO);
+		loginScrinImageMapper.updateLoginScrinImage(loginScrinImageVO);
 	}
 
 	/**
@@ -72,7 +75,7 @@ public class LoginScrinImageDAO extends EgovComAbstractDAO {
 	 * @param loginScrinImageVO - 로그인화면이미지 VO
 	 */
 	public void deleteLoginScrinImage(LoginScrinImageVO loginScrinImageVO) throws Exception {
-        delete("loginScrinImageDAO.deleteLoginScrinImage",loginScrinImageVO);
+		loginScrinImageMapper.deleteLoginScrinImage(loginScrinImageVO);
 	}
 
 	/**
@@ -80,7 +83,7 @@ public class LoginScrinImageDAO extends EgovComAbstractDAO {
 	 * @param loginScrinImageVO - 로그인화면이미지 VO
 	 */
 	public FileVO selectLoginScrinImageFile(LoginScrinImageVO loginScrinImageVO) throws Exception {
-		return (FileVO) selectOne("loginScrinImageDAO.selectLoginScrinImageFile", loginScrinImageVO);
+		return loginScrinImageMapper.selectLoginScrinImageFile(loginScrinImageVO);
 	}
 
 	/**
@@ -89,6 +92,6 @@ public class LoginScrinImageDAO extends EgovComAbstractDAO {
 	 * @return LoginScrinImageVO - 로그인화면이미지 VO
 	 */
 	public List<LoginScrinImageVO> selectLoginScrinImageResult(LoginScrinImageVO loginScrinImageVO) throws Exception {
-		return selectList("loginScrinImageDAO.selectLoginScrinImageResult", loginScrinImageVO);
+		return loginScrinImageMapper.selectLoginScrinImageResult(loginScrinImageVO);
 	}
 }

--- a/src/main/java/egovframework/com/uss/ion/lsi/service/impl/LoginScrinImageMapper.java
+++ b/src/main/java/egovframework/com/uss/ion/lsi/service/impl/LoginScrinImageMapper.java
@@ -1,0 +1,57 @@
+package egovframework.com.uss.ion.lsi.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.EgovMapper;
+
+import egovframework.com.cmm.service.FileVO;
+import egovframework.com.uss.ion.lsi.service.LoginScrinImageVO;
+
+/**
+ * 로그인화면이미지 관리에 대한 Mapper 인터페이스
+ * @author lee.m.j
+ * @version 1.0
+ */
+@EgovMapper("loginScrinImageMapper")
+public interface LoginScrinImageMapper {
+
+	/**
+	 * 로그인화면이미지 목록을 조회한다.
+	 */
+	List<LoginScrinImageVO> selectLoginScrinImageList(LoginScrinImageVO loginScrinImageVO);
+
+	/**
+	 * 로그인화면이미지 목록 총 개수를 조회한다.
+	 */
+	int selectLoginScrinImageListTotCnt(LoginScrinImageVO loginScrinImageVO);
+
+	/**
+	 * 로그인화면이미지 상세정보를 조회한다.
+	 */
+	LoginScrinImageVO selectLoginScrinImage(LoginScrinImageVO loginScrinImageVO);
+
+	/**
+	 * 로그인화면이미지를 등록한다.
+	 */
+	void insertLoginScrinImage(LoginScrinImageVO loginScrinImageVO);
+
+	/**
+	 * 로그인화면이미지를 수정한다.
+	 */
+	void updateLoginScrinImage(LoginScrinImageVO loginScrinImageVO);
+
+	/**
+	 * 로그인화면이미지를 삭제한다.
+	 */
+	void deleteLoginScrinImage(LoginScrinImageVO loginScrinImageVO);
+
+	/**
+	 * 로그인화면이미지 파일정보를 조회한다.
+	 */
+	FileVO selectLoginScrinImageFile(LoginScrinImageVO loginScrinImageVO);
+
+	/**
+	 * 로그인화면이미지 반영 결과를 조회한다.
+	 */
+	List<LoginScrinImageVO> selectLoginScrinImageResult(LoginScrinImageVO loginScrinImageVO);
+}

--- a/src/main/java/egovframework/com/uss/ion/nws/service/impl/EgovNewsDAO.java
+++ b/src/main/java/egovframework/com/uss/ion/nws/service/impl/EgovNewsDAO.java
@@ -4,34 +4,36 @@ import java.util.List;
 
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.uss.ion.nws.service.NewsVO;
+import jakarta.annotation.Resource;
 
 @Repository("EgovNewsDAO")
-public class EgovNewsDAO extends EgovComAbstractDAO {
+public class EgovNewsDAO {
+
+	@Resource(name = "EgovNewsMapper")
+	private EgovNewsMapper egovNewsMapper;
 
 	public List<NewsVO> selectNewsList(NewsVO newsVO) {
-		return selectList("NewsManage.selectNewsList", newsVO);
+		return egovNewsMapper.selectNewsList(newsVO);
 	}
 
 	public int selectNewsListCnt(NewsVO newsVO) {
-		return (Integer) selectOne("NewsManage.selectNewsListCnt", newsVO);
+		return egovNewsMapper.selectNewsListCnt(newsVO);
 	}
 
 	public void insertNews(NewsVO newsVO) {
-		insert("NewsManage.insertNews", newsVO);
+		egovNewsMapper.insertNews(newsVO);
 	}
 
 	public NewsVO selectNewsDetail(NewsVO newsVO) {
-		return (NewsVO) selectOne("NewsManage.selectNewsDetail", newsVO);
+		return egovNewsMapper.selectNewsDetail(newsVO);
 	}
 
 	public void updateNews(NewsVO newsVO) {
-		update("NewsManage.updateNews", newsVO);
+		egovNewsMapper.updateNews(newsVO);
 	}
 
 	public void deleteNews(NewsVO newsVO) {
-		delete("NewsManage.deleteNews", newsVO);
+		egovNewsMapper.deleteNews(newsVO);
 	}
-
 }

--- a/src/main/java/egovframework/com/uss/ion/nws/service/impl/EgovNewsMapper.java
+++ b/src/main/java/egovframework/com/uss/ion/nws/service/impl/EgovNewsMapper.java
@@ -1,0 +1,27 @@
+package egovframework.com.uss.ion.nws.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.EgovMapper;
+
+import egovframework.com.uss.ion.nws.service.NewsVO;
+
+/**
+ * 뉴스관리에 대한 Mapper 인터페이스
+ * @version 1.0
+ */
+@EgovMapper("EgovNewsMapper")
+public interface EgovNewsMapper {
+
+	List<NewsVO> selectNewsList(NewsVO newsVO);
+
+	int selectNewsListCnt(NewsVO newsVO);
+
+	void insertNews(NewsVO newsVO);
+
+	NewsVO selectNewsDetail(NewsVO newsVO);
+
+	void updateNews(NewsVO newsVO);
+
+	void deleteNews(NewsVO newsVO);
+}

--- a/src/main/java/egovframework/com/uss/ion/sit/service/impl/EgovSiteDAO.java
+++ b/src/main/java/egovframework/com/uss/ion/sit/service/impl/EgovSiteDAO.java
@@ -4,34 +4,36 @@ import java.util.List;
 
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.uss.ion.sit.service.SiteVO;
+import jakarta.annotation.Resource;
 
 @Repository("EgovSiteDAO")
-public class EgovSiteDAO extends EgovComAbstractDAO {
+public class EgovSiteDAO {
+
+	@Resource(name = "EgovSiteMapper")
+	private EgovSiteMapper egovSiteMapper;
 
 	public List<SiteVO> selectSiteList(SiteVO siteVO) {
-		return selectList("SiteManage.selectSiteList", siteVO);
+		return egovSiteMapper.selectSiteList(siteVO);
 	}
 
 	public int selectSiteListCnt(SiteVO siteVO) {
-		return (Integer) selectOne("SiteManage.selectSiteListCnt", siteVO);
+		return egovSiteMapper.selectSiteListCnt(siteVO);
 	}
 
 	public SiteVO selectSiteDetail(SiteVO siteVO) {
-		return (SiteVO) selectOne("SiteManage.selectSiteDetail", siteVO);
+		return egovSiteMapper.selectSiteDetail(siteVO);
 	}
 
 	public void insertSite(SiteVO siteVO) {
-		insert("SiteManage.insertSite", siteVO);
+		egovSiteMapper.insertSite(siteVO);
 	}
 
 	public void updateSite(SiteVO siteVO) {
-		update("SiteManage.updateSite", siteVO);	
+		egovSiteMapper.updateSite(siteVO);
 	}
 
 	public void deleteSite(SiteVO siteVO) {
-		delete("SiteManage.deleteSite", siteVO);
+		egovSiteMapper.deleteSite(siteVO);
 	}
-
 }

--- a/src/main/java/egovframework/com/uss/ion/sit/service/impl/EgovSiteMapper.java
+++ b/src/main/java/egovframework/com/uss/ion/sit/service/impl/EgovSiteMapper.java
@@ -1,0 +1,27 @@
+package egovframework.com.uss.ion.sit.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.EgovMapper;
+
+import egovframework.com.uss.ion.sit.service.SiteVO;
+
+/**
+ * 사이트관리에 대한 Mapper 인터페이스
+ * @version 1.0
+ */
+@EgovMapper("EgovSiteMapper")
+public interface EgovSiteMapper {
+
+	List<SiteVO> selectSiteList(SiteVO siteVO);
+
+	int selectSiteListCnt(SiteVO siteVO);
+
+	SiteVO selectSiteDetail(SiteVO siteVO);
+
+	void insertSite(SiteVO siteVO);
+
+	void updateSite(SiteVO siteVO);
+
+	void deleteSite(SiteVO siteVO);
+}

--- a/src/main/resources/egovframework/mapper/com/uss/ion/bnr/EgovBanner_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/bnr/EgovBanner_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="bannerDAO">
+<mapper namespace="egovframework.com.uss.ion.bnr.service.impl.BannerMapper">
 
     <resultMap id="banner" type="egovframework.com.uss.ion.bnr.service.BannerVO">
         <result property="bannerId" column="BANNER_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/bnr/EgovBanner_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/bnr/EgovBanner_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="bannerDAO">
+<mapper namespace="egovframework.com.uss.ion.bnr.service.impl.BannerMapper">
 
     <resultMap id="banner" type="egovframework.com.uss.ion.bnr.service.BannerVO">
         <result property="bannerId" column="BANNER_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/bnr/EgovBanner_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/bnr/EgovBanner_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="bannerDAO">
+<mapper namespace="egovframework.com.uss.ion.bnr.service.impl.BannerMapper">
 
     <resultMap id="banner" type="egovframework.com.uss.ion.bnr.service.BannerVO">
         <result property="bannerId" column="BANNER_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/bnr/EgovBanner_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/bnr/EgovBanner_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:51:02 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="bannerDAO">
+<mapper namespace="egovframework.com.uss.ion.bnr.service.impl.BannerMapper">
 
     <resultMap id="banner" type="egovframework.com.uss.ion.bnr.service.BannerVO">
         <result property="bannerId" column="BANNER_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/bnr/EgovBanner_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/bnr/EgovBanner_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:51:02 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="bannerDAO">
+<mapper namespace="egovframework.com.uss.ion.bnr.service.impl.BannerMapper">
 
     <resultMap id="banner" type="egovframework.com.uss.ion.bnr.service.BannerVO">
         <result property="bannerId" column="BANNER_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/bnr/EgovBanner_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/bnr/EgovBanner_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:51:02 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="bannerDAO">
+<mapper namespace="egovframework.com.uss.ion.bnr.service.impl.BannerMapper">
 
 
     <resultMap id="banner" type="egovframework.com.uss.ion.bnr.service.BannerVO">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/bnr/EgovBanner_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/bnr/EgovBanner_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:51:02 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="bannerDAO">
+<mapper namespace="egovframework.com.uss.ion.bnr.service.impl.BannerMapper">
 
     <resultMap id="banner" type="egovframework.com.uss.ion.bnr.service.BannerVO">
         <result property="bannerId" column="BANNER_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/bnr/EgovBanner_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/bnr/EgovBanner_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:51:02 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="bannerDAO">
+<mapper namespace="egovframework.com.uss.ion.bnr.service.impl.BannerMapper">
 
     <resultMap id="banner" type="egovframework.com.uss.ion.bnr.service.BannerVO">
         <result property="bannerId" column="BANNER_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/ctn/EgovCtsnnManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/ctn/EgovCtsnnManage_SQL_altibase.xml
@@ -7,7 +7,7 @@
 --><!--Converted at: Wed May 11 15:51:03 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ctsnnManageDAO">
+<mapper namespace="egovframework.com.uss.ion.ctn.service.impl.CtsnnManageMapper">
 
    <select id="selectCtsnnManageList" parameterType="egovframework.com.uss.ion.ctn.service.CtsnnManageVO" resultType="egovframework.com.uss.ion.ctn.service.CtsnnManageVO">
         

--- a/src/main/resources/egovframework/mapper/com/uss/ion/ctn/EgovCtsnnManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/ctn/EgovCtsnnManage_SQL_cubrid.xml
@@ -7,7 +7,7 @@
 --><!--Converted at: Wed May 11 15:51:04 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ctsnnManageDAO">
+<mapper namespace="egovframework.com.uss.ion.ctn.service.impl.CtsnnManageMapper">
 
    <select id="selectCtsnnManageList" parameterType="egovframework.com.uss.ion.ctn.service.CtsnnManageVO" resultType="egovframework.com.uss.ion.ctn.service.CtsnnManageVO">
         

--- a/src/main/resources/egovframework/mapper/com/uss/ion/ctn/EgovCtsnnManage_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/ctn/EgovCtsnnManage_SQL_goldilocks.xml
@@ -7,7 +7,7 @@
 --><!--Converted at: Wed May 11 15:51:03 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ctsnnManageDAO">
+<mapper namespace="egovframework.com.uss.ion.ctn.service.impl.CtsnnManageMapper">
 
    <select id="selectCtsnnManageList" parameterType="egovframework.com.uss.ion.ctn.service.CtsnnManageVO" resultType="egovframework.com.uss.ion.ctn.service.CtsnnManageVO">
         

--- a/src/main/resources/egovframework/mapper/com/uss/ion/ctn/EgovCtsnnManage_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/ctn/EgovCtsnnManage_SQL_maria.xml
@@ -7,7 +7,7 @@
 --><!--Converted at: Wed May 11 15:51:04 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ctsnnManageDAO">
+<mapper namespace="egovframework.com.uss.ion.ctn.service.impl.CtsnnManageMapper">
 
    <select id="selectCtsnnManageList" parameterType="egovframework.com.uss.ion.ctn.service.CtsnnManageVO" resultType="egovframework.com.uss.ion.ctn.service.CtsnnManageVO">
         

--- a/src/main/resources/egovframework/mapper/com/uss/ion/ctn/EgovCtsnnManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/ctn/EgovCtsnnManage_SQL_mysql.xml
@@ -7,7 +7,7 @@
 --><!--Converted at: Wed May 11 15:51:04 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ctsnnManageDAO">
+<mapper namespace="egovframework.com.uss.ion.ctn.service.impl.CtsnnManageMapper">
 
    <select id="selectCtsnnManageList" parameterType="egovframework.com.uss.ion.ctn.service.CtsnnManageVO" resultType="egovframework.com.uss.ion.ctn.service.CtsnnManageVO">
         

--- a/src/main/resources/egovframework/mapper/com/uss/ion/ctn/EgovCtsnnManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/ctn/EgovCtsnnManage_SQL_oracle.xml
@@ -7,7 +7,7 @@
 --><!--Converted at: Wed May 11 15:51:04 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ctsnnManageDAO">
+<mapper namespace="egovframework.com.uss.ion.ctn.service.impl.CtsnnManageMapper">
 
    <select id="selectCtsnnManageList" parameterType="egovframework.com.uss.ion.ctn.service.CtsnnManageVO" resultType="egovframework.com.uss.ion.ctn.service.CtsnnManageVO">
         

--- a/src/main/resources/egovframework/mapper/com/uss/ion/ctn/EgovCtsnnManage_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/ctn/EgovCtsnnManage_SQL_postgres.xml
@@ -8,7 +8,7 @@
 --><!--Converted at: Wed May 11 15:51:04 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ctsnnManageDAO">
+<mapper namespace="egovframework.com.uss.ion.ctn.service.impl.CtsnnManageMapper">
    <select id="selectCtsnnManageList" parameterType="egovframework.com.uss.ion.ctn.service.CtsnnManageVO" resultType="egovframework.com.uss.ion.ctn.service.CtsnnManageVO">
         
 

--- a/src/main/resources/egovframework/mapper/com/uss/ion/ctn/EgovCtsnnManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/ctn/EgovCtsnnManage_SQL_tibero.xml
@@ -7,7 +7,7 @@
 --><!--Converted at: Wed May 11 15:51:04 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ctsnnManageDAO">
+<mapper namespace="egovframework.com.uss.ion.ctn.service.impl.CtsnnManageMapper">
 
    <select id="selectCtsnnManageList" parameterType="egovframework.com.uss.ion.ctn.service.CtsnnManageVO" resultType="egovframework.com.uss.ion.ctn.service.CtsnnManageVO">
         

--- a/src/main/resources/egovframework/mapper/com/uss/ion/lsi/EgovLoginScrinImage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/lsi/EgovLoginScrinImage_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="loginScrinImageDAO">
+<mapper namespace="egovframework.com.uss.ion.lsi.service.impl.LoginScrinImageMapper">
 
     <resultMap id="loginScrinImage" type="egovframework.com.uss.ion.lsi.service.LoginScrinImageVO">
         <result property="imageId" column="IMAGE_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/lsi/EgovLoginScrinImage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/lsi/EgovLoginScrinImage_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="loginScrinImageDAO">
+<mapper namespace="egovframework.com.uss.ion.lsi.service.impl.LoginScrinImageMapper">
 
     <resultMap id="loginScrinImage" type="egovframework.com.uss.ion.lsi.service.LoginScrinImageVO">
         <result property="imageId" column="IMAGE_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/lsi/EgovLoginScrinImage_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/lsi/EgovLoginScrinImage_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="loginScrinImageDAO">
+<mapper namespace="egovframework.com.uss.ion.lsi.service.impl.LoginScrinImageMapper">
 
     <resultMap id="loginScrinImage" type="egovframework.com.uss.ion.lsi.service.LoginScrinImageVO">
         <result property="imageId" column="IMAGE_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/lsi/EgovLoginScrinImage_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/lsi/EgovLoginScrinImage_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="loginScrinImageDAO">
+<mapper namespace="egovframework.com.uss.ion.lsi.service.impl.LoginScrinImageMapper">
 
     <resultMap id="loginScrinImage" type="egovframework.com.uss.ion.lsi.service.LoginScrinImageVO">
         <result property="imageId" column="IMAGE_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/lsi/EgovLoginScrinImage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/lsi/EgovLoginScrinImage_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="loginScrinImageDAO">
+<mapper namespace="egovframework.com.uss.ion.lsi.service.impl.LoginScrinImageMapper">
 
     <resultMap id="loginScrinImage" type="egovframework.com.uss.ion.lsi.service.LoginScrinImageVO">
         <result property="imageId" column="IMAGE_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/lsi/EgovLoginScrinImage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/lsi/EgovLoginScrinImage_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="loginScrinImageDAO">
+<mapper namespace="egovframework.com.uss.ion.lsi.service.impl.LoginScrinImageMapper">
 
 
     <resultMap id="loginScrinImage" type="egovframework.com.uss.ion.lsi.service.LoginScrinImageVO">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/lsi/EgovLoginScrinImage_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/lsi/EgovLoginScrinImage_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="loginScrinImageDAO">
+<mapper namespace="egovframework.com.uss.ion.lsi.service.impl.LoginScrinImageMapper">
 
     <resultMap id="loginScrinImage" type="egovframework.com.uss.ion.lsi.service.LoginScrinImageVO">
         <result property="imageId" column="IMAGE_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/lsi/EgovLoginScrinImage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/lsi/EgovLoginScrinImage_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="loginScrinImageDAO">
+<mapper namespace="egovframework.com.uss.ion.lsi.service.impl.LoginScrinImageMapper">
 
 
     <resultMap id="loginScrinImage" type="egovframework.com.uss.ion.lsi.service.LoginScrinImageVO">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/nws/EgovNews_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/nws/EgovNews_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="NewsManage">
+<mapper namespace="egovframework.com.uss.ion.nws.service.impl.EgovNewsMapper">
 
 	<resultMap id="NewsManage" type="egovframework.com.uss.ion.nws.service.NewsVO">
 		<result property="newsId" column="NEWS_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/nws/EgovNews_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/nws/EgovNews_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="NewsManage">
+<mapper namespace="egovframework.com.uss.ion.nws.service.impl.EgovNewsMapper">
 
 	<resultMap id="NewsManage" type="egovframework.com.uss.ion.nws.service.NewsVO">
 		<result property="newsId" column="NEWS_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/nws/EgovNews_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/nws/EgovNews_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="NewsManage">
+<mapper namespace="egovframework.com.uss.ion.nws.service.impl.EgovNewsMapper">
 
 	<resultMap id="NewsManage" type="egovframework.com.uss.ion.nws.service.NewsVO">
 		<result property="newsId" column="NEWS_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/nws/EgovNews_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/nws/EgovNews_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="NewsManage">
+<mapper namespace="egovframework.com.uss.ion.nws.service.impl.EgovNewsMapper">
 
 	<resultMap id="NewsManage" type="egovframework.com.uss.ion.nws.service.NewsVO">
 		<result property="newsId" column="NEWS_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/nws/EgovNews_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/nws/EgovNews_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="NewsManage">
+<mapper namespace="egovframework.com.uss.ion.nws.service.impl.EgovNewsMapper">
 
 	<resultMap id="NewsManage" type="egovframework.com.uss.ion.nws.service.NewsVO">
 		<result property="newsId" column="NEWS_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/nws/EgovNews_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/nws/EgovNews_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="NewsManage">
+<mapper namespace="egovframework.com.uss.ion.nws.service.impl.EgovNewsMapper">
 
 	<resultMap id="NewsManage" type="egovframework.com.uss.ion.nws.service.NewsVO">
 		<result property="newsId" column="NEWS_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/nws/EgovNews_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/nws/EgovNews_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="NewsManage">
+<mapper namespace="egovframework.com.uss.ion.nws.service.impl.EgovNewsMapper">
 
 	<resultMap id="NewsManage" type="egovframework.com.uss.ion.nws.service.NewsVO">
 		<result property="newsId" column="NEWS_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/nws/EgovNews_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/nws/EgovNews_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="NewsManage">
+<mapper namespace="egovframework.com.uss.ion.nws.service.impl.EgovNewsMapper">
 
 	<resultMap id="NewsManage" type="egovframework.com.uss.ion.nws.service.NewsVO">
 		<result property="newsId" column="NEWS_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/sit/EgovSite_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/sit/EgovSite_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="SiteManage">
+<mapper namespace="egovframework.com.uss.ion.sit.service.impl.EgovSiteMapper">
 
 	<resultMap id="SiteManage" type="egovframework.com.uss.ion.sit.service.SiteVO">
 		<result property="siteId" column="SITE_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/sit/EgovSite_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/sit/EgovSite_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="SiteManage">
+<mapper namespace="egovframework.com.uss.ion.sit.service.impl.EgovSiteMapper">
 
 	<resultMap id="SiteManage" type="egovframework.com.uss.ion.sit.service.SiteVO">
 		<result property="siteId" column="SITE_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/sit/EgovSite_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/sit/EgovSite_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="SiteManage">
+<mapper namespace="egovframework.com.uss.ion.sit.service.impl.EgovSiteMapper">
 
 	<resultMap id="SiteManage" type="egovframework.com.uss.ion.sit.service.SiteVO">
 		<result property="siteId" column="SITE_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/sit/EgovSite_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/sit/EgovSite_SQL_maria.xml
@@ -6,7 +6,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="SiteManage">
+<mapper namespace="egovframework.com.uss.ion.sit.service.impl.EgovSiteMapper">
 
 	<resultMap id="SiteManage" type="egovframework.com.uss.ion.sit.service.SiteVO">
 		<result property="siteId" column="SITE_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/sit/EgovSite_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/sit/EgovSite_SQL_mysql.xml
@@ -6,7 +6,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="SiteManage">
+<mapper namespace="egovframework.com.uss.ion.sit.service.impl.EgovSiteMapper">
 
 	<resultMap id="SiteManage" type="egovframework.com.uss.ion.sit.service.SiteVO">
 		<result property="siteId" column="SITE_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/sit/EgovSite_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/sit/EgovSite_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="SiteManage">
+<mapper namespace="egovframework.com.uss.ion.sit.service.impl.EgovSiteMapper">
 
 	<resultMap id="SiteManage" type="egovframework.com.uss.ion.sit.service.SiteVO">
 		<result property="siteId" column="SITE_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/sit/EgovSite_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/sit/EgovSite_SQL_postgres.xml
@@ -6,7 +6,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="SiteManage">
+<mapper namespace="egovframework.com.uss.ion.sit.service.impl.EgovSiteMapper">
 
 	<resultMap id="SiteManage" type="egovframework.com.uss.ion.sit.service.SiteVO">
 		<result property="siteId" column="SITE_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/sit/EgovSite_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/sit/EgovSite_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="SiteManage">
+<mapper namespace="egovframework.com.uss.ion.sit.service.impl.EgovSiteMapper">
 
 	<resultMap id="SiteManage" type="egovframework.com.uss.ion.sit.service.SiteVO">
 		<result property="siteId" column="SITE_ID"/>

--- a/src/main/resources/egovframework/spring/com/context-mapper.xml
+++ b/src/main/resources/egovframework/spring/com/context-mapper.xml
@@ -21,5 +21,10 @@
 	<bean id="egov.sqlSessionTemplate" class="org.mybatis.spring.SqlSessionTemplate">
 		<constructor-arg ref="egov.sqlSession"/>
 	</bean>
-	
+
+	<bean class="org.mybatis.spring.mapper.MapperScannerConfigurer">
+		<property name="basePackage" value="egovframework.com" />
+		<property name="annotationClass" value="org.egovframe.rte.psl.dataaccess.mapper.EgovMapper" />
+	</bean>
+
 </beans>


### PR DESCRIPTION
## 변경 사유
기존 XML namespace 기반 DAO를 5.0 신규 @EgovMapper 인터페이스 방식으로 전환

## 변경 내용
- BannerMapper, CtsnnManageMapper, LoginScrinImageMapper, EgovNewsMapper, EgovSiteMapper 인터페이스 신규 추가
- uss/ion/{bnr,ctn,lsi,nws,sit} 5개 DAO를 mapper 위임 구조로 리팩토링
- XML namespace를 mapper FQN으로 변경
- context-mapper.xml MapperScannerConfigurer 추가

## 영향 범위
- uss/ion 5개 서브 모듈
- DAO bean name 유지

## 체크리스트
- [x] 단일 주제만 다룸
- [x] 기존 동작 호환
