### PR TITLE
[fix][5.0.x][공통컴포넌트] maven-compiler-plugin Lombok annotationProcessorPaths 설정 추가 (빌드 오류 149→0)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -597,6 +597,13 @@
 					<artifactId>maven-compiler-plugin</artifactId>
 					<configuration>
 						<release>${java.version}</release>
+						<annotationProcessorPaths>
+							<path>
+								<groupId>org.projectlombok</groupId>
+								<artifactId>lombok</artifactId>
+								<version>1.18.42</version>
+							</path>
+						</annotationProcessorPaths>
 					</configuration>
 				</plugin>
 				<plugin>


### PR DESCRIPTION
## 변경 사유
upstream 5.0.x 브랜치에서 `mvn compile` 시 `@Slf4j`, `@Getter`, `@Setter` 등 Lombok 어노테이션이 처리되지 않아 약 149개의 컴파일 오류가 발생합니다. maven-compiler-plugin에 Lombok annotation processor 경로가 설정되어 있지 않은 것이 원인입니다.

## 변경 내용
- `pom.xml` maven-compiler-plugin `<configuration>`에 `annotationProcessorPaths`로 Lombok 등록

## 영향 범위
- 빌드 설정만 변경, 소스 코드/런타임 동작 변경 없음
- 변경 후 `mvn compile` 오류 149 → 0 확인

## 체크리스트
- [x] 단일 주제만 다룸
- [x] 컴파일 검증 완료
