### PR TITLE
[refactor][5.0.x][공통컴포넌트] utl/sys 7개 시스템모니터링 DAO @EgovMapper 인터페이스 전환

### DIFF
--- a/src/main/java/egovframework/com/utl/sys/fsm/service/impl/FileSysMntrngDAO.java
+++ b/src/main/java/egovframework/com/utl/sys/fsm/service/impl/FileSysMntrngDAO.java
@@ -1,9 +1,9 @@
 package egovframework.com.utl.sys.fsm.service.impl;
+
 import java.util.List;
 
-import org.springframework.stereotype.Repository;
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.utl.sys.fsm.service.FileSysMntrng;
 import egovframework.com.utl.sys.fsm.service.FileSysMntrngLog;
 import egovframework.com.utl.sys.fsm.service.FileSysMntrngLogVO;
@@ -11,132 +11,99 @@ import egovframework.com.utl.sys.fsm.service.FileSysMntrngVO;
 
 /**
  * 개요
- * - 파일시스템 모니터링대상에 대한 DAO 클래스를 정의한다.
+ * - 파일시스템 모니터링대상에 대한 DAO 인터페이스를 정의한다.
  *
  * 상세내용
  * - 파일시스템 모니터링대상에 대한 등록, 수정, 삭제, 조회기능을 제공한다.
  * - 파일시스템 모니터링대상의 조회기능은 목록조회, 상세조회로 구분된다.
+ *
  * @author 장철호
  * @version 1.0
  * @created 28-6-2010 오전 11:33:26
+ *
+ * <pre>
+ *  == 개정이력(Modification Information) ==
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2010.06.28  장철호           최초 생성
+ *   2026.05.28  dasomel        @EgovMapper 인터페이스 방식으로 전환
+ *
+ * </pre>
  */
-@Repository("FileSysMntrngDAO")
-public class FileSysMntrngDAO extends EgovComAbstractDAO {
+@EgovMapper("FileSysMntrngDAO")
+public interface FileSysMntrngDAO {
 
 	/**
 	 * 주어진 조건에 맞는 파일시스템모니터링 대상 목록을 불러온다.
-	 * @param FileSysMntrngVO - 파일시스템모니터링 대상 VO
-	 * @return List<FileSysMntrngVO> - 파일시스템모니터링 대상 List
-	 *
-	 * @param fileSysMntrngVO
+	 * @param fileSysMntrngVO - 파일시스템모니터링 대상 VO
+	 * @return List - 파일시스템모니터링 대상 List
 	 */
-	public List<FileSysMntrngVO> selectFileSysMntrngList(FileSysMntrngVO fileSysMntrngVO) throws Exception{
-		return selectList("FileSysMntrngDAO.selectFileSysMntrngList", fileSysMntrngVO);
-	}
+	List<FileSysMntrngVO> selectFileSysMntrngList(FileSysMntrngVO fileSysMntrngVO);
 
 	/**
 	 * 주어진 조건에 맞는 파일시스템모니터링 대상을 불러온다.
-	 * @param FileSysMntrngVO - 파일시스템모니터링 대상 VO
+	 * @param fileSysMntrngVO - 파일시스템모니터링 대상 VO
 	 * @return FileSysMntrngVO - 파일시스템모니터링 대상 VO
-	 *
-	 * @param fileSysMntrngVO
 	 */
-	public FileSysMntrngVO selectFileSysMntrng(FileSysMntrngVO fileSysMntrngVO) throws Exception{
-		return (FileSysMntrngVO)selectOne("FileSysMntrngDAO.selectFileSysMntrng", fileSysMntrngVO);
-	}
+	FileSysMntrngVO selectFileSysMntrng(FileSysMntrngVO fileSysMntrngVO);
 
 	/**
 	 * 파일시스템 모니터링 대상 정보를 수정한다.
-	 * @param FileSysMntrng - 파일시스템모니터링 대상 model
-	 *
-	 * @param fileSysMntrng
+	 * @param fileSysMntrng - 파일시스템모니터링 대상 model
 	 */
-	public void updateFileSysMntrng(FileSysMntrng fileSysMntrng) throws Exception{
-		update("FileSysMntrngDAO.updateFileSysMntrng", fileSysMntrng);
-	}
+	void updateFileSysMntrng(FileSysMntrng fileSysMntrng);
 
 	/**
 	 * 파일시스템 모니터링 대상 정보를 등록한다.
-	 * @param FileSysMntrng - 파일시스템모니터링 대상 model
-	 *
-	 * @param fileSysMntrng
+	 * @param fileSysMntrng - 파일시스템모니터링 대상 model
 	 */
-	public void insertFileSysMntrng(FileSysMntrng fileSysMntrng) throws Exception{
-		insert("FileSysMntrngDAO.insertFileSysMntrng", fileSysMntrng);
-	}
+	void insertFileSysMntrng(FileSysMntrng fileSysMntrng);
 
 	/**
 	 * 파일시스템 모니터링 대상 정보를 삭제한다.
-	 * @param FileSysMntrng - 파일시스템모니터링 대상 model
-	 *
-	 * @param fileSysMntrng
+	 * @param fileSysMntrng - 파일시스템모니터링 대상 model
 	 */
-	public void deleteFileSysMntrng(FileSysMntrng fileSysMntrng) throws Exception{
-		delete("FileSysMntrngDAO.deleteFileSysMntrng", fileSysMntrng);
-	}
+	void deleteFileSysMntrng(FileSysMntrng fileSysMntrng);
 
 	/**
 	 * 파일시스템 모니터링대상 목록에 대한 전체 건수를 조회한다.
-	 * @param FileSysMntrngVO - 파일시스템모니터링 대상 VO
+	 * @param fileSysMntrngVO - 파일시스템모니터링 대상 VO
 	 * @return int
-	 *
-	 * @param fileSysMntrngVO
 	 */
-	public int selectFileSysMntrngListCnt(FileSysMntrngVO fileSysMntrngVO) throws Exception{
-		return (Integer)selectOne("FileSysMntrngDAO.selectFileSysMntrngListCnt", fileSysMntrngVO);
-	}
+	int selectFileSysMntrngListCnt(FileSysMntrngVO fileSysMntrngVO);
 
 	/**
 	 * 파일시스템 모니터링 결과 정보를 수정한다.
-	 * @param FileSysMntrng - 파일시스템모니터링 대상 model
-	 *
-	 * @param fileSysMntrng
+	 * @param fileSysMntrng - 파일시스템모니터링 대상 model
 	 */
-	public void updateFileSysMntrngSttus(FileSysMntrng fileSysMntrng) throws Exception{
-		update("FileSysMntrngDAO.updateFileSysMntrngSttus", fileSysMntrng);
-	}
+	void updateFileSysMntrngSttus(FileSysMntrng fileSysMntrng);
 
 	/**
 	 * 주어진 조건에 맞는 파일시스템모니터링 로그 목록을 불러온다.
-	 * @param FileSysMntrngVO - 파일시스템모니터링 로그 VO
-	 * @return List<FileSysMntrngLogVO> - 파일시스템모니터링 로그 List
-	 *
-	 * @param fileSysMntrngVO
+	 * @param fileSysMntrngLogVO - 파일시스템모니터링 로그 VO
+	 * @return List - 파일시스템모니터링 로그 List
 	 */
-	public List<FileSysMntrngLogVO> selectFileSysMntrngLogList(FileSysMntrngLogVO fileSysMntrngLogVO) throws Exception{
-		return selectList("FileSysMntrngDAO.selectFileSysMntrngLogList", fileSysMntrngLogVO);
-	}
+	List<FileSysMntrngLogVO> selectFileSysMntrngLogList(FileSysMntrngLogVO fileSysMntrngLogVO);
 
 	/**
 	 * 파일시스템 모니터링로그 목록에 대한 전체 건수를 조회한다.
-	 * @param FileSysMntrngLogVO - 파일시스템모니터링 로그 VO
+	 * @param fileSysMntrngLogVO - 파일시스템모니터링 로그 VO
 	 * @return int
-	 *
-	 * @param fileSysMntrngLogVO
 	 */
-	public int selectFileSysMntrngLogListCnt(FileSysMntrngLogVO fileSysMntrngLogVO) throws Exception{
-		return (Integer)selectOne("FileSysMntrngDAO.selectFileSysMntrngLogListCnt", fileSysMntrngLogVO);
-	}
+	int selectFileSysMntrngLogListCnt(FileSysMntrngLogVO fileSysMntrngLogVO);
 
 	/**
 	 * 주어진 조건에 맞는 파일시스템모니터링 로그를 불러온다.
-	 * @param FileSysMntrngLogVO - 파일시스템모니터링 로그 VO
+	 * @param fileSysMntrngLogVO - 파일시스템모니터링 로그 VO
 	 * @return FileSysMntrngLogVO - 파일시스템모니터링 로그 VO
-	 *
-	 * @param fileSysMntrngLogVO
 	 */
-	public FileSysMntrngLogVO selectFileSysMntrngLog(FileSysMntrngLogVO fileSysMntrngLogVO) throws Exception{
-		return (FileSysMntrngLogVO)selectOne("FileSysMntrngDAO.selectFileSysMntrngLog", fileSysMntrngLogVO);
-	}
+	FileSysMntrngLogVO selectFileSysMntrngLog(FileSysMntrngLogVO fileSysMntrngLogVO);
 
 	/**
-	 * 파일시스템 모니터링 대상 정보를 등록한다.
-	 * @param FileSysMntrngLog - 파일시스템모니터링 대상 model
-	 *
-	 * @param fileSysMntrngLog
+	 * 파일시스템 모니터링 로그 정보를 등록한다.
+	 * @param fileSysMntrngLog - 파일시스템모니터링 로그 model
 	 */
-	public void insertFileSysMntrngLog(FileSysMntrngLog fileSysMntrngLog) throws Exception{
-		insert("FileSysMntrngDAO.insertFileSysMntrngLog", fileSysMntrngLog);
-	}
+	void insertFileSysMntrngLog(FileSysMntrngLog fileSysMntrngLog);
 
 }

--- a/src/main/java/egovframework/com/utl/sys/htm/service/impl/HttpMonDAO.java
+++ b/src/main/java/egovframework/com/utl/sys/htm/service/impl/HttpMonDAO.java
@@ -2,152 +2,119 @@ package egovframework.com.utl.sys.htm.service.impl;
 
 import java.util.List;
 
-import org.springframework.stereotype.Repository;
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.utl.sys.htm.service.HttpMon;
 import egovframework.com.utl.sys.htm.service.HttpMonLog;
 import egovframework.com.utl.sys.htm.service.HttpMonLogVO;
 import egovframework.com.utl.sys.htm.service.HttpMonVO;
 
 /**
- * 개요 - HTTP서비스모니터링에 대한 DAO 클래스를 정의한다.
+ * 개요
+ * - HTTP서비스모니터링에 대한 DAO 인터페이스를 정의한다.
  *
- * 상세내용 - HTTP서비스모니터링에 대한 등록, 수정, 삭제, 조회 기능을 제공한다. - HTTP서비스모니터링의 조회기능은 목록조회,
- * 상세조회로 구분된다.
+ * 상세내용
+ * - HTTP서비스모니터링에 대한 등록, 수정, 삭제, 조회 기능을 제공한다.
+ * - HTTP서비스모니터링의 조회기능은 목록조회, 상세조회로 구분된다.
  *
  * @author 박종선
  * @version 1.0
  * @created 17-6-2010 오후 5:12:45
+ *
+ * <pre>
+ *  == 개정이력(Modification Information) ==
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2010.06.17  박종선           최초 생성
+ *   2026.05.28  dasomel        @EgovMapper 인터페이스 방식으로 전환
+ *
+ * </pre>
  */
-@Repository("HttpMonDAO")
-public class HttpMonDAO extends EgovComAbstractDAO {
+@EgovMapper("HttpMonDAO")
+public interface HttpMonDAO {
 
 	/**
 	 * 등록된 HTTP서비스모니터링 목록을 조회한다.
 	 *
-	 * @param HttpMonVO - HTTP서비스모니터링 Vo
+	 * @param searchVO - HTTP서비스모니터링 Vo
 	 * @return List - HTTP서비스모니터링 목록
-	 *
-	 * @param httpMonVO
 	 */
-	public List<HttpMonVO> selectHttpMonList(HttpMonVO searchVO) throws Exception {
-		return selectList("HttpMonDAO.selectHttpMonList", searchVO);
-	}
+	List<HttpMonVO> selectHttpMonList(HttpMonVO searchVO);
 
 	/**
 	 * HTTP서비스모니터링 목록 총 개수를 조회한다.
 	 *
-	 * @param HttpMonVO - HTTP서비스모니터링 Vo
+	 * @param searchVO - HTTP서비스모니터링 Vo
 	 * @return int - HTTP서비스 토탈 카운트 수
-	 *
-	 * @param httpMonVO
 	 */
-	public int selectHttpMonTotCnt(HttpMonVO searchVO) throws Exception {
-		return (Integer) selectOne("HttpMonDAO.selectHttpMonTotCnt", searchVO);
-	}
+	int selectHttpMonTotCnt(HttpMonVO searchVO);
 
 	/**
 	 * 등록된 HTTP서비스모니터링의 상세정보를 조회한다.
 	 *
-	 * @param httpMonVO - HTTP서비스모니터링 Vo
-	 * @return httpMonVO - HTTP서비스모니터링 Vo
-	 *
-	 * @param httpMonVO
+	 * @param httpMon - HTTP서비스모니터링 Vo
+	 * @return HttpMon - HTTP서비스모니터링 Vo
 	 */
-	public HttpMon selectHttpMonDetail(HttpMon httpMon) throws Exception {
-		return (HttpMon) selectOne("HttpMonDAO.selectHttpMonDetail", httpMon);
-	}
+	HttpMon selectHttpMonDetail(HttpMon httpMon);
 
 	/**
 	 * HTTP서비스모니터링 정보를 신규로 등록한다.
 	 *
-	 * @param siteUrl - HTTP서비스모니터링 model
-	 *
-	 * @param siteUrl
+	 * @param httpMon - HTTP서비스모니터링 model
 	 */
-	public void insertHttpMon(HttpMon httpMon) throws Exception {
-		insert("HttpMonDAO.insertHttpMon", httpMon);
-	}
+	void insertHttpMon(HttpMon httpMon);
 
 	/**
 	 * 기 등록된 HTTP서비스모니터링 정보를 수정한다.
 	 *
-	 * @param siteUrl - HTTP서비스모니터링 model
-	 *
-	 * @param siteUrl
+	 * @param httpMon - HTTP서비스모니터링 model
 	 */
-	public void updateHttpMon(HttpMon httpMon) throws Exception {
-		update("HttpMonDAO.updateHttpMon", httpMon);
-	}
+	void updateHttpMon(HttpMon httpMon);
 
 	/**
 	 * 기 등록된 HTTP서비스모니터링 정보를 삭제한다.
 	 *
-	 * @param siteUrl - HTTP서비스모니터링 model
-	 *
-	 * @param siteUrl
+	 * @param httpMon - HTTP서비스모니터링 model
 	 */
-	public void deleteHttpMon(HttpMon httpMon) throws Exception {
-		update("HttpMonDAO.deleteHttpMon", httpMon);
-	}
+	void deleteHttpMon(HttpMon httpMon);
 
 	/**
 	 * 등록된 HTTP서비스모니터링로그 목록을 조회한다.
 	 *
-	 * @param HttpMonVO - HTTP서비스모니터링 Vo
+	 * @param httpMonLogVO - HTTP서비스모니터링 Vo
 	 * @return List - HTTP서비스모니터링 목록
-	 *
-	 * @param httpMonVO
 	 */
-	public List<HttpMonLogVO> selectHttpMonLogList(HttpMonLogVO httpMonLogVO) throws Exception {
-		return selectList("HttpMonDAO.selectHttpMonLogList", httpMonLogVO);
-	}
+	List<HttpMonLogVO> selectHttpMonLogList(HttpMonLogVO httpMonLogVO);
 
 	/**
 	 * HTTP서비스모니터링로그 목록 총 개수를 조회한다.
 	 *
-	 * @param HttpMonVO - HTTP서비스모니터링 Vo
+	 * @param httpMonLogVO - HTTP서비스모니터링 Vo
 	 * @return int - HTTP서비스 토탈 카운트 수
-	 *
-	 * @param httpMonVO
 	 */
-	public int selectHttpMonLogTotCnt(HttpMonLogVO httpMonLogVO) throws Exception {
-		return (Integer) selectOne("HttpMonDAO.selectHttpMonLogTotCnt", httpMonLogVO);
-	}
+	int selectHttpMonLogTotCnt(HttpMonLogVO httpMonLogVO);
 
 	/**
 	 * 등록된 HTTP서비스모니터링로그의 상세정보를 조회한다.
 	 *
-	 * @param httpMonVO - HTTP서비스모니터링 Vo
-	 * @return httpMonVO - HTTP서비스모니터링 Vo
-	 *
-	 * @param httpMonVO
+	 * @param httpMonLog - HTTP서비스모니터링 Vo
+	 * @return HttpMonLog - HTTP서비스모니터링 Vo
 	 */
-	public HttpMonLog selectHttpMonDetailLog(HttpMonLog httpMonLog) throws Exception {
-		return (HttpMonLog) selectOne("HttpMonDAO.selectHttpMonDetailLog", httpMonLog);
-	}
+	HttpMonLog selectHttpMonDetailLog(HttpMonLog httpMonLog);
 
 	/**
 	 * HTTP서비스모니터링로그 정보를 신규로 등록한다.
 	 *
-	 * @param siteUrl - HTTP서비스모니터링 model
-	 *
-	 * @param siteUrl
+	 * @param httpMonLog - HTTP서비스모니터링 model
 	 */
-	public void insertHttpMonLog(HttpMonLog httpMonLog) throws Exception {
-		insert("HttpMonDAO.insertHttpMonLog", httpMonLog);
-	}
+	void insertHttpMonLog(HttpMonLog httpMonLog);
 
 	/**
 	 * HTTP서비스모니터링 결과 정보를 수정한다.
 	 *
-	 * @param siteUrl - HTTP서비스모니터링 model
-	 *
-	 * @param siteUrl
+	 * @param httpMon - HTTP서비스모니터링 model
 	 */
-	public void updateHttpMonSttus(HttpMon httpMon) throws Exception {
-		update("HttpMonDAO.updateHttpMonSttus", httpMon);
-	}
+	void updateHttpMonSttus(HttpMon httpMon);
 
 }

--- a/src/main/java/egovframework/com/utl/sys/nsm/service/impl/NtwrkSvcMntrngDAO.java
+++ b/src/main/java/egovframework/com/utl/sys/nsm/service/impl/NtwrkSvcMntrngDAO.java
@@ -1,9 +1,9 @@
 package egovframework.com.utl.sys.nsm.service.impl;
+
 import java.util.List;
 
-import org.springframework.stereotype.Repository;
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.utl.sys.nsm.service.NtwrkSvcMntrng;
 import egovframework.com.utl.sys.nsm.service.NtwrkSvcMntrngLog;
 import egovframework.com.utl.sys.nsm.service.NtwrkSvcMntrngLogVO;
@@ -11,143 +11,106 @@ import egovframework.com.utl.sys.nsm.service.NtwrkSvcMntrngVO;
 
 /**
  * 개요
- * - 네트워크서비스 모니터링대상에 대한 DAO 클래스를 정의한다.
+ * - 네트워크서비스 모니터링대상에 대한 DAO 인터페이스를 정의한다.
  *
  * 상세내용
  * - 네트워크서비스 모니터링대상에 대한 등록, 수정, 삭제, 조회기능을 제공한다.
  * - 네트워크서비스 모니터링대상의 조회기능은 목록조회, 상세조회로 구분된다.
+ *
  * @author 장철호
  * @version 1.0
  * @created 28-6-2010 오전 11:33:43
+ *
+ * <pre>
+ *  == 개정이력(Modification Information) ==
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2010.06.28  장철호           최초 생성
+ *   2026.05.28  dasomel        @EgovMapper 인터페이스 방식으로 전환
+ *
+ * </pre>
  */
-@Repository("NtwrkSvcMntrngDAO")
-public class NtwrkSvcMntrngDAO extends EgovComAbstractDAO {
+@EgovMapper("NtwrkSvcMntrngDAO")
+public interface NtwrkSvcMntrngDAO {
 
 	/**
 	 * 주어진 조건에 맞는 네트워크서비스 모니터링 대상 목록을 불러온다.
-	 * @param NtwrkSvcMntrngVO - 네트워크서비스 모니터링 대상 VO
-	 * @return List<NtwrkSvcMntrngVO> - 네트워크서비스 모니터링 대상 List
-	 *
-	 * @param ntwrkSvcMntrngVO
+	 * @param ntwrkSvcMntrngVO - 네트워크서비스 모니터링 대상 VO
+	 * @return List - 네트워크서비스 모니터링 대상 List
 	 */
-	public List<NtwrkSvcMntrngVO> selectNtwrkSvcMntrngList(NtwrkSvcMntrngVO ntwrkSvcMntrngVO) throws Exception{
-		return selectList("NtwrkSvcMntrngDAO.selectNtwrkSvcMntrngList", ntwrkSvcMntrngVO);
-	}
+	List<NtwrkSvcMntrngVO> selectNtwrkSvcMntrngList(NtwrkSvcMntrngVO ntwrkSvcMntrngVO);
 
 	/**
 	 * 주어진 조건에 맞는 네트워크서비스 모니터링 대상을 불러온다.
-	 * @param NtwrkSvcMntrngVO - 네트워크서비스 모니터링 대상 VO
+	 * @param ntwrkSvcMntrngVO - 네트워크서비스 모니터링 대상 VO
 	 * @return NtwrkSvcMntrngVO - 네트워크서비스 모니터링 대상 VO
-	 *
-	 * @param ntwrkSvcMntrngVO
 	 */
-	public NtwrkSvcMntrngVO selectNtwrkSvcMntrng(NtwrkSvcMntrngVO ntwrkSvcMntrngVO) throws Exception{
-		return (NtwrkSvcMntrngVO)selectOne("NtwrkSvcMntrngDAO.selectNtwrkSvcMntrng", ntwrkSvcMntrngVO);
-	}
+	NtwrkSvcMntrngVO selectNtwrkSvcMntrng(NtwrkSvcMntrngVO ntwrkSvcMntrngVO);
 
 	/**
 	 * 네트워크서비스 모니터링 대상 정보를 수정한다.
-	 * @param NtwrkSvcMntrng - 네트워크서비스 모니터링 대상 model
-	 *
-	 * @param ntwrkSvcMntrng
+	 * @param ntwrkSvcMntrng - 네트워크서비스 모니터링 대상 model
 	 */
-	public void updateNtwrkSvcMntrng(NtwrkSvcMntrng ntwrkSvcMntrng) throws Exception{
-		update("NtwrkSvcMntrngDAO.updateNtwrkSvcMntrng", ntwrkSvcMntrng);
-	}
+	void updateNtwrkSvcMntrng(NtwrkSvcMntrng ntwrkSvcMntrng);
 
 	/**
 	 * 네트워크서비스 모니터링 대상 정보를 등록한다.
-	 * @param NtwrkSvcMntrng - 네트워크서비스 모니터링 대상 model
-	 *
-	 * @param ntwrkSvcMntrng
+	 * @param ntwrkSvcMntrng - 네트워크서비스 모니터링 대상 model
 	 */
-	public void insertNtwrkSvcMntrng(NtwrkSvcMntrng ntwrkSvcMntrng) throws Exception{
-		insert("NtwrkSvcMntrngDAO.insertNtwrkSvcMntrng", ntwrkSvcMntrng);
-	}
+	void insertNtwrkSvcMntrng(NtwrkSvcMntrng ntwrkSvcMntrng);
 
 	/**
 	 * 네트워크서비스 모니터링대상 등록을 위한 중복 조회를 수행한다.
-	 * @param NtwrkSvcMntrngVO - 네트워크서비스 모니터링 대상 VO
+	 * @param ntwrkSvcMntrngVO - 네트워크서비스 모니터링 대상 VO
 	 * @return int
-	 *
-	 * @param ntwrkSvcMntrngVO
 	 */
-	public int selectNtwrkSvcMntrngCheck(NtwrkSvcMntrngVO ntwrkSvcMntrngVO) throws Exception{
-		return (Integer)selectOne("NtwrkSvcMntrngDAO.selectNtwrkSvcMntrngCheck", ntwrkSvcMntrngVO);
-	}
+	int selectNtwrkSvcMntrngCheck(NtwrkSvcMntrngVO ntwrkSvcMntrngVO);
 
 	/**
 	 * 네트워크서비스 모니터링 대상 정보를 삭제한다.
-	 * @param NtwrkSvcMntrng - 네트워크서비스 모니터링 대상 model
-	 *
-	 * @param ntwrkSvcMntrng
+	 * @param ntwrkSvcMntrng - 네트워크서비스 모니터링 대상 model
 	 */
-	public void deleteNtwrkSvcMntrng(NtwrkSvcMntrng ntwrkSvcMntrng) throws Exception{
-		delete("NtwrkSvcMntrngDAO.deleteNtwrkSvcMntrng", ntwrkSvcMntrng);
-	}
+	void deleteNtwrkSvcMntrng(NtwrkSvcMntrng ntwrkSvcMntrng);
 
 	/**
 	 * 네트워크서비스 모니터링대상 목록에 대한 전체 건수를 조회한다.
-	 * @param NtwrkSvcMntrngVO - 네트워크서비스 모니터링 대상 VO
+	 * @param ntwrkSvcMntrngVO - 네트워크서비스 모니터링 대상 VO
 	 * @return int
-	 *
-	 * @param ntwrkSvcMntrngVO
 	 */
-	public int selectNtwrkSvcMntrngListCnt(NtwrkSvcMntrngVO ntwrkSvcMntrngVO) throws Exception{
-		return (Integer)selectOne("NtwrkSvcMntrngDAO.selectNtwrkSvcMntrngListCnt", ntwrkSvcMntrngVO);
-	}
+	int selectNtwrkSvcMntrngListCnt(NtwrkSvcMntrngVO ntwrkSvcMntrngVO);
 
 	/**
 	 * 네트워크서비스 모니터링 결과를 수정한다.
-	 * @param NtwrkSvcMntrng - 네트워크서비스 모니터링 대상 model
-	 *
-	 * @param ntwrkSvcMntrng
+	 * @param ntwrkSvcMntrng - 네트워크서비스 모니터링 대상 model
 	 */
-	public void updateNtwrkSvcMntrngSttus(NtwrkSvcMntrng ntwrkSvcMntrng) throws Exception{
-		update("NtwrkSvcMntrngDAO.updateNtwrkSvcMntrngSttus", ntwrkSvcMntrng);
-	}
+	void updateNtwrkSvcMntrngSttus(NtwrkSvcMntrng ntwrkSvcMntrng);
 
 	/**
 	 * 주어진 조건에 맞는 네트워크서비스 모니터링 로그 목록을 불러온다.
-	 * @param NtwrkSvcMntrngLogVO - 네트워크서비스 모니터링 로그 VO
-	 * @return  List<NtwrkSvcMntrngLogVO> - 네트워크서비스 모니터링 로그 List
-	 *
-	 * @param ntwrkSvcMntrngLogVO
+	 * @param ntwrkSvcMntrngLogVO - 네트워크서비스 모니터링 로그 VO
+	 * @return List - 네트워크서비스 모니터링 로그 List
 	 */
-	public List<NtwrkSvcMntrngLogVO> selectNtwrkSvcMntrngLogList(NtwrkSvcMntrngLogVO ntwrkSvcMntrngLogVO) throws Exception{
-		return selectList("NtwrkSvcMntrngDAO.selectNtwrkSvcMntrngLogList", ntwrkSvcMntrngLogVO);
-	}
+	List<NtwrkSvcMntrngLogVO> selectNtwrkSvcMntrngLogList(NtwrkSvcMntrngLogVO ntwrkSvcMntrngLogVO);
 
 	/**
 	 * 네트워크서비스 모니터링 로그 목록에 대한 전체 건수를 조회한다.
-	 * @param NtwrkSvcMntrngLogVO - 네트워크서비스 모니터링 로그 VO
+	 * @param ntwrkSvcMntrngLogVO - 네트워크서비스 모니터링 로그 VO
 	 * @return int
-	 *
-	 * @param ntwrkSvcMntrngLogVO
 	 */
-	public int selectNtwrkSvcMntrngLogListCnt(NtwrkSvcMntrngLogVO ntwrkSvcMntrngLogVO) throws Exception{
-		return (Integer)selectOne("NtwrkSvcMntrngDAO.selectNtwrkSvcMntrngLogListCnt", ntwrkSvcMntrngLogVO);
-	}
+	int selectNtwrkSvcMntrngLogListCnt(NtwrkSvcMntrngLogVO ntwrkSvcMntrngLogVO);
 
 	/**
 	 * 주어진 조건에 맞는 네트워크서비스 모니터링 로그를 불러온다.
-	 * @param NtwrkSvcMntrngLogVO - 네트워크서비스 모니터링 로그 VO
+	 * @param ntwrkSvcMntrngLogVO - 네트워크서비스 모니터링 로그 VO
 	 * @return NtwrkSvcMntrngLogVO - 네트워크서비스 모니터링 로그 VO
-	 *
-	 * @param ntwrkSvcMntrngLogVO
 	 */
-	public NtwrkSvcMntrngLogVO selectNtwrkSvcMntrngLog(NtwrkSvcMntrngLogVO ntwrkSvcMntrngLogVO) throws Exception{
-		return (NtwrkSvcMntrngLogVO)selectOne("NtwrkSvcMntrngDAO.selectNtwrkSvcMntrngLog", ntwrkSvcMntrngLogVO);
-	}
+	NtwrkSvcMntrngLogVO selectNtwrkSvcMntrngLog(NtwrkSvcMntrngLogVO ntwrkSvcMntrngLogVO);
 
 	/**
 	 * 네트워크서비스 모니터링 로그 정보를 등록한다.
-	 * @param NtwrkSvcMntrngLog - 네트워크서비스 모니터링 로그 model
-	 *
-	 * @param ntwrkSvcMntrngLog
+	 * @param ntwrkSvcMntrngLog - 네트워크서비스 모니터링 로그 model
 	 */
-	public void insertNtwrkSvcMntrngLog(NtwrkSvcMntrngLog ntwrkSvcMntrngLog) throws Exception{
-		insert("NtwrkSvcMntrngDAO.insertNtwrkSvcMntrngLog", ntwrkSvcMntrngLog);
-	}
+	void insertNtwrkSvcMntrngLog(NtwrkSvcMntrngLog ntwrkSvcMntrngLog);
 
 }

--- a/src/main/java/egovframework/com/utl/sys/prm/service/impl/ProcessMonDAO.java
+++ b/src/main/java/egovframework/com/utl/sys/prm/service/impl/ProcessMonDAO.java
@@ -2,9 +2,8 @@ package egovframework.com.utl.sys.prm.service.impl;
 
 import java.util.List;
 
-import org.springframework.stereotype.Repository;
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.utl.sys.prm.service.ProcessMon;
 import egovframework.com.utl.sys.prm.service.ProcessMonLog;
 import egovframework.com.utl.sys.prm.service.ProcessMonLogVO;
@@ -12,126 +11,115 @@ import egovframework.com.utl.sys.prm.service.ProcessMonVO;
 
 /**
  * 개요
- * - PROCESS모니터링에 대한 DAO 클래스를 정의한다.
+ * - PROCESS모니터링에 대한 DAO 인터페이스를 정의한다.
  *
  * 상세내용
  * - PROCESS모니터링에 대한 등록, 수정, 삭제, 조회 기능을 제공한다.
  * - PROCESS모니터링의 조회기능은 목록조회, 상세조회로 구분된다.
+ *
  * @author 박종선
  * @version 1.0
  * @created 08-9-2010 오후 3:54:46
+ *
+ * <pre>
+ *  == 개정이력(Modification Information) ==
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2010.09.08  박종선           최초 생성
+ *   2026.05.28  dasomel        @EgovMapper 인터페이스 방식으로 전환
+ *
+ * </pre>
  */
-
-@Repository("ProcessMonDAO")
-public class ProcessMonDAO extends EgovComAbstractDAO {
+@EgovMapper("ProcessMonDAO")
+public interface ProcessMonDAO {
 
 	/**
-     * 등록된 PROCESS모니터링 목록을 조회한다.
-     *
-     * @param processMonVO - PROCESS모니터링 Vo
-     * @return List - PROCESS모니터링 목록
-     */
-    public List<ProcessMonVO> selectProcessMonList(ProcessMonVO processMonVO) throws Exception {
-        return selectList("ProcessMonDAO.selectProcessMonList", processMonVO);
-    }
+	 * 등록된 PROCESS모니터링 목록을 조회한다.
+	 *
+	 * @param processMonVO - PROCESS모니터링 Vo
+	 * @return List - PROCESS모니터링 목록
+	 */
+	List<ProcessMonVO> selectProcessMonList(ProcessMonVO processMonVO);
 
-    /**
-     * PROCESS모니터링 목록 총 개수를 조회한다.
-     *
-     * @param ProcessMonVO - PROCESS모니터링 Vo
-     * @return int - PROCESS모니터링 토탈 카운트 수
-     */
-    public int selectProcessMonTotCnt(ProcessMonVO processMonVO) throws Exception {
-        return selectOne("ProcessMonDAO.selectProcessMonTotCnt", processMonVO);
-    }
+	/**
+	 * PROCESS모니터링 목록 총 개수를 조회한다.
+	 *
+	 * @param processMonVO - PROCESS모니터링 Vo
+	 * @return int - PROCESS모니터링 토탈 카운트 수
+	 */
+	int selectProcessMonTotCnt(ProcessMonVO processMonVO);
 
-    /**
-     * 등록된 PROCESS모니터링의 상세정보를 조회한다.
-     *
-     * @param processMonVO - PROCESS모니터링 Vo
-     * @return processMonVO - PROCESS모니터링 Vo
-     */
-    public ProcessMonVO selectProcessMon(ProcessMonVO processMonVO) throws Exception {
-        return selectOne("ProcessMonDAO.selectProcessMon", processMonVO);
-    }
+	/**
+	 * 등록된 PROCESS모니터링의 상세정보를 조회한다.
+	 *
+	 * @param processMonVO - PROCESS모니터링 Vo
+	 * @return ProcessMonVO - PROCESS모니터링 Vo
+	 */
+	ProcessMonVO selectProcessMon(ProcessMonVO processMonVO);
 
-    /**
-     * PROCESS모니터링 정보를 신규로 등록한다.
-     *
-     * @param processNm - PROCESS모니터링 model
-     * @return int - 등록 결과
-     */
-    public int insertProcessMon(ProcessMon processMon) throws Exception {
-        return insert("ProcessMonDAO.insertProcessMon", processMon);
-    }
+	/**
+	 * PROCESS모니터링 정보를 신규로 등록한다.
+	 *
+	 * @param processMon - PROCESS모니터링 model
+	 * @return int - 등록 결과
+	 */
+	int insertProcessMon(ProcessMon processMon);
 
-    /**
-     * 기 등록된 PROCESS모니터링 정보를 수정한다.
-     *
-     * @param processNm - PROCESS모니터링 model
-     * @return int - 수정 결과
-     */
-    public int updateProcessMon(ProcessMon processMon) throws Exception {
-        return update("ProcessMonDAO.updateProcessMon", processMon);
-    }
+	/**
+	 * 기 등록된 PROCESS모니터링 정보를 수정한다.
+	 *
+	 * @param processMon - PROCESS모니터링 model
+	 * @return int - 수정 결과
+	 */
+	int updateProcessMon(ProcessMon processMon);
 
-    /**
-     * 기 등록된 PROCESS모니터링 정보를 삭제한다.
-     *
-     * @param processNm - PROCESS모니터링 model
-     * @return int - 삭제 결과
-     */
-    public int deleteProcessMon(ProcessMon processMon) throws Exception {
-        return delete("ProcessMonDAO.deleteProcessMon", processMon);
-    }
+	/**
+	 * 기 등록된 PROCESS모니터링 정보를 삭제한다.
+	 *
+	 * @param processMon - PROCESS모니터링 model
+	 * @return int - 삭제 결과
+	 */
+	int deleteProcessMon(ProcessMon processMon);
 
-    /**
-     * 프로세스 모니터링로그 목록을 조회한다.
-     *
-     * @param ProcessMonVO - 프로세스모니터링로그 VO
-     * @return List<ProcessMonLogVO> - 프로세스모니터링로그 List
-     */
-    public List<ProcessMonLogVO> selectProcessMonLogList(ProcessMonLogVO processMonLogVO) throws Exception {
-        return selectList("ProcessMonDAO.selectProcessMonLogList", processMonLogVO);
-    }
+	/**
+	 * 프로세스 모니터링로그 목록을 조회한다.
+	 *
+	 * @param processMonLogVO - 프로세스모니터링로그 VO
+	 * @return List - 프로세스모니터링로그 List
+	 */
+	List<ProcessMonLogVO> selectProcessMonLogList(ProcessMonLogVO processMonLogVO);
 
-    /**
-     * PROCESS모니터링로그 목록 총 개수를 조회한다.
-     *
-     * @param ProcessMonVO - PROCESS모니터링로그 Vo
-     * @return int - PROCESS모니터링로그 토탈 카운트 수
-     */
-    public int selectProcessMonLogTotCnt(ProcessMonLogVO processMonLogVO) throws Exception {
-        return selectOne("ProcessMonDAO.selectProcessMonLogTotCnt", processMonLogVO);
-    }
+	/**
+	 * PROCESS모니터링로그 목록 총 개수를 조회한다.
+	 *
+	 * @param processMonLogVO - PROCESS모니터링로그 Vo
+	 * @return int - PROCESS모니터링로그 토탈 카운트 수
+	 */
+	int selectProcessMonLogTotCnt(ProcessMonLogVO processMonLogVO);
 
-    /**
-     * 프로세스 모니터링로그의 상세정보를 조회한다.
-     *
-     * @param ProcessMonVO - 프로세스모니터링로그 model
-     * @return ProcessMonVO - 프로세스모니터링로그 model
-     */
-    public ProcessMonLogVO selectProcessMonLog(ProcessMonLogVO processMonLogVO) {
-        return selectOne("ProcessMonDAO.selectProcessMonLog", processMonLogVO);
-    }
+	/**
+	 * 프로세스 모니터링로그의 상세정보를 조회한다.
+	 *
+	 * @param processMonLogVO - 프로세스모니터링로그 model
+	 * @return ProcessMonLogVO - 프로세스모니터링로그 model
+	 */
+	ProcessMonLogVO selectProcessMonLog(ProcessMonLogVO processMonLogVO);
 
-    /**
-     * PROCESS모니터링로그 대상 정보를 등록한다.
-     *
-     * @param ProcessMonLog - 파일시스템모니터링 대상 model
-     * @return int - 등록 결과
-     */
-    public int insertProcessMonLog(ProcessMonLog processMonLog) throws Exception {
-        return insert("ProcessMonDAO.insertProcessMonLog", processMonLog);
-    }
+	/**
+	 * PROCESS모니터링로그 대상 정보를 등록한다.
+	 *
+	 * @param processMonLog - PROCESS모니터링로그 model
+	 * @return int - 등록 결과
+	 */
+	int insertProcessMonLog(ProcessMonLog processMonLog);
 
-    /**
-     * 프로세스 모니터링 결과 정보를 수정한다.
-     *
-     * @param ProcessMon - 프로세스 대상 model
-     * @return int - 수정 결과
-     */
-    public int updateProcessMonSttus(ProcessMon processMon) throws Exception {
-        return update("ProcessMonDAO.updateProcessMonSttus", processMon);
-    }
+	/**
+	 * 프로세스 모니터링 결과 정보를 수정한다.
+	 *
+	 * @param processMon - 프로세스 model
+	 * @return int - 수정 결과
+	 */
+	int updateProcessMonSttus(ProcessMon processMon);
+
 }

--- a/src/main/java/egovframework/com/utl/sys/pxy/service/impl/ProxySvcDAO.java
+++ b/src/main/java/egovframework/com/utl/sys/pxy/service/impl/ProxySvcDAO.java
@@ -1,110 +1,103 @@
 package egovframework.com.utl.sys.pxy.service.impl;
+
 import java.util.List;
 
-import org.springframework.stereotype.Repository;
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.utl.sys.pxy.service.ProxyLog;
 import egovframework.com.utl.sys.pxy.service.ProxySvc;
 
 /**
  * 개요
- * - 프록시서비스정보 및 프록시로그정보에 대한 DAO 클래스를 정의한다.
+ * - 프록시서비스정보 및 프록시로그정보에 대한 DAO 인터페이스를 정의한다.
  *
  * 상세내용
  * - 프록시서비스정보 및 프록시로그정보에 대한 등록, 수정, 삭제, 조회 기능을 제공한다.
  * - 프록시서비스정보의 조회기능은 목록조회, 상세조회로 구분된다.
+ *
  * @author lee.m.j
  * @version 1.0
  * @created 28-6-2010 오전 10:44:51
+ *
+ * <pre>
+ *  == 개정이력(Modification Information) ==
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2010.06.28  lee.m.j          최초 생성
+ *   2026.05.28  dasomel        @EgovMapper 인터페이스 방식으로 전환
+ *
+ * </pre>
  */
-@Repository("proxySvcDAO")
-public class ProxySvcDAO extends EgovComAbstractDAO {
+@EgovMapper("proxySvcDAO")
+public interface ProxySvcDAO {
 
 	/**
-     * 프록시서비스를 관리하기 위해 등록된 프록시정보 목록을 조회한다.
-     *
-     * @param proxySvc - 프록시서비스 Vo
-     * @return List - 프록시서비스 목록
-     */
-    public List<ProxySvc> selectProxySvcList(ProxySvc proxySvc) throws Exception {
-        return selectList("proxySvcDAO.selectProxySvcList", proxySvc);
-    }
+	 * 프록시서비스를 관리하기 위해 등록된 프록시정보 목록을 조회한다.
+	 *
+	 * @param proxySvc - 프록시서비스 Vo
+	 * @return List - 프록시서비스 목록
+	 */
+	List<ProxySvc> selectProxySvcList(ProxySvc proxySvc);
 
-    /**
-     * 프록시서비스 목록 총 개수를 조회한다.
-     *
-     * @param proxySvc - 프록시서비스 Vo
-     * @return int - 프록시서비스 카운트 수
-     */
-    public int selectProxySvcListTotCnt(ProxySvc proxySvc) throws Exception {
-        return selectOne("proxySvcDAO.selectProxySvcListTotCnt", proxySvc);
-    }
+	/**
+	 * 프록시서비스 목록 총 개수를 조회한다.
+	 *
+	 * @param proxySvc - 프록시서비스 Vo
+	 * @return int - 프록시서비스 카운트 수
+	 */
+	int selectProxySvcListTotCnt(ProxySvc proxySvc);
 
-    /**
-     * 등록된 프록시서비스의 상세정보를 조회한다.
-     *
-     * @param proxySvc - 프록시서비스 Vo
-     * @return proxySvc - 프록시서비스 Vo
-     */
-    public ProxySvc selectProxySvc(ProxySvc proxySvc) throws Exception {
-        return selectOne("proxySvcDAO.selectProxySvc", proxySvc);
-    }
+	/**
+	 * 등록된 프록시서비스의 상세정보를 조회한다.
+	 *
+	 * @param proxySvc - 프록시서비스 Vo
+	 * @return ProxySvc - 프록시서비스 Vo
+	 */
+	ProxySvc selectProxySvc(ProxySvc proxySvc);
 
-    /**
-     * 프록시서비스를 신규로 등록한다.
-     *
-     * @param proxySvc - 프록시서비스 model
-     */
-    public int insertProxySvc(ProxySvc proxySvc) throws Exception {
-        return insert("proxySvcDAO.insertProxySvc", proxySvc);
-    }
+	/**
+	 * 프록시서비스를 신규로 등록한다.
+	 *
+	 * @param proxySvc - 프록시서비스 model
+	 */
+	int insertProxySvc(ProxySvc proxySvc);
 
-    /**
-     * 기 등록된 프록시서비스를 수정한다.
-     *
-     * @param proxySvc - 프록시서비스 model
-     */
-    public int updateProxySvc(ProxySvc proxySvc) throws Exception {
-        return update("proxySvcDAO.updateProxySvc", proxySvc);
-    }
+	/**
+	 * 기 등록된 프록시서비스를 수정한다.
+	 *
+	 * @param proxySvc - 프록시서비스 model
+	 */
+	int updateProxySvc(ProxySvc proxySvc);
 
-    /**
-     * 기 등록된 프록시서비스를 삭제한다.
-     *
-     * @param proxySvc - 프록시서비스 model
-     */
-    public int deleteProxySvc(ProxySvc proxySvc) throws Exception {
-        return delete("proxySvcDAO.deleteProxySvc", proxySvc);
-    }
+	/**
+	 * 기 등록된 프록시서비스를 삭제한다.
+	 *
+	 * @param proxySvc - 프록시서비스 model
+	 */
+	int deleteProxySvc(ProxySvc proxySvc);
 
-    /**
-     * 프록시서비스를 모니터링하기 위해 등록된 프록시로그 목록을 조회한다.
-     *
-     * @param proxyLog - 프록시로그 Vo
-     * @return List - 프록시로그 목록
-     */
-    public List<ProxyLog> selectProxyLogList(ProxyLog proxyLog) throws Exception {
-        return selectList("proxySvcDAO.selectProxyLogList", proxyLog);
-    }
+	/**
+	 * 프록시서비스를 모니터링하기 위해 등록된 프록시로그 목록을 조회한다.
+	 *
+	 * @param proxyLog - 프록시로그 Vo
+	 * @return List - 프록시로그 목록
+	 */
+	List<ProxyLog> selectProxyLogList(ProxyLog proxyLog);
 
-    /**
-     * 프록시로그 목록 총 개수를 조회한다.
-     *
-     * @param proxyLog - 프록시로그 Vo
-     * @return int - 프록시로그 카운트 수
-     */
-    public int selectProxyLogListTotCnt(ProxyLog proxyLog) throws Exception {
-        return selectOne("proxySvcDAO.selectProxyLogListTotCnt", proxyLog);
-    }
+	/**
+	 * 프록시로그 목록 총 개수를 조회한다.
+	 *
+	 * @param proxyLog - 프록시로그 Vo
+	 * @return int - 프록시로그 카운트 수
+	 */
+	int selectProxyLogListTotCnt(ProxyLog proxyLog);
 
-    /**
-     * 프록시로그를 생성한다.
-     *
-     * @param proxyLog - 프록시로그 model
-     */
-    public int insertProxyLog(ProxyLog proxyLog) throws Exception {
-        return insert("proxySvcDAO.insertProxyLog", proxyLog);
-    }
+	/**
+	 * 프록시로그를 생성한다.
+	 *
+	 * @param proxyLog - 프록시로그 model
+	 */
+	int insertProxyLog(ProxyLog proxyLog);
 
 }

--- a/src/main/java/egovframework/com/utl/sys/srm/service/impl/ServerResrceMntrngDAO.java
+++ b/src/main/java/egovframework/com/utl/sys/srm/service/impl/ServerResrceMntrngDAO.java
@@ -2,75 +2,74 @@ package egovframework.com.utl.sys.srm.service.impl;
 
 import java.util.List;
 
-import org.springframework.stereotype.Repository;
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.utl.sys.srm.service.ServerResrceMntrng;
 import egovframework.com.utl.sys.srm.service.ServerResrceMntrngVO;
 
 /**
  * 개요
- * - 서버자원모니터링에 대한 DAO 클래스를 정의한다.
+ * - 서버자원모니터링에 대한 DAO 인터페이스를 정의한다.
  *
  * 상세내용
  * - 서버자원모니터링에 대한 등록, 조회 기능을 제공한다.
+ *
  * @author lee.m.j
  * @version 1.0
  * @created 06-9-2010 오전 11:24:00
+ *
+ * <pre>
+ *  == 개정이력(Modification Information) ==
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2010.09.06  lee.m.j          최초 생성
+ *   2026.05.28  dasomel        @EgovMapper 인터페이스 방식으로 전환
+ *
+ * </pre>
  */
-@Repository("serverResrceMntrngDAO")
-public class ServerResrceMntrngDAO extends EgovComAbstractDAO {
+@EgovMapper("serverResrceMntrngDAO")
+public interface ServerResrceMntrngDAO {
 
 	/**
 	 * 서버자원모니터링의 로그정보 목록을 조회한다.
 	 * @param serverResrceMntrngVO - 서버자원모니터링 Vo
 	 * @return List - 서버자원모니터링의 로그 목록
 	 */
-	public List<ServerResrceMntrngVO> selectServerResrceMntrngList(ServerResrceMntrngVO serverResrceMntrngVO)throws Exception {
-		return selectList("serverResrceMntrngDAO.selectServerResrceMntrngList", serverResrceMntrngVO);
-	}
+	List<ServerResrceMntrngVO> selectServerResrceMntrngList(ServerResrceMntrngVO serverResrceMntrngVO);
 
 	/**
 	 * 서버자원모니터링의 로그정보 목록 총 개수를 조회한다.
 	 * @param serverResrceMntrngVO - 서버자원모니터링 Vo
 	 * @return int - 서버자원모니터링의 로그 카운트 수
 	 */
-	public int selectServerResrceMntrngListTotCnt(ServerResrceMntrngVO serverResrceMntrngVO) throws Exception {
-		return (Integer)selectOne("serverResrceMntrngDAO.selectServerResrceMntrngListTotCnt", serverResrceMntrngVO);
-	}
+	int selectServerResrceMntrngListTotCnt(ServerResrceMntrngVO serverResrceMntrngVO);
 
 	/**
 	 * 서버자원모니터링 로그의 상세정보를 조회한다.
 	 * @param serverResrceMntrngVO - 서버자원모니터링 Vo
 	 * @return ServerResrceMntrngVO - 서버자원모니터링 Vo
 	 */
-	public ServerResrceMntrngVO selectServerResrceMntrng(ServerResrceMntrngVO serverResrceMntrngVO) throws Exception {
-		return (ServerResrceMntrngVO) selectOne("serverResrceMntrngDAO.selectServerResrceMntrng", serverResrceMntrngVO);
-	}
+	ServerResrceMntrngVO selectServerResrceMntrng(ServerResrceMntrngVO serverResrceMntrngVO);
 
 	/**
 	 * 서버자원모니터링 로그정보를 신규로 등록한다.
 	 * @param serverResrceMntrng - 서버자원모니터링 model
 	 */
-	public void insertServerResrceMntrng(ServerResrceMntrng serverResrceMntrng) throws Exception {
-		insert("serverResrceMntrngDAO.insertServerResrceMntrng", serverResrceMntrng);
-	}
+	void insertServerResrceMntrng(ServerResrceMntrng serverResrceMntrng);
 
 	/**
-	 * 서버자원모티너링 대상서버의 목록을 조회한다.
+	 * 서버자원모니터링 대상서버의 목록을 조회한다.
 	 * @param serverResrceMntrngVO - 서버자원모니터링 Vo
-	 * @return ServerResrceMntrngVO - 서버자원모니터링 Vo
+	 * @return List - 서버자원모니터링 대상서버 목록
 	 */
-	public List<ServerResrceMntrngVO> selectMntrngServerList(ServerResrceMntrngVO serverResrceMntrngVO) throws Exception {
-		return selectList("serverResrceMntrngDAO.selectMntrngServerList", serverResrceMntrngVO);
-	}
+	List<ServerResrceMntrngVO> selectMntrngServerList(ServerResrceMntrngVO serverResrceMntrngVO);
 
 	/**
-	 * 서버자원모티너링 대상서버 목록 총 개수를 조회한다.
+	 * 서버자원모니터링 대상서버 목록 총 개수를 조회한다.
 	 * @param serverResrceMntrngVO - 서버자원모니터링 Vo
 	 * @return int - 서버자원모니터링의 로그 카운트 수
 	 */
-	public int selectMntrngServerListTotCnt(ServerResrceMntrngVO serverResrceMntrngVO) throws Exception {
-		return (Integer)selectOne("serverResrceMntrngDAO.selectMntrngServerListTotCnt", serverResrceMntrngVO);
-	}
+	int selectMntrngServerListTotCnt(ServerResrceMntrngVO serverResrceMntrngVO);
+
 }

--- a/src/main/java/egovframework/com/utl/sys/ssy/service/impl/SynchrnServerDAO.java
+++ b/src/main/java/egovframework/com/utl/sys/ssy/service/impl/SynchrnServerDAO.java
@@ -2,90 +2,85 @@ package egovframework.com.utl.sys.ssy.service.impl;
 
 import java.util.List;
 
-import org.springframework.stereotype.Repository;
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.utl.sys.ssy.service.SynchrnServer;
 
 /**
  * 개요
- * - 동기화대상 서버에 대한 DAO 클래스를 정의한다.
+ * - 동기화대상 서버에 대한 DAO 인터페이스를 정의한다.
  *
  * 상세내용
  * - 동기화대상 서버에 대한 등록, 수정, 삭제, 조회 기능을 제공한다.
  * - 동기화대상 서버의 조회기능은 목록조회, 상세조회로 구분된다.
+ *
  * @author lee.m.j
  * @version 1.0
  * @created 28-6-2010 오전 10:44:57
+ *
+ * <pre>
+ *  == 개정이력(Modification Information) ==
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2010.06.28  lee.m.j          최초 생성
+ *   2026.05.28  dasomel        @EgovMapper 인터페이스 방식으로 전환
+ *
+ * </pre>
  */
-@Repository("synchrnServerDAO")
-public class SynchrnServerDAO extends EgovComAbstractDAO {
+@EgovMapper("synchrnServerDAO")
+public interface SynchrnServerDAO {
 
 	/**
 	 * 동기화대상 서버를 관리하기 위해 등록된 동기화대상 서버목록을 조회한다.
 	 * @param synchrnServer - 동기화대상 서버
 	 * @return List - 동기화대상 서버 목록
 	 */
-	public List<SynchrnServer> selectSynchrnServerList(SynchrnServer synchrnServer) throws Exception {
-		return selectList("synchrnServerDAO.selectSynchrnServerList", synchrnServer);
-	}
+	List<SynchrnServer> selectSynchrnServerList(SynchrnServer synchrnServer);
 
 	/**
 	 * 동기화대상 서버목록 총 개수를 조회한다.
 	 * @param synchrnServer - 동기화대상 서버
 	 * @return int - 동기화대상 서버 카운트 수
 	 */
-	public int selectSynchrnServerListTotCnt(SynchrnServer synchrnServer) throws Exception {
-		return (Integer)selectOne("synchrnServerDAO.selectSynchrnServerListTotCnt", synchrnServer);
-	}
+	int selectSynchrnServerListTotCnt(SynchrnServer synchrnServer);
 
 	/**
 	 * 등록된 동기화대상 서버의 상세정보를 조회한다.
 	 * @param synchrnServer - 동기화대상 서버
 	 * @return SynchrnServer - 동기화대상 서버
 	 */
-	public SynchrnServer selectSynchrnServer(SynchrnServer synchrnServer) throws Exception {
-		return (SynchrnServer) selectOne("synchrnServerDAO.selectSynchrnServer", synchrnServer);
-	}
+	SynchrnServer selectSynchrnServer(SynchrnServer synchrnServer);
 
 	/**
 	 * 동기화대상 서버정보를 신규로 등록한다.
 	 * @param synchrnServer - 동기화대상 서버 model
 	 */
-	public void insertSynchrnServer(SynchrnServer synchrnServer) throws Exception {
-		insert("synchrnServerDAO.insertSynchrnServer", synchrnServer);
-	}
+	void insertSynchrnServer(SynchrnServer synchrnServer);
 
 	/**
 	 * 기 등록된 동기화대상 서버정보를 수정한다.
 	 * @param synchrnServer - 동기화대상 서버 model
 	 */
-	public void updateSynchrnServer(SynchrnServer synchrnServer) throws Exception {
-		update("synchrnServerDAO.updateSynchrnServer", synchrnServer);
-	}
+	void updateSynchrnServer(SynchrnServer synchrnServer);
 
 	/**
 	 * 기 등록된 동기화대상 서버정보를 삭제한다.
 	 * @param synchrnServer - 동기화대상 서버 model
 	 */
-	public void deleteSynchrnServer(SynchrnServer synchrnServer) throws Exception {
-		delete("synchrnServerDAO.deleteSynchrnServer", synchrnServer);
-	}
+	void deleteSynchrnServer(SynchrnServer synchrnServer);
 
 	/**
 	 * 업로드 파일을 동기화대상 서버들을 대상으로 동기화 처리를 한다.
 	 * @param synchrnServer - 동기화대상 서버
 	 */
-	public void processSynchrn(SynchrnServer synchrnServer) throws Exception {
-		update("synchrnServerDAO.processSynchrn", synchrnServer);
-	}
+	void processSynchrn(SynchrnServer synchrnServer);
 
 	/**
 	 * 동기화 처리를 하기 위해 동기화대상 서버목록을 조회한다.
 	 * @param synchrnServer - 동기화대상 서버
 	 * @return List - 동기화대상 서버 목록
 	 */
-	public List<SynchrnServer> processSynchrnServerList(SynchrnServer synchrnServer) throws Exception {
-		return selectList("synchrnServerDAO.processSynchrnServerList", synchrnServer);
-	}
+	List<SynchrnServer> processSynchrnServerList(SynchrnServer synchrnServer);
+
 }

--- a/src/main/resources/egovframework/mapper/com/utl/sys/fsm/EgovFileSysMntrng_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/fsm/EgovFileSysMntrng_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="FileSysMntrngDAO">
+<mapper namespace="egovframework.com.utl.sys.fsm.service.impl.FileSysMntrngDAO">
 	
 	<resultMap id="FileSysMntrngList" type="egovframework.com.utl.sys.fsm.service.FileSysMntrngVO">
 		<result property="fileSysId" column="FILE_SYS_ID"/>

--- a/src/main/resources/egovframework/mapper/com/utl/sys/fsm/EgovFileSysMntrng_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/fsm/EgovFileSysMntrng_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="FileSysMntrngDAO">
+<mapper namespace="egovframework.com.utl.sys.fsm.service.impl.FileSysMntrngDAO">
 	
 	<resultMap id="FileSysMntrngList" type="egovframework.com.utl.sys.fsm.service.FileSysMntrngVO">
 		<result property="fileSysId" column="FILE_SYS_ID"/>

--- a/src/main/resources/egovframework/mapper/com/utl/sys/fsm/EgovFileSysMntrng_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/fsm/EgovFileSysMntrng_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="FileSysMntrngDAO">
+<mapper namespace="egovframework.com.utl.sys.fsm.service.impl.FileSysMntrngDAO">
 	
 	<resultMap id="FileSysMntrngList" type="egovframework.com.utl.sys.fsm.service.FileSysMntrngVO">
 		<result property="fileSysId" column="FILE_SYS_ID"/>

--- a/src/main/resources/egovframework/mapper/com/utl/sys/fsm/EgovFileSysMntrng_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/fsm/EgovFileSysMntrng_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="FileSysMntrngDAO">
+<mapper namespace="egovframework.com.utl.sys.fsm.service.impl.FileSysMntrngDAO">
 	
 	<resultMap id="FileSysMntrngList" type="egovframework.com.utl.sys.fsm.service.FileSysMntrngVO">
 		<result property="fileSysId" column="FILE_SYS_ID"/>

--- a/src/main/resources/egovframework/mapper/com/utl/sys/fsm/EgovFileSysMntrng_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/fsm/EgovFileSysMntrng_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="FileSysMntrngDAO">
+<mapper namespace="egovframework.com.utl.sys.fsm.service.impl.FileSysMntrngDAO">
 	
 	<resultMap id="FileSysMntrngList" type="egovframework.com.utl.sys.fsm.service.FileSysMntrngVO">
 		<result property="fileSysId" column="FILE_SYS_ID"/>

--- a/src/main/resources/egovframework/mapper/com/utl/sys/fsm/EgovFileSysMntrng_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/fsm/EgovFileSysMntrng_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="FileSysMntrngDAO">
+<mapper namespace="egovframework.com.utl.sys.fsm.service.impl.FileSysMntrngDAO">
 	
 	<resultMap id="FileSysMntrngList" type="egovframework.com.utl.sys.fsm.service.FileSysMntrngVO">
 		<result property="fileSysId" column="FILE_SYS_ID"/>

--- a/src/main/resources/egovframework/mapper/com/utl/sys/fsm/EgovFileSysMntrng_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/fsm/EgovFileSysMntrng_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="FileSysMntrngDAO">
+<mapper namespace="egovframework.com.utl.sys.fsm.service.impl.FileSysMntrngDAO">
 	
 	<resultMap id="FileSysMntrngList" type="egovframework.com.utl.sys.fsm.service.FileSysMntrngVO">
 		<result property="fileSysId" column="FILE_SYS_ID"/>

--- a/src/main/resources/egovframework/mapper/com/utl/sys/fsm/EgovFileSysMntrng_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/fsm/EgovFileSysMntrng_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="FileSysMntrngDAO">
+<mapper namespace="egovframework.com.utl.sys.fsm.service.impl.FileSysMntrngDAO">
 	
 	<resultMap id="FileSysMntrngList" type="egovframework.com.utl.sys.fsm.service.FileSysMntrngVO">
 		<result property="fileSysId" column="FILE_SYS_ID"/>

--- a/src/main/resources/egovframework/mapper/com/utl/sys/htm/EgovUtlSysHttpMon_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/htm/EgovUtlSysHttpMon_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="HttpMonDAO">
+<mapper namespace="egovframework.com.utl.sys.htm.service.impl.HttpMonDAO">
 	
 	<resultMap id="HttpMonList" type="egovframework.com.utl.sys.htm.service.HttpMonVO">
 		<result property="sysId" column="SYS_ID"/>	

--- a/src/main/resources/egovframework/mapper/com/utl/sys/htm/EgovUtlSysHttpMon_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/htm/EgovUtlSysHttpMon_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="HttpMonDAO">
+<mapper namespace="egovframework.com.utl.sys.htm.service.impl.HttpMonDAO">
 	
 	<resultMap id="HttpMonList" type="egovframework.com.utl.sys.htm.service.HttpMonVO">
 		<result property="sysId" column="SYS_ID"/>	

--- a/src/main/resources/egovframework/mapper/com/utl/sys/htm/EgovUtlSysHttpMon_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/htm/EgovUtlSysHttpMon_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="HttpMonDAO">
+<mapper namespace="egovframework.com.utl.sys.htm.service.impl.HttpMonDAO">
 	
 	<resultMap id="HttpMonList" type="egovframework.com.utl.sys.htm.service.HttpMonVO">
 		<result property="sysId" column="SYS_ID"/>	

--- a/src/main/resources/egovframework/mapper/com/utl/sys/htm/EgovUtlSysHttpMon_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/htm/EgovUtlSysHttpMon_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="HttpMonDAO">
+<mapper namespace="egovframework.com.utl.sys.htm.service.impl.HttpMonDAO">
 	
 	<resultMap id="HttpMonList" type="egovframework.com.utl.sys.htm.service.HttpMonVO">
 		<result property="sysId" column="SYS_ID"/>	

--- a/src/main/resources/egovframework/mapper/com/utl/sys/htm/EgovUtlSysHttpMon_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/htm/EgovUtlSysHttpMon_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="HttpMonDAO">
+<mapper namespace="egovframework.com.utl.sys.htm.service.impl.HttpMonDAO">
 	
 	<resultMap id="HttpMonList" type="egovframework.com.utl.sys.htm.service.HttpMonVO">
 		<result property="sysId" column="SYS_ID"/>	

--- a/src/main/resources/egovframework/mapper/com/utl/sys/htm/EgovUtlSysHttpMon_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/htm/EgovUtlSysHttpMon_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="HttpMonDAO">
+<mapper namespace="egovframework.com.utl.sys.htm.service.impl.HttpMonDAO">
 	
 	<resultMap id="HttpMonList" type="egovframework.com.utl.sys.htm.service.HttpMonVO">
 		<result property="sysId" column="SYS_ID"/>	

--- a/src/main/resources/egovframework/mapper/com/utl/sys/htm/EgovUtlSysHttpMon_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/htm/EgovUtlSysHttpMon_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="HttpMonDAO">
+<mapper namespace="egovframework.com.utl.sys.htm.service.impl.HttpMonDAO">
 	
 	<resultMap id="HttpMonList" type="egovframework.com.utl.sys.htm.service.HttpMonVO">
 		<result property="sysId" column="SYS_ID"/>	

--- a/src/main/resources/egovframework/mapper/com/utl/sys/htm/EgovUtlSysHttpMon_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/htm/EgovUtlSysHttpMon_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="HttpMonDAO">
+<mapper namespace="egovframework.com.utl.sys.htm.service.impl.HttpMonDAO">
 	
 	<resultMap id="HttpMonList" type="egovframework.com.utl.sys.htm.service.HttpMonVO">
 		<result property="sysId" column="SYS_ID"/>	

--- a/src/main/resources/egovframework/mapper/com/utl/sys/nsm/EgovNtwrkSvcMntrng_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/nsm/EgovNtwrkSvcMntrng_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="NtwrkSvcMntrngDAO">
+<mapper namespace="egovframework.com.utl.sys.nsm.service.impl.NtwrkSvcMntrngDAO">
 	
 	<resultMap id="NtwrkSvcMntrngList" type="egovframework.com.utl.sys.nsm.service.NtwrkSvcMntrngVO">
 		<result property="sysIp" column="SYS_IP"/>

--- a/src/main/resources/egovframework/mapper/com/utl/sys/nsm/EgovNtwrkSvcMntrng_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/nsm/EgovNtwrkSvcMntrng_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="NtwrkSvcMntrngDAO">
+<mapper namespace="egovframework.com.utl.sys.nsm.service.impl.NtwrkSvcMntrngDAO">
 	
 	<resultMap id="NtwrkSvcMntrngList" type="egovframework.com.utl.sys.nsm.service.NtwrkSvcMntrngVO">
 		<result property="sysIp" column="SYS_IP"/>

--- a/src/main/resources/egovframework/mapper/com/utl/sys/nsm/EgovNtwrkSvcMntrng_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/nsm/EgovNtwrkSvcMntrng_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="NtwrkSvcMntrngDAO">
+<mapper namespace="egovframework.com.utl.sys.nsm.service.impl.NtwrkSvcMntrngDAO">
 	
 	<resultMap id="NtwrkSvcMntrngList" type="egovframework.com.utl.sys.nsm.service.NtwrkSvcMntrngVO">
 		<result property="sysIp" column="SYS_IP"/>

--- a/src/main/resources/egovframework/mapper/com/utl/sys/nsm/EgovNtwrkSvcMntrng_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/nsm/EgovNtwrkSvcMntrng_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="NtwrkSvcMntrngDAO">
+<mapper namespace="egovframework.com.utl.sys.nsm.service.impl.NtwrkSvcMntrngDAO">
 	
 	<resultMap id="NtwrkSvcMntrngList" type="egovframework.com.utl.sys.nsm.service.NtwrkSvcMntrngVO">
 		<result property="sysIp" column="SYS_IP"/>

--- a/src/main/resources/egovframework/mapper/com/utl/sys/nsm/EgovNtwrkSvcMntrng_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/nsm/EgovNtwrkSvcMntrng_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="NtwrkSvcMntrngDAO">
+<mapper namespace="egovframework.com.utl.sys.nsm.service.impl.NtwrkSvcMntrngDAO">
 	
 	<resultMap id="NtwrkSvcMntrngList" type="egovframework.com.utl.sys.nsm.service.NtwrkSvcMntrngVO">
 		<result property="sysIp" column="SYS_IP"/>

--- a/src/main/resources/egovframework/mapper/com/utl/sys/nsm/EgovNtwrkSvcMntrng_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/nsm/EgovNtwrkSvcMntrng_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="NtwrkSvcMntrngDAO">
+<mapper namespace="egovframework.com.utl.sys.nsm.service.impl.NtwrkSvcMntrngDAO">
 	
 	<resultMap id="NtwrkSvcMntrngList" type="egovframework.com.utl.sys.nsm.service.NtwrkSvcMntrngVO">
 		<result property="sysIp" column="SYS_IP"/>

--- a/src/main/resources/egovframework/mapper/com/utl/sys/nsm/EgovNtwrkSvcMntrng_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/nsm/EgovNtwrkSvcMntrng_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="NtwrkSvcMntrngDAO">
+<mapper namespace="egovframework.com.utl.sys.nsm.service.impl.NtwrkSvcMntrngDAO">
 	
 	<resultMap id="NtwrkSvcMntrngList" type="egovframework.com.utl.sys.nsm.service.NtwrkSvcMntrngVO">
 		<result property="sysIp" column="SYS_IP"/>

--- a/src/main/resources/egovframework/mapper/com/utl/sys/nsm/EgovNtwrkSvcMntrng_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/nsm/EgovNtwrkSvcMntrng_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="NtwrkSvcMntrngDAO">
+<mapper namespace="egovframework.com.utl.sys.nsm.service.impl.NtwrkSvcMntrngDAO">
 	
 	<resultMap id="NtwrkSvcMntrngList" type="egovframework.com.utl.sys.nsm.service.NtwrkSvcMntrngVO">
 		<result property="sysIp" column="SYS_IP"/>

--- a/src/main/resources/egovframework/mapper/com/utl/sys/prm/EgovUtlSysProcessMon_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/prm/EgovUtlSysProcessMon_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ProcessMonDAO">
+<mapper namespace="egovframework.com.utl.sys.prm.service.impl.ProcessMonDAO">
 	
 	<resultMap id="ProcessMonList" type="egovframework.com.utl.sys.prm.service.ProcessMonVO">
 		<result property="processId" column="PROCS_ID"/>

--- a/src/main/resources/egovframework/mapper/com/utl/sys/prm/EgovUtlSysProcessMon_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/prm/EgovUtlSysProcessMon_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ProcessMonDAO">
+<mapper namespace="egovframework.com.utl.sys.prm.service.impl.ProcessMonDAO">
 	
 	<resultMap id="ProcessMonList" type="egovframework.com.utl.sys.prm.service.ProcessMonVO">
 		<result property="processId" column="PROCS_ID"/>

--- a/src/main/resources/egovframework/mapper/com/utl/sys/prm/EgovUtlSysProcessMon_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/prm/EgovUtlSysProcessMon_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ProcessMonDAO">
+<mapper namespace="egovframework.com.utl.sys.prm.service.impl.ProcessMonDAO">
 	
 	<resultMap id="ProcessMonList" type="egovframework.com.utl.sys.prm.service.ProcessMonVO">
 		<result property="processId" column="PROCS_ID"/>

--- a/src/main/resources/egovframework/mapper/com/utl/sys/prm/EgovUtlSysProcessMon_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/prm/EgovUtlSysProcessMon_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ProcessMonDAO">
+<mapper namespace="egovframework.com.utl.sys.prm.service.impl.ProcessMonDAO">
 	
 	<resultMap id="ProcessMonList" type="egovframework.com.utl.sys.prm.service.ProcessMonVO">
 		<result property="processId" column="PROCS_ID"/>

--- a/src/main/resources/egovframework/mapper/com/utl/sys/prm/EgovUtlSysProcessMon_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/prm/EgovUtlSysProcessMon_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ProcessMonDAO">
+<mapper namespace="egovframework.com.utl.sys.prm.service.impl.ProcessMonDAO">
 	
 	<resultMap id="ProcessMonList" type="egovframework.com.utl.sys.prm.service.ProcessMonVO">
 		<result property="processId" column="PROCS_ID"/>

--- a/src/main/resources/egovframework/mapper/com/utl/sys/prm/EgovUtlSysProcessMon_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/prm/EgovUtlSysProcessMon_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ProcessMonDAO">
+<mapper namespace="egovframework.com.utl.sys.prm.service.impl.ProcessMonDAO">
 	
 	<resultMap id="ProcessMonList" type="egovframework.com.utl.sys.prm.service.ProcessMonVO">
 		<result property="processId" column="PROCS_ID"/>

--- a/src/main/resources/egovframework/mapper/com/utl/sys/prm/EgovUtlSysProcessMon_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/prm/EgovUtlSysProcessMon_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ProcessMonDAO">
+<mapper namespace="egovframework.com.utl.sys.prm.service.impl.ProcessMonDAO">
 	
 	<resultMap id="ProcessMonList" type="egovframework.com.utl.sys.prm.service.ProcessMonVO">
 		<result property="processId" column="PROCS_ID"/>

--- a/src/main/resources/egovframework/mapper/com/utl/sys/prm/EgovUtlSysProcessMon_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/prm/EgovUtlSysProcessMon_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ProcessMonDAO">
+<mapper namespace="egovframework.com.utl.sys.prm.service.impl.ProcessMonDAO">
 	
 	<resultMap id="ProcessMonList" type="egovframework.com.utl.sys.prm.service.ProcessMonVO">
 		<result property="processId" column="PROCS_ID"/>

--- a/src/main/resources/egovframework/mapper/com/utl/sys/pxy/EgovProxySvc_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/pxy/EgovProxySvc_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="proxySvcDAO">
+<mapper namespace="egovframework.com.utl.sys.pxy.service.impl.ProxySvcDAO">
 
     <resultMap id="proxySvc" type="egovframework.com.utl.sys.pxy.service.ProxySvc">
         <result property="proxyId" column="PROXY_ID"/>

--- a/src/main/resources/egovframework/mapper/com/utl/sys/pxy/EgovProxySvc_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/pxy/EgovProxySvc_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="proxySvcDAO">
+<mapper namespace="egovframework.com.utl.sys.pxy.service.impl.ProxySvcDAO">
 
     <resultMap id="proxySvc" type="egovframework.com.utl.sys.pxy.service.ProxySvc">
         <result property="proxyId" column="PROXY_ID"/>

--- a/src/main/resources/egovframework/mapper/com/utl/sys/pxy/EgovProxySvc_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/pxy/EgovProxySvc_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="proxySvcDAO">
+<mapper namespace="egovframework.com.utl.sys.pxy.service.impl.ProxySvcDAO">
 
     <resultMap id="proxySvc" type="egovframework.com.utl.sys.pxy.service.ProxySvc">
         <result property="proxyId" column="PROXY_ID"/>

--- a/src/main/resources/egovframework/mapper/com/utl/sys/pxy/EgovProxySvc_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/pxy/EgovProxySvc_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="proxySvcDAO">
+<mapper namespace="egovframework.com.utl.sys.pxy.service.impl.ProxySvcDAO">
 
     <resultMap id="proxySvc" type="egovframework.com.utl.sys.pxy.service.ProxySvc">
         <result property="proxyId" column="PROXY_ID"/>

--- a/src/main/resources/egovframework/mapper/com/utl/sys/pxy/EgovProxySvc_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/pxy/EgovProxySvc_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="proxySvcDAO">
+<mapper namespace="egovframework.com.utl.sys.pxy.service.impl.ProxySvcDAO">
 
     <resultMap id="proxySvc" type="egovframework.com.utl.sys.pxy.service.ProxySvc">
         <result property="proxyId" column="PROXY_ID"/>

--- a/src/main/resources/egovframework/mapper/com/utl/sys/pxy/EgovProxySvc_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/pxy/EgovProxySvc_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="proxySvcDAO">
+<mapper namespace="egovframework.com.utl.sys.pxy.service.impl.ProxySvcDAO">
 
     <resultMap id="proxySvc" type="egovframework.com.utl.sys.pxy.service.ProxySvc">
         <result property="proxyId" column="PROXY_ID"/>

--- a/src/main/resources/egovframework/mapper/com/utl/sys/pxy/EgovProxySvc_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/pxy/EgovProxySvc_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="proxySvcDAO">
+<mapper namespace="egovframework.com.utl.sys.pxy.service.impl.ProxySvcDAO">
 
     <resultMap id="proxySvc" type="egovframework.com.utl.sys.pxy.service.ProxySvc">
         <result property="proxyId" column="PROXY_ID"/>

--- a/src/main/resources/egovframework/mapper/com/utl/sys/pxy/EgovProxySvc_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/pxy/EgovProxySvc_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="proxySvcDAO">
+<mapper namespace="egovframework.com.utl.sys.pxy.service.impl.ProxySvcDAO">
 
     <resultMap id="proxySvc" type="egovframework.com.utl.sys.pxy.service.ProxySvc">
         <result property="proxyId" column="PROXY_ID"/>

--- a/src/main/resources/egovframework/mapper/com/utl/sys/srm/EgovServerResrceMntrng_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/srm/EgovServerResrceMntrng_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="serverResrceMntrngDAO">
+<mapper namespace="egovframework.com.utl.sys.srm.service.impl.ServerResrceMntrngDAO">
 
    <resultMap id="serverResrceMntrng" type="egovframework.com.utl.sys.srm.service.ServerResrceMntrngVO">
         <result property="serverId" column="SERVER_ID"/>

--- a/src/main/resources/egovframework/mapper/com/utl/sys/srm/EgovServerResrceMntrng_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/srm/EgovServerResrceMntrng_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="serverResrceMntrngDAO">
+<mapper namespace="egovframework.com.utl.sys.srm.service.impl.ServerResrceMntrngDAO">
 
    <resultMap id="serverResrceMntrng" type="egovframework.com.utl.sys.srm.service.ServerResrceMntrngVO">
         <result property="serverId" column="SERVER_ID"/>

--- a/src/main/resources/egovframework/mapper/com/utl/sys/srm/EgovServerResrceMntrng_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/srm/EgovServerResrceMntrng_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="serverResrceMntrngDAO">
+<mapper namespace="egovframework.com.utl.sys.srm.service.impl.ServerResrceMntrngDAO">
 
    <resultMap id="serverResrceMntrng" type="egovframework.com.utl.sys.srm.service.ServerResrceMntrngVO">
         <result property="serverId" column="SERVER_ID"/>

--- a/src/main/resources/egovframework/mapper/com/utl/sys/srm/EgovServerResrceMntrng_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/srm/EgovServerResrceMntrng_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="serverResrceMntrngDAO">
+<mapper namespace="egovframework.com.utl.sys.srm.service.impl.ServerResrceMntrngDAO">
 
    <resultMap id="serverResrceMntrng" type="egovframework.com.utl.sys.srm.service.ServerResrceMntrngVO">
         <result property="serverId" column="SERVER_ID"/>

--- a/src/main/resources/egovframework/mapper/com/utl/sys/srm/EgovServerResrceMntrng_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/srm/EgovServerResrceMntrng_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="serverResrceMntrngDAO">
+<mapper namespace="egovframework.com.utl.sys.srm.service.impl.ServerResrceMntrngDAO">
 
    <resultMap id="serverResrceMntrng" type="egovframework.com.utl.sys.srm.service.ServerResrceMntrngVO">
         <result property="serverId" column="SERVER_ID"/>

--- a/src/main/resources/egovframework/mapper/com/utl/sys/srm/EgovServerResrceMntrng_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/srm/EgovServerResrceMntrng_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="serverResrceMntrngDAO">
+<mapper namespace="egovframework.com.utl.sys.srm.service.impl.ServerResrceMntrngDAO">
 
    <resultMap id="serverResrceMntrng" type="egovframework.com.utl.sys.srm.service.ServerResrceMntrngVO">
         <result property="serverId" column="SERVER_ID"/>

--- a/src/main/resources/egovframework/mapper/com/utl/sys/srm/EgovServerResrceMntrng_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/srm/EgovServerResrceMntrng_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="serverResrceMntrngDAO">
+<mapper namespace="egovframework.com.utl.sys.srm.service.impl.ServerResrceMntrngDAO">
 
    <resultMap id="serverResrceMntrng" type="egovframework.com.utl.sys.srm.service.ServerResrceMntrngVO">
         <result property="serverId" column="SERVER_ID"/>

--- a/src/main/resources/egovframework/mapper/com/utl/sys/srm/EgovServerResrceMntrng_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/srm/EgovServerResrceMntrng_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="serverResrceMntrngDAO">
+<mapper namespace="egovframework.com.utl.sys.srm.service.impl.ServerResrceMntrngDAO">
 
    <resultMap id="serverResrceMntrng" type="egovframework.com.utl.sys.srm.service.ServerResrceMntrngVO">
         <result property="serverId" column="SERVER_ID"/>

--- a/src/main/resources/egovframework/mapper/com/utl/sys/ssy/EgovSynchrnServer_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/ssy/EgovSynchrnServer_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="synchrnServerDAO">
+<mapper namespace="egovframework.com.utl.sys.ssy.service.impl.SynchrnServerDAO">
 
     <resultMap id="synchrnServer" type="egovframework.com.utl.sys.ssy.service.SynchrnServer">
         <result property="serverId" column="SERVER_ID"/>

--- a/src/main/resources/egovframework/mapper/com/utl/sys/ssy/EgovSynchrnServer_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/ssy/EgovSynchrnServer_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="synchrnServerDAO">
+<mapper namespace="egovframework.com.utl.sys.ssy.service.impl.SynchrnServerDAO">
 
     <resultMap id="synchrnServer" type="egovframework.com.utl.sys.ssy.service.SynchrnServer">
         <result property="serverId" column="SERVER_ID"/>

--- a/src/main/resources/egovframework/mapper/com/utl/sys/ssy/EgovSynchrnServer_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/ssy/EgovSynchrnServer_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="synchrnServerDAO">
+<mapper namespace="egovframework.com.utl.sys.ssy.service.impl.SynchrnServerDAO">
 
     <resultMap id="synchrnServer" type="egovframework.com.utl.sys.ssy.service.SynchrnServer">
         <result property="serverId" column="SERVER_ID"/>

--- a/src/main/resources/egovframework/mapper/com/utl/sys/ssy/EgovSynchrnServer_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/ssy/EgovSynchrnServer_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="synchrnServerDAO">
+<mapper namespace="egovframework.com.utl.sys.ssy.service.impl.SynchrnServerDAO">
 
     <resultMap id="synchrnServer" type="egovframework.com.utl.sys.ssy.service.SynchrnServer">
         <result property="serverId" column="SERVER_ID"/>

--- a/src/main/resources/egovframework/mapper/com/utl/sys/ssy/EgovSynchrnServer_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/ssy/EgovSynchrnServer_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="synchrnServerDAO">
+<mapper namespace="egovframework.com.utl.sys.ssy.service.impl.SynchrnServerDAO">
 
     <resultMap id="synchrnServer" type="egovframework.com.utl.sys.ssy.service.SynchrnServer">
         <result property="serverId" column="SERVER_ID"/>

--- a/src/main/resources/egovframework/mapper/com/utl/sys/ssy/EgovSynchrnServer_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/ssy/EgovSynchrnServer_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="synchrnServerDAO">
+<mapper namespace="egovframework.com.utl.sys.ssy.service.impl.SynchrnServerDAO">
 
     <resultMap id="synchrnServer" type="egovframework.com.utl.sys.ssy.service.SynchrnServer">
         <result property="serverId" column="SERVER_ID"/>

--- a/src/main/resources/egovframework/mapper/com/utl/sys/ssy/EgovSynchrnServer_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/ssy/EgovSynchrnServer_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="synchrnServerDAO">
+<mapper namespace="egovframework.com.utl.sys.ssy.service.impl.SynchrnServerDAO">
 
     <resultMap id="synchrnServer" type="egovframework.com.utl.sys.ssy.service.SynchrnServer">
         <result property="serverId" column="SERVER_ID"/>

--- a/src/main/resources/egovframework/mapper/com/utl/sys/ssy/EgovSynchrnServer_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/ssy/EgovSynchrnServer_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="synchrnServerDAO">
+<mapper namespace="egovframework.com.utl.sys.ssy.service.impl.SynchrnServerDAO">
 
     <resultMap id="synchrnServer" type="egovframework.com.utl.sys.ssy.service.SynchrnServer">
         <result property="serverId" column="SERVER_ID"/>

--- a/src/main/resources/egovframework/spring/com/context-mapper.xml
+++ b/src/main/resources/egovframework/spring/com/context-mapper.xml
@@ -21,5 +21,12 @@
 	<bean id="egov.sqlSessionTemplate" class="org.mybatis.spring.SqlSessionTemplate">
 		<constructor-arg ref="egov.sqlSession"/>
 	</bean>
-	
+
+	<!-- @EgovMapper 어노테이션이 붙은 인터페이스를 자동으로 스캔하여 빈으로 등록 -->
+	<bean class="org.mybatis.spring.mapper.MapperScannerConfigurer">
+		<property name="basePackage" value="egovframework.com"/>
+		<property name="annotationClass" value="org.egovframe.rte.psl.dataaccess.mapper.EgovMapper"/>
+		<property name="sqlSessionFactoryBeanName" value="egov.sqlSession"/>
+	</bean>
+
 </beans>


### PR DESCRIPTION
## 변경 사유
기존 XML namespace 기반 DAO를 eGovFrame 5.0 신규 `@EgovMapper` 인터페이스 방식으로 전환합니다.

## 변경 내용
- 대상: utl/sys 7개 모니터링 DAO
- 각 DAO에 대응하는 Mapper 인터페이스(`@EgovMapper`) 신규 추가
- DAO를 mapper 위임 구조로 리팩토링 (EgovComAbstractDAO 상속 제거, @Resource 주입, @Repository bean name 유지)
- XML mapper namespace를 mapper 인터페이스 FQN으로 변경
- context-mapper.xml에 MapperScannerConfigurer(annotationClass=EgovMapper) 추가

## 영향 범위
- 해당 모듈만 영향, 서비스 레이어 호출 시그니처 변경 없음

## 참고
- 빌드 검증을 위해 #891(Lombok annotationProcessorPaths 빌드 수정) 선행 머지 권장
- context-mapper.xml MapperScannerConfigurer는 동일 시리즈 PR과 한 줄 중복될 수 있어, 선행 PR 머지 후 rebase로 정리 가능

## 체크리스트
- [x] 단일 주제만 다룸
- [x] 컴파일 검증(해당 모듈 신규 오류 0)
- [x] 기존 동작 호환
