### PR TITLE
[refactor][5.0.x][공통컴포넌트] uss/olh 6개 DAO @EgovMapper 인터페이스 전환

### DIFF
--- a/src/main/java/egovframework/com/uss/olh/awm/service/impl/EgovAdministrationWordDAO.java
+++ b/src/main/java/egovframework/com/uss/olh/awm/service/impl/EgovAdministrationWordDAO.java
@@ -4,34 +4,38 @@ import java.util.List;
 
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.uss.olh.awm.service.AdministrationWordVO;
 
+import jakarta.annotation.Resource;
+
 @Repository("EgovAdministrationWordDAO")
-public class EgovAdministrationWordDAO extends EgovComAbstractDAO {
+public class EgovAdministrationWordDAO {
+
+	@Resource(name = "EgovAdministrationWordMapper")
+	private EgovAdministrationWordMapper egovAdministrationWordMapper;
 
 	public List<AdministrationWordVO> selectAdministrationWordList(AdministrationWordVO searchVO) {
-		return selectList("AdministrationWord.selectAdministrationWordList", searchVO);
+		return egovAdministrationWordMapper.selectAdministrationWordList(searchVO);
 	}
 
 	public int selectAdministrationWordListCnt(AdministrationWordVO searchVO) {
-		return (Integer) selectOne("AdministrationWord.selectAdministrationWordListCnt", searchVO);
+		return egovAdministrationWordMapper.selectAdministrationWordListCnt(searchVO);
 	}
 
 	public AdministrationWordVO selectAdministrationWordDetail(AdministrationWordVO administrationWord) {
-		return (AdministrationWordVO) selectOne("AdministrationWord.selectAdministrationWordDetail", administrationWord);
+		return egovAdministrationWordMapper.selectAdministrationWordDetail(administrationWord);
 	}
 
 	public void insertAdministrationWord(AdministrationWordVO administrationWordVO) {
-		insert("AdministrationWord.insertAdministrationWord", administrationWordVO);
+		egovAdministrationWordMapper.insertAdministrationWord(administrationWordVO);
 	}
 
 	public void updateAdministrationWord(AdministrationWordVO administrationWordVO) {
-		update("AdministrationWord.updateAdministrationWord", administrationWordVO);
+		egovAdministrationWordMapper.updateAdministrationWord(administrationWordVO);
 	}
 
 	public void deleteAdministrationWord(AdministrationWordVO administrationWordVO) {
-		delete("AdministrationWord.deleteAdministrationWord", administrationWordVO);
+		egovAdministrationWordMapper.deleteAdministrationWord(administrationWordVO);
 	}
 
 }

--- a/src/main/java/egovframework/com/uss/olh/awm/service/impl/EgovAdministrationWordMapper.java
+++ b/src/main/java/egovframework/com/uss/olh/awm/service/impl/EgovAdministrationWordMapper.java
@@ -1,0 +1,39 @@
+package egovframework.com.uss.olh.awm.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.uss.olh.awm.service.AdministrationWordVO;
+
+/**
+ * 행정용어사전 정보를 관리하기 위한 Mapper 인터페이스
+ * @author 공통서비스 개발팀
+ * @since 2009.04.01
+ * @version 1.0
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일         수정자       수정내용
+ *  ----------    --------    ---------------------------
+ *   2009.04.01    개발팀       최초 생성
+ *
+ * </pre>
+ */
+@EgovMapper
+public interface EgovAdministrationWordMapper {
+
+	List<AdministrationWordVO> selectAdministrationWordList(AdministrationWordVO searchVO);
+
+	int selectAdministrationWordListCnt(AdministrationWordVO searchVO);
+
+	AdministrationWordVO selectAdministrationWordDetail(AdministrationWordVO administrationWord);
+
+	void insertAdministrationWord(AdministrationWordVO administrationWordVO);
+
+	void updateAdministrationWord(AdministrationWordVO administrationWordVO);
+
+	void deleteAdministrationWord(AdministrationWordVO administrationWordVO);
+
+}

--- a/src/main/java/egovframework/com/uss/olh/faq/service/impl/EgovFaqDAO.java
+++ b/src/main/java/egovframework/com/uss/olh/faq/service/impl/EgovFaqDAO.java
@@ -4,38 +4,42 @@ import java.util.List;
 
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.uss.olh.faq.service.FaqVO;
 
+import jakarta.annotation.Resource;
+
 @Repository("EgovFaqDAO")
-public class EgovFaqDAO extends EgovComAbstractDAO {
+public class EgovFaqDAO {
+
+	@Resource(name = "EgovFaqMapper")
+	private EgovFaqMapper egovFaqMapper;
 
 	public List<FaqVO> selectFaqList(FaqVO searchVO) {
-		return selectList("FaqManage.selectFaqList", searchVO);
+		return egovFaqMapper.selectFaqList(searchVO);
 	}
 
 	public int selectFaqListCnt(FaqVO searchVO) {
-		return (Integer) selectOne("FaqManage.selectFaqListCnt", searchVO);
+		return egovFaqMapper.selectFaqListCnt(searchVO);
 	}
 
 	public void updateFaqInqireCo(FaqVO searchVO) {
-		update("FaqManage.updateFaqInqireCo", searchVO);
+		egovFaqMapper.updateFaqInqireCo(searchVO);
 	}
 
 	public FaqVO selectFaqDetail(FaqVO searchVO) {
-		return (FaqVO) selectOne("FaqManage.selectFaqDetail", searchVO);
+		return egovFaqMapper.selectFaqDetail(searchVO);
 	}
 
 	public void insertFaq(FaqVO faqVO) {
-		insert("FaqManage.insertFaq", faqVO);
+		egovFaqMapper.insertFaq(faqVO);
 	}
 
 	public void updateFaq(FaqVO faqVO) {
-		update("FaqManage.updateFaq", faqVO);
+		egovFaqMapper.updateFaq(faqVO);
 	}
 
 	public void deleteFaq(FaqVO faqVO) {
-		delete("FaqManage.deleteFaq", faqVO);
+		egovFaqMapper.deleteFaq(faqVO);
 	}
 
 }

--- a/src/main/java/egovframework/com/uss/olh/faq/service/impl/EgovFaqMapper.java
+++ b/src/main/java/egovframework/com/uss/olh/faq/service/impl/EgovFaqMapper.java
@@ -1,0 +1,41 @@
+package egovframework.com.uss.olh.faq.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.uss.olh.faq.service.FaqVO;
+
+/**
+ * FAQ 정보를 관리하기 위한 Mapper 인터페이스
+ * @author 공통서비스 개발팀
+ * @since 2009.04.01
+ * @version 1.0
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일         수정자       수정내용
+ *  ----------    --------    ---------------------------
+ *   2009.04.01    개발팀       최초 생성
+ *
+ * </pre>
+ */
+@EgovMapper
+public interface EgovFaqMapper {
+
+	List<FaqVO> selectFaqList(FaqVO searchVO);
+
+	int selectFaqListCnt(FaqVO searchVO);
+
+	void updateFaqInqireCo(FaqVO searchVO);
+
+	FaqVO selectFaqDetail(FaqVO searchVO);
+
+	void insertFaq(FaqVO faqVO);
+
+	void updateFaq(FaqVO faqVO);
+
+	void deleteFaq(FaqVO faqVO);
+
+}

--- a/src/main/java/egovframework/com/uss/olh/hpc/service/impl/EgovHpcmDAO.java
+++ b/src/main/java/egovframework/com/uss/olh/hpc/service/impl/EgovHpcmDAO.java
@@ -4,35 +4,39 @@ import java.util.List;
 
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.uss.olh.hpc.service.HpcmDefaultVO;
 import egovframework.com.uss.olh.hpc.service.HpcmVO;
 
+import jakarta.annotation.Resource;
+
 @Repository("EgovHpcmDAO")
-public class EgovHpcmDAO extends EgovComAbstractDAO {
+public class EgovHpcmDAO {
+
+	@Resource(name = "EgovHpcmMapper")
+	private EgovHpcmMapper egovHpcmMapper;
 
 	public List<HpcmVO> selectHpcmList(HpcmDefaultVO searchVO) {
-		return selectList("Hpcm.selectHpcmList", searchVO);
+		return egovHpcmMapper.selectHpcmList(searchVO);
 	}
 
 	public int selectHpcmListCnt(HpcmDefaultVO searchVO) {
-		return (Integer)selectOne("Hpcm.selectHpcmListCnt", searchVO);
+		return egovHpcmMapper.selectHpcmListCnt(searchVO);
 	}
 
 	public HpcmVO selectHpcmDetail(HpcmVO hpcmManageVO) {
-		return (HpcmVO) selectOne("Hpcm.selectHpcmDetail", hpcmManageVO);
+		return egovHpcmMapper.selectHpcmDetail(hpcmManageVO);
 	}
 
 	public void insertHpcm(HpcmVO hpcmVO) {
-		insert ("Hpcm.insertHpcm", hpcmVO);
+		egovHpcmMapper.insertHpcm(hpcmVO);
 	}
 
 	public void updateHpcm(HpcmVO hpcmVO) {
-		update("Hpcm.updateHpcm", hpcmVO);
+		egovHpcmMapper.updateHpcm(hpcmVO);
 	}
 
 	public void deleteHpcm(HpcmVO hpcmVO) {
-		delete("Hpcm.deleteHpcm", hpcmVO);
+		egovHpcmMapper.deleteHpcm(hpcmVO);
 	}
 
 }

--- a/src/main/java/egovframework/com/uss/olh/hpc/service/impl/EgovHpcmMapper.java
+++ b/src/main/java/egovframework/com/uss/olh/hpc/service/impl/EgovHpcmMapper.java
@@ -1,0 +1,40 @@
+package egovframework.com.uss.olh.hpc.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.uss.olh.hpc.service.HpcmDefaultVO;
+import egovframework.com.uss.olh.hpc.service.HpcmVO;
+
+/**
+ * 헬프케어 정보를 관리하기 위한 Mapper 인터페이스
+ * @author 공통서비스 개발팀
+ * @since 2009.04.01
+ * @version 1.0
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일         수정자       수정내용
+ *  ----------    --------    ---------------------------
+ *   2009.04.01    개발팀       최초 생성
+ *
+ * </pre>
+ */
+@EgovMapper
+public interface EgovHpcmMapper {
+
+	List<HpcmVO> selectHpcmList(HpcmDefaultVO searchVO);
+
+	int selectHpcmListCnt(HpcmDefaultVO searchVO);
+
+	HpcmVO selectHpcmDetail(HpcmVO hpcmManageVO);
+
+	void insertHpcm(HpcmVO hpcmVO);
+
+	void updateHpcm(HpcmVO hpcmVO);
+
+	void deleteHpcm(HpcmVO hpcmVO);
+
+}

--- a/src/main/java/egovframework/com/uss/olh/omm/service/impl/EgovOnlineManualDAO.java
+++ b/src/main/java/egovframework/com/uss/olh/omm/service/impl/EgovOnlineManualDAO.java
@@ -4,34 +4,38 @@ import java.util.List;
 
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.uss.olh.omm.service.OnlineManualVO;
 
+import jakarta.annotation.Resource;
+
 @Repository("EgovOnlineManualDAO")
-public class EgovOnlineManualDAO extends EgovComAbstractDAO {
+public class EgovOnlineManualDAO {
+
+	@Resource(name = "EgovOnlineManualMapper")
+	private EgovOnlineManualMapper egovOnlineManualMapper;
 
 	public List<OnlineManualVO> selectOnlineManualList(OnlineManualVO searchVO) {
-		return selectList("OnlineManual.selectOnlineManualList", searchVO);
+		return egovOnlineManualMapper.selectOnlineManualList(searchVO);
 	}
 
 	public int selectOnlineManualListCnt(OnlineManualVO searchVO) {
-		return (Integer) selectOne("OnlineManual.selectOnlineManualListCnt", searchVO);
+		return egovOnlineManualMapper.selectOnlineManualListCnt(searchVO);
 	}
 
 	public OnlineManualVO selectOnlineManualDetail(OnlineManualVO onlineManualVO) {
-		return (OnlineManualVO) selectOne("OnlineManual.selectOnlineManualDetail", onlineManualVO);
+		return egovOnlineManualMapper.selectOnlineManualDetail(onlineManualVO);
 	}
 
 	public void insertOnlineManual(OnlineManualVO onlineManualVO) {
-		insert("OnlineManual.insertOnlineManual", onlineManualVO);
+		egovOnlineManualMapper.insertOnlineManual(onlineManualVO);
 	}
 
 	public void updateOnlineManual(OnlineManualVO onlineManualVO) {
-		update("OnlineManual.updateOnlineManual", onlineManualVO);
+		egovOnlineManualMapper.updateOnlineManual(onlineManualVO);
 	}
 
 	public void deleteOnlineManual(OnlineManualVO onlineManualVO) {
-		delete("OnlineManual.deleteOnlineManual", onlineManualVO);
+		egovOnlineManualMapper.deleteOnlineManual(onlineManualVO);
 	}
 
 }

--- a/src/main/java/egovframework/com/uss/olh/omm/service/impl/EgovOnlineManualMapper.java
+++ b/src/main/java/egovframework/com/uss/olh/omm/service/impl/EgovOnlineManualMapper.java
@@ -1,0 +1,39 @@
+package egovframework.com.uss.olh.omm.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.uss.olh.omm.service.OnlineManualVO;
+
+/**
+ * 온라인매뉴얼 정보를 관리하기 위한 Mapper 인터페이스
+ * @author 공통서비스 개발팀
+ * @since 2009.04.01
+ * @version 1.0
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일         수정자       수정내용
+ *  ----------    --------    ---------------------------
+ *   2009.04.01    개발팀       최초 생성
+ *
+ * </pre>
+ */
+@EgovMapper
+public interface EgovOnlineManualMapper {
+
+	List<OnlineManualVO> selectOnlineManualList(OnlineManualVO searchVO);
+
+	int selectOnlineManualListCnt(OnlineManualVO searchVO);
+
+	OnlineManualVO selectOnlineManualDetail(OnlineManualVO onlineManualVO);
+
+	void insertOnlineManual(OnlineManualVO onlineManualVO);
+
+	void updateOnlineManual(OnlineManualVO onlineManualVO);
+
+	void deleteOnlineManual(OnlineManualVO onlineManualVO);
+
+}

--- a/src/main/java/egovframework/com/uss/olh/qna/service/impl/EgovQnaDAO.java
+++ b/src/main/java/egovframework/com/uss/olh/qna/service/impl/EgovQnaDAO.java
@@ -4,50 +4,54 @@ import java.util.List;
 
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.uss.olh.qna.service.QnaVO;
 
+import jakarta.annotation.Resource;
+
 @Repository("EgovQnaDAO")
-public class EgovQnaDAO extends EgovComAbstractDAO {
+public class EgovQnaDAO {
+
+	@Resource(name = "EgovQnaMapper")
+	private EgovQnaMapper egovQnaMapper;
 
 	public List<QnaVO> selectQnaList(QnaVO searchVO) {
-		return selectList("QnaManage.selectQnaList", searchVO);
+		return egovQnaMapper.selectQnaList(searchVO);
 	}
 
 	public int selectQnaListCnt(QnaVO searchVO) {
-		return (Integer) selectOne("QnaManage.selectQnaListCnt", searchVO);
+		return egovQnaMapper.selectQnaListCnt(searchVO);
 	}
 
 	public QnaVO selectQnaDetail(QnaVO qnaVO) {
-		return (QnaVO) selectOne("QnaManage.selectQnaDetail", qnaVO);
+		return egovQnaMapper.selectQnaDetail(qnaVO);
 	}
 
 	public void updateQnaInqireCo(QnaVO qnaVO) {
-		update("QnaManage.updateQnaInqireCo", qnaVO);
+		egovQnaMapper.updateQnaInqireCo(qnaVO);
 	}
 
 	public void insertQna(QnaVO qnaVO) {
-		insert("QnaManage.insertQna", qnaVO);
+		egovQnaMapper.insertQna(qnaVO);
 	}
 
 	public void updateQna(QnaVO qnaVO) {
-		update("QnaManage.updateQna", qnaVO);
+		egovQnaMapper.updateQna(qnaVO);
 	}
 
 	public void deleteQna(QnaVO qnaVO) {
-		delete("QnaManage.deleteQna", qnaVO);
+		egovQnaMapper.deleteQna(qnaVO);
 	}
 
 	public List<QnaVO> selectQnaAnswerList(QnaVO searchVO) {
-		return selectList("QnaManage.selectQnaAnswerList", searchVO);
+		return egovQnaMapper.selectQnaAnswerList(searchVO);
 	}
 
 	public int selectQnaAnswerListCnt(QnaVO searchVO) {
-		return (Integer) selectOne("QnaManage.selectQnaAnswerListCnt", searchVO);
+		return egovQnaMapper.selectQnaAnswerListCnt(searchVO);
 	}
 
 	public void updateQnaAnswer(QnaVO qnaVO) {
-		update("QnaManage.updateQnaAnswer", qnaVO);
+		egovQnaMapper.updateQnaAnswer(qnaVO);
 	}
 
 }

--- a/src/main/java/egovframework/com/uss/olh/qna/service/impl/EgovQnaMapper.java
+++ b/src/main/java/egovframework/com/uss/olh/qna/service/impl/EgovQnaMapper.java
@@ -1,0 +1,47 @@
+package egovframework.com.uss.olh.qna.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.uss.olh.qna.service.QnaVO;
+
+/**
+ * Q&A 정보를 관리하기 위한 Mapper 인터페이스
+ * @author 공통서비스 개발팀
+ * @since 2009.04.01
+ * @version 1.0
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일         수정자       수정내용
+ *  ----------    --------    ---------------------------
+ *   2009.04.01    개발팀       최초 생성
+ *
+ * </pre>
+ */
+@EgovMapper
+public interface EgovQnaMapper {
+
+	List<QnaVO> selectQnaList(QnaVO searchVO);
+
+	int selectQnaListCnt(QnaVO searchVO);
+
+	QnaVO selectQnaDetail(QnaVO qnaVO);
+
+	void updateQnaInqireCo(QnaVO qnaVO);
+
+	void insertQna(QnaVO qnaVO);
+
+	void updateQna(QnaVO qnaVO);
+
+	void deleteQna(QnaVO qnaVO);
+
+	List<QnaVO> selectQnaAnswerList(QnaVO searchVO);
+
+	int selectQnaAnswerListCnt(QnaVO searchVO);
+
+	void updateQnaAnswer(QnaVO qnaVO);
+
+}

--- a/src/main/java/egovframework/com/uss/olh/wor/service/impl/EgovWordDicaryDAO.java
+++ b/src/main/java/egovframework/com/uss/olh/wor/service/impl/EgovWordDicaryDAO.java
@@ -4,34 +4,38 @@ import java.util.List;
 
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.uss.olh.wor.service.WordDicaryVO;
 
+import jakarta.annotation.Resource;
+
 @Repository("EgovWordDicaryDAO")
-public class EgovWordDicaryDAO extends EgovComAbstractDAO {
+public class EgovWordDicaryDAO {
+
+	@Resource(name = "EgovWordDicaryMapper")
+	private EgovWordDicaryMapper egovWordDicaryMapper;
 
 	public List<WordDicaryVO> selectWordDicaryList(WordDicaryVO searchVO) {
-		return selectList("WordDicary.selectWordDicaryList", searchVO);
+		return egovWordDicaryMapper.selectWordDicaryList(searchVO);
 	}
 
 	public int selectWordDicaryListCnt(WordDicaryVO searchVO) {
-		return (Integer)selectOne("WordDicary.selectWordDicaryListCnt", searchVO);
+		return egovWordDicaryMapper.selectWordDicaryListCnt(searchVO);
 	}
 
 	public WordDicaryVO selectWordDicaryDetail(WordDicaryVO wordDicaryVO) {
-		return (WordDicaryVO)selectOne("WordDicary.selectWordDicaryDetail", wordDicaryVO);
+		return egovWordDicaryMapper.selectWordDicaryDetail(wordDicaryVO);
 	}
 
 	public void insertWordDicary(WordDicaryVO wordDicaryVO) {
-		insert("WordDicary.insertWordDicary", wordDicaryVO);
+		egovWordDicaryMapper.insertWordDicary(wordDicaryVO);
 	}
 
 	public void updateWordDicary(WordDicaryVO wordDicaryVO) {
-		update("WordDicary.updateWordDicary", wordDicaryVO);
+		egovWordDicaryMapper.updateWordDicary(wordDicaryVO);
 	}
 
 	public void deleteWordDicary(WordDicaryVO wordDicaryVO) {
-		delete("WordDicary.deleteWordDicary", wordDicaryVO);
+		egovWordDicaryMapper.deleteWordDicary(wordDicaryVO);
 	}
 
 }

--- a/src/main/java/egovframework/com/uss/olh/wor/service/impl/EgovWordDicaryMapper.java
+++ b/src/main/java/egovframework/com/uss/olh/wor/service/impl/EgovWordDicaryMapper.java
@@ -1,0 +1,39 @@
+package egovframework.com.uss.olh.wor.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.uss.olh.wor.service.WordDicaryVO;
+
+/**
+ * 단어사전 정보를 관리하기 위한 Mapper 인터페이스
+ * @author 공통서비스 개발팀
+ * @since 2009.04.01
+ * @version 1.0
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일         수정자       수정내용
+ *  ----------    --------    ---------------------------
+ *   2009.04.01    개발팀       최초 생성
+ *
+ * </pre>
+ */
+@EgovMapper
+public interface EgovWordDicaryMapper {
+
+	List<WordDicaryVO> selectWordDicaryList(WordDicaryVO searchVO);
+
+	int selectWordDicaryListCnt(WordDicaryVO searchVO);
+
+	WordDicaryVO selectWordDicaryDetail(WordDicaryVO wordDicaryVO);
+
+	void insertWordDicary(WordDicaryVO wordDicaryVO);
+
+	void updateWordDicary(WordDicaryVO wordDicaryVO);
+
+	void deleteWordDicary(WordDicaryVO wordDicaryVO);
+
+}

--- a/src/main/resources/egovframework/mapper/com/uss/olh/awm/EgovAdministrationWord_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olh/awm/EgovAdministrationWord_SQL_altibase.xml
@@ -10,7 +10,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="AdministrationWord">
+<mapper namespace="egovframework.com.uss.olh.awm.service.impl.EgovAdministrationWordMapper">
 
 	<!-- 행정전문용어사전::ResultMap 선언 -->
 	<resultMap id="AdministrationWordVO" type="egovframework.com.uss.olh.awm.service.AdministrationWordVO">

--- a/src/main/resources/egovframework/mapper/com/uss/olh/awm/EgovAdministrationWord_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olh/awm/EgovAdministrationWord_SQL_cubrid.xml
@@ -10,7 +10,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="AdministrationWord">
+<mapper namespace="egovframework.com.uss.olh.awm.service.impl.EgovAdministrationWordMapper">
 
 	<!-- 행정전문용어사전::ResultMap 선언 -->
 	<resultMap id="AdministrationWordVO" type="egovframework.com.uss.olh.awm.service.AdministrationWordVO">

--- a/src/main/resources/egovframework/mapper/com/uss/olh/awm/EgovAdministrationWord_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olh/awm/EgovAdministrationWord_SQL_goldilocks.xml
@@ -10,7 +10,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="AdministrationWord">
+<mapper namespace="egovframework.com.uss.olh.awm.service.impl.EgovAdministrationWordMapper">
 
 	<!-- 행정전문용어사전::ResultMap 선언 -->
 	<resultMap id="AdministrationWordVO" type="egovframework.com.uss.olh.awm.service.AdministrationWordVO">

--- a/src/main/resources/egovframework/mapper/com/uss/olh/awm/EgovAdministrationWord_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olh/awm/EgovAdministrationWord_SQL_maria.xml
@@ -10,7 +10,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="AdministrationWord">
+<mapper namespace="egovframework.com.uss.olh.awm.service.impl.EgovAdministrationWordMapper">
 
 	<!-- 행정전문용어사전::ResultMap 선언 -->
 	<resultMap id="AdministrationWordVO" type="egovframework.com.uss.olh.awm.service.AdministrationWordVO">

--- a/src/main/resources/egovframework/mapper/com/uss/olh/awm/EgovAdministrationWord_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olh/awm/EgovAdministrationWord_SQL_mysql.xml
@@ -10,7 +10,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="AdministrationWord">
+<mapper namespace="egovframework.com.uss.olh.awm.service.impl.EgovAdministrationWordMapper">
 
 	<!-- 행정전문용어사전::ResultMap 선언 -->
 	<resultMap id="AdministrationWordVO" type="egovframework.com.uss.olh.awm.service.AdministrationWordVO">

--- a/src/main/resources/egovframework/mapper/com/uss/olh/awm/EgovAdministrationWord_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olh/awm/EgovAdministrationWord_SQL_oracle.xml
@@ -10,7 +10,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="AdministrationWord">
+<mapper namespace="egovframework.com.uss.olh.awm.service.impl.EgovAdministrationWordMapper">
 
 	<!-- 행정전문용어사전::ResultMap 선언 -->
 	<resultMap id="AdministrationWordVO" type="egovframework.com.uss.olh.awm.service.AdministrationWordVO">

--- a/src/main/resources/egovframework/mapper/com/uss/olh/awm/EgovAdministrationWord_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olh/awm/EgovAdministrationWord_SQL_postgres.xml
@@ -10,7 +10,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="AdministrationWord">
+<mapper namespace="egovframework.com.uss.olh.awm.service.impl.EgovAdministrationWordMapper">
 
 	<!-- 행정전문용어사전::ResultMap 선언 -->
 	<resultMap id="AdministrationWordVO" type="egovframework.com.uss.olh.awm.service.AdministrationWordVO">

--- a/src/main/resources/egovframework/mapper/com/uss/olh/awm/EgovAdministrationWord_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olh/awm/EgovAdministrationWord_SQL_tibero.xml
@@ -10,7 +10,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="AdministrationWord">
+<mapper namespace="egovframework.com.uss.olh.awm.service.impl.EgovAdministrationWordMapper">
 
 	<!-- 행정전문용어사전::ResultMap 선언 -->
 	<resultMap id="AdministrationWordVO" type="egovframework.com.uss.olh.awm.service.AdministrationWordVO">

--- a/src/main/resources/egovframework/mapper/com/uss/olh/faq/EgovFaqManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olh/faq/EgovFaqManage_SQL_altibase.xml
@@ -9,7 +9,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="FaqManage">
+<mapper namespace="egovframework.com.uss.olh.faq.service.impl.EgovFaqMapper">
 
 	<resultMap id="FaqManage" type="egovframework.com.uss.olh.faq.service.FaqVO">
 		<result property="faqId" column="FAQ_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/olh/faq/EgovFaqManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olh/faq/EgovFaqManage_SQL_cubrid.xml
@@ -9,7 +9,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="FaqManage">
+<mapper namespace="egovframework.com.uss.olh.faq.service.impl.EgovFaqMapper">
 
 	<resultMap id="FaqManage" type="egovframework.com.uss.olh.faq.service.FaqVO">
 		<result property="faqId" column="FAQ_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/olh/faq/EgovFaqManage_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olh/faq/EgovFaqManage_SQL_goldilocks.xml
@@ -9,7 +9,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="FaqManage">
+<mapper namespace="egovframework.com.uss.olh.faq.service.impl.EgovFaqMapper">
 
 	<resultMap id="FaqManage" type="egovframework.com.uss.olh.faq.service.FaqVO">
 		<result property="faqId" column="FAQ_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/olh/faq/EgovFaqManage_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olh/faq/EgovFaqManage_SQL_maria.xml
@@ -9,7 +9,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="FaqManage">
+<mapper namespace="egovframework.com.uss.olh.faq.service.impl.EgovFaqMapper">
 
 	<resultMap id="FaqManage" type="egovframework.com.uss.olh.faq.service.FaqVO">
 		<result property="faqId" column="FAQ_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/olh/faq/EgovFaqManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olh/faq/EgovFaqManage_SQL_mysql.xml
@@ -9,7 +9,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="FaqManage">
+<mapper namespace="egovframework.com.uss.olh.faq.service.impl.EgovFaqMapper">
 
 	<resultMap id="FaqManage" type="egovframework.com.uss.olh.faq.service.FaqVO">
 		<result property="faqId" column="FAQ_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/olh/faq/EgovFaqManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olh/faq/EgovFaqManage_SQL_oracle.xml
@@ -9,7 +9,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="FaqManage">
+<mapper namespace="egovframework.com.uss.olh.faq.service.impl.EgovFaqMapper">
 
 	<resultMap id="FaqManage" type="egovframework.com.uss.olh.faq.service.FaqVO">
 		<result property="faqId" column="FAQ_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/olh/faq/EgovFaqManage_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olh/faq/EgovFaqManage_SQL_postgres.xml
@@ -9,7 +9,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="FaqManage">
+<mapper namespace="egovframework.com.uss.olh.faq.service.impl.EgovFaqMapper">
 
 	<resultMap id="FaqManage" type="egovframework.com.uss.olh.faq.service.FaqVO">
 		<result property="faqId" column="FAQ_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/olh/faq/EgovFaqManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olh/faq/EgovFaqManage_SQL_tibero.xml
@@ -9,7 +9,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="FaqManage">
+<mapper namespace="egovframework.com.uss.olh.faq.service.impl.EgovFaqMapper">
 
 	<resultMap id="FaqManage" type="egovframework.com.uss.olh.faq.service.FaqVO">
 		<result property="faqId" column="FAQ_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/olh/hpc/EgovHpcm_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olh/hpc/EgovHpcm_SQL_altibase.xml
@@ -6,7 +6,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="Hpcm">
+<mapper namespace="egovframework.com.uss.olh.hpc.service.impl.EgovHpcmMapper">
 
 	<resultMap id="HpcmManage" type="egovframework.com.uss.olh.hpc.service.HpcmVO">
 		<result property="hpcmId" column="HPCM_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/olh/hpc/EgovHpcm_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olh/hpc/EgovHpcm_SQL_cubrid.xml
@@ -6,7 +6,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="Hpcm">
+<mapper namespace="egovframework.com.uss.olh.hpc.service.impl.EgovHpcmMapper">
 
 	<resultMap id="HpcmManage" type="egovframework.com.uss.olh.hpc.service.HpcmVO">
 		<result property="hpcmId" column="HPCM_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/olh/hpc/EgovHpcm_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olh/hpc/EgovHpcm_SQL_goldilocks.xml
@@ -6,7 +6,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="Hpcm">
+<mapper namespace="egovframework.com.uss.olh.hpc.service.impl.EgovHpcmMapper">
 
 	<resultMap id="HpcmManage" type="egovframework.com.uss.olh.hpc.service.HpcmVO">
 		<result property="hpcmId" column="HPCM_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/olh/hpc/EgovHpcm_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olh/hpc/EgovHpcm_SQL_maria.xml
@@ -6,7 +6,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="Hpcm">
+<mapper namespace="egovframework.com.uss.olh.hpc.service.impl.EgovHpcmMapper">
 
 	<resultMap id="HpcmManage" type="egovframework.com.uss.olh.hpc.service.HpcmVO">
 		<result property="hpcmId" column="HPCM_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/olh/hpc/EgovHpcm_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olh/hpc/EgovHpcm_SQL_mysql.xml
@@ -6,7 +6,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="Hpcm">
+<mapper namespace="egovframework.com.uss.olh.hpc.service.impl.EgovHpcmMapper">
 
 	<resultMap id="HpcmManage" type="egovframework.com.uss.olh.hpc.service.HpcmVO">
 		<result property="hpcmId" column="HPCM_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/olh/hpc/EgovHpcm_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olh/hpc/EgovHpcm_SQL_oracle.xml
@@ -6,7 +6,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="Hpcm">
+<mapper namespace="egovframework.com.uss.olh.hpc.service.impl.EgovHpcmMapper">
 
 	<resultMap id="HpcmManage" type="egovframework.com.uss.olh.hpc.service.HpcmVO">
 		<result property="hpcmId" column="HPCM_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/olh/hpc/EgovHpcm_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olh/hpc/EgovHpcm_SQL_postgres.xml
@@ -6,7 +6,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="Hpcm">
+<mapper namespace="egovframework.com.uss.olh.hpc.service.impl.EgovHpcmMapper">
 
 	<resultMap id="HpcmManage" type="egovframework.com.uss.olh.hpc.service.HpcmVO">
 		<result property="hpcmId" column="HPCM_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/olh/hpc/EgovHpcm_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olh/hpc/EgovHpcm_SQL_tibero.xml
@@ -6,7 +6,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="Hpcm">
+<mapper namespace="egovframework.com.uss.olh.hpc.service.impl.EgovHpcmMapper">
 
 	<resultMap id="HpcmManage" type="egovframework.com.uss.olh.hpc.service.HpcmVO">
 		<result property="hpcmId" column="HPCM_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/olh/omm/EgovOnlineManual_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olh/omm/EgovOnlineManual_SQL_altibase.xml
@@ -7,7 +7,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="OnlineManual">
+<mapper namespace="egovframework.com.uss.olh.omm.service.impl.EgovOnlineManualMapper">
 
 	<!-- 온라인메뉴얼::ResultMap 선언 -->
 	<resultMap id="OnlineManualVO" type="egovframework.com.uss.olh.omm.service.OnlineManualVO">

--- a/src/main/resources/egovframework/mapper/com/uss/olh/omm/EgovOnlineManual_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olh/omm/EgovOnlineManual_SQL_cubrid.xml
@@ -7,7 +7,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="OnlineManual">
+<mapper namespace="egovframework.com.uss.olh.omm.service.impl.EgovOnlineManualMapper">
 
 	<!-- 온라인메뉴얼::ResultMap 선언 -->
 	<resultMap id="OnlineManualVO" type="egovframework.com.uss.olh.omm.service.OnlineManualVO">

--- a/src/main/resources/egovframework/mapper/com/uss/olh/omm/EgovOnlineManual_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olh/omm/EgovOnlineManual_SQL_goldilocks.xml
@@ -7,7 +7,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="OnlineManual">
+<mapper namespace="egovframework.com.uss.olh.omm.service.impl.EgovOnlineManualMapper">
 
 	<!-- 온라인메뉴얼::ResultMap 선언 -->
 	<resultMap id="OnlineManualVO" type="egovframework.com.uss.olh.omm.service.OnlineManualVO">

--- a/src/main/resources/egovframework/mapper/com/uss/olh/omm/EgovOnlineManual_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olh/omm/EgovOnlineManual_SQL_maria.xml
@@ -7,7 +7,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="OnlineManual">
+<mapper namespace="egovframework.com.uss.olh.omm.service.impl.EgovOnlineManualMapper">
 
 	<!-- 온라인메뉴얼::ResultMap 선언 -->
 	<resultMap id="OnlineManualVO" type="egovframework.com.uss.olh.omm.service.OnlineManualVO">

--- a/src/main/resources/egovframework/mapper/com/uss/olh/omm/EgovOnlineManual_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olh/omm/EgovOnlineManual_SQL_mysql.xml
@@ -7,7 +7,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="OnlineManual">
+<mapper namespace="egovframework.com.uss.olh.omm.service.impl.EgovOnlineManualMapper">
 
 	<!-- 온라인메뉴얼::ResultMap 선언 -->
 	<resultMap id="OnlineManualVO" type="egovframework.com.uss.olh.omm.service.OnlineManualVO">

--- a/src/main/resources/egovframework/mapper/com/uss/olh/omm/EgovOnlineManual_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olh/omm/EgovOnlineManual_SQL_oracle.xml
@@ -7,7 +7,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="OnlineManual">
+<mapper namespace="egovframework.com.uss.olh.omm.service.impl.EgovOnlineManualMapper">
 
 	<!-- 온라인메뉴얼::ResultMap 선언 -->
 	<resultMap id="OnlineManualVO" type="egovframework.com.uss.olh.omm.service.OnlineManualVO">

--- a/src/main/resources/egovframework/mapper/com/uss/olh/omm/EgovOnlineManual_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olh/omm/EgovOnlineManual_SQL_postgres.xml
@@ -7,7 +7,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="OnlineManual">
+<mapper namespace="egovframework.com.uss.olh.omm.service.impl.EgovOnlineManualMapper">
 
 	<!-- 온라인메뉴얼::ResultMap 선언 -->
 	<resultMap id="OnlineManualVO" type="egovframework.com.uss.olh.omm.service.OnlineManualVO">

--- a/src/main/resources/egovframework/mapper/com/uss/olh/omm/EgovOnlineManual_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olh/omm/EgovOnlineManual_SQL_tibero.xml
@@ -7,7 +7,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="OnlineManual">
+<mapper namespace="egovframework.com.uss.olh.omm.service.impl.EgovOnlineManualMapper">
 
 	<!-- 온라인메뉴얼::ResultMap 선언 -->
 	<resultMap id="OnlineManualVO" type="egovframework.com.uss.olh.omm.service.OnlineManualVO">

--- a/src/main/resources/egovframework/mapper/com/uss/olh/qna/EgovQnaManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olh/qna/EgovQnaManage_SQL_altibase.xml
@@ -9,7 +9,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QnaManage">
+<mapper namespace="egovframework.com.uss.olh.qna.service.impl.EgovQnaMapper">
 
 	<resultMap id="QnaManage" type="egovframework.com.uss.olh.qna.service.QnaVO">
 		<result property="qaId" column="QA_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/olh/qna/EgovQnaManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olh/qna/EgovQnaManage_SQL_cubrid.xml
@@ -9,7 +9,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QnaManage">
+<mapper namespace="egovframework.com.uss.olh.qna.service.impl.EgovQnaMapper">
 
 	<resultMap id="QnaManage" type="egovframework.com.uss.olh.qna.service.QnaVO">
 		<result property="qaId" column="QA_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/olh/qna/EgovQnaManage_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olh/qna/EgovQnaManage_SQL_goldilocks.xml
@@ -9,7 +9,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QnaManage">
+<mapper namespace="egovframework.com.uss.olh.qna.service.impl.EgovQnaMapper">
 
 	<resultMap id="QnaManage" type="egovframework.com.uss.olh.qna.service.QnaVO">
 		<result property="qaId" column="QA_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/olh/qna/EgovQnaManage_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olh/qna/EgovQnaManage_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QnaManage">
+<mapper namespace="egovframework.com.uss.olh.qna.service.impl.EgovQnaMapper">
 
 	<resultMap id="QnaManage" type="egovframework.com.uss.olh.qna.service.QnaVO">
 		<result property="qaId" column="QA_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/olh/qna/EgovQnaManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olh/qna/EgovQnaManage_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QnaManage">
+<mapper namespace="egovframework.com.uss.olh.qna.service.impl.EgovQnaMapper">
 
 	<resultMap id="QnaManage" type="egovframework.com.uss.olh.qna.service.QnaVO">
 		<result property="qaId" column="QA_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/olh/qna/EgovQnaManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olh/qna/EgovQnaManage_SQL_oracle.xml
@@ -9,7 +9,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QnaManage">
+<mapper namespace="egovframework.com.uss.olh.qna.service.impl.EgovQnaMapper">
 
 	<resultMap id="QnaManage" type="egovframework.com.uss.olh.qna.service.QnaVO">
 		<result property="qaId" column="QA_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/olh/qna/EgovQnaManage_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olh/qna/EgovQnaManage_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QnaManage">
+<mapper namespace="egovframework.com.uss.olh.qna.service.impl.EgovQnaMapper">
 
 	<resultMap id="QnaManage" type="egovframework.com.uss.olh.qna.service.QnaVO">
 		<result property="qaId" column="QA_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/olh/qna/EgovQnaManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olh/qna/EgovQnaManage_SQL_tibero.xml
@@ -9,7 +9,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QnaManage">
+<mapper namespace="egovframework.com.uss.olh.qna.service.impl.EgovQnaMapper">
 
 	<resultMap id="QnaManage" type="egovframework.com.uss.olh.qna.service.QnaVO">
 		<result property="qaId" column="QA_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/olh/wor/EgovWordDicary_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olh/wor/EgovWordDicary_SQL_altibase.xml
@@ -8,7 +8,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="WordDicary">
+<mapper namespace="egovframework.com.uss.olh.wor.service.impl.EgovWordDicaryMapper">
 
 	<resultMap id="WordDicary" type="egovframework.com.uss.olh.wor.service.WordDicaryVO">
 		<result property="wordId" column="WORD_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/olh/wor/EgovWordDicary_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olh/wor/EgovWordDicary_SQL_cubrid.xml
@@ -8,7 +8,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="WordDicary">
+<mapper namespace="egovframework.com.uss.olh.wor.service.impl.EgovWordDicaryMapper">
 
 	<resultMap id="WordDicary" type="egovframework.com.uss.olh.wor.service.WordDicaryVO">
 		<result property="wordId" column="WORD_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/olh/wor/EgovWordDicary_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olh/wor/EgovWordDicary_SQL_goldilocks.xml
@@ -8,7 +8,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="WordDicary">
+<mapper namespace="egovframework.com.uss.olh.wor.service.impl.EgovWordDicaryMapper">
 
 	<resultMap id="WordDicary" type="egovframework.com.uss.olh.wor.service.WordDicaryVO">
 		<result property="wordId" column="WORD_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/olh/wor/EgovWordDicary_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olh/wor/EgovWordDicary_SQL_maria.xml
@@ -11,7 +11,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="WordDicary">
+<mapper namespace="egovframework.com.uss.olh.wor.service.impl.EgovWordDicaryMapper">
 
 	<resultMap id="WordDicary" type="egovframework.com.uss.olh.wor.service.WordDicaryVO">
 		<result property="wordId" column="WORD_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/olh/wor/EgovWordDicary_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olh/wor/EgovWordDicary_SQL_mysql.xml
@@ -11,7 +11,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="WordDicary">
+<mapper namespace="egovframework.com.uss.olh.wor.service.impl.EgovWordDicaryMapper">
 
 	<resultMap id="WordDicary" type="egovframework.com.uss.olh.wor.service.WordDicaryVO">
 		<result property="wordId" column="WORD_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/olh/wor/EgovWordDicary_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olh/wor/EgovWordDicary_SQL_oracle.xml
@@ -8,7 +8,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="WordDicary">
+<mapper namespace="egovframework.com.uss.olh.wor.service.impl.EgovWordDicaryMapper">
 
 	<resultMap id="WordDicary" type="egovframework.com.uss.olh.wor.service.WordDicaryVO">
 		<result property="wordId" column="WORD_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/olh/wor/EgovWordDicary_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olh/wor/EgovWordDicary_SQL_postgres.xml
@@ -11,7 +11,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="WordDicary">
+<mapper namespace="egovframework.com.uss.olh.wor.service.impl.EgovWordDicaryMapper">
 
 	<resultMap id="WordDicary" type="egovframework.com.uss.olh.wor.service.WordDicaryVO">
 		<result property="wordId" column="WORD_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/olh/wor/EgovWordDicary_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olh/wor/EgovWordDicary_SQL_tibero.xml
@@ -8,7 +8,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="WordDicary">
+<mapper namespace="egovframework.com.uss.olh.wor.service.impl.EgovWordDicaryMapper">
 
 	<resultMap id="WordDicary" type="egovframework.com.uss.olh.wor.service.WordDicaryVO">
 		<result property="wordId" column="WORD_ID"/>

--- a/src/main/resources/egovframework/spring/com/context-mapper.xml
+++ b/src/main/resources/egovframework/spring/com/context-mapper.xml
@@ -21,5 +21,11 @@
 	<bean id="egov.sqlSessionTemplate" class="org.mybatis.spring.SqlSessionTemplate">
 		<constructor-arg ref="egov.sqlSession"/>
 	</bean>
-	
+
+	<!-- @EgovMapper 어노테이션 기반 Mapper 인터페이스 자동 등록 -->
+	<bean class="org.mybatis.spring.mapper.MapperScannerConfigurer">
+		<property name="basePackage" value="egovframework.com"/>
+		<property name="annotationClass" value="org.egovframe.rte.psl.dataaccess.mapper.EgovMapper"/>
+	</bean>
+
 </beans>


### PR DESCRIPTION
## 변경 사유
기존 XML namespace 기반 DAO를 eGovFrame 5.0 신규 `@EgovMapper` 인터페이스 방식으로 전환합니다.

## 변경 내용
- 대상: uss/olh(hpc·omm·faq·awm·qna·wor) 6개 DAO
- 각 DAO에 대응하는 Mapper 인터페이스(`@EgovMapper`) 신규 추가
- DAO를 mapper 위임 구조로 리팩토링 (EgovComAbstractDAO 상속 제거, @Resource 주입, @Repository bean name 유지)
- XML mapper namespace를 mapper 인터페이스 FQN으로 변경
- context-mapper.xml에 MapperScannerConfigurer(annotationClass=EgovMapper) 추가

## 영향 범위
- 해당 모듈만 영향, 서비스 레이어 호출 시그니처 변경 없음

## 참고
- 빌드 검증을 위해 #891(Lombok annotationProcessorPaths 빌드 수정) 선행 머지 권장
- context-mapper.xml MapperScannerConfigurer는 동일 시리즈 PR과 한 줄 중복될 수 있어, 선행 PR 머지 후 rebase로 정리 가능

## 체크리스트
- [x] 단일 주제만 다룸
- [x] 컴파일 검증(해당 모듈 신규 오류 0)
- [x] 기존 동작 호환
