### PR TITLE
[refactor][5.0.x][공통컴포넌트] uss/ion(isg·rwd·noi·rmm·yrc·rec·vct) 7개 DAO @EgovMapper 인터페이스 전환

### DIFF
--- a/src/main/java/egovframework/com/uss/ion/isg/service/impl/IntnetSvcGuidanceDAO.java
+++ b/src/main/java/egovframework/com/uss/ion/isg/service/impl/IntnetSvcGuidanceDAO.java
@@ -1,13 +1,22 @@
 /**
  * 개요
  * - 인터넷서비스안내에 대한 DAO 클래스를 정의한다.
- * 
+ *
  * 상세내용
  * - 인터넷서비스안내에 대한 등록, 수정, 삭제, 조회 기능을 제공한다.
  * - 인터넷서비스안내의 조회기능은 목록조회, 상세조회로 구분된다.
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2009.08.03  lee.m.j         최초 생성
+ *   2026.05.28  dasomel         @EgovMapper 인터페이스 위임 방식으로 전환
+ * </pre>
+ *
  * @author lee.m.j
  * @version 1.0
- * @created 03-8-2009 오후 2:08:52
  */
 
 package egovframework.com.uss.ion.isg.service.impl;
@@ -16,37 +25,40 @@ import java.util.List;
 
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.uss.ion.isg.service.IntnetSvcGuidanceVO;
+import jakarta.annotation.Resource;
 
 @Repository("intnetSvcGuidanceDAO")
-public class IntnetSvcGuidanceDAO extends EgovComAbstractDAO {
+public class IntnetSvcGuidanceDAO {
+
+	@Resource(name = "intnetSvcGuidanceMapper")
+	private IntnetSvcGuidanceMapper mapper;
 
 	/**
 	 * 인터넷서비스안내정보를 관리하기 위해 등록된 인터넷서비스안내 목록을 조회한다.
 	 * @param intnetSvcGuidanceVO - 인터넷서비스안내 VO
 	 * @return List - 인터넷서비스안내 목록
-	 */	
+	 */
 	public List<IntnetSvcGuidanceVO> selectIntnetSvcGuidanceList(IntnetSvcGuidanceVO intnetSvcGuidanceVO) throws Exception {
-		return selectList("intnetSvcGuidanceDAO.selectIntnetSvcGuidanceList", intnetSvcGuidanceVO);
+		return mapper.selectIntnetSvcGuidanceList(intnetSvcGuidanceVO);
 	}
 
-    /**
+	/**
 	 * 인터넷서비스안내목록 총 개수를 조회한다.
-	 * @param mainImageVO - 인터넷서비스안내 VO
+	 * @param intnetSvcGuidanceVO - 인터넷서비스안내 VO
 	 * @return int
 	 */
-    public int selectIntnetSvcGuidanceListTotCnt(IntnetSvcGuidanceVO intnetSvcGuidanceVO) throws Exception {
-        return (Integer)selectOne("intnetSvcGuidanceDAO.selectIntnetSvcGuidanceListTotCnt", intnetSvcGuidanceVO);
-    }
-	
+	public int selectIntnetSvcGuidanceListTotCnt(IntnetSvcGuidanceVO intnetSvcGuidanceVO) throws Exception {
+		return mapper.selectIntnetSvcGuidanceListTotCnt(intnetSvcGuidanceVO);
+	}
+
 	/**
 	 * 등록된 인터넷서비스안내의 상세정보를 조회한다.
 	 * @param intnetSvcGuidanceVO - 인터넷서비스안내 VO
 	 * @return IntnetSvcGuidanceVO - 인터넷서비스안내 VO
 	 */
 	public IntnetSvcGuidanceVO selectIntnetSvcGuidance(IntnetSvcGuidanceVO intnetSvcGuidanceVO) throws Exception {
-		return (IntnetSvcGuidanceVO) selectOne("intnetSvcGuidanceDAO.selectIntnetSvcGuidance", intnetSvcGuidanceVO);
+		return mapper.selectIntnetSvcGuidance(intnetSvcGuidanceVO);
 	}
 
 	/**
@@ -54,7 +66,7 @@ public class IntnetSvcGuidanceDAO extends EgovComAbstractDAO {
 	 * @param intnetSvcGuidanceVO - 인터넷서비스안내 VO
 	 */
 	public void insertIntnetSvcGuidance(IntnetSvcGuidanceVO intnetSvcGuidanceVO) throws Exception {
-		insert("intnetSvcGuidanceDAO.insertIntnetSvcGuidance", intnetSvcGuidanceVO);
+		mapper.insertIntnetSvcGuidance(intnetSvcGuidanceVO);
 	}
 
 	/**
@@ -62,7 +74,7 @@ public class IntnetSvcGuidanceDAO extends EgovComAbstractDAO {
 	 * @param intnetSvcGuidanceVO - 인터넷서비스안내 VO
 	 */
 	public void updateIntnetSvcGuidance(IntnetSvcGuidanceVO intnetSvcGuidanceVO) throws Exception {
-		update("intnetSvcGuidanceDAO.updateIntnetSvcGuidance", intnetSvcGuidanceVO);
+		mapper.updateIntnetSvcGuidance(intnetSvcGuidanceVO);
 	}
 
 	/**
@@ -70,15 +82,15 @@ public class IntnetSvcGuidanceDAO extends EgovComAbstractDAO {
 	 * @param intnetSvcGuidanceVO - 인터넷서비스안내 VO
 	 */
 	public void deleteIntnetSvcGuidance(IntnetSvcGuidanceVO intnetSvcGuidanceVO) throws Exception {
-		delete("intnetSvcGuidanceDAO.deleteIntnetSvcGuidance", intnetSvcGuidanceVO);
+		mapper.deleteIntnetSvcGuidance(intnetSvcGuidanceVO);
 	}
-	
+
 	/**
 	 * 인터넷서비스안내정보 적용결과를 조회한다.
 	 * @param intnetSvcGuidanceVO - 인터넷서비스안내 VO
 	 * @return List - 인터넷서비스안내 목록
 	 */
 	public List<IntnetSvcGuidanceVO> selectIntnetSvcGuidanceResult(IntnetSvcGuidanceVO intnetSvcGuidanceVO) throws Exception {
-		return selectList("intnetSvcGuidanceDAO.selectIntnetSvcGuidanceResult", intnetSvcGuidanceVO);
-	}	
+		return mapper.selectIntnetSvcGuidanceResult(intnetSvcGuidanceVO);
+	}
 }

--- a/src/main/java/egovframework/com/uss/ion/isg/service/impl/IntnetSvcGuidanceMapper.java
+++ b/src/main/java/egovframework/com/uss/ion/isg/service/impl/IntnetSvcGuidanceMapper.java
@@ -1,0 +1,36 @@
+package egovframework.com.uss.ion.isg.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.uss.ion.isg.service.IntnetSvcGuidanceVO;
+
+/**
+ * 인터넷서비스안내에 대한 Mapper 인터페이스
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2026.05.28  dasomel         XML 기반 DAO → @EgovMapper 인터페이스로 전환
+ * </pre>
+ */
+@EgovMapper("intnetSvcGuidanceMapper")
+public interface IntnetSvcGuidanceMapper {
+
+	List<IntnetSvcGuidanceVO> selectIntnetSvcGuidanceList(IntnetSvcGuidanceVO intnetSvcGuidanceVO);
+
+	int selectIntnetSvcGuidanceListTotCnt(IntnetSvcGuidanceVO intnetSvcGuidanceVO);
+
+	IntnetSvcGuidanceVO selectIntnetSvcGuidance(IntnetSvcGuidanceVO intnetSvcGuidanceVO);
+
+	void insertIntnetSvcGuidance(IntnetSvcGuidanceVO intnetSvcGuidanceVO);
+
+	void updateIntnetSvcGuidance(IntnetSvcGuidanceVO intnetSvcGuidanceVO);
+
+	void deleteIntnetSvcGuidance(IntnetSvcGuidanceVO intnetSvcGuidanceVO);
+
+	List<IntnetSvcGuidanceVO> selectIntnetSvcGuidanceResult(IntnetSvcGuidanceVO intnetSvcGuidanceVO);
+}

--- a/src/main/java/egovframework/com/uss/ion/noi/service/impl/NotificationDAO.java
+++ b/src/main/java/egovframework/com/uss/ion/noi/service/impl/NotificationDAO.java
@@ -4,15 +4,11 @@ import java.util.List;
 
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.uss.ion.noi.service.NotificationVO;
+import jakarta.annotation.Resource;
 
 /**
  * 정보알림이를 위한 데이터 접근 클래스
- * @author 공통컴포넌트개발팀 한성곤
- * @since 2009.06.08
- * @version 1.0
- * @see
  *
  * <pre>
  * << 개정이력(Modification Information) >>
@@ -20,58 +16,65 @@ import egovframework.com.uss.ion.noi.service.NotificationVO;
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.06.08  한성곤          최초 생성
- *
+ *   2026.05.28  dasomel         @EgovMapper 인터페이스 위임 방식으로 전환
  * </pre>
+ *
+ * @author 공통컴포넌트개발팀 한성곤
+ * @since 2009.06.08
+ * @version 1.0
  */
 @Repository("NotificationDAO")
-public class NotificationDAO extends EgovComAbstractDAO {
+public class NotificationDAO {
 
-    /**
-     * 정보알림이 목록을 조회한다.
-     */
-    public List<NotificationVO> selectNotificationInfs(NotificationVO notificationVO) throws Exception {
-        return selectList("NotificationDAO.selectNotificationInfs", notificationVO);
-    }
+	@Resource(name = "notificationMapper")
+	private NotificationMapper mapper;
 
-    /**
-     * 정보알림이 목록 숫자를 조회한다
-     */
-    public int selectNotificationInfsCnt(NotificationVO notificationVO) throws Exception {
-        return (Integer) selectOne("NotificationDAO.selectNotificationInfsCnt", notificationVO);
-    }
+	/**
+	 * 정보알림이 목록을 조회한다.
+	 */
+	public List<NotificationVO> selectNotificationInfs(NotificationVO notificationVO) throws Exception {
+		return mapper.selectNotificationInfs(notificationVO);
+	}
 
-    /**
-     * 정보알림이 정보를 등록한다.
-     */
-    public String insertNotificationInf(NotificationVO notificationVO) throws Exception {
-        return Integer.toString(insert("NotificationDAO.insertNotificationInf", notificationVO));
-    }
+	/**
+	 * 정보알림이 목록 숫자를 조회한다.
+	 */
+	public int selectNotificationInfsCnt(NotificationVO notificationVO) throws Exception {
+		return mapper.selectNotificationInfsCnt(notificationVO);
+	}
 
-    /**
-     * 정보알림이에 대한 상세정보를 조회한다.
-     */
-    public NotificationVO selectNotificationInf(NotificationVO notificationVO) {
-        return (NotificationVO) selectOne("NotificationDAO.selectNotificationInf", notificationVO);
-    }
+	/**
+	 * 정보알림이 정보를 등록한다.
+	 */
+	public String insertNotificationInf(NotificationVO notificationVO) throws Exception {
+		return Integer.toString(mapper.insertNotificationInf(notificationVO));
+	}
 
-    /**
-     * 정보알림이 정보를 수정한다.
-     */
-    public void updateNotificationInf(NotificationVO notificationVO) throws Exception {
-        update("NotificationDAO.updateNotificationInf", notificationVO);
-    }
+	/**
+	 * 정보알림이에 대한 상세정보를 조회한다.
+	 */
+	public NotificationVO selectNotificationInf(NotificationVO notificationVO) {
+		return mapper.selectNotificationInf(notificationVO);
+	}
 
-    /**
-     * 정보알림이 정보를 삭제한다.
-     */
-    public void deleteNotificationInf(NotificationVO notificationVO) throws Exception {
-        update("NotificationDAO.deleteNotificationInf", notificationVO);
-    }
+	/**
+	 * 정보알림이 정보를 수정한다.
+	 */
+	public void updateNotificationInf(NotificationVO notificationVO) throws Exception {
+		mapper.updateNotificationInf(notificationVO);
+	}
 
-    /**
-     * 정보알림이 표시를 위한 대상 알림 정보를 얻는다.
-     */
-    public List<NotificationVO> getNotificationData(NotificationVO notificationVO) throws Exception {
-        return selectList("NotificationDAO.getNotificationData", notificationVO);
-    }
+	/**
+	 * 정보알림이 정보를 삭제한다.
+	 */
+	public void deleteNotificationInf(NotificationVO notificationVO) throws Exception {
+		mapper.deleteNotificationInf(notificationVO);
+	}
+
+	/**
+	 * 정보알림이 표시를 위한 대상 알림 정보를 얻는다.
+	 */
+	public List<NotificationVO> getNotificationData(NotificationVO notificationVO) throws Exception {
+		return mapper.getNotificationData(notificationVO);
+	}
 }

--- a/src/main/java/egovframework/com/uss/ion/noi/service/impl/NotificationMapper.java
+++ b/src/main/java/egovframework/com/uss/ion/noi/service/impl/NotificationMapper.java
@@ -1,0 +1,36 @@
+package egovframework.com.uss.ion.noi.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.uss.ion.noi.service.NotificationVO;
+
+/**
+ * 정보알림이에 대한 Mapper 인터페이스
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2026.05.28  dasomel         XML 기반 DAO → @EgovMapper 인터페이스로 전환
+ * </pre>
+ */
+@EgovMapper("notificationMapper")
+public interface NotificationMapper {
+
+	List<NotificationVO> selectNotificationInfs(NotificationVO notificationVO);
+
+	int selectNotificationInfsCnt(NotificationVO notificationVO);
+
+	int insertNotificationInf(NotificationVO notificationVO);
+
+	NotificationVO selectNotificationInf(NotificationVO notificationVO);
+
+	void updateNotificationInf(NotificationVO notificationVO);
+
+	void deleteNotificationInf(NotificationVO notificationVO);
+
+	List<NotificationVO> getNotificationData(NotificationVO notificationVO);
+}

--- a/src/main/java/egovframework/com/uss/ion/rec/service/impl/EgovRecomendSiteDAO.java
+++ b/src/main/java/egovframework/com/uss/ion/rec/service/impl/EgovRecomendSiteDAO.java
@@ -4,34 +4,47 @@ import java.util.List;
 
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.uss.ion.rec.service.RecomendSiteVO;
+import jakarta.annotation.Resource;
 
+/**
+ * 추천사이트에 대한 DAO 클래스
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2026.05.28  dasomel         @EgovMapper 인터페이스 위임 방식으로 전환
+ * </pre>
+ */
 @Repository("EgovRecomendSiteDAO")
-public class EgovRecomendSiteDAO extends EgovComAbstractDAO{
+public class EgovRecomendSiteDAO {
+
+	@Resource(name = "egovRecomendSiteMapper")
+	private EgovRecomendSiteMapper mapper;
 
 	public List<RecomendSiteVO> selectRecomendSiteList(RecomendSiteVO recomendSiteVO) {
-		return selectList("RecomendSite.selectRecomendSiteList", recomendSiteVO);
+		return mapper.selectRecomendSiteList(recomendSiteVO);
 	}
 
 	public int selectRecomendSiteListCnt(RecomendSiteVO recomendSiteVO) {
-		return (Integer) selectOne("RecomendSite.selectRecomendSiteListCnt", recomendSiteVO);
+		return mapper.selectRecomendSiteListCnt(recomendSiteVO);
 	}
 
 	public void insertRecomendSite(RecomendSiteVO recomendSiteVO) {
-		insert("RecomendSite.insertRecomendSite", recomendSiteVO);
+		mapper.insertRecomendSite(recomendSiteVO);
 	}
 
 	public RecomendSiteVO selectRecomendSiteDetail(RecomendSiteVO recomendSiteVO) {
-		return (RecomendSiteVO) selectOne("RecomendSite.selectRecomendSiteDetail", recomendSiteVO);
+		return mapper.selectRecomendSiteDetail(recomendSiteVO);
 	}
 
 	public void updateRecomendSite(RecomendSiteVO recomendSiteVO) {
-		update("RecomendSite.updateRecomendSite", recomendSiteVO);
+		mapper.updateRecomendSite(recomendSiteVO);
 	}
 
 	public void deleteRecomendSite(RecomendSiteVO recomendSiteVO) {
-		delete("RecomendSite.deleteRecomendSite", recomendSiteVO);
+		mapper.deleteRecomendSite(recomendSiteVO);
 	}
-
 }

--- a/src/main/java/egovframework/com/uss/ion/rec/service/impl/EgovRecomendSiteMapper.java
+++ b/src/main/java/egovframework/com/uss/ion/rec/service/impl/EgovRecomendSiteMapper.java
@@ -1,0 +1,34 @@
+package egovframework.com.uss.ion.rec.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.uss.ion.rec.service.RecomendSiteVO;
+
+/**
+ * 추천사이트에 대한 Mapper 인터페이스
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2026.05.28  dasomel         XML 기반 DAO → @EgovMapper 인터페이스로 전환
+ * </pre>
+ */
+@EgovMapper("egovRecomendSiteMapper")
+public interface EgovRecomendSiteMapper {
+
+	List<RecomendSiteVO> selectRecomendSiteList(RecomendSiteVO recomendSiteVO);
+
+	int selectRecomendSiteListCnt(RecomendSiteVO recomendSiteVO);
+
+	void insertRecomendSite(RecomendSiteVO recomendSiteVO);
+
+	RecomendSiteVO selectRecomendSiteDetail(RecomendSiteVO recomendSiteVO);
+
+	void updateRecomendSite(RecomendSiteVO recomendSiteVO);
+
+	void deleteRecomendSite(RecomendSiteVO recomendSiteVO);
+}

--- a/src/main/java/egovframework/com/uss/ion/rmm/service/impl/EgovRoughMapDAO.java
+++ b/src/main/java/egovframework/com/uss/ion/rmm/service/impl/EgovRoughMapDAO.java
@@ -5,9 +5,9 @@ import java.util.List;
 import org.egovframe.rte.psl.dataaccess.util.EgovMap;
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.uss.ion.rmm.service.RoughMapDefaultVO;
 import egovframework.com.uss.ion.rmm.service.RoughMapVO;
+import jakarta.annotation.Resource;
 
 /**
  * 개요
@@ -17,81 +17,78 @@ import egovframework.com.uss.ion.rmm.service.RoughMapVO;
  * - 건물 위치정보에 대한 등록, 수정, 삭제 기능을 제공한다.
  * - 건물 위치정보의 조회기능은 목록, 상세조회로 구분된다.
  *
- * @author 옥찬우
- * @since 2014.08.27
- * @version 1.0
- * @see
- *
  * <pre>
  * << 개정이력(Modification Information) >>
  *
- *   수정일			수정자		수정내용
- *  -----------		------		---------
- *   2014.08.27		옥찬우		최초 생성
- *
+ *   수정일         수정자      수정내용
+ *  -----------    ------    ---------
+ *   2014.08.27    옥찬우      최초 생성
+ *   2026.05.28    dasomel    @EgovMapper 인터페이스 위임 방식으로 전환
  * </pre>
+ *
+ * @author 옥찬우
+ * @since 2014.08.27
+ * @version 1.0
  */
-
 @Repository("roughMapDAO")
-public class EgovRoughMapDAO extends EgovComAbstractDAO {
+public class EgovRoughMapDAO {
 
-    /**
-     * 약도 목록을 조회한다.
-     * @param roughMapVO
-     * @return List<RoughMapVO> 건물 위치정보 리스트
-     * @throws Exception
-    */
+	@Resource(name = "roughMapMapper")
+	private EgovRoughMapMapper mapper;
+
+	/**
+	 * 약도 목록을 조회한다.
+	 * @param searchVO
+	 * @return List 건물 위치정보 리스트
+	 * @throws Exception
+	 */
 	public List<EgovMap> selectRoughMapList(RoughMapDefaultVO searchVO) throws Exception {
-        return selectList("RoughMapDAO.selectRoughMapList", searchVO);
-    }
+		return mapper.selectRoughMapList(searchVO);
+	}
 
-    /**
-     * 약도 목록의 건수를 조회 한다.
-     * @param roughMapVO
-     * @return int 건물 위치정보 목록 건수
-     * @throws Exception
-    */
-    public int selectRoughMapListTotCnt(RoughMapDefaultVO searchVO){
-        return (Integer)selectOne("RoughMapDAO.selectRoughMapListTotCnt", searchVO);
-    }
+	/**
+	 * 약도 목록의 건수를 조회 한다.
+	 * @param searchVO
+	 * @return int 건물 위치정보 목록 건수
+	 */
+	public int selectRoughMapListTotCnt(RoughMapDefaultVO searchVO) {
+		return mapper.selectRoughMapListTotCnt(searchVO);
+	}
 
-    /**
-     * 약도를 조회한다.
-     * @param roughMapVO
-     * @return RoughMap
-     * @throws Exception
-    */
-    public RoughMapVO selectRoughMap(RoughMapVO roughMapVO) throws Exception {
-        return (RoughMapVO)selectOne("RoughMapDAO.selectRoughMapDetail", roughMapVO);
-    }
+	/**
+	 * 약도를 조회한다.
+	 * @param roughMapVO
+	 * @return RoughMapVO
+	 * @throws Exception
+	 */
+	public RoughMapVO selectRoughMap(RoughMapVO roughMapVO) throws Exception {
+		return mapper.selectRoughMapDetail(roughMapVO);
+	}
 
-    /**
-     * 약도를 DB에 등록한다.
-     *
-     * @param roughMap
-     * @throws Exception
-     */
-    public void insertRoughMap(RoughMapVO roughMap) throws Exception {
-        insert("RoughMapDAO.insertRoughMap", roughMap);
-    }
+	/**
+	 * 약도를 DB에 등록한다.
+	 * @param roughMap
+	 * @throws Exception
+	 */
+	public void insertRoughMap(RoughMapVO roughMap) throws Exception {
+		mapper.insertRoughMap(roughMap);
+	}
 
-    /**
-     * 약도를 DB에서 수정한다.
-     *
-     * @param roughMap
-     * @throws Exception
-     */
-    public void updateRoughMap(RoughMapVO roughMap) throws Exception {
-            update("RoughMapDAO.updateRoughMap", roughMap);
-    }
+	/**
+	 * 약도를 DB에서 수정한다.
+	 * @param roughMap
+	 * @throws Exception
+	 */
+	public void updateRoughMap(RoughMapVO roughMap) throws Exception {
+		mapper.updateRoughMap(roughMap);
+	}
 
-    /**
-     * 약도를 DB에서 삭제한다.
-     *
-     * @param roughMap
-     * @throws Exception
-     */
-    public void deleteRoughMap(RoughMapVO roughMap) throws Exception {
-            delete("RoughMapDAO.deleteRoughMap", roughMap);
-    }
+	/**
+	 * 약도를 DB에서 삭제한다.
+	 * @param roughMap
+	 * @throws Exception
+	 */
+	public void deleteRoughMap(RoughMapVO roughMap) throws Exception {
+		mapper.deleteRoughMap(roughMap);
+	}
 }

--- a/src/main/java/egovframework/com/uss/ion/rmm/service/impl/EgovRoughMapMapper.java
+++ b/src/main/java/egovframework/com/uss/ion/rmm/service/impl/EgovRoughMapMapper.java
@@ -1,0 +1,36 @@
+package egovframework.com.uss.ion.rmm.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+import org.egovframe.rte.psl.dataaccess.util.EgovMap;
+
+import egovframework.com.uss.ion.rmm.service.RoughMapDefaultVO;
+import egovframework.com.uss.ion.rmm.service.RoughMapVO;
+
+/**
+ * 건물 위치정보(약도)에 대한 Mapper 인터페이스
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2026.05.28  dasomel         XML 기반 DAO → @EgovMapper 인터페이스로 전환
+ * </pre>
+ */
+@EgovMapper("roughMapMapper")
+public interface EgovRoughMapMapper {
+
+	List<EgovMap> selectRoughMapList(RoughMapDefaultVO searchVO);
+
+	int selectRoughMapListTotCnt(RoughMapDefaultVO searchVO);
+
+	RoughMapVO selectRoughMapDetail(RoughMapVO roughMapVO);
+
+	void insertRoughMap(RoughMapVO roughMap);
+
+	void updateRoughMap(RoughMapVO roughMap);
+
+	void deleteRoughMap(RoughMapVO roughMap);
+}

--- a/src/main/java/egovframework/com/uss/ion/rwd/service/impl/RwardManageDAO.java
+++ b/src/main/java/egovframework/com/uss/ion/rwd/service/impl/RwardManageDAO.java
@@ -1,29 +1,39 @@
-
-
 package egovframework.com.uss.ion.rwd.service.impl;
 
 import java.util.List;
 
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.uss.ion.rwd.service.RwardManage;
 import egovframework.com.uss.ion.rwd.service.RwardManageVO;
+import jakarta.annotation.Resource;
 
 /**
  * 개요
  * - 포상관리에 대한 DAO 클래스를 정의한다.
- * 
+ *
  * 상세내용
  * - 포상관리에 대한 등록, 수정, 삭제, 조회, 승인처리 기능을 제공한다.
  * - 포상관리의 조회기능은 목록조회, 상세조회로 구분된다.
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2010.06.15  이용              최초 생성
+ *   2026.05.28  dasomel           @EgovMapper 인터페이스 위임 방식으로 전환
+ * </pre>
+ *
  * @author 이용
  * @version 1.0
- * @created 06-15-2010 오후 2:08:56
  */
 
 @Repository("rwardManageDAO")
-public class RwardManageDAO extends EgovComAbstractDAO {
+public class RwardManageDAO {
+
+	@Resource(name = "rwardManageMapper")
+	private RwardManageMapper mapper;
 
 	/**
 	 * 포상관리정보를 관리하기 위해 등록된 포상관리 목록을 조회한다.
@@ -31,26 +41,26 @@ public class RwardManageDAO extends EgovComAbstractDAO {
 	 * @return List - 포상관리 목록
 	 */
 	public List<RwardManageVO> selectRwardManageList(RwardManageVO rwardManageVO) throws Exception {
-		return selectList("rwardManageDAO.selectRwardManageList", rwardManageVO);
+		return mapper.selectRwardManageList(rwardManageVO);
 	}
 
-    /**
+	/**
 	 * 포상관리목록 총 개수를 조회한다.
 	 * @param rwardManageVO - 포상관리 VO
 	 * @return int
 	 * @exception Exception
 	 */
-    public int selectRwardManageListTotCnt(RwardManageVO rwardManageVO) throws Exception {
-        return (Integer)selectOne("rwardManageDAO.selectRwardManageListTotCnt", rwardManageVO);
-    }
+	public int selectRwardManageListTotCnt(RwardManageVO rwardManageVO) throws Exception {
+		return mapper.selectRwardManageListTotCnt(rwardManageVO);
+	}
 
 	/**
 	 * 등록된 포상관리의 상세정보를 조회한다.
 	 * @param rwardManageVO - 포상관리 VO
 	 * @return RwardManageVO - 포상관리 VO
 	 */
-	public RwardManageVO selectRwardManage(RwardManageVO rwardManageVO)  throws Exception {
-		return (RwardManageVO) selectOne("rwardManageDAO.selectRwardManage", rwardManageVO);
+	public RwardManageVO selectRwardManage(RwardManageVO rwardManageVO) throws Exception {
+		return mapper.selectRwardManage(rwardManageVO);
 	}
 
 	/**
@@ -58,7 +68,7 @@ public class RwardManageDAO extends EgovComAbstractDAO {
 	 * @param rwardManage - 포상관리 model
 	 */
 	public void insertRwardManage(RwardManage rwardManage) throws Exception {
-		insert("rwardManageDAO.insertRwardManage", rwardManage);
+		mapper.insertRwardManage(rwardManage);
 	}
 
 	/**
@@ -66,7 +76,7 @@ public class RwardManageDAO extends EgovComAbstractDAO {
 	 * @param rwardManage - 포상관리 model
 	 */
 	public void updtRwardManage(RwardManage rwardManage) throws Exception {
-		update("rwardManageDAO.updtRwardManage", rwardManage);
+		mapper.updtRwardManage(rwardManage);
 	}
 
 	/**
@@ -74,34 +84,34 @@ public class RwardManageDAO extends EgovComAbstractDAO {
 	 * @param rwardManage - 포상관리 model
 	 */
 	public void deleteRwardManage(RwardManage rwardManage) throws Exception {
-        delete("rwardManageDAO.deleteRwardManage",rwardManage);
+		mapper.deleteRwardManage(rwardManage);
 	}
 
-    /*** 승인처리관련 ***/
+	/*** 승인처리관련 ***/
 	/**
 	 * 포상관리정보 승인 처리를 위해 신청된 포상관리 목록을 조회한다.
 	 * @param rwardManageVO - 포상관리 VO
 	 * @return List - 포상관리 목록
 	 */
 	public List<RwardManageVO> selectRwardManageConfmList(RwardManageVO rwardManageVO) throws Exception {
-		return selectList("rwardManageDAO.selectRwardManageConfmList", rwardManageVO);
+		return mapper.selectRwardManageConfmList(rwardManageVO);
 	}
 
-    /**
+	/**
 	 * 포상관리정보 승인 처리를 위해 신청된 포상관리 목록 총 개수를 조회한다.
 	 * @param rwardManageVO - 포상관리 VO
 	 * @return int
 	 * @exception Exception
 	 */
-    public int selectRwardManageConfmListTotCnt(RwardManageVO rwardManageVO) throws Exception {
-        return (Integer)selectOne("rwardManageDAO.selectRwardManageConfmListTotCnt", rwardManageVO);
-    }
-	
+	public int selectRwardManageConfmListTotCnt(RwardManageVO rwardManageVO) throws Exception {
+		return mapper.selectRwardManageConfmListTotCnt(rwardManageVO);
+	}
+
 	/**
-	 *포상정보를 승인/반려처리 한다.
+	 * 포상정보를 승인/반려처리 한다.
 	 * @param rwardManage - 포상관리 model
 	 */
 	public void updtRwardManageConfm(RwardManage rwardManage) throws Exception {
-		update("rwardManageDAO.updtRwardManageConfm", rwardManage);
+		mapper.updtRwardManageConfm(rwardManage);
 	}
 }

--- a/src/main/java/egovframework/com/uss/ion/rwd/service/impl/RwardManageMapper.java
+++ b/src/main/java/egovframework/com/uss/ion/rwd/service/impl/RwardManageMapper.java
@@ -1,0 +1,41 @@
+package egovframework.com.uss.ion.rwd.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.uss.ion.rwd.service.RwardManage;
+import egovframework.com.uss.ion.rwd.service.RwardManageVO;
+
+/**
+ * 포상관리에 대한 Mapper 인터페이스
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2026.05.28  dasomel         XML 기반 DAO → @EgovMapper 인터페이스로 전환
+ * </pre>
+ */
+@EgovMapper("rwardManageMapper")
+public interface RwardManageMapper {
+
+	List<RwardManageVO> selectRwardManageList(RwardManageVO rwardManageVO);
+
+	int selectRwardManageListTotCnt(RwardManageVO rwardManageVO);
+
+	RwardManageVO selectRwardManage(RwardManageVO rwardManageVO);
+
+	void insertRwardManage(RwardManage rwardManage);
+
+	void updtRwardManage(RwardManage rwardManage);
+
+	void deleteRwardManage(RwardManage rwardManage);
+
+	List<RwardManageVO> selectRwardManageConfmList(RwardManageVO rwardManageVO);
+
+	int selectRwardManageConfmListTotCnt(RwardManageVO rwardManageVO);
+
+	void updtRwardManageConfm(RwardManage rwardManage);
+}

--- a/src/main/java/egovframework/com/uss/ion/vct/service/impl/VcatnManageDAO.java
+++ b/src/main/java/egovframework/com/uss/ion/vct/service/impl/VcatnManageDAO.java
@@ -4,23 +4,34 @@ import java.util.List;
 
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.uss.ion.vct.service.VcatnManageVO;
+import jakarta.annotation.Resource;
 
 /**
  * 개요
  * - 휴가관리에 대한 DAO 클래스를 정의한다.
- * 
+ *
  * 상세내용
  * - 휴가관리에 대한 등록, 수정, 삭제, 조회, 반영확인 기능을 제공한다.
  * - 휴가관리의 조회기능은 목록조회, 상세조회로 구분된다.
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2010.06.15  이용              최초 생성
+ *   2026.05.28  dasomel           @EgovMapper 인터페이스 위임 방식으로 전환
+ * </pre>
+ *
  * @author 이용
  * @version 1.0
- * @created 06-15-2010 오후 2:08:56
  */
-
 @Repository("vcatnManageDAO")
-public class VcatnManageDAO extends EgovComAbstractDAO {
+public class VcatnManageDAO {
+
+	@Resource(name = "vcatnManageMapper")
+	private VcatnManageMapper mapper;
 
 	/**
 	 * 휴가관리정보를 관리하기 위해 등록된 휴가관리 목록을 조회한다.
@@ -28,26 +39,26 @@ public class VcatnManageDAO extends EgovComAbstractDAO {
 	 * @return List - 휴가관리 목록
 	 */
 	public List<VcatnManageVO> selectVcatnManageList(VcatnManageVO vcatnManageVO) throws Exception {
-		return selectList("vcatnManageDAO.selectVcatnManageList", vcatnManageVO);
+		return mapper.selectVcatnManageList(vcatnManageVO);
 	}
 
-    /**
+	/**
 	 * 휴가관리목록 총 개수를 조회한다.
 	 * @param vcatnManageVO - 휴가관리 VO
 	 * @return int
 	 * @exception Exception
 	 */
-    public int selectVcatnManageListTotCnt(VcatnManageVO vcatnManageVO) throws Exception {
-        return (Integer)selectOne("vcatnManageDAO.selectVcatnManageListTotCnt", vcatnManageVO);
-    }
+	public int selectVcatnManageListTotCnt(VcatnManageVO vcatnManageVO) throws Exception {
+		return mapper.selectVcatnManageListTotCnt(vcatnManageVO);
+	}
 
 	/**
 	 * 등록된 휴가관리의 상세정보를 조회한다.
 	 * @param vcatnManageVO - 휴가관리 VO
 	 * @return VcatnManageVO - 휴가관리 VO
 	 */
-	public VcatnManageVO selectVcatnManage(VcatnManageVO vcatnManageVO)  throws Exception {
-		return (VcatnManageVO) selectOne("vcatnManageDAO.selectVcatnManage", vcatnManageVO);
+	public VcatnManageVO selectVcatnManage(VcatnManageVO vcatnManageVO) throws Exception {
+		return mapper.selectVcatnManage(vcatnManageVO);
 	}
 
 	/**
@@ -55,7 +66,7 @@ public class VcatnManageDAO extends EgovComAbstractDAO {
 	 * @param vcatnManageVO - 휴가관리 VO
 	 */
 	public void insertVcatnManage(VcatnManageVO vcatnManageVO) throws Exception {
-		insert("vcatnManageDAO.insertVcatnManage", vcatnManageVO);
+		mapper.insertVcatnManage(vcatnManageVO);
 	}
 
 	/**
@@ -63,7 +74,7 @@ public class VcatnManageDAO extends EgovComAbstractDAO {
 	 * @param vcatnManageVO - 휴가관리 VO
 	 */
 	public void updtVcatnManage(VcatnManageVO vcatnManageVO) throws Exception {
-		update("vcatnManageDAO.updateVcatnManage", vcatnManageVO);
+		mapper.updateVcatnManage(vcatnManageVO);
 	}
 
 	/**
@@ -71,67 +82,62 @@ public class VcatnManageDAO extends EgovComAbstractDAO {
 	 * @param vcatnManageVO - 휴가관리 VO
 	 */
 	public void deleteVcatnManage(VcatnManageVO vcatnManageVO) throws Exception {
-        delete("vcatnManageDAO.deleteVcatnManage",vcatnManageVO);
+		mapper.deleteVcatnManage(vcatnManageVO);
 	}
 
-    /**
+	/**
 	 * 휴가일자 중복여부 체크
 	 * @param vcatnManageVO - 휴가관리 VO
 	 * @return int
 	 * @exception Exception
 	 */
-    public int selectVcatnManageDplctAt(VcatnManageVO vcatnManageVO) throws Exception {
-        return (Integer)selectOne("vcatnManageDAO.selectVcatnManageDplctAt", vcatnManageVO);
-    }
-	
-	
-    /*** 승인관련 ***/	
+	public int selectVcatnManageDplctAt(VcatnManageVO vcatnManageVO) throws Exception {
+		return mapper.selectVcatnManageDplctAt(vcatnManageVO);
+	}
+
+	/*** 승인관련 ***/
 	/**
 	 * 휴가관리정보 승인 처리를 위해 신청된 휴가관리 목록을 조회한다.
 	 * @param vcatnManageVO - 휴가관리 VO
 	 * @return List - 휴가관리 목록
 	 */
 	public List<VcatnManageVO> selectVcatnManageConfmList(VcatnManageVO vcatnManageVO) throws Exception {
-		return selectList("vcatnManageDAO.selectVcatnManageConfmList", vcatnManageVO);
+		return mapper.selectVcatnManageConfmList(vcatnManageVO);
 	}
 
-    /**
+	/**
 	 * 휴가관리정보 승인 처리를 위해 신청된 휴가관리 목록 총 개수를 조회한다.
 	 * @param vcatnManageVO - 휴가관리 VO
 	 * @return int
 	 * @exception Exception
 	 */
-    public int selectVcatnManageConfmListTotCnt(VcatnManageVO vcatnManageVO) throws Exception {
-        return (Integer)selectOne("vcatnManageDAO.selectVcatnManageConfmListTotCnt", vcatnManageVO);
-    }
-	
+	public int selectVcatnManageConfmListTotCnt(VcatnManageVO vcatnManageVO) throws Exception {
+		return mapper.selectVcatnManageConfmListTotCnt(vcatnManageVO);
+	}
+
 	/**
 	 * 신청된 휴가를 승인처리한다.
 	 * @param vcatnManageVO - 휴가관리 VO
 	 */
 	public void updtVcatnManageConfm(VcatnManageVO vcatnManageVO) throws Exception {
-		update("vcatnManageDAO.updateVcatnManageConfm", vcatnManageVO);
-	}	
+		mapper.updateVcatnManageConfm(vcatnManageVO);
+	}
 
-
-
-    /*** 연차관련 ***/	
+	/*** 연차관련 ***/
 	/**
 	 * 개인별 연차관리의 상세정보를 조회한다.
 	 * @param vcatnManageVO - 휴가관리 VO
 	 * @return VcatnManageVO - 휴가관리 VO
 	 */
-	public VcatnManageVO selectIndvdlYrycManage(VcatnManageVO vcatnManageVO)  throws Exception {
-		return (VcatnManageVO) selectOne("vcatnManageDAO.selectIndvdlYrycManage", vcatnManageVO);
+	public VcatnManageVO selectIndvdlYrycManage(VcatnManageVO vcatnManageVO) throws Exception {
+		return mapper.selectIndvdlYrycManage(vcatnManageVO);
 	}
-	
-	
+
 	/**
 	 * 연차정보를 수정처리한다.
 	 * @param vcatnManageVO - 휴가관리 VO
 	 */
 	public void updtIndvdlYrycManage(VcatnManageVO vcatnManageVO) throws Exception {
-		update("vcatnManageDAO.updateIndvdlYrycManage", vcatnManageVO);
+		mapper.updateIndvdlYrycManage(vcatnManageVO);
 	}
-
 }

--- a/src/main/java/egovframework/com/uss/ion/vct/service/impl/VcatnManageMapper.java
+++ b/src/main/java/egovframework/com/uss/ion/vct/service/impl/VcatnManageMapper.java
@@ -1,0 +1,46 @@
+package egovframework.com.uss.ion.vct.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.uss.ion.vct.service.VcatnManageVO;
+
+/**
+ * 휴가관리에 대한 Mapper 인터페이스
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2026.05.28  dasomel         XML 기반 DAO → @EgovMapper 인터페이스로 전환
+ * </pre>
+ */
+@EgovMapper("vcatnManageMapper")
+public interface VcatnManageMapper {
+
+	List<VcatnManageVO> selectVcatnManageList(VcatnManageVO vcatnManageVO);
+
+	int selectVcatnManageListTotCnt(VcatnManageVO vcatnManageVO);
+
+	VcatnManageVO selectVcatnManage(VcatnManageVO vcatnManageVO);
+
+	void insertVcatnManage(VcatnManageVO vcatnManageVO);
+
+	void updateVcatnManage(VcatnManageVO vcatnManageVO);
+
+	void deleteVcatnManage(VcatnManageVO vcatnManageVO);
+
+	int selectVcatnManageDplctAt(VcatnManageVO vcatnManageVO);
+
+	List<VcatnManageVO> selectVcatnManageConfmList(VcatnManageVO vcatnManageVO);
+
+	int selectVcatnManageConfmListTotCnt(VcatnManageVO vcatnManageVO);
+
+	void updateVcatnManageConfm(VcatnManageVO vcatnManageVO);
+
+	VcatnManageVO selectIndvdlYrycManage(VcatnManageVO vcatnManageVO);
+
+	void updateIndvdlYrycManage(VcatnManageVO vcatnManageVO);
+}

--- a/src/main/java/egovframework/com/uss/ion/yrc/service/impl/IndvdlYrycDAO.java
+++ b/src/main/java/egovframework/com/uss/ion/yrc/service/impl/IndvdlYrycDAO.java
@@ -4,8 +4,8 @@ import java.util.List;
 
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.uss.ion.yrc.service.IndvdlYrycManage;
+import jakarta.annotation.Resource;
 
 /**
  * 개요
@@ -13,20 +13,31 @@ import egovframework.com.uss.ion.yrc.service.IndvdlYrycManage;
  *
  * 상세내용
  * - 연차관리에 대한 등록, 수정, 삭제, 조회 기능을 제공한다.
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2014.11.14  이기하          최초 생성
+ *   2026.05.28  dasomel         @EgovMapper 인터페이스 위임 방식으로 전환
+ * </pre>
+ *
  * @author 이기하
  * @version 1.0
- * @created 2014.11.14
  */
-
 @Repository("indvdlYrycDAO")
-public class IndvdlYrycDAO extends EgovComAbstractDAO {
+public class IndvdlYrycDAO {
+
+	@Resource(name = "indvdlYrycMapper")
+	private IndvdlYrycMapper mapper;
 
 	/**
 	 * 연차를 조회처리한다.
 	 * @param indvdlYrycManage - 연차관리 model
 	 */
 	public List<IndvdlYrycManage> selectIndvdlYrycManageList(IndvdlYrycManage indvdlYrycManage) throws Exception {
-		return selectList("indvdlYrycDAO.selectIndvdlYrycManageList", indvdlYrycManage);
+		return mapper.selectIndvdlYrycManageList(indvdlYrycManage);
 	}
 
 	/**
@@ -34,7 +45,7 @@ public class IndvdlYrycDAO extends EgovComAbstractDAO {
 	 * @param indvdlYrycManage - 연차관리 model
 	 */
 	public int selectIndvdlYrycManageListTotCnt(IndvdlYrycManage indvdlYrycManage) throws Exception {
-		return (Integer)selectOne("indvdlYrycDAO.selectIndvdlYrycManageListTotCnt", indvdlYrycManage);
+		return mapper.selectIndvdlYrycManageListTotCnt(indvdlYrycManage);
 	}
 
 	/**
@@ -42,7 +53,7 @@ public class IndvdlYrycDAO extends EgovComAbstractDAO {
 	 * @param indvdlYrycManage - 연차관리 model
 	 */
 	public void insertIndvdlYrycManage(IndvdlYrycManage indvdlYrycManage) throws Exception {
-		insert("indvdlYrycDAO.insertIndvdlYrycManage", indvdlYrycManage);
+		mapper.insertIndvdlYrycManage(indvdlYrycManage);
 	}
 
 	/**
@@ -50,7 +61,7 @@ public class IndvdlYrycDAO extends EgovComAbstractDAO {
 	 * @param indvdlYrycManage - 연차관리 model
 	 */
 	public void updtIndvdlYrycManage(IndvdlYrycManage indvdlYrycManage) throws Exception {
-		update("indvdlYrycDAO.updateIndvdlYrycManage", indvdlYrycManage);
+		mapper.updateIndvdlYrycManage(indvdlYrycManage);
 	}
 
 	/**
@@ -58,7 +69,6 @@ public class IndvdlYrycDAO extends EgovComAbstractDAO {
 	 * @param indvdlYrycManage - 연차관리 model
 	 */
 	public void deleteIndvdlYrycManage(IndvdlYrycManage indvdlYrycManage) throws Exception {
-		delete("indvdlYrycDAO.deleteIndvdlYrycManage", indvdlYrycManage);
+		mapper.deleteIndvdlYrycManage(indvdlYrycManage);
 	}
-
 }

--- a/src/main/java/egovframework/com/uss/ion/yrc/service/impl/IndvdlYrycMapper.java
+++ b/src/main/java/egovframework/com/uss/ion/yrc/service/impl/IndvdlYrycMapper.java
@@ -1,0 +1,32 @@
+package egovframework.com.uss.ion.yrc.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.uss.ion.yrc.service.IndvdlYrycManage;
+
+/**
+ * 연차관리에 대한 Mapper 인터페이스
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2026.05.28  dasomel         XML 기반 DAO → @EgovMapper 인터페이스로 전환
+ * </pre>
+ */
+@EgovMapper("indvdlYrycMapper")
+public interface IndvdlYrycMapper {
+
+	List<IndvdlYrycManage> selectIndvdlYrycManageList(IndvdlYrycManage indvdlYrycManage);
+
+	int selectIndvdlYrycManageListTotCnt(IndvdlYrycManage indvdlYrycManage);
+
+	void insertIndvdlYrycManage(IndvdlYrycManage indvdlYrycManage);
+
+	void updateIndvdlYrycManage(IndvdlYrycManage indvdlYrycManage);
+
+	void deleteIndvdlYrycManage(IndvdlYrycManage indvdlYrycManage);
+}

--- a/src/main/resources/egovframework/mapper/com/uss/ion/isg/EgovIntnetSvcGuidance_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/isg/EgovIntnetSvcGuidance_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:51:06 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="intnetSvcGuidanceDAO">
+<mapper namespace="egovframework.com.uss.ion.isg.service.impl.IntnetSvcGuidanceMapper">
 
     <resultMap id="intnetSvcGuidance" type="egovframework.com.uss.ion.isg.service.IntnetSvcGuidanceVO">
         <result property="intnetSvcId" column="INTNET_SVC_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/isg/EgovIntnetSvcGuidance_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/isg/EgovIntnetSvcGuidance_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:51:06 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="intnetSvcGuidanceDAO">
+<mapper namespace="egovframework.com.uss.ion.isg.service.impl.IntnetSvcGuidanceMapper">
 
     <resultMap id="intnetSvcGuidance" type="egovframework.com.uss.ion.isg.service.IntnetSvcGuidanceVO">
         <result property="intnetSvcId" column="INTNET_SVC_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/isg/EgovIntnetSvcGuidance_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/isg/EgovIntnetSvcGuidance_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:51:06 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="intnetSvcGuidanceDAO">
+<mapper namespace="egovframework.com.uss.ion.isg.service.impl.IntnetSvcGuidanceMapper">
 
     <resultMap id="intnetSvcGuidance" type="egovframework.com.uss.ion.isg.service.IntnetSvcGuidanceVO">
         <result property="intnetSvcId" column="INTNET_SVC_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/isg/EgovIntnetSvcGuidance_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/isg/EgovIntnetSvcGuidance_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:51:06 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="intnetSvcGuidanceDAO">
+<mapper namespace="egovframework.com.uss.ion.isg.service.impl.IntnetSvcGuidanceMapper">
 
     <resultMap id="intnetSvcGuidance" type="egovframework.com.uss.ion.isg.service.IntnetSvcGuidanceVO">
         <result property="intnetSvcId" column="INTNET_SVC_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/isg/EgovIntnetSvcGuidance_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/isg/EgovIntnetSvcGuidance_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:51:06 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="intnetSvcGuidanceDAO">
+<mapper namespace="egovframework.com.uss.ion.isg.service.impl.IntnetSvcGuidanceMapper">
 
     <resultMap id="intnetSvcGuidance" type="egovframework.com.uss.ion.isg.service.IntnetSvcGuidanceVO">
         <result property="intnetSvcId" column="INTNET_SVC_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/isg/EgovIntnetSvcGuidance_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/isg/EgovIntnetSvcGuidance_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:51:07 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="intnetSvcGuidanceDAO">
+<mapper namespace="egovframework.com.uss.ion.isg.service.impl.IntnetSvcGuidanceMapper">
 
     <resultMap id="intnetSvcGuidance" type="egovframework.com.uss.ion.isg.service.IntnetSvcGuidanceVO">
         <result property="intnetSvcId" column="INTNET_SVC_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/isg/EgovIntnetSvcGuidance_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/isg/EgovIntnetSvcGuidance_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:51:06 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="intnetSvcGuidanceDAO">
+<mapper namespace="egovframework.com.uss.ion.isg.service.impl.IntnetSvcGuidanceMapper">
 
     <resultMap id="intnetSvcGuidance" type="egovframework.com.uss.ion.isg.service.IntnetSvcGuidanceVO">
         <result property="intnetSvcId" column="INTNET_SVC_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/isg/EgovIntnetSvcGuidance_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/isg/EgovIntnetSvcGuidance_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:51:07 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="intnetSvcGuidanceDAO">
+<mapper namespace="egovframework.com.uss.ion.isg.service.impl.IntnetSvcGuidanceMapper">
 
     <resultMap id="intnetSvcGuidance" type="egovframework.com.uss.ion.isg.service.IntnetSvcGuidanceVO">
         <result property="intnetSvcId" column="INTNET_SVC_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/noi/EgovNotification_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/noi/EgovNotification_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:51:11 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="NotificationDAO">
+<mapper namespace="egovframework.com.uss.ion.noi.service.impl.NotificationMapper">
 
 	<resultMap id="notificationList" type="egovframework.com.uss.ion.noi.service.NotificationVO">
 		<result property="ntfcNo" column="NTCN_NO"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/noi/EgovNotification_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/noi/EgovNotification_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:51:11 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="NotificationDAO">
+<mapper namespace="egovframework.com.uss.ion.noi.service.impl.NotificationMapper">
 
 	<resultMap id="notificationList" type="egovframework.com.uss.ion.noi.service.NotificationVO">
 		<result property="ntfcNo" column="NTCN_NO"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/noi/EgovNotification_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/noi/EgovNotification_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:51:11 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="NotificationDAO">
+<mapper namespace="egovframework.com.uss.ion.noi.service.impl.NotificationMapper">
 
 	<resultMap id="notificationList" type="egovframework.com.uss.ion.noi.service.NotificationVO">
 		<result property="ntfcNo" column="NTCN_NO"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/noi/EgovNotification_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/noi/EgovNotification_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:51:11 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="NotificationDAO">
+<mapper namespace="egovframework.com.uss.ion.noi.service.impl.NotificationMapper">
 
 	<resultMap id="notificationList" type="egovframework.com.uss.ion.noi.service.NotificationVO">
 		<result property="ntfcNo" column="NTCN_NO"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/noi/EgovNotification_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/noi/EgovNotification_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:51:11 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="NotificationDAO">
+<mapper namespace="egovframework.com.uss.ion.noi.service.impl.NotificationMapper">
 
 	<resultMap id="notificationList" type="egovframework.com.uss.ion.noi.service.NotificationVO">
 		<result property="ntfcNo" column="NTCN_NO"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/noi/EgovNotification_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/noi/EgovNotification_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:51:11 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="NotificationDAO">
+<mapper namespace="egovframework.com.uss.ion.noi.service.impl.NotificationMapper">
 
 	<resultMap id="notificationList" type="egovframework.com.uss.ion.noi.service.NotificationVO">
 		<result property="ntfcNo" column="NTCN_NO"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/noi/EgovNotification_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/noi/EgovNotification_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="NotificationDAO">
+<mapper namespace="egovframework.com.uss.ion.noi.service.impl.NotificationMapper">
 
 	<resultMap id="notificationList" type="egovframework.com.uss.ion.noi.service.NotificationVO">
 		<result property="ntfcNo" column="NTCN_NO"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/noi/EgovNotification_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/noi/EgovNotification_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:51:11 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="NotificationDAO">
+<mapper namespace="egovframework.com.uss.ion.noi.service.impl.NotificationMapper">
 
 	<resultMap id="notificationList" type="egovframework.com.uss.ion.noi.service.NotificationVO">
 		<result property="ntfcNo" column="NTCN_NO"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/rec/EgovRecomendSite_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/rec/EgovRecomendSite_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="RecomendSite">
+<mapper namespace="egovframework.com.uss.ion.rec.service.impl.EgovRecomendSiteMapper">
 
 	<resultMap id="RecomendSiteManage" type="egovframework.com.uss.ion.rec.service.RecomendSiteVO">
 		<result property="recomendSiteId" column="RECOMEND_SITE_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/rec/EgovRecomendSite_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/rec/EgovRecomendSite_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="RecomendSite">
+<mapper namespace="egovframework.com.uss.ion.rec.service.impl.EgovRecomendSiteMapper">
 
 	<resultMap id="RecomendSiteManage" type="egovframework.com.uss.ion.rec.service.RecomendSiteVO">
 		<result property="recomendSiteId" column="RECOMEND_SITE_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/rec/EgovRecomendSite_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/rec/EgovRecomendSite_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="RecomendSite">
+<mapper namespace="egovframework.com.uss.ion.rec.service.impl.EgovRecomendSiteMapper">
 
 	<resultMap id="RecomendSiteManage" type="egovframework.com.uss.ion.rec.service.RecomendSiteVO">
 		<result property="recomendSiteId" column="RECOMEND_SITE_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/rec/EgovRecomendSite_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/rec/EgovRecomendSite_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="RecomendSite">
+<mapper namespace="egovframework.com.uss.ion.rec.service.impl.EgovRecomendSiteMapper">
 
 	<resultMap id="RecomendSiteManage" type="egovframework.com.uss.ion.rec.service.RecomendSiteVO">
 		<result property="recomendSiteId" column="RECOMEND_SITE_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/rec/EgovRecomendSite_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/rec/EgovRecomendSite_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="RecomendSite">
+<mapper namespace="egovframework.com.uss.ion.rec.service.impl.EgovRecomendSiteMapper">
 
 	<resultMap id="RecomendSiteManage" type="egovframework.com.uss.ion.rec.service.RecomendSiteVO">
 		<result property="recomendSiteId" column="RECOMEND_SITE_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/rec/EgovRecomendSite_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/rec/EgovRecomendSite_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="RecomendSite">
+<mapper namespace="egovframework.com.uss.ion.rec.service.impl.EgovRecomendSiteMapper">
 
 	<resultMap id="RecomendSiteManage" type="egovframework.com.uss.ion.rec.service.RecomendSiteVO">
 		<result property="recomendSiteId" column="RECOMEND_SITE_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/rec/EgovRecomendSite_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/rec/EgovRecomendSite_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="RecomendSite">
+<mapper namespace="egovframework.com.uss.ion.rec.service.impl.EgovRecomendSiteMapper">
 
 	<resultMap id="RecomendSiteManage" type="egovframework.com.uss.ion.rec.service.RecomendSiteVO">
 		<result property="recomendSiteId" column="RECOMEND_SITE_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/rec/EgovRecomendSite_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/rec/EgovRecomendSite_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="RecomendSite">
+<mapper namespace="egovframework.com.uss.ion.rec.service.impl.EgovRecomendSiteMapper">
 
 	<resultMap id="RecomendSiteManage" type="egovframework.com.uss.ion.rec.service.RecomendSiteVO">
 		<result property="recomendSiteId" column="RECOMEND_SITE_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/rmm/EgovRoughMap_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/rmm/EgovRoughMap_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:51:17 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="RoughMapDAO">
+<mapper namespace="egovframework.com.uss.ion.rmm.service.impl.EgovRoughMapMapper">
 
 	<resultMap id="RoughMap" type="egovframework.com.uss.ion.rmm.service.RoughMapVO">
 		<result property="roughMapId" column="ROUGHMAP_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/rmm/EgovRoughMap_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/rmm/EgovRoughMap_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:51:17 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="RoughMapDAO">
+<mapper namespace="egovframework.com.uss.ion.rmm.service.impl.EgovRoughMapMapper">
 
 	<resultMap id="RoughMap" type="egovframework.com.uss.ion.rmm.service.RoughMapVO">
 		<result property="roughMapId" column="ROUGHMAP_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/rmm/EgovRoughMap_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/rmm/EgovRoughMap_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:51:17 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="RoughMapDAO">
+<mapper namespace="egovframework.com.uss.ion.rmm.service.impl.EgovRoughMapMapper">
 
 	<resultMap id="RoughMap" type="egovframework.com.uss.ion.rmm.service.RoughMapVO">
 		<result property="roughMapId" column="ROUGHMAP_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/rmm/EgovRoughMap_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/rmm/EgovRoughMap_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:51:17 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="RoughMapDAO">
+<mapper namespace="egovframework.com.uss.ion.rmm.service.impl.EgovRoughMapMapper">
 
 	<resultMap id="RoughMap" type="egovframework.com.uss.ion.rmm.service.RoughMapVO">
 		<result property="roughMapId" column="ROUGHMAP_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/rmm/EgovRoughMap_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/rmm/EgovRoughMap_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:51:17 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="RoughMapDAO">
+<mapper namespace="egovframework.com.uss.ion.rmm.service.impl.EgovRoughMapMapper">
 
 	<resultMap id="RoughMap" type="egovframework.com.uss.ion.rmm.service.RoughMapVO">
 		<result property="roughMapId" column="ROUGHMAP_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/rmm/EgovRoughMap_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/rmm/EgovRoughMap_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:51:17 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="RoughMapDAO">
+<mapper namespace="egovframework.com.uss.ion.rmm.service.impl.EgovRoughMapMapper">
 
 	<resultMap id="RoughMap" type="egovframework.com.uss.ion.rmm.service.RoughMapVO">
 		<result property="roughMapId" column="ROUGHMAP_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/rmm/EgovRoughMap_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/rmm/EgovRoughMap_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:51:17 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="RoughMapDAO">
+<mapper namespace="egovframework.com.uss.ion.rmm.service.impl.EgovRoughMapMapper">
 
 	<resultMap id="RoughMap" type="egovframework.com.uss.ion.rmm.service.RoughMapVO">
 		<result property="roughMapId" column="ROUGHMAP_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/rmm/EgovRoughMap_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/rmm/EgovRoughMap_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:51:17 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="RoughMapDAO">
+<mapper namespace="egovframework.com.uss.ion.rmm.service.impl.EgovRoughMapMapper">
 
 	<resultMap id="RoughMap" type="egovframework.com.uss.ion.rmm.service.RoughMapVO">
 		<result property="roughMapId" column="ROUGHMAP_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/rwd/EgovRwardManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/rwd/EgovRwardManage_SQL_altibase.xml
@@ -7,7 +7,7 @@
  --><!--Converted at: Wed May 11 15:51:20 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="rwardManageDAO">
+<mapper namespace="egovframework.com.uss.ion.rwd.service.impl.RwardManageMapper">
 
     <resultMap id="rwardManage" type="egovframework.com.uss.ion.rwd.service.RwardManageVO">
         <result property="rwardManId" column="RWARDWNR_ID"/> 

--- a/src/main/resources/egovframework/mapper/com/uss/ion/rwd/EgovRwardManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/rwd/EgovRwardManage_SQL_cubrid.xml
@@ -7,7 +7,7 @@
  --><!--Converted at: Wed May 11 15:51:20 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="rwardManageDAO">
+<mapper namespace="egovframework.com.uss.ion.rwd.service.impl.RwardManageMapper">
 
     <resultMap id="rwardManage" type="egovframework.com.uss.ion.rwd.service.RwardManageVO">
         <result property="rwardManId" column="RWARDWNR_ID"/> 

--- a/src/main/resources/egovframework/mapper/com/uss/ion/rwd/EgovRwardManage_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/rwd/EgovRwardManage_SQL_goldilocks.xml
@@ -7,7 +7,7 @@
  --><!--Converted at: Wed May 11 15:51:20 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="rwardManageDAO">
+<mapper namespace="egovframework.com.uss.ion.rwd.service.impl.RwardManageMapper">
 
     <resultMap id="rwardManage" type="egovframework.com.uss.ion.rwd.service.RwardManageVO">
         <result property="rwardManId" column="RWARDWNR_ID"/> 

--- a/src/main/resources/egovframework/mapper/com/uss/ion/rwd/EgovRwardManage_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/rwd/EgovRwardManage_SQL_maria.xml
@@ -7,7 +7,7 @@
  --><!--Converted at: Wed May 11 15:51:21 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="rwardManageDAO">
+<mapper namespace="egovframework.com.uss.ion.rwd.service.impl.RwardManageMapper">
 
     <resultMap id="rwardManage" type="egovframework.com.uss.ion.rwd.service.RwardManageVO">
         <result property="rwardManId" column="RWARDWNR_ID"/> 

--- a/src/main/resources/egovframework/mapper/com/uss/ion/rwd/EgovRwardManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/rwd/EgovRwardManage_SQL_mysql.xml
@@ -7,7 +7,7 @@
  --><!--Converted at: Wed May 11 15:51:21 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="rwardManageDAO">
+<mapper namespace="egovframework.com.uss.ion.rwd.service.impl.RwardManageMapper">
 
     <resultMap id="rwardManage" type="egovframework.com.uss.ion.rwd.service.RwardManageVO">
         <result property="rwardManId" column="RWARDWNR_ID"/> 

--- a/src/main/resources/egovframework/mapper/com/uss/ion/rwd/EgovRwardManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/rwd/EgovRwardManage_SQL_oracle.xml
@@ -7,7 +7,7 @@
  --><!--Converted at: Wed May 11 15:51:21 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="rwardManageDAO">
+<mapper namespace="egovframework.com.uss.ion.rwd.service.impl.RwardManageMapper">
 
     <resultMap id="rwardManage" type="egovframework.com.uss.ion.rwd.service.RwardManageVO">
         <result property="rwardManId" column="RWARDWNR_ID"/> 

--- a/src/main/resources/egovframework/mapper/com/uss/ion/rwd/EgovRwardManage_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/rwd/EgovRwardManage_SQL_postgres.xml
@@ -7,7 +7,7 @@
  --><!--Converted at: Wed May 11 15:51:21 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="rwardManageDAO">
+<mapper namespace="egovframework.com.uss.ion.rwd.service.impl.RwardManageMapper">
 
     <resultMap id="rwardManage" type="egovframework.com.uss.ion.rwd.service.RwardManageVO">
         <result property="rwardManId" column="RWARDWNR_ID"/> 

--- a/src/main/resources/egovframework/mapper/com/uss/ion/rwd/EgovRwardManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/rwd/EgovRwardManage_SQL_tibero.xml
@@ -7,7 +7,7 @@
  --><!--Converted at: Wed May 11 15:51:21 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="rwardManageDAO">
+<mapper namespace="egovframework.com.uss.ion.rwd.service.impl.RwardManageMapper">
 
     <resultMap id="rwardManage" type="egovframework.com.uss.ion.rwd.service.RwardManageVO">
         <result property="rwardManId" column="RWARDWNR_ID"/> 

--- a/src/main/resources/egovframework/mapper/com/uss/ion/vct/EgovVcatnManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/vct/EgovVcatnManage_SQL_altibase.xml
@@ -8,7 +8,7 @@
 --><!--Converted at: Wed May 11 15:51:25 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="vcatnManageDAO">
+<mapper namespace="egovframework.com.uss.ion.vct.service.impl.VcatnManageMapper">
 
     <select id="selectVcatnManageList" parameterType="egovframework.com.uss.ion.vct.service.VcatnManageVO" resultType="egovframework.com.uss.ion.vct.service.VcatnManageVO">
         <![CDATA[

--- a/src/main/resources/egovframework/mapper/com/uss/ion/vct/EgovVcatnManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/vct/EgovVcatnManage_SQL_cubrid.xml
@@ -8,7 +8,7 @@
 --><!--Converted at: Wed May 11 15:51:25 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="vcatnManageDAO">
+<mapper namespace="egovframework.com.uss.ion.vct.service.impl.VcatnManageMapper">
 
     <select id="selectVcatnManageList" parameterType="egovframework.com.uss.ion.vct.service.VcatnManageVO" resultType="egovframework.com.uss.ion.vct.service.VcatnManageVO">
         <![CDATA[

--- a/src/main/resources/egovframework/mapper/com/uss/ion/vct/EgovVcatnManage_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/vct/EgovVcatnManage_SQL_goldilocks.xml
@@ -8,7 +8,7 @@
 --><!--Converted at: Wed May 11 15:51:25 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="vcatnManageDAO">
+<mapper namespace="egovframework.com.uss.ion.vct.service.impl.VcatnManageMapper">
 
     <select id="selectVcatnManageList" parameterType="egovframework.com.uss.ion.vct.service.VcatnManageVO" resultType="egovframework.com.uss.ion.vct.service.VcatnManageVO">
         <![CDATA[

--- a/src/main/resources/egovframework/mapper/com/uss/ion/vct/EgovVcatnManage_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/vct/EgovVcatnManage_SQL_maria.xml
@@ -8,7 +8,7 @@
 --><!--Converted at: Wed May 11 15:51:25 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="vcatnManageDAO">
+<mapper namespace="egovframework.com.uss.ion.vct.service.impl.VcatnManageMapper">
 
     <select id="selectVcatnManageList" parameterType="egovframework.com.uss.ion.vct.service.VcatnManageVO" resultType="egovframework.com.uss.ion.vct.service.VcatnManageVO">
         

--- a/src/main/resources/egovframework/mapper/com/uss/ion/vct/EgovVcatnManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/vct/EgovVcatnManage_SQL_mysql.xml
@@ -8,7 +8,7 @@
 --><!--Converted at: Wed May 11 15:51:25 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="vcatnManageDAO">
+<mapper namespace="egovframework.com.uss.ion.vct.service.impl.VcatnManageMapper">
 
     <select id="selectVcatnManageList" parameterType="egovframework.com.uss.ion.vct.service.VcatnManageVO" resultType="egovframework.com.uss.ion.vct.service.VcatnManageVO">
         

--- a/src/main/resources/egovframework/mapper/com/uss/ion/vct/EgovVcatnManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/vct/EgovVcatnManage_SQL_oracle.xml
@@ -8,7 +8,7 @@
 --><!--Converted at: Wed May 11 15:51:25 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="vcatnManageDAO">
+<mapper namespace="egovframework.com.uss.ion.vct.service.impl.VcatnManageMapper">
 
     <select id="selectVcatnManageList" parameterType="egovframework.com.uss.ion.vct.service.VcatnManageVO" resultType="egovframework.com.uss.ion.vct.service.VcatnManageVO">
         <![CDATA[

--- a/src/main/resources/egovframework/mapper/com/uss/ion/vct/EgovVcatnManage_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/vct/EgovVcatnManage_SQL_postgres.xml
@@ -8,7 +8,7 @@
 --><!--Converted at: Wed May 11 15:51:25 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="vcatnManageDAO">
+<mapper namespace="egovframework.com.uss.ion.vct.service.impl.VcatnManageMapper">
 
     <select id="selectVcatnManageList" parameterType="egovframework.com.uss.ion.vct.service.VcatnManageVO" resultType="egovframework.com.uss.ion.vct.service.VcatnManageVO">
         

--- a/src/main/resources/egovframework/mapper/com/uss/ion/vct/EgovVcatnManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/vct/EgovVcatnManage_SQL_tibero.xml
@@ -8,7 +8,7 @@
 --><!--Converted at: Wed May 11 15:51:25 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="vcatnManageDAO">
+<mapper namespace="egovframework.com.uss.ion.vct.service.impl.VcatnManageMapper">
 
     <select id="selectVcatnManageList" parameterType="egovframework.com.uss.ion.vct.service.VcatnManageVO" resultType="egovframework.com.uss.ion.vct.service.VcatnManageVO">
         <![CDATA[

--- a/src/main/resources/egovframework/mapper/com/uss/ion/yrc/EgovIndvdlYrycManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/yrc/EgovIndvdlYrycManage_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:51:27 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="indvdlYrycDAO">
+<mapper namespace="egovframework.com.uss.ion.yrc.service.impl.IndvdlYrycMapper">
 
     <select id="selectIndvdlYrycManageList" parameterType="egovframework.com.uss.ion.yrc.service.IndvdlYrycManage" resultType="egovframework.com.uss.ion.yrc.service.IndvdlYrycManage">
         

--- a/src/main/resources/egovframework/mapper/com/uss/ion/yrc/EgovIndvdlYrycManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/yrc/EgovIndvdlYrycManage_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:51:27 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="indvdlYrycDAO">
+<mapper namespace="egovframework.com.uss.ion.yrc.service.impl.IndvdlYrycMapper">
 
     <select id="selectIndvdlYrycManageList" parameterType="egovframework.com.uss.ion.yrc.service.IndvdlYrycManage" resultType="egovframework.com.uss.ion.yrc.service.IndvdlYrycManage">
         

--- a/src/main/resources/egovframework/mapper/com/uss/ion/yrc/EgovIndvdlYrycManage_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/yrc/EgovIndvdlYrycManage_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:51:27 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="indvdlYrycDAO">
+<mapper namespace="egovframework.com.uss.ion.yrc.service.impl.IndvdlYrycMapper">
 
     <select id="selectIndvdlYrycManageList" parameterType="egovframework.com.uss.ion.yrc.service.IndvdlYrycManage" resultType="egovframework.com.uss.ion.yrc.service.IndvdlYrycManage">
         

--- a/src/main/resources/egovframework/mapper/com/uss/ion/yrc/EgovIndvdlYrycManage_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/yrc/EgovIndvdlYrycManage_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:51:27 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="indvdlYrycDAO">
+<mapper namespace="egovframework.com.uss.ion.yrc.service.impl.IndvdlYrycMapper">
 
     <select id="selectIndvdlYrycManageList" parameterType="egovframework.com.uss.ion.yrc.service.IndvdlYrycManage" resultType="egovframework.com.uss.ion.yrc.service.IndvdlYrycManage">
         

--- a/src/main/resources/egovframework/mapper/com/uss/ion/yrc/EgovIndvdlYrycManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/yrc/EgovIndvdlYrycManage_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:51:27 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="indvdlYrycDAO">
+<mapper namespace="egovframework.com.uss.ion.yrc.service.impl.IndvdlYrycMapper">
 
     <select id="selectIndvdlYrycManageList" parameterType="egovframework.com.uss.ion.yrc.service.IndvdlYrycManage" resultType="egovframework.com.uss.ion.yrc.service.IndvdlYrycManage">
         

--- a/src/main/resources/egovframework/mapper/com/uss/ion/yrc/EgovIndvdlYrycManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/yrc/EgovIndvdlYrycManage_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:51:27 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="indvdlYrycDAO">
+<mapper namespace="egovframework.com.uss.ion.yrc.service.impl.IndvdlYrycMapper">
 
     <select id="selectIndvdlYrycManageList" parameterType="egovframework.com.uss.ion.yrc.service.IndvdlYrycManage" resultType="egovframework.com.uss.ion.yrc.service.IndvdlYrycManage">
         

--- a/src/main/resources/egovframework/mapper/com/uss/ion/yrc/EgovIndvdlYrycManage_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/yrc/EgovIndvdlYrycManage_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:51:27 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="indvdlYrycDAO">
+<mapper namespace="egovframework.com.uss.ion.yrc.service.impl.IndvdlYrycMapper">
 
     <select id="selectIndvdlYrycManageList" parameterType="egovframework.com.uss.ion.yrc.service.IndvdlYrycManage" resultType="egovframework.com.uss.ion.yrc.service.IndvdlYrycManage">
         

--- a/src/main/resources/egovframework/mapper/com/uss/ion/yrc/EgovIndvdlYrycManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/yrc/EgovIndvdlYrycManage_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:51:27 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="indvdlYrycDAO">
+<mapper namespace="egovframework.com.uss.ion.yrc.service.impl.IndvdlYrycMapper">
 
     <select id="selectIndvdlYrycManageList" parameterType="egovframework.com.uss.ion.yrc.service.IndvdlYrycManage" resultType="egovframework.com.uss.ion.yrc.service.IndvdlYrycManage">
         

--- a/src/main/resources/egovframework/spring/com/context-mapper.xml
+++ b/src/main/resources/egovframework/spring/com/context-mapper.xml
@@ -21,5 +21,12 @@
 	<bean id="egov.sqlSessionTemplate" class="org.mybatis.spring.SqlSessionTemplate">
 		<constructor-arg ref="egov.sqlSession"/>
 	</bean>
-	
+
+	<!-- @EgovMapper 어노테이션이 붙은 인터페이스를 자동으로 스캔하여 빈으로 등록 -->
+	<bean class="org.mybatis.spring.mapper.MapperScannerConfigurer">
+		<property name="basePackage" value="egovframework.com"/>
+		<property name="annotationClass" value="org.egovframe.rte.psl.dataaccess.mapper.EgovMapper"/>
+		<property name="sqlSessionFactoryBeanName" value="egov.sqlSession"/>
+	</bean>
+
 </beans>


### PR DESCRIPTION
## 변경 사유
기존 XML namespace 기반 DAO를 eGovFrame 5.0 신규 `@EgovMapper` 인터페이스 방식으로 전환합니다.

## 변경 내용
- 대상: uss/ion 하위 7개 모듈 DAO
- 각 DAO에 대응하는 Mapper 인터페이스(`@EgovMapper`) 신규 추가
- DAO를 mapper 위임 구조로 리팩토링 (EgovComAbstractDAO 상속 제거, @Resource 주입, @Repository bean name 유지)
- XML mapper namespace를 mapper 인터페이스 FQN으로 변경
- context-mapper.xml에 MapperScannerConfigurer(annotationClass=EgovMapper) 추가

## 영향 범위
- 해당 모듈만 영향, 서비스 레이어 호출 시그니처 변경 없음

## 참고
- 빌드 검증을 위해 #891(Lombok annotationProcessorPaths 빌드 수정) 선행 머지 권장
- context-mapper.xml MapperScannerConfigurer는 동일 시리즈 PR과 한 줄 중복될 수 있어, 선행 PR 머지 후 rebase로 정리 가능

## 체크리스트
- [x] 단일 주제만 다룸
- [x] 컴파일 검증(해당 모듈 신규 오류 0)
- [x] 기존 동작 호환
