### PR TITLE
[refactor][5.0.x][공통컴포넌트] uss/umt 4개 사용자관리 DAO @EgovMapper 인터페이스 전환

### DIFF
--- a/src/main/java/egovframework/com/uss/umt/service/impl/DeptManageDAO.java
+++ b/src/main/java/egovframework/com/uss/umt/service/impl/DeptManageDAO.java
@@ -2,69 +2,86 @@ package egovframework.com.uss.umt.service.impl;
 
 import java.util.List;
 
+import jakarta.annotation.Resource;
+
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.uss.umt.service.DeptManageVO;
 
+/**
+ * 부서관리에 관한 데이터 접근 클래스를 정의한다.
+ * @author 공통서비스 개발팀
+ * @since 2009.04.10
+ * @version 1.0
+ * @see
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2009.04.10  공통서비스 개발팀   최초 생성
+ *   2026.05.28  표준프레임워크센터   @EgovMapper 인터페이스 방식으로 전환
+ *
+ * </pre>
+ */
 @Repository("deptManageDAO")
-public class DeptManageDAO extends EgovComAbstractDAO {
+public class DeptManageDAO {
 
-	/**
-	 * 부서를 관리하기 위해 등록된 부서목록을 조회한다.
-	 * @param deptManageVO - 부서 Vo
-	 * @return List - 부서 목록
-	 * @exception Exception
-	 */
-	public List<DeptManageVO> selectDeptManageList(DeptManageVO deptManageVO) throws Exception {
-		return selectList("deptManageDAO.selectDeptManageList", deptManageVO);
-	}
+    @Resource(name = "deptManageMapper")
+    private DeptManageMapper deptManageMapper;
 
     /**
-	 * 부서목록 총 개수를 조회한다.
-	 * @param deptManageVO - 부서 Vo
-	 * @return int - 부서 카운트 수
-	 * @exception Exception
-	 */
-    public int selectDeptManageListTotCnt(DeptManageVO deptManageVO) throws Exception {
-        return (Integer)selectOne("deptManageDAO.selectDeptManageListTotCnt", deptManageVO);
+     * 부서를 관리하기 위해 등록된 부서목록을 조회한다.
+     * @param deptManageVO - 부서 Vo
+     * @return List - 부서 목록
+     * @exception Exception
+     */
+    public List<DeptManageVO> selectDeptManageList(DeptManageVO deptManageVO) throws Exception {
+        return deptManageMapper.selectDeptManageList(deptManageVO);
     }
 
-	/**
-	 * 등록된 부서의 상세정보를 조회한다.
-	 * @param deptManageVO - 부서 Vo
-	 * @return deptManageVO - 부서 Vo
-	 *
-	 * @param bannerVO
-	 */
-	public DeptManageVO selectDeptManage(DeptManageVO deptManageVO) throws Exception {
-		return (DeptManageVO) selectOne("deptManageDAO.selectDeptManage", deptManageVO);
-	}
+    /**
+     * 부서목록 총 개수를 조회한다.
+     * @param deptManageVO - 부서 Vo
+     * @return int - 부서 카운트 수
+     * @exception Exception
+     */
+    public int selectDeptManageListTotCnt(DeptManageVO deptManageVO) throws Exception {
+        return deptManageMapper.selectDeptManageListTotCnt(deptManageVO);
+    }
 
-	/**
-	 * 부서정보를 신규로 등록한다.
-	 * @param deptManageVO - 부서 model
-	 */
-	public void insertDeptManage(DeptManageVO deptManageVO) throws Exception {
-		insert("deptManageDAO.insertDeptManage", deptManageVO);
-	}
+    /**
+     * 등록된 부서의 상세정보를 조회한다.
+     * @param deptManageVO - 부서 Vo
+     * @return deptManageVO - 부서 Vo
+     */
+    public DeptManageVO selectDeptManage(DeptManageVO deptManageVO) throws Exception {
+        return deptManageMapper.selectDeptManage(deptManageVO);
+    }
 
-	/**
-	 * 기 등록된 부서정보를 수정한다.
-	 * @param deptManageVO - 부서 model
-	 */
-	public void updateDeptManage(DeptManageVO deptManageVO) throws Exception {
-        update("deptManageDAO.updateDeptManage", deptManageVO);
-	}
+    /**
+     * 부서정보를 신규로 등록한다.
+     * @param deptManageVO - 부서 model
+     */
+    public void insertDeptManage(DeptManageVO deptManageVO) throws Exception {
+        deptManageMapper.insertDeptManage(deptManageVO);
+    }
 
-	/**
-	 * 기 등록된 부서정보를 삭제한다.
-	 * @param deptManageVO - 부서 model
-	 *
-	 * @param banner
-	 */
-	public void deleteDeptManage(DeptManageVO deptManageVO) throws Exception {
-		delete("deptManageDAO.deleteDeptManage", deptManageVO);
-	}
+    /**
+     * 기 등록된 부서정보를 수정한다.
+     * @param deptManageVO - 부서 model
+     */
+    public void updateDeptManage(DeptManageVO deptManageVO) throws Exception {
+        deptManageMapper.updateDeptManage(deptManageVO);
+    }
+
+    /**
+     * 기 등록된 부서정보를 삭제한다.
+     * @param deptManageVO - 부서 model
+     */
+    public void deleteDeptManage(DeptManageVO deptManageVO) throws Exception {
+        deptManageMapper.deleteDeptManage(deptManageVO);
+    }
 
 }

--- a/src/main/java/egovframework/com/uss/umt/service/impl/DeptManageMapper.java
+++ b/src/main/java/egovframework/com/uss/umt/service/impl/DeptManageMapper.java
@@ -1,0 +1,68 @@
+package egovframework.com.uss.umt.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.uss.umt.service.DeptManageVO;
+
+/**
+ * 부서관리에 관한 데이터 접근 Mapper 인터페이스를 정의한다.
+ * @author 공통서비스 개발팀
+ * @since 2009.04.10
+ * @version 1.0
+ * @see
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2009.04.10  공통서비스 개발팀   최초 생성
+ *   2026.05.28  표준프레임워크센터   @EgovMapper 인터페이스 방식으로 전환
+ *
+ * </pre>
+ */
+@EgovMapper("deptManageMapper")
+public interface DeptManageMapper {
+
+    /**
+     * 부서목록을 조회한다.
+     * @param deptManageVO 부서 Vo
+     * @return List 부서 목록
+     */
+    List<DeptManageVO> selectDeptManageList(DeptManageVO deptManageVO);
+
+    /**
+     * 부서목록 총 개수를 조회한다.
+     * @param deptManageVO 부서 Vo
+     * @return int 부서 카운트 수
+     */
+    int selectDeptManageListTotCnt(DeptManageVO deptManageVO);
+
+    /**
+     * 부서 상세정보를 조회한다.
+     * @param deptManageVO 부서 Vo
+     * @return DeptManageVO 부서 Vo
+     */
+    DeptManageVO selectDeptManage(DeptManageVO deptManageVO);
+
+    /**
+     * 부서정보를 신규로 등록한다.
+     * @param deptManageVO 부서 model
+     */
+    void insertDeptManage(DeptManageVO deptManageVO);
+
+    /**
+     * 기 등록된 부서정보를 수정한다.
+     * @param deptManageVO 부서 model
+     */
+    void updateDeptManage(DeptManageVO deptManageVO);
+
+    /**
+     * 기 등록된 부서정보를 삭제한다.
+     * @param deptManageVO 부서 model
+     */
+    void deleteDeptManage(DeptManageVO deptManageVO);
+
+}

--- a/src/main/java/egovframework/com/uss/umt/service/impl/EmplyrManageDAO.java
+++ b/src/main/java/egovframework/com/uss/umt/service/impl/EmplyrManageDAO.java
@@ -2,10 +2,11 @@ package egovframework.com.uss.umt.service.impl;
 
 import java.util.List;
 
+import jakarta.annotation.Resource;
+
 import org.egovframe.rte.psl.dataaccess.util.EgovMap;
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.uss.umt.service.UserDefaultVO;
 import egovframework.com.uss.umt.service.EmplyrManageVO;
 import egovframework.com.uss.umt.service.EmplyrPasswordManageVO;
@@ -23,48 +24,51 @@ import egovframework.com.uss.umt.service.EmplyrPasswordManageVO;
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.04.10  조재영          최초 생성
- *   2017.07.21  장동한 			로그인인증제한 작업
+ *   2017.07.21  장동한          로그인인증제한 작업
+ *   2026.05.28  표준프레임워크센터   @EgovMapper 인터페이스 방식으로 전환
  *
  * </pre>
  */
 @Repository("emplyrManageDAO")
-public class EmplyrManageDAO extends EgovComAbstractDAO{
+public class EmplyrManageDAO {
+
+    @Resource(name = "emplyrManageMapper")
+    private EmplyrManageMapper emplyrManageMapper;
 
     /**
      * 입력한 사용자아이디의 중복여부를 체크하여 사용가능여부를 확인
      * @param checkId 중복체크대상 아이디
      * @return int 사용가능여부(아이디 사용회수 )
      */
-    public int checkIdDplct(String checkId){
-        return (Integer)selectOne("emplyrManageDAO.checkIdDplct_S", checkId);
+    public int checkIdDplct(String checkId) {
+        return emplyrManageMapper.checkIdDplct_S(checkId);
     }
 
     /**
      * 화면에 조회된 사용자의 정보를 데이터베이스에서 삭제
      * @param delId 삭제대상 업무사용자 아이디
      */
-    public void deleteEmplyr(String delId){
-        delete("emplyrManageDAO.deleteEmplyrInfoChangeDtls_S", delId);
-        delete("emplyrManageDAO.deleteEmplyr_S", delId);
+    public void deleteEmplyr(String delId) {
+        emplyrManageMapper.deleteEmplyrInfoChangeDtls_S(delId);
+        emplyrManageMapper.deleteEmplyr_S(delId);
     }
-
 
     /**
      * 사용자의 기본정보를 화면에서 입력하여 항목의 정합성을 체크하고 데이터베이스에 저장
-     * @param userManageVO 업무사용자 등록정보
+     * @param emplyrManageVO 업무사용자 등록정보
      * @return String result 등록결과
      */
-    public String insertEmplyr(EmplyrManageVO emplyrManageVO){
-        return String.valueOf(insert("emplyrManageDAO.insertEmplyr_S", emplyrManageVO));
+    public String insertEmplyr(EmplyrManageVO emplyrManageVO) {
+        return String.valueOf(emplyrManageMapper.insertEmplyr_S(emplyrManageVO));
     }
 
     /**
      * 기 등록된 사용자 중 검색조건에 맞는 사용자들의 정보를 데이터베이스에서 읽어와 화면에 출력
      * @param uniqId 상세조회대상 업무사용자아이디
-     * @return UserManageVO 업무사용자  상세정보
+     * @return EmplyrManageVO 업무사용자 상세정보
      */
-    public EmplyrManageVO selectEmplyr(String uniqId){
-        return (EmplyrManageVO) selectOne("emplyrManageDAO.selectEmplyr_S", uniqId);
+    public EmplyrManageVO selectEmplyr(String uniqId) {
+        return emplyrManageMapper.selectEmplyr_S(uniqId);
     }
 
     /**
@@ -72,8 +76,8 @@ public class EmplyrManageDAO extends EgovComAbstractDAO{
      * @param userSearchVO 검색조건
      * @return List 업무사용자 목록정보
      */
-    public List<EgovMap> selectEmplyrList(UserDefaultVO userSearchVO){
-        return selectList("emplyrManageDAO.selectEmplyrList_S", userSearchVO);
+    public List<EgovMap> selectEmplyrList(UserDefaultVO userSearchVO) {
+        return emplyrManageMapper.selectEmplyrList_S(userSearchVO);
     }
 
     /**
@@ -82,24 +86,24 @@ public class EmplyrManageDAO extends EgovComAbstractDAO{
      * @return int 업무사용자 총개수
      */
     public int selectEmplyrListTotCnt(UserDefaultVO userSearchVO) {
-        return (Integer)selectOne("emplyrManageDAO.selectEmplyrListTotCnt_S", userSearchVO);
+        return emplyrManageMapper.selectEmplyrListTotCnt_S(userSearchVO);
     }
 
     /**
      * 화면에 조회된 사용자의 기본정보를 수정하여 항목의 정합성을 체크하고 수정된 데이터를 데이터베이스에 반영
-     * @param userManageVO 업무사용자 수정정보
+     * @param emplyrManageVO 업무사용자 수정정보
      */
-    public void updateEmplyr(EmplyrManageVO emplyrManageVO){
-        update("emplyrManageDAO.updateEmplyr_S",emplyrManageVO);
+    public void updateEmplyr(EmplyrManageVO emplyrManageVO) {
+        emplyrManageMapper.updateEmplyr_S(emplyrManageVO);
     }
 
     /**
      * 사용자정보 수정시 히스토리 정보를 추가
-     * @param userManageVO 업무사용자 히스토리 정보
+     * @param emplyrManageVO 업무사용자 히스토리 정보
      * @return String 히스토리 등록결과
      */
-    public String insertEmplyrHistory(EmplyrManageVO emplyrManageVO){
-    	return String.valueOf(insert("emplyrManageDAO.insertEmplyrHistory_S", emplyrManageVO));
+    public String insertEmplyrHistory(EmplyrManageVO emplyrManageVO) {
+        return String.valueOf(emplyrManageMapper.insertEmplyrHistory_S(emplyrManageVO));
     }
 
     /**
@@ -107,7 +111,7 @@ public class EmplyrManageDAO extends EgovComAbstractDAO{
      * @param emplyrPasswordManageVO 업무사용자 비밀번호 수정정보
      */
     public void updatePassword(EmplyrPasswordManageVO emplyrPasswordManageVO) {
-        update("emplyrManageDAO.updatePassword_S", emplyrPasswordManageVO);
+        emplyrManageMapper.updatePassword_S(emplyrPasswordManageVO);
     }
 
     /**
@@ -115,17 +119,16 @@ public class EmplyrManageDAO extends EgovComAbstractDAO{
      * @param emplyrPasswordManageVO 업무사용자 암호 조회조건정보
      * @return EmplyrPasswordManageVO 업무사용자 암호정보
      */
-    public EmplyrPasswordManageVO selectPassword(EmplyrPasswordManageVO emplyrPasswordManageVO){
-    	return (EmplyrPasswordManageVO) selectOne("emplyrManageDAO.selectPassword_S", emplyrPasswordManageVO);
+    public EmplyrPasswordManageVO selectPassword(EmplyrPasswordManageVO emplyrPasswordManageVO) {
+        return emplyrManageMapper.selectPassword_S(emplyrPasswordManageVO);
     }
-
 
     /**
      * 로그인인증제한 해제
-     * @param passVO 업무사용자
+     * @param emplyrManageVO 업무사용자
      */
     public void updateLockIncorrect(EmplyrManageVO emplyrManageVO) {
-        update("emplyrManageDAO.updateLockIncorrect", emplyrManageVO);
+        emplyrManageMapper.updateLockIncorrect(emplyrManageVO);
     }
 
 }

--- a/src/main/java/egovframework/com/uss/umt/service/impl/EmplyrManageMapper.java
+++ b/src/main/java/egovframework/com/uss/umt/service/impl/EmplyrManageMapper.java
@@ -1,0 +1,112 @@
+package egovframework.com.uss.umt.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+import org.egovframe.rte.psl.dataaccess.util.EgovMap;
+
+import egovframework.com.uss.umt.service.EmplyrManageVO;
+import egovframework.com.uss.umt.service.EmplyrPasswordManageVO;
+import egovframework.com.uss.umt.service.UserDefaultVO;
+
+/**
+ * 사용자관리에 관한 데이터 접근 Mapper 인터페이스를 정의한다.
+ * @author 공통서비스 개발팀 조재영
+ * @since 2009.04.10
+ * @version 1.0
+ * @see
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2009.04.10  조재영          최초 생성
+ *   2017.07.21  장동한          로그인인증제한 작업
+ *   2026.05.28  표준프레임워크센터   @EgovMapper 인터페이스 방식으로 전환
+ *
+ * </pre>
+ */
+@EgovMapper("emplyrManageMapper")
+public interface EmplyrManageMapper {
+
+    /**
+     * 입력한 사용자아이디의 중복여부를 체크하여 사용가능여부를 확인
+     * @param checkId 중복체크대상 아이디
+     * @return int 사용가능여부(아이디 사용회수)
+     */
+    int checkIdDplct_S(String checkId);
+
+    /**
+     * 사용자 정보변경 이력을 삭제
+     * @param delId 삭제대상 업무사용자 아이디
+     */
+    void deleteEmplyrInfoChangeDtls_S(String delId);
+
+    /**
+     * 업무사용자 정보를 삭제
+     * @param delId 삭제대상 업무사용자 아이디
+     */
+    void deleteEmplyr_S(String delId);
+
+    /**
+     * 사용자의 기본정보를 데이터베이스에 저장
+     * @param emplyrManageVO 업무사용자 등록정보
+     * @return String 등록결과
+     */
+    String insertEmplyr_S(EmplyrManageVO emplyrManageVO);
+
+    /**
+     * 사용자 상세정보를 조회
+     * @param uniqId 상세조회대상 업무사용자아이디
+     * @return EmplyrManageVO 업무사용자 상세정보
+     */
+    EmplyrManageVO selectEmplyr_S(String uniqId);
+
+    /**
+     * 업무사용자 목록을 조회
+     * @param userSearchVO 검색조건
+     * @return List 업무사용자 목록정보
+     */
+    List<EgovMap> selectEmplyrList_S(UserDefaultVO userSearchVO);
+
+    /**
+     * 업무사용자 총 개수를 조회
+     * @param userSearchVO 검색조건
+     * @return int 업무사용자 총개수
+     */
+    int selectEmplyrListTotCnt_S(UserDefaultVO userSearchVO);
+
+    /**
+     * 사용자의 기본정보를 수정
+     * @param emplyrManageVO 업무사용자 수정정보
+     */
+    void updateEmplyr_S(EmplyrManageVO emplyrManageVO);
+
+    /**
+     * 사용자정보 수정시 히스토리 정보를 추가
+     * @param emplyrManageVO 업무사용자 히스토리 정보
+     * @return String 히스토리 등록결과
+     */
+    String insertEmplyrHistory_S(EmplyrManageVO emplyrManageVO);
+
+    /**
+     * 업무사용자 암호수정
+     * @param emplyrPasswordManageVO 업무사용자 비밀번호 수정정보
+     */
+    void updatePassword_S(EmplyrPasswordManageVO emplyrPasswordManageVO);
+
+    /**
+     * 업무사용자 암호 조회
+     * @param emplyrPasswordManageVO 업무사용자 암호 조회조건정보
+     * @return EmplyrPasswordManageVO 업무사용자 암호정보
+     */
+    EmplyrPasswordManageVO selectPassword_S(EmplyrPasswordManageVO emplyrPasswordManageVO);
+
+    /**
+     * 로그인인증제한 해제
+     * @param emplyrManageVO 업무사용자
+     */
+    void updateLockIncorrect(EmplyrManageVO emplyrManageVO);
+
+}

--- a/src/main/java/egovframework/com/uss/umt/service/impl/EntrprsManageDAO.java
+++ b/src/main/java/egovframework/com/uss/umt/service/impl/EntrprsManageDAO.java
@@ -2,9 +2,10 @@ package egovframework.com.uss.umt.service.impl;
 
 import java.util.List;
 
+import jakarta.annotation.Resource;
+
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.uss.umt.service.EntrprsManageVO;
 import egovframework.com.uss.umt.service.EntrprsPasswordManageVO;
 import egovframework.com.uss.umt.service.StplatVO;
@@ -23,19 +24,23 @@ import egovframework.com.uss.umt.service.UserDefaultVO;
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.04.10  조재영          최초 생성
- *   2017.07.21  장동한 			로그인인증제한 작업
+ *   2017.07.21  장동한          로그인인증제한 작업
+ *   2026.05.28  표준프레임워크센터   @EgovMapper 인터페이스 방식으로 전환
  *
  * </pre>
  */
 @Repository("entrprsManageDAO")
-public class EntrprsManageDAO extends EgovComAbstractDAO{
+public class EntrprsManageDAO {
+
+    @Resource(name = "entrprsManageMapper")
+    private EntrprsManageMapper entrprsManageMapper;
 
     /**
      * 화면에 조회된 기업회원의 정보를 데이터베이스에서 삭제
-     * @param delId
+     * @param delId 삭제대상 기업회원 아이디
      */
-    public void deleteEntrprsmber(String delId){
-        delete("entrprsManageDAO.deleteEntrprs_S", delId);
+    public void deleteEntrprsmber(String delId) {
+        entrprsManageMapper.deleteEntrprs_S(delId);
     }
 
     /**
@@ -43,8 +48,8 @@ public class EntrprsManageDAO extends EgovComAbstractDAO{
      * @param entrprsManageVO 기업회원 등록정보
      * @return String 등록결과
      */
-    public String insertEntrprsmber(EntrprsManageVO entrprsManageVO){
-        return String.valueOf(insert("entrprsManageDAO.insertEntrprs_S", entrprsManageVO));
+    public String insertEntrprsmber(EntrprsManageVO entrprsManageVO) {
+        return String.valueOf(entrprsManageMapper.insertEntrprs_S(entrprsManageVO));
     }
 
     /**
@@ -52,16 +57,16 @@ public class EntrprsManageDAO extends EgovComAbstractDAO{
      * @param entrprsmberId 상세조회대상 기업회원아이디
      * @return EntrprsManageVO 기업회원 상세정보
      */
-    public EntrprsManageVO selectEntrprsmber(String entrprsmberId){
-        return (EntrprsManageVO) selectOne("entrprsManageDAO.selectEntrprs_S", entrprsmberId);
+    public EntrprsManageVO selectEntrprsmber(String entrprsmberId) {
+        return entrprsManageMapper.selectEntrprs_S(entrprsmberId);
     }
 
     /**
      * 화면에 조회된 사용자의 기본정보를 수정하여 항목의 정합성을 체크하고 수정된 데이터를 데이터베이스에 반영
      * @param entrprsManageVO 기업회원 수정정보
      */
-    public void updateEntrprsmber(EntrprsManageVO entrprsManageVO){
-        update("entrprsManageDAO.updateEntrprs_S",entrprsManageVO);
+    public void updateEntrprsmber(EntrprsManageVO entrprsManageVO) {
+        entrprsManageMapper.updateEntrprs_S(entrprsManageVO);
     }
 
     /**
@@ -70,7 +75,7 @@ public class EntrprsManageDAO extends EgovComAbstractDAO{
      * @return List 기업회원약관정보
      */
     public List<StplatVO> selectStplat(String stplatId) {
-    	return selectList("entrprsManageDAO.selectStplat_S", stplatId);
+        return entrprsManageMapper.selectStplat_S(stplatId);
     }
 
     /**
@@ -78,41 +83,42 @@ public class EntrprsManageDAO extends EgovComAbstractDAO{
      * @param passVO 기업회원수정정보(비밀번호)
      */
     public void updatePassword(EntrprsPasswordManageVO passVO) {
-    	update("entrprsManageDAO.updatePassword_S", passVO);
+        entrprsManageMapper.updatePassword_S(passVO);
     }
 
     /**
      * 기업회원이 비밀번호를 기억하지 못할 때 비밀번호를 찾을 수 있도록 함
-     * @param entrprsManageVO 기업회원암호 조회조건정보
-     * @return EntrprsManageVO 기업회원암호정보
+     * @param passVO 기업회원암호 조회조건정보
+     * @return EntrprsPasswordManageVO 기업회원암호정보
      */
-    public EntrprsPasswordManageVO selectPassword(EntrprsPasswordManageVO passVO){
-    	return (EntrprsPasswordManageVO) selectOne("entrprsManageDAO.selectPassword_S", passVO);
+    public EntrprsPasswordManageVO selectPassword(EntrprsPasswordManageVO passVO) {
+        return entrprsManageMapper.selectPassword_S(passVO);
     }
 
     /**
      * 기 등록된 특정 기업회원의 정보를 데이터베이스에서 읽어와 화면에 출력
      * @param userSearchVO 검색조건
-     * @return List<EntrprsManageVO>
+     * @return List 기업회원 목록정보
      */
-	public List<EntrprsManageVO> selectEntrprsMberList(UserDefaultVO userSearchVO){
-        return selectList("entrprsManageDAO.selectEntrprsMberList", userSearchVO);
+    public List<EntrprsManageVO> selectEntrprsMberList(UserDefaultVO userSearchVO) {
+        return entrprsManageMapper.selectEntrprsMberList(userSearchVO);
     }
+
     /**
      * 기업회원 총 개수를 조회한다.
      * @param userSearchVO 검색조건
      * @return int 기업회원총개수
      */
     public int selectEntrprsMberListTotCnt(UserDefaultVO userSearchVO) {
-        return (Integer)selectOne("entrprsManageDAO.selectEntrprsMberListTotCnt", userSearchVO);
+        return entrprsManageMapper.selectEntrprsMberListTotCnt(userSearchVO);
     }
-
 
     /**
      * 로그인인증제한 해제
      * @param entrprsManageVO 기업회원정보
      */
     public void updateLockIncorrect(EntrprsManageVO entrprsManageVO) {
-        update("entrprsManageDAO.updateLockIncorrect", entrprsManageVO);
+        entrprsManageMapper.updateLockIncorrect(entrprsManageVO);
     }
+
 }

--- a/src/main/java/egovframework/com/uss/umt/service/impl/EntrprsManageMapper.java
+++ b/src/main/java/egovframework/com/uss/umt/service/impl/EntrprsManageMapper.java
@@ -1,0 +1,99 @@
+package egovframework.com.uss.umt.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.uss.umt.service.EntrprsManageVO;
+import egovframework.com.uss.umt.service.EntrprsPasswordManageVO;
+import egovframework.com.uss.umt.service.StplatVO;
+import egovframework.com.uss.umt.service.UserDefaultVO;
+
+/**
+ * 기업회원관리에 관한 데이터 접근 Mapper 인터페이스를 정의한다.
+ * @author 공통서비스 개발팀 조재영
+ * @since 2009.04.10
+ * @version 1.0
+ * @see
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2009.04.10  조재영          최초 생성
+ *   2017.07.21  장동한          로그인인증제한 작업
+ *   2026.05.28  표준프레임워크센터   @EgovMapper 인터페이스 방식으로 전환
+ *
+ * </pre>
+ */
+@EgovMapper("entrprsManageMapper")
+public interface EntrprsManageMapper {
+
+    /**
+     * 기업회원 정보를 삭제
+     * @param delId 삭제대상 기업회원 아이디
+     */
+    void deleteEntrprs_S(String delId);
+
+    /**
+     * 기업회원의 기본정보를 데이터베이스에 저장
+     * @param entrprsManageVO 기업회원 등록정보
+     * @return String 등록결과
+     */
+    String insertEntrprs_S(EntrprsManageVO entrprsManageVO);
+
+    /**
+     * 기업회원 상세정보를 조회
+     * @param entrprsmberId 상세조회대상 기업회원아이디
+     * @return EntrprsManageVO 기업회원 상세정보
+     */
+    EntrprsManageVO selectEntrprs_S(String entrprsmberId);
+
+    /**
+     * 기업회원 기본정보를 수정
+     * @param entrprsManageVO 기업회원 수정정보
+     */
+    void updateEntrprs_S(EntrprsManageVO entrprsManageVO);
+
+    /**
+     * 약관정보를 조회
+     * @param stplatId 기업회원 약관아이디
+     * @return List 기업회원약관정보
+     */
+    List<StplatVO> selectStplat_S(String stplatId);
+
+    /**
+     * 기업회원 암호수정
+     * @param passVO 기업회원수정정보(비밀번호)
+     */
+    void updatePassword_S(EntrprsPasswordManageVO passVO);
+
+    /**
+     * 기업회원 암호 조회
+     * @param passVO 기업회원암호 조회조건정보
+     * @return EntrprsPasswordManageVO 기업회원암호정보
+     */
+    EntrprsPasswordManageVO selectPassword_S(EntrprsPasswordManageVO passVO);
+
+    /**
+     * 기업회원 목록을 조회
+     * @param userSearchVO 검색조건
+     * @return List 기업회원 목록정보
+     */
+    List<EntrprsManageVO> selectEntrprsMberList(UserDefaultVO userSearchVO);
+
+    /**
+     * 기업회원 총 개수를 조회
+     * @param userSearchVO 검색조건
+     * @return int 기업회원총개수
+     */
+    int selectEntrprsMberListTotCnt(UserDefaultVO userSearchVO);
+
+    /**
+     * 로그인인증제한 해제
+     * @param entrprsManageVO 기업회원정보
+     */
+    void updateLockIncorrect(EntrprsManageVO entrprsManageVO);
+
+}

--- a/src/main/java/egovframework/com/uss/umt/service/impl/MberManageDAO.java
+++ b/src/main/java/egovframework/com/uss/umt/service/impl/MberManageDAO.java
@@ -2,9 +2,10 @@ package egovframework.com.uss.umt.service.impl;
 
 import java.util.List;
 
+import jakarta.annotation.Resource;
+
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.uss.umt.service.MberManageVO;
 import egovframework.com.uss.umt.service.MberPasswordManageVO;
 import egovframework.com.uss.umt.service.StplatVO;
@@ -23,20 +24,24 @@ import egovframework.com.uss.umt.service.UserDefaultVO;
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.04.10  조재영          최초 생성
- *   2017.07.21  장동한 			로그인인증제한 작업
+ *   2017.07.21  장동한          로그인인증제한 작업
+ *   2026.05.28  표준프레임워크센터   @EgovMapper 인터페이스 방식으로 전환
  *
  * </pre>
  */
 @Repository("mberManageDAO")
-public class MberManageDAO extends EgovComAbstractDAO{
+public class MberManageDAO {
+
+    @Resource(name = "mberManageMapper")
+    private MberManageMapper mberManageMapper;
 
     /**
      * 기 등록된 특정 일반회원의 정보를 데이터베이스에서 읽어와 화면에 출력
      * @param userSearchVO 검색조건
-     * @return List<MberManageVO> 기업회원 목록정보
+     * @return List 일반회원 목록정보
      */
-	public List<MberManageVO> selectMberList(UserDefaultVO userSearchVO){
-        return selectList("mberManageDAO.selectMberList", userSearchVO);
+    public List<MberManageVO> selectMberList(UserDefaultVO userSearchVO) {
+        return mberManageMapper.selectMberList(userSearchVO);
     }
 
     /**
@@ -45,15 +50,15 @@ public class MberManageDAO extends EgovComAbstractDAO{
      * @return int 일반회원총개수
      */
     public int selectMberListTotCnt(UserDefaultVO userSearchVO) {
-        return (Integer)selectOne("mberManageDAO.selectMberListTotCnt", userSearchVO);
+        return mberManageMapper.selectMberListTotCnt(userSearchVO);
     }
 
     /**
      * 화면에 조회된 일반회원의 정보를 데이터베이스에서 삭제
      * @param delId 삭제 대상 일반회원아이디
      */
-    public void deleteMber(String delId){
-        delete("mberManageDAO.deleteMber_S", delId);
+    public void deleteMber(String delId) {
+        mberManageMapper.deleteMber_S(delId);
     }
 
     /**
@@ -61,25 +66,25 @@ public class MberManageDAO extends EgovComAbstractDAO{
      * @param mberManageVO 일반회원 등록정보
      * @return String 등록결과
      */
-    public String insertMber(MberManageVO mberManageVO){
-        return String.valueOf(insert("mberManageDAO.insertMber_S", mberManageVO));
+    public String insertMber(MberManageVO mberManageVO) {
+        return String.valueOf(mberManageMapper.insertMber_S(mberManageVO));
     }
 
     /**
-     * 기 등록된 사용자 중 검색조건에 맞는일반회원의 정보를 데이터베이스에서 읽어와 화면에 출력
+     * 기 등록된 사용자 중 검색조건에 맞는 일반회원의 정보를 데이터베이스에서 읽어와 화면에 출력
      * @param mberId 상세조회대상 일반회원아이디
      * @return MberManageVO 일반회원 상세정보
      */
-    public MberManageVO selectMber(String mberId){
-        return (MberManageVO) selectOne("mberManageDAO.selectMber_S", mberId);
+    public MberManageVO selectMber(String mberId) {
+        return mberManageMapper.selectMber_S(mberId);
     }
 
     /**
-     * 화면에 조회된일반회원의 기본정보를 수정하여 항목의 정합성을 체크하고 수정된 데이터를 데이터베이스에 반영
+     * 화면에 조회된 일반회원의 기본정보를 수정하여 항목의 정합성을 체크하고 수정된 데이터를 데이터베이스에 반영
      * @param mberManageVO 일반회원수정정보
      */
-    public void updateMber(MberManageVO mberManageVO){
-        update("mberManageDAO.updateMber_S",mberManageVO);
+    public void updateMber(MberManageVO mberManageVO) {
+        mberManageMapper.updateMber_S(mberManageVO);
     }
 
     /**
@@ -87,8 +92,8 @@ public class MberManageDAO extends EgovComAbstractDAO{
      * @param stplatId 일반회원약관아이디
      * @return List 일반회원약관정보
      */
-    public List<StplatVO> selectStplat(String stplatId){
-    	return selectList("mberManageDAO.selectStplat_S", stplatId);
+    public List<StplatVO> selectStplat(String stplatId) {
+        return mberManageMapper.selectStplat_S(stplatId);
     }
 
     /**
@@ -96,7 +101,7 @@ public class MberManageDAO extends EgovComAbstractDAO{
      * @param mberPasswordManageVO 일반회원 비밀번호 수정정보
      */
     public void updatePassword(MberPasswordManageVO mberPasswordManageVO) {
-        update("mberManageDAO.updatePassword_S", mberPasswordManageVO);
+        mberManageMapper.updatePassword_S(mberPasswordManageVO);
     }
 
     /**
@@ -104,17 +109,16 @@ public class MberManageDAO extends EgovComAbstractDAO{
      * @param mberPasswordManageVO 일반회원 암호 조회조건정보
      * @return MberPasswordManageVO 일반회원 암호정보
      */
-    public MberPasswordManageVO selectPassword(MberPasswordManageVO mberPasswordManageVO){
-    	return (MberPasswordManageVO) selectOne("mberManageDAO.selectPassword_S", mberPasswordManageVO);
+    public MberPasswordManageVO selectPassword(MberPasswordManageVO mberPasswordManageVO) {
+        return mberManageMapper.selectPassword_S(mberPasswordManageVO);
     }
-
 
     /**
      * 로그인인증제한 해제
      * @param mberManageVO 일반회원정보
      */
     public void updateLockIncorrect(MberManageVO mberManageVO) {
-        update("mberManageDAO.updateLockIncorrect", mberManageVO);
+        mberManageMapper.updateLockIncorrect(mberManageVO);
     }
 
 }

--- a/src/main/java/egovframework/com/uss/umt/service/impl/MberManageMapper.java
+++ b/src/main/java/egovframework/com/uss/umt/service/impl/MberManageMapper.java
@@ -1,0 +1,99 @@
+package egovframework.com.uss.umt.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.uss.umt.service.MberManageVO;
+import egovframework.com.uss.umt.service.MberPasswordManageVO;
+import egovframework.com.uss.umt.service.StplatVO;
+import egovframework.com.uss.umt.service.UserDefaultVO;
+
+/**
+ * 일반회원관리에 관한 데이터 접근 Mapper 인터페이스를 정의한다.
+ * @author 공통서비스 개발팀 조재영
+ * @since 2009.04.10
+ * @version 1.0
+ * @see
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2009.04.10  조재영          최초 생성
+ *   2017.07.21  장동한          로그인인증제한 작업
+ *   2026.05.28  표준프레임워크센터   @EgovMapper 인터페이스 방식으로 전환
+ *
+ * </pre>
+ */
+@EgovMapper("mberManageMapper")
+public interface MberManageMapper {
+
+    /**
+     * 일반회원 목록을 조회
+     * @param userSearchVO 검색조건
+     * @return List 일반회원 목록정보
+     */
+    List<MberManageVO> selectMberList(UserDefaultVO userSearchVO);
+
+    /**
+     * 일반회원 총 개수를 조회
+     * @param userSearchVO 검색조건
+     * @return int 일반회원총개수
+     */
+    int selectMberListTotCnt(UserDefaultVO userSearchVO);
+
+    /**
+     * 일반회원 정보를 삭제
+     * @param delId 삭제 대상 일반회원아이디
+     */
+    void deleteMber_S(String delId);
+
+    /**
+     * 일반회원의 기본정보를 데이터베이스에 저장
+     * @param mberManageVO 일반회원 등록정보
+     * @return String 등록결과
+     */
+    String insertMber_S(MberManageVO mberManageVO);
+
+    /**
+     * 일반회원 상세정보를 조회
+     * @param mberId 상세조회대상 일반회원아이디
+     * @return MberManageVO 일반회원 상세정보
+     */
+    MberManageVO selectMber_S(String mberId);
+
+    /**
+     * 일반회원 기본정보를 수정
+     * @param mberManageVO 일반회원수정정보
+     */
+    void updateMber_S(MberManageVO mberManageVO);
+
+    /**
+     * 일반회원 약관확인
+     * @param stplatId 일반회원약관아이디
+     * @return List 일반회원약관정보
+     */
+    List<StplatVO> selectStplat_S(String stplatId);
+
+    /**
+     * 일반회원 암호수정
+     * @param mberPasswordManageVO 일반회원 비밀번호 수정정보
+     */
+    void updatePassword_S(MberPasswordManageVO mberPasswordManageVO);
+
+    /**
+     * 일반회원 암호 조회
+     * @param mberPasswordManageVO 일반회원 암호 조회조건정보
+     * @return MberPasswordManageVO 일반회원 암호정보
+     */
+    MberPasswordManageVO selectPassword_S(MberPasswordManageVO mberPasswordManageVO);
+
+    /**
+     * 로그인인증제한 해제
+     * @param mberManageVO 일반회원정보
+     */
+    void updateLockIncorrect(MberManageVO mberManageVO);
+
+}

--- a/src/main/resources/egovframework/mapper/com/uss/umt/EgovDeptManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/umt/EgovDeptManage_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="deptManageDAO">
+<mapper namespace="egovframework.com.uss.umt.service.impl.DeptManageMapper">
 
     <resultMap id="deptManageVO" type="egovframework.com.uss.umt.service.DeptManageVO">
         <result property="orgnztId" column="ORGNZT_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/umt/EgovDeptManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/umt/EgovDeptManage_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="deptManageDAO">
+<mapper namespace="egovframework.com.uss.umt.service.impl.DeptManageMapper">
 
     <resultMap id="deptManageVO" type="egovframework.com.uss.umt.service.DeptManageVO">
         <result property="orgnztId" column="ORGNZT_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/umt/EgovDeptManage_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/umt/EgovDeptManage_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="deptManageDAO">
+<mapper namespace="egovframework.com.uss.umt.service.impl.DeptManageMapper">
 
     <resultMap id="deptManageVO" type="egovframework.com.uss.umt.service.DeptManageVO">
         <result property="orgnztId" column="ORGNZT_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/umt/EgovDeptManage_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/umt/EgovDeptManage_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="deptManageDAO">
+<mapper namespace="egovframework.com.uss.umt.service.impl.DeptManageMapper">
 
     <resultMap id="deptManageVO" type="egovframework.com.uss.umt.service.DeptManageVO">
         <result property="orgnztId" column="ORGNZT_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/umt/EgovDeptManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/umt/EgovDeptManage_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="deptManageDAO">
+<mapper namespace="egovframework.com.uss.umt.service.impl.DeptManageMapper">
 
     <resultMap id="deptManageVO" type="egovframework.com.uss.umt.service.DeptManageVO">
         <result property="orgnztId" column="ORGNZT_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/umt/EgovDeptManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/umt/EgovDeptManage_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="deptManageDAO">
+<mapper namespace="egovframework.com.uss.umt.service.impl.DeptManageMapper">
 
     <resultMap id="deptManageVO" type="egovframework.com.uss.umt.service.DeptManageVO">
         <result property="orgnztId" column="ORGNZT_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/umt/EgovDeptManage_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/umt/EgovDeptManage_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="deptManageDAO">
+<mapper namespace="egovframework.com.uss.umt.service.impl.DeptManageMapper">
 
     <resultMap id="deptManageVO" type="egovframework.com.uss.umt.service.DeptManageVO">
         <result property="orgnztId" column="ORGNZT_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/umt/EgovDeptManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/umt/EgovDeptManage_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="DeptManage">
+<mapper namespace="egovframework.com.uss.umt.service.impl.DeptManageMapper">
 
     <resultMap id="deptManageVO" type="egovframework.com.uss.umt.service.DeptManageVO">
         <result property="orgnztId" column="ORGNZT_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/umt/EgovEmplyrManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/umt/EgovEmplyrManage_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="emplyrManageDAO">
+<mapper namespace="egovframework.com.uss.umt.service.impl.EmplyrManageMapper">
 
     <select id="selectEmplyrList_S" resultType="egovMap">
 SELECT * FROM ( SELECT rownum rn, TB.* FROM (

--- a/src/main/resources/egovframework/mapper/com/uss/umt/EgovEmplyrManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/umt/EgovEmplyrManage_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="emplyrManageDAO">
+<mapper namespace="egovframework.com.uss.umt.service.impl.EmplyrManageMapper">
 
     <select id="selectEmplyrList_S" resultType="egovMap">
 SELECT * FROM ( SELECT rownum rn, TB.* FROM (

--- a/src/main/resources/egovframework/mapper/com/uss/umt/EgovEmplyrManage_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/umt/EgovEmplyrManage_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="emplyrManageDAO">
+<mapper namespace="egovframework.com.uss.umt.service.impl.EmplyrManageMapper">
 
     <select id="selectEmplyrList_S" resultType="egovMap">
 SELECT * FROM ( SELECT rownum rn, TB.* FROM (

--- a/src/main/resources/egovframework/mapper/com/uss/umt/EgovEmplyrManage_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/umt/EgovEmplyrManage_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="emplyrManageDAO">
+<mapper namespace="egovframework.com.uss.umt.service.impl.EmplyrManageMapper">
 
     <select id="selectEmplyrList_S" resultType="egovMap">
 SELECT 

--- a/src/main/resources/egovframework/mapper/com/uss/umt/EgovEmplyrManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/umt/EgovEmplyrManage_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="emplyrManageDAO">
+<mapper namespace="egovframework.com.uss.umt.service.impl.EmplyrManageMapper">
 
     <select id="selectEmplyrList_S" resultType="egovMap">
 SELECT 

--- a/src/main/resources/egovframework/mapper/com/uss/umt/EgovEmplyrManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/umt/EgovEmplyrManage_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="emplyrManageDAO">
+<mapper namespace="egovframework.com.uss.umt.service.impl.EmplyrManageMapper">
 
     <select id="selectEmplyrList_S" resultType="egovMap">
 SELECT * FROM ( SELECT rownum rn, TB.* FROM (

--- a/src/main/resources/egovframework/mapper/com/uss/umt/EgovEmplyrManage_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/umt/EgovEmplyrManage_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="emplyrManageDAO">
+<mapper namespace="egovframework.com.uss.umt.service.impl.EmplyrManageMapper">
 
     <select id="selectEmplyrList_S" resultType="egovMap">
 	    SELECT

--- a/src/main/resources/egovframework/mapper/com/uss/umt/EgovEmplyrManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/umt/EgovEmplyrManage_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="emplyrManageDAO">
+<mapper namespace="egovframework.com.uss.umt.service.impl.EmplyrManageMapper">
 
     <select id="selectEmplyrList_S" resultType="egovMap">
 SELECT * FROM ( SELECT rownum rn, TB.* FROM (

--- a/src/main/resources/egovframework/mapper/com/uss/umt/EgovEntrprsManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/umt/EgovEntrprsManage_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="entrprsManageDAO">
+<mapper namespace="egovframework.com.uss.umt.service.impl.EntrprsManageMapper">
 
     <resultMap id="stplatMap" type="egovframework.com.uss.umt.service.StplatVO">
         <result property="useStplatId" column="USE_STPLAT_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/umt/EgovEntrprsManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/umt/EgovEntrprsManage_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="entrprsManageDAO">
+<mapper namespace="egovframework.com.uss.umt.service.impl.EntrprsManageMapper">
 
     <resultMap id="stplatMap" type="egovframework.com.uss.umt.service.StplatVO">
         <result property="useStplatId" column="USE_STPLAT_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/umt/EgovEntrprsManage_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/umt/EgovEntrprsManage_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="entrprsManageDAO">
+<mapper namespace="egovframework.com.uss.umt.service.impl.EntrprsManageMapper">
 
     <resultMap id="stplatMap" type="egovframework.com.uss.umt.service.StplatVO">
         <result property="useStplatId" column="USE_STPLAT_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/umt/EgovEntrprsManage_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/umt/EgovEntrprsManage_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="entrprsManageDAO">
+<mapper namespace="egovframework.com.uss.umt.service.impl.EntrprsManageMapper">
 
     <resultMap id="stplatMap" type="egovframework.com.uss.umt.service.StplatVO">
         <result property="useStplatId" column="USE_STPLAT_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/umt/EgovEntrprsManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/umt/EgovEntrprsManage_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="entrprsManageDAO">
+<mapper namespace="egovframework.com.uss.umt.service.impl.EntrprsManageMapper">
 
     <resultMap id="stplatMap" type="egovframework.com.uss.umt.service.StplatVO">
         <result property="useStplatId" column="USE_STPLAT_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/umt/EgovEntrprsManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/umt/EgovEntrprsManage_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="entrprsManageDAO">
+<mapper namespace="egovframework.com.uss.umt.service.impl.EntrprsManageMapper">
 
     <resultMap id="stplatMap" type="egovframework.com.uss.umt.service.StplatVO">
         <result property="useStplatId" column="USE_STPLAT_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/umt/EgovEntrprsManage_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/umt/EgovEntrprsManage_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="entrprsManageDAO">
+<mapper namespace="egovframework.com.uss.umt.service.impl.EntrprsManageMapper">
 
     <resultMap id="stplatMap" type="egovframework.com.uss.umt.service.StplatVO">
         <result property="useStplatId" column="USE_STPLAT_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/umt/EgovEntrprsManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/umt/EgovEntrprsManage_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="entrprsManageDAO">
+<mapper namespace="egovframework.com.uss.umt.service.impl.EntrprsManageMapper">
 
     <resultMap id="stplatMap" type="egovframework.com.uss.umt.service.StplatVO">
         <result property="useStplatId" column="USE_STPLAT_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/umt/EgovMberManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/umt/EgovMberManage_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="mberManageDAO">
+<mapper namespace="egovframework.com.uss.umt.service.impl.MberManageMapper">
 
     <resultMap id="stplatMap" type="egovframework.com.uss.umt.service.StplatVO">
         <result property="useStplatId" column="USE_STPLAT_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/umt/EgovMberManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/umt/EgovMberManage_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="mberManageDAO">
+<mapper namespace="egovframework.com.uss.umt.service.impl.MberManageMapper">
 
     <resultMap id="stplatMap" type="egovframework.com.uss.umt.service.StplatVO">
         <result property="useStplatId" column="USE_STPLAT_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/umt/EgovMberManage_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/umt/EgovMberManage_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="mberManageDAO">
+<mapper namespace="egovframework.com.uss.umt.service.impl.MberManageMapper">
 
     <resultMap id="stplatMap" type="egovframework.com.uss.umt.service.StplatVO">
         <result property="useStplatId" column="USE_STPLAT_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/umt/EgovMberManage_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/umt/EgovMberManage_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="mberManageDAO">
+<mapper namespace="egovframework.com.uss.umt.service.impl.MberManageMapper">
 
     <resultMap id="stplatMap" type="egovframework.com.uss.umt.service.StplatVO">
         <result property="useStplatId" column="USE_STPLAT_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/umt/EgovMberManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/umt/EgovMberManage_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="mberManageDAO">
+<mapper namespace="egovframework.com.uss.umt.service.impl.MberManageMapper">
 
     <resultMap id="stplatMap" type="egovframework.com.uss.umt.service.StplatVO">
         <result property="useStplatId" column="USE_STPLAT_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/umt/EgovMberManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/umt/EgovMberManage_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="mberManageDAO">
+<mapper namespace="egovframework.com.uss.umt.service.impl.MberManageMapper">
 
     <resultMap id="stplatMap" type="egovframework.com.uss.umt.service.StplatVO">
         <result property="useStplatId" column="USE_STPLAT_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/umt/EgovMberManage_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/umt/EgovMberManage_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="mberManageDAO">
+<mapper namespace="egovframework.com.uss.umt.service.impl.MberManageMapper">
 
     <resultMap id="stplatMap" type="egovframework.com.uss.umt.service.StplatVO">
         <result property="useStplatId" column="USE_STPLAT_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/umt/EgovMberManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/umt/EgovMberManage_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="mberManageDAO">
+<mapper namespace="egovframework.com.uss.umt.service.impl.MberManageMapper">
 
     <resultMap id="stplatMap" type="egovframework.com.uss.umt.service.StplatVO">
         <result property="useStplatId" column="USE_STPLAT_ID"/>

--- a/src/main/resources/egovframework/spring/com/context-mapper.xml
+++ b/src/main/resources/egovframework/spring/com/context-mapper.xml
@@ -21,5 +21,10 @@
 	<bean id="egov.sqlSessionTemplate" class="org.mybatis.spring.SqlSessionTemplate">
 		<constructor-arg ref="egov.sqlSession"/>
 	</bean>
-	
+
+	<bean class="org.mybatis.spring.mapper.MapperScannerConfigurer">
+		<property name="basePackage" value="egovframework.com" />
+		<property name="annotationClass" value="org.egovframe.rte.psl.dataaccess.mapper.EgovMapper" />
+	</bean>
+
 </beans>


### PR DESCRIPTION
## 변경 사유
기존 XML namespace 기반 DAO를 eGovFrame 5.0 신규 `@EgovMapper` 인터페이스 방식으로 전환합니다.

## 변경 내용
- 대상: uss/umt(Emplyr·Entrprs·Dept·Mber) 4개 DAO
- 각 DAO에 대응하는 Mapper 인터페이스(`@EgovMapper`) 신규 추가
- DAO를 mapper 위임 구조로 리팩토링 (EgovComAbstractDAO 상속 제거, @Resource 주입, @Repository bean name 유지)
- XML mapper namespace를 mapper 인터페이스 FQN으로 변경
- context-mapper.xml에 MapperScannerConfigurer(annotationClass=EgovMapper) 추가

## 영향 범위
- 해당 모듈만 영향, 서비스 레이어 호출 시그니처 변경 없음

## 참고
- 빌드 검증을 위해 #891(Lombok annotationProcessorPaths 빌드 수정) 선행 머지 권장
- context-mapper.xml MapperScannerConfigurer는 동일 시리즈 PR과 한 줄 중복될 수 있어, 선행 PR 머지 후 rebase로 정리 가능

## 체크리스트
- [x] 단일 주제만 다룸
- [x] 컴파일 검증(해당 모듈 신규 오류 0)
- [x] 기존 동작 호환
