### PR TITLE
[refactor][5.0.x][공통컴포넌트] dam 지식맵/전문가 및 cop/tpl·uss 7개 DAO @EgovMapper 인터페이스 전환

### DIFF
--- a/src/main/java/egovframework/com/cop/tpl/service/impl/TemplateManageDAO.java
+++ b/src/main/java/egovframework/com/cop/tpl/service/impl/TemplateManageDAO.java
@@ -4,9 +4,9 @@ import java.util.List;
 
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.cop.tpl.service.TemplateInf;
 import egovframework.com.cop.tpl.service.TemplateInfVO;
+import jakarta.annotation.Resource;
 
 /**
  * 템플릿 정보관리를 위한 데이터 접근 클래스
@@ -17,7 +17,7 @@ import egovframework.com.cop.tpl.service.TemplateInfVO;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *  수정일               수정자            수정내용
  *  ----------   --------   ---------------------------
  *  2009.03.17   이삼섭           최초 생성
@@ -26,103 +26,104 @@ import egovframework.com.cop.tpl.service.TemplateInfVO;
  * </pre>
  */
 @Repository("TemplateManageDAO")
-public class TemplateManageDAO extends EgovComAbstractDAO {
+public class TemplateManageDAO {
+
+    @Resource(name = "templateManageMapper")
+    private TemplateManageMapper templateManageMapper;
 
     /**
      * 템플릿 정보를 삭제한다.
-     * 
+     *
      * @param tmplatInf
      * @throws Exception
      */
     public void deleteTemplateInf(TemplateInf tmplatInf) throws Exception {
-	update("TemplateManageDAO.deleteTemplateInf", tmplatInf);
+        templateManageMapper.deleteTemplateInf(tmplatInf);
     }
 
     /**
      * 템플릿 정보를 등록한다.
-     * 
+     *
      * @param tmplatInf
      * @throws Exception
      */
     public void insertTemplateInf(TemplateInf tmplatInf) throws Exception {
-	insert("TemplateManageDAO.insertTemplateInf", tmplatInf);
+        templateManageMapper.insertTemplateInf(tmplatInf);
     }
 
     /**
      * 템플릿 정보를 수정한다.
-     * 
+     *
      * @param tmplatInf
      * @throws Exception
      */
     public void updateTemplateInf(TemplateInf tmplatInf) throws Exception {
-	update("TemplateManageDAO.updateTemplateInf", tmplatInf);
+        templateManageMapper.updateTemplateInf(tmplatInf);
     }
 
     /**
-     * 템플릿에 대한 화이트리스트 목록를 조회한다.
-     * 
-     * @param tmplatInfVO
+     * 템플릿에 대한 화이트리스트 목록을 조회한다.
+     *
      * @return
      * @throws Exception
      */
     public List<TemplateInfVO> selectTemplateWhiteList() throws Exception {
-    	return selectList("TemplateManageDAO.selectTemplateWhiteList");
+        return templateManageMapper.selectTemplateWhiteList();
     }
-    
+
     /**
-     * 템플릿에 대한 목록를 조회한다.
-     * 
+     * 템플릿에 대한 목록을 조회한다.
+     *
      * @param tmplatInfVO
      * @return
      * @throws Exception
      */
     public List<TemplateInfVO> selectTemplateInfs(TemplateInfVO tmplatInfVO) throws Exception {
-	return selectList("TemplateManageDAO.selectTemplateInfs", tmplatInfVO);
+        return templateManageMapper.selectTemplateInfs(tmplatInfVO);
     }
 
     /**
      * 템플릿에 대한 목록 전체 건수를 조회한다.
-     * 
+     *
      * @param tmplatInfVO
      * @return
      * @throws Exception
      */
     public int selectTemplateInfsCnt(TemplateInfVO tmplatInfVO) throws Exception {
-	return (Integer)selectOne("TemplateManageDAO.selectTemplateInfsCnt", tmplatInfVO);
+        return templateManageMapper.selectTemplateInfsCnt(tmplatInfVO);
     }
 
     /**
      * 템플릿에 대한 상세정보를 조회한다.
-     * 
+     *
      * @param tmplatInfVO
      * @return
      * @throws Exception
      */
     public TemplateInfVO selectTemplateInf(TemplateInfVO tmplatInfVO) throws Exception {
-	return (TemplateInfVO)selectOne("TemplateManageDAO.selectTemplateInf", tmplatInfVO);
-
+        return templateManageMapper.selectTemplateInf(tmplatInfVO);
     }
 
     /**
      * 템플릿에 대한 미리보기 정보를 조회한다.
-     * 
+     *
      * @param tmplatInfVO
      * @return
      * @throws Exception
      */
     public TemplateInfVO selectTemplatePreview(TemplateInfVO tmplatInfVO) throws Exception {
-	return null;
+        return null;
     }
 
     /**
      * 템플릿 구분에 따른 목록을 조회한다.
-     * 
+     *
      * @param tmplatInfVO
      * @return
      * @throws Exception
      */
     public List<TemplateInfVO> selectTemplateInfsByCode(TemplateInfVO tmplatInfVO) throws Exception {
-	return selectList("TemplateManageDAO.selectTemplateInfsByCode", tmplatInfVO);
+        return templateManageMapper.selectTemplateInfsByCode(tmplatInfVO);
     }
-	
+
 }

--- a/src/main/java/egovframework/com/cop/tpl/service/impl/TemplateManageMapper.java
+++ b/src/main/java/egovframework/com/cop/tpl/service/impl/TemplateManageMapper.java
@@ -1,0 +1,59 @@
+package egovframework.com.cop.tpl.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.cop.tpl.service.TemplateInf;
+import egovframework.com.cop.tpl.service.TemplateInfVO;
+
+/**
+ * 템플릿 정보관리에 대한 Mapper 인터페이스
+ * @author 공통서비스개발팀 이삼섭
+ * @since 2009.06.01
+ * @version 1.0
+ */
+@EgovMapper("templateManageMapper")
+public interface TemplateManageMapper {
+
+	/**
+	 * 템플릿 정보를 삭제한다.
+	 */
+	void deleteTemplateInf(TemplateInf tmplatInf);
+
+	/**
+	 * 템플릿 정보를 등록한다.
+	 */
+	void insertTemplateInf(TemplateInf tmplatInf);
+
+	/**
+	 * 템플릿 정보를 수정한다.
+	 */
+	void updateTemplateInf(TemplateInf tmplatInf);
+
+	/**
+	 * 템플릿 화이트리스트 목록을 조회한다.
+	 */
+	List<TemplateInfVO> selectTemplateWhiteList();
+
+	/**
+	 * 템플릿 목록을 조회한다.
+	 */
+	List<TemplateInfVO> selectTemplateInfs(TemplateInfVO tmplatInfVO);
+
+	/**
+	 * 템플릿 목록 전체 건수를 조회한다.
+	 */
+	int selectTemplateInfsCnt(TemplateInfVO tmplatInfVO);
+
+	/**
+	 * 템플릿 상세정보를 조회한다.
+	 */
+	TemplateInfVO selectTemplateInf(TemplateInfVO tmplatInfVO);
+
+	/**
+	 * 템플릿 구분에 따른 목록을 조회한다.
+	 */
+	List<TemplateInfVO> selectTemplateInfsByCode(TemplateInfVO tmplatInfVO);
+
+}

--- a/src/main/java/egovframework/com/dam/map/mat/service/impl/MapMaterialDAO.java
+++ b/src/main/java/egovframework/com/dam/map/mat/service/impl/MapMaterialDAO.java
@@ -4,9 +4,9 @@ import java.util.List;
 
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.dam.map.mat.service.MapMaterial;
 import egovframework.com.dam.map.mat.service.MapMaterialVO;
+import jakarta.annotation.Resource;
 
 /**
  * 개요
@@ -19,80 +19,70 @@ import egovframework.com.dam.map.mat.service.MapMaterialVO;
  * @version 1.0
  * @created 12-8-2010 오후 3:44:52
  */
-
 @Repository("MapMaterialDAO")
-public class MapMaterialDAO extends EgovComAbstractDAO {
+public class MapMaterialDAO {
+
+	@Resource(name = "mapMaterialMapper")
+	private MapMaterialMapper mapMaterialMapper;
 
 	/**
-	 * 등록된 지식맵(지식유형) 정보를 조회 한다.
-	 * @param mapMaterialVO- 지식맵(지식유형) VO
-	 * @return String - 지식맵(지식유형)목록
-	 *
-	 * @param MapMaterialVO
+	 * 등록된 지식맵(지식유형) 목록을 조회한다.
+	 * @param searchVO - 지식맵(지식유형) VO
+	 * @return List - 지식맵(지식유형) 목록
 	 */
 	public List<MapMaterialVO> selectMapMaterialList(MapMaterialVO searchVO) throws Exception {
-		return  selectList("MapMaterialDAO.selectMapMaterialList", searchVO);
+		return mapMaterialMapper.selectMapMaterialList(searchVO);
 	}
 
 	/**
 	 * 지식맵(지식유형) 목록 총 개수를 조회한다.
-	 * @param MapMaterialVO - 지식맵(지식유형) Vo
+	 * @param searchVO - 지식맵(지식유형) Vo
 	 * @return int - 지식맵(지식유형) 토탈 카운트 수
-	 *
-	 * @param MapMaterialVO
 	 */
 	public int selectMapMaterialTotCnt(MapMaterialVO searchVO) throws Exception {
-		return  (Integer)selectOne("MapMaterialDAO.selectMapMaterialTotCnt", searchVO);
+		return mapMaterialMapper.selectMapMaterialTotCnt(searchVO);
 	}
 
 	/**
-	 * 지식맵(지식유형)상세 정보를 조회 한다.
-	 * @param MapMaterialVO - 지식맵(지식유형) VO
-	 * @return String - 지식맵(지식유형)VO
-	 *
-	 * @param MapMaterialVO
+	 * 지식맵(지식유형) 상세 정보를 조회한다.
+	 * @param mapMaterial - 지식맵(지식유형) VO
+	 * @return MapMaterial - 지식맵(지식유형) VO
 	 */
 	public MapMaterial selectMapMaterial(MapMaterial mapMaterial) throws Exception {
-		return (MapMaterial)selectOne("MapMaterialDAO.selectMapMaterial", mapMaterial);
+		return mapMaterialMapper.selectMapMaterial(mapMaterial);
 	}
 
 	/**
 	 * 지식맵(지식유형) 정보를 신규로 등록한다.
-	 * @param konTypeNm - 지식맵(지식유형) model
-	 *
-	 * @param MapMaterialVO
+	 * @param mapMaterial - 지식맵(지식유형) model
 	 */
 	public void insertMapMaterial(MapMaterial mapMaterial) throws Exception {
-		insert("MapMaterialDAO.insertMapMaterial", mapMaterial);
+		mapMaterialMapper.insertMapMaterial(mapMaterial);
 	}
 
 	/**
-	 * 기 등록 된 지식맵(지식유형)링 정보를 수정 한다.
-	 * @param konTypeNm - 지식맵(지식유형) model
-	 *
-	 * @param MapMaterialVO
+	 * 기 등록 된 지식맵(지식유형) 정보를 수정한다.
+	 * @param mapMaterial - 지식맵(지식유형) model
 	 */
 	public void updateMapMaterial(MapMaterial mapMaterial) throws Exception {
-		update("MapMaterialDAO.updateMapMaterial", mapMaterial);
+		mapMaterialMapper.updateMapMaterial(mapMaterial);
 	}
 
 	/**
 	 * 기 등록된 지식맵(지식유형) 정보를 삭제한다.
-	 * @param konTypeNm - 지식맵(지식유형) model
-	 *
-	 * @param MapMaterialVO
+	 * @param mapMaterial - 지식맵(지식유형) model
 	 */
 	public void deleteMapMaterial(MapMaterial mapMaterial) throws Exception {
-		delete("MapMaterialDAO.deleteMapMaterial", mapMaterial);
+		mapMaterialMapper.deleteMapMaterial(mapMaterial);
 	}
 
 	/**
-	 * 지식유형코드 중복 여부 체크(위치 : 1260.지식맵관리(유형) > 등록)
+	 * 지식유형코드 중복 여부 체크
 	 * @param knoTypeCd
 	 * @return 중복 여부
-	 * @throws Exception
 	 */
 	public int knoTypeCdCheck(String knoTypeCd) throws Exception {
-		return (Integer)selectOne("MapMaterialDAO.selectKnoTypeCdCheck", knoTypeCd);
+		return mapMaterialMapper.selectKnoTypeCdCheck(knoTypeCd);
 	}
+
 }

--- a/src/main/java/egovframework/com/dam/map/mat/service/impl/MapMaterialMapper.java
+++ b/src/main/java/egovframework/com/dam/map/mat/service/impl/MapMaterialMapper.java
@@ -1,0 +1,53 @@
+package egovframework.com.dam.map.mat.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.dam.map.mat.service.MapMaterial;
+import egovframework.com.dam.map.mat.service.MapMaterialVO;
+
+/**
+ * 지식맵(지식유형)에 대한 Mapper 인터페이스
+ * @author 박종선
+ * @version 1.0
+ */
+@EgovMapper("mapMaterialMapper")
+public interface MapMaterialMapper {
+
+	/**
+	 * 등록된 지식맵(지식유형) 목록을 조회한다.
+	 */
+	List<MapMaterialVO> selectMapMaterialList(MapMaterialVO searchVO);
+
+	/**
+	 * 지식맵(지식유형) 목록 총 개수를 조회한다.
+	 */
+	int selectMapMaterialTotCnt(MapMaterialVO searchVO);
+
+	/**
+	 * 지식맵(지식유형) 상세 정보를 조회한다.
+	 */
+	MapMaterial selectMapMaterial(MapMaterial mapMaterial);
+
+	/**
+	 * 지식맵(지식유형) 정보를 등록한다.
+	 */
+	void insertMapMaterial(MapMaterial mapMaterial);
+
+	/**
+	 * 지식맵(지식유형) 정보를 수정한다.
+	 */
+	void updateMapMaterial(MapMaterial mapMaterial);
+
+	/**
+	 * 지식맵(지식유형) 정보를 삭제한다.
+	 */
+	void deleteMapMaterial(MapMaterial mapMaterial);
+
+	/**
+	 * 지식유형코드 중복 여부를 체크한다.
+	 */
+	int selectKnoTypeCdCheck(String knoTypeCd);
+
+}

--- a/src/main/java/egovframework/com/dam/map/tea/service/impl/MapTeamDAO.java
+++ b/src/main/java/egovframework/com/dam/map/tea/service/impl/MapTeamDAO.java
@@ -4,9 +4,9 @@ import java.util.List;
 
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.dam.map.tea.service.MapTeam;
 import egovframework.com.dam.map.tea.service.MapTeamVO;
+import jakarta.annotation.Resource;
 
 /**
  * 개요
@@ -20,69 +20,60 @@ import egovframework.com.dam.map.tea.service.MapTeamVO;
  * @created 22-7-2010 오전 10:57:44
  */
 @Repository("MapTeamDAO")
-public class MapTeamDAO extends EgovComAbstractDAO{
+public class MapTeamDAO {
+
+	@Resource(name = "mapTeamMapper")
+	private MapTeamMapper mapTeamMapper;
 
 	/**
 	 * 등록된 지식맵(조직별) 목록을 조회 한다.
-	 * @param mapTeamVO- 지식맵(조직별) VO
-	 * @return String - 지식맵(조직별) 목록
-	 *
-	 * @param MapTeamVO
+	 * @param searchVO - 지식맵(조직별) VO
+	 * @return List - 지식맵(조직별) 목록
 	 */
 	public List<MapTeamVO> selectMapTeamList(MapTeamVO searchVO) throws Exception {
-		return selectList("MapTeamDAO.selectMapTeamList", searchVO);
+		return mapTeamMapper.selectMapTeamList(searchVO);
 	}
 
 	/**
 	 * 지식맵(조직별) 목록 총 개수를 조회한다.
-	 * @param MapTeamVO - 지식맵(조직별) Vo
+	 * @param searchVO - 지식맵(조직별) Vo
 	 * @return int - 지식맵(조직별) 토탈 카운트 수
-	 *
-	 * @param MapTeamVO
 	 */
 	public int selectMapTeamTotCnt(MapTeamVO searchVO) throws Exception {
-		return (Integer)selectOne("MapTeamDAO.selectMapTeamTotCnt", searchVO);
+		return mapTeamMapper.selectMapTeamTotCnt(searchVO);
 	}
 
 	/**
-	 * 지식맵(조직별)상세 정보를 조회 한다.
-	 * @param MapTeamVO - 지식맵(조직별) VO
-	 * @return String - 지식맵(조직별) VO
-	 *
-	 * @param MapTeamVO
+	 * 지식맵(조직별) 상세 정보를 조회 한다.
+	 * @param mapTeam - 지식맵(조직별) VO
+	 * @return MapTeam - 지식맵(조직별) VO
 	 */
 	public MapTeam selectMapTeamDetail(MapTeam mapTeam) throws Exception {
-		return (MapTeam)selectOne("MapTeamDAO.selectMapTeamDetail", mapTeam);
+		return mapTeamMapper.selectMapTeamDetail(mapTeam);
 	}
 
 	/**
 	 * 지식맵(조직별) 정보를 신규로 등록한다.
-	 * @param siteUrl - 지식맵(조직별) model
-	 *
-	 * @param orgnztNm
+	 * @param mapTeam - 지식맵(조직별) model
 	 */
 	public void insertMapTeam(MapTeam mapTeam) throws Exception {
-		insert("MapTeamDAO.insertMapTeam", mapTeam);
+		mapTeamMapper.insertMapTeam(mapTeam);
 	}
 
 	/**
 	 * 기 등록 된 지식맵(조직별) 정보를 수정 한다.
-	 * @param siteUrl - 지식맵(조직별) model
-	 *
-	 * @param orgnztNm
+	 * @param mapTeam - 지식맵(조직별) model
 	 */
 	public void updateMapTeam(MapTeam mapTeam) throws Exception {
-		update("MapTeamDAO.updateMapTeam", mapTeam);
+		mapTeamMapper.updateMapTeam(mapTeam);
 	}
 
 	/**
 	 * 기 등록된 지식맵(조직별) 정보를 삭제한다.
-	 * @param siteUrl - 지식맵(조직별) model
-	 *
-	 * @param orgnztNm
+	 * @param mapTeam - 지식맵(조직별) model
 	 */
 	public void deleteMapTeam(MapTeam mapTeam) throws Exception {
-		delete("MapTeamDAO.deleteMapTeam", mapTeam);
+		mapTeamMapper.deleteMapTeam(mapTeam);
 	}
 
 }

--- a/src/main/java/egovframework/com/dam/map/tea/service/impl/MapTeamMapper.java
+++ b/src/main/java/egovframework/com/dam/map/tea/service/impl/MapTeamMapper.java
@@ -1,0 +1,48 @@
+package egovframework.com.dam.map.tea.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.dam.map.tea.service.MapTeam;
+import egovframework.com.dam.map.tea.service.MapTeamVO;
+
+/**
+ * 지식맵(조직별)에 대한 Mapper 인터페이스
+ * @author 박종선
+ * @version 1.0
+ */
+@EgovMapper("mapTeamMapper")
+public interface MapTeamMapper {
+
+	/**
+	 * 등록된 지식맵(조직별) 목록을 조회한다.
+	 */
+	List<MapTeamVO> selectMapTeamList(MapTeamVO searchVO);
+
+	/**
+	 * 지식맵(조직별) 목록 총 개수를 조회한다.
+	 */
+	int selectMapTeamTotCnt(MapTeamVO searchVO);
+
+	/**
+	 * 지식맵(조직별) 상세 정보를 조회한다.
+	 */
+	MapTeam selectMapTeamDetail(MapTeam mapTeam);
+
+	/**
+	 * 지식맵(조직별) 정보를 등록한다.
+	 */
+	void insertMapTeam(MapTeam mapTeam);
+
+	/**
+	 * 지식맵(조직별) 정보를 수정한다.
+	 */
+	void updateMapTeam(MapTeam mapTeam);
+
+	/**
+	 * 지식맵(조직별) 정보를 삭제한다.
+	 */
+	void deleteMapTeam(MapTeam mapTeam);
+
+}

--- a/src/main/java/egovframework/com/dam/spe/spe/service/impl/KnoSpecialistDAO.java
+++ b/src/main/java/egovframework/com/dam/spe/spe/service/impl/KnoSpecialistDAO.java
@@ -4,9 +4,9 @@ import java.util.List;
 
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.dam.spe.spe.service.KnoSpecialist;
 import egovframework.com.dam.spe.spe.service.KnoSpecialistVO;
+import jakarta.annotation.Resource;
 
 /**
  * 개요
@@ -19,71 +19,61 @@ import egovframework.com.dam.spe.spe.service.KnoSpecialistVO;
  * @version 1.0
  * @created 12-8-2010 오후 3:44:52
  */
-
 @Repository("KnoSpecialistDAO")
-public class KnoSpecialistDAO extends EgovComAbstractDAO {
+public class KnoSpecialistDAO {
+
+	@Resource(name = "knoSpecialistMapper")
+	private KnoSpecialistMapper knoSpecialistMapper;
 
 	/**
-	 * 등록된 지식전문가 정보를 조회 한다.
-	 * @param KnoSpecialistVO- 지식전문가 VO
-	 * @return String - 지식전문가 목록
-	 *
-	 * @param KnoSpecialistVO
+	 * 등록된 지식전문가 목록을 조회한다.
+	 * @param searchVO - 지식전문가 VO
+	 * @return List - 지식전문가 목록
 	 */
 	public List<KnoSpecialistVO> selectKnoSpecialistList(KnoSpecialistVO searchVO) throws Exception {
-		return  selectList("KnoSpecialistDAO.selectKnoSpecialistList", searchVO);
+		return knoSpecialistMapper.selectKnoSpecialistList(searchVO);
 	}
 
 	/**
 	 * 지식전문가 목록 총 개수를 조회한다.
-	 * @param KnoSpecialistVO - 지식전문가 Vo
+	 * @param searchVO - 지식전문가 Vo
 	 * @return int - 지식전문가 토탈 카운트 수
-	 *
-	 * @param KnoSpecialistVO
 	 */
 	public int selectKnoSpecialistTotCnt(KnoSpecialistVO searchVO) throws Exception {
-		return  (Integer)selectOne("KnoSpecialistDAO.selectKnoSpecialistTotCnt", searchVO);
+		return knoSpecialistMapper.selectKnoSpecialistTotCnt(searchVO);
 	}
 
 	/**
-	 * 지식전문가 상세 정보를 조회 한다.
-	 * @param KonSpecialistVO - 지식전문가 VO
-	 * @return String - 지식전문가 VO
-	 *
-	 * @param KonSpecialistVO
+	 * 지식전문가 상세 정보를 조회한다.
+	 * @param knoSpecialist - 지식전문가 VO
+	 * @return KnoSpecialist - 지식전문가 VO
 	 */
 	public KnoSpecialist selectKnoSpecialist(KnoSpecialist knoSpecialist) throws Exception {
-		return (KnoSpecialist)selectOne("KnoSpecialistDAO.selectKnoSpecialist", knoSpecialist);
+		return knoSpecialistMapper.selectKnoSpecialist(knoSpecialist);
 	}
 
 	/**
 	 * 지식전문가 정보를 신규로 등록한다.
-	 * @param speNm - 지식전문가 model
-	 *
-	 * @param speNm
+	 * @param knoSpecialist - 지식전문가 model
 	 */
 	public void insertKnoSpecialist(KnoSpecialist knoSpecialist) throws Exception {
-		insert("KnoSpecialistDAO.insertKnoSpecialist", knoSpecialist);
+		knoSpecialistMapper.insertKnoSpecialist(knoSpecialist);
 	}
 
 	/**
-	 * 기 등록 된 지식전문가 정보를 수정 한다.
-	 * @param speNm - 지식전문가 model
-	 *
-	 * @param speNm
+	 * 기 등록 된 지식전문가 정보를 수정한다.
+	 * @param knoSpecialist - 지식전문가 model
 	 */
 	public void updateKnoSpecialist(KnoSpecialist knoSpecialist) throws Exception {
-		update("KnoSpecialistDAO.updateKnoSpecialist", knoSpecialist);
+		knoSpecialistMapper.updateKnoSpecialist(knoSpecialist);
 	}
 
 	/**
 	 * 기 등록된 지식전문가 정보를 삭제한다.
-	 * @param siteUrl - 지식전문가 model
-	 *
-	 * @param speNm
+	 * @param knoSpecialist - 지식전문가 model
 	 */
 	public void deleteKnoSpecialist(KnoSpecialist knoSpecialist) throws Exception {
-		delete("KnoSpecialistDAO.deleteKnoSpecialist", knoSpecialist);
+		knoSpecialistMapper.deleteKnoSpecialist(knoSpecialist);
 	}
 
 }

--- a/src/main/java/egovframework/com/dam/spe/spe/service/impl/KnoSpecialistMapper.java
+++ b/src/main/java/egovframework/com/dam/spe/spe/service/impl/KnoSpecialistMapper.java
@@ -1,0 +1,48 @@
+package egovframework.com.dam.spe.spe.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.dam.spe.spe.service.KnoSpecialist;
+import egovframework.com.dam.spe.spe.service.KnoSpecialistVO;
+
+/**
+ * 지식전문가에 대한 Mapper 인터페이스
+ * @author 박종선
+ * @version 1.0
+ */
+@EgovMapper("knoSpecialistMapper")
+public interface KnoSpecialistMapper {
+
+	/**
+	 * 등록된 지식전문가 목록을 조회한다.
+	 */
+	List<KnoSpecialistVO> selectKnoSpecialistList(KnoSpecialistVO searchVO);
+
+	/**
+	 * 지식전문가 목록 총 개수를 조회한다.
+	 */
+	int selectKnoSpecialistTotCnt(KnoSpecialistVO searchVO);
+
+	/**
+	 * 지식전문가 상세 정보를 조회한다.
+	 */
+	KnoSpecialist selectKnoSpecialist(KnoSpecialist knoSpecialist);
+
+	/**
+	 * 지식전문가 정보를 등록한다.
+	 */
+	void insertKnoSpecialist(KnoSpecialist knoSpecialist);
+
+	/**
+	 * 지식전문가 정보를 수정한다.
+	 */
+	void updateKnoSpecialist(KnoSpecialist knoSpecialist);
+
+	/**
+	 * 지식전문가 정보를 삭제한다.
+	 */
+	void deleteKnoSpecialist(KnoSpecialist knoSpecialist);
+
+}

--- a/src/main/java/egovframework/com/uss/cmt/service/impl/EgovCmtManageDAO.java
+++ b/src/main/java/egovframework/com/uss/cmt/service/impl/EgovCmtManageDAO.java
@@ -4,9 +4,9 @@ import java.util.List;
 
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.uss.cmt.service.CmtDefaultVO;
 import egovframework.com.uss.cmt.service.CmtManageVO;
+import jakarta.annotation.Resource;
 
 /**
  * 출퇴근관리에 관한 데이터 접근 클래스를 정의한다.
@@ -25,10 +25,13 @@ import egovframework.com.uss.cmt.service.CmtManageVO;
  * </pre>
  */
 @Repository("cmtManageDAO")
-public class EgovCmtManageDAO extends EgovComAbstractDAO {
+public class EgovCmtManageDAO {
+
+	@Resource(name = "cmtManageMapper")
+	private EgovCmtManageMapper cmtManageMapper;
 
 	public List<CmtManageVO> selectCmtInfoList(CmtDefaultVO cmtSearchVO) {
-		return selectList("cmtManageDAO.selectCmtList_S", cmtSearchVO);
+		return cmtManageMapper.selectCmtList_S(cmtSearchVO);
 	}
 
 	/**
@@ -37,16 +40,16 @@ public class EgovCmtManageDAO extends EgovComAbstractDAO {
 	* @return String result 등록결과
 	*/
 	public String insertWrkStartCmtInfo(CmtManageVO cmtManageVO) {
-		return Integer.toString(insert("cmtManageDAO.insertWrkStartCmtInfo_S", cmtManageVO));
+		return Integer.toString(cmtManageMapper.insertWrkStartCmtInfo_S(cmtManageVO));
 	}
 
 	/**
 	* 퇴근 기본정보를 화면에서 입력하여 항목의 정합성을 체크하고 데이터베이스에 저장
 	* @param cmtManageVO 업무사용자 등록정보
-	* @return String result 등록결과
+	* @return int result 등록결과
 	*/
 	public int insertWrkEndCmtInfo(CmtManageVO cmtManageVO) {
-		return update("cmtManageDAO.insertWrkEndCmtInfo_S", cmtManageVO);
+		return cmtManageMapper.insertWrkEndCmtInfo_S(cmtManageVO);
 	}
 
 	/**
@@ -54,9 +57,8 @@ public class EgovCmtManageDAO extends EgovComAbstractDAO {
 	 * @param cmtManageVO
 	 * @return String wrktmId
 	 */
-
 	public String selectWrktmId(CmtManageVO cmtManageVO) {
-		return (String) selectOne("cmtManageDAO.selectWrktmId_S", cmtManageVO);
+		return cmtManageMapper.selectWrktmId_S(cmtManageVO);
 	}
 
 	/**
@@ -64,11 +66,8 @@ public class EgovCmtManageDAO extends EgovComAbstractDAO {
 	 * @param cmtManageVO
 	 * @return cmtManageVO
 	 */
-
 	public CmtManageVO selectWrkStartInfo(CmtManageVO cmtManageVO) {
-		CmtManageVO cmtVO = (CmtManageVO) selectOne("cmtManageDAO.selectWrkStartInfo_S", cmtManageVO);
-
-		return cmtVO;
+		return cmtManageMapper.selectWrkStartInfo_S(cmtManageVO);
 	}
 
 }

--- a/src/main/java/egovframework/com/uss/cmt/service/impl/EgovCmtManageMapper.java
+++ b/src/main/java/egovframework/com/uss/cmt/service/impl/EgovCmtManageMapper.java
@@ -1,0 +1,44 @@
+package egovframework.com.uss.cmt.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.uss.cmt.service.CmtDefaultVO;
+import egovframework.com.uss.cmt.service.CmtManageVO;
+
+/**
+ * 출퇴근관리에 대한 Mapper 인터페이스
+ * @author 표준프레임워크 개발팀
+ * @since 2014.11.10
+ * @version 1.0
+ */
+@EgovMapper("cmtManageMapper")
+public interface EgovCmtManageMapper {
+
+	/**
+	 * 출퇴근 정보 목록을 조회한다.
+	 */
+	List<CmtManageVO> selectCmtList_S(CmtDefaultVO cmtSearchVO);
+
+	/**
+	 * 출근 정보를 등록한다.
+	 */
+	int insertWrkStartCmtInfo_S(CmtManageVO cmtManageVO);
+
+	/**
+	 * 퇴근 정보를 수정한다.
+	 */
+	int insertWrkEndCmtInfo_S(CmtManageVO cmtManageVO);
+
+	/**
+	 * 퇴근 정보 입력을 위한 출근 정보 id를 조회한다.
+	 */
+	String selectWrktmId_S(CmtManageVO cmtManageVO);
+
+	/**
+	 * 퇴근 정보 입력을 위한 출근 정보를 조회한다.
+	 */
+	CmtManageVO selectWrkStartInfo_S(CmtManageVO cmtManageVO);
+
+}

--- a/src/main/java/egovframework/com/uss/mpe/service/impl/EgovIndvdlPgeDAO.java
+++ b/src/main/java/egovframework/com/uss/mpe/service/impl/EgovIndvdlPgeDAO.java
@@ -4,30 +4,33 @@ import java.util.List;
 
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.uss.mpe.service.IndvdlPgeVO;
+import jakarta.annotation.Resource;
 
 @Repository("EgovIndvdlPgeDAO")
-public class EgovIndvdlPgeDAO extends EgovComAbstractDAO {
+public class EgovIndvdlPgeDAO {
+
+	@Resource(name = "egovIndvdlPgeMapper")
+	private EgovIndvdlPgeMapper egovIndvdlPgeMapper;
 
 	public List<IndvdlPgeVO> selectIndvdlPgeList(IndvdlPgeVO searchVO) {
-		return selectList("IndvdlPge.selectIndvdlPgeList", searchVO);
+		return egovIndvdlPgeMapper.selectIndvdlPgeList(searchVO);
 	}
 
 	public int selectIndvdlPgeListCnt(IndvdlPgeVO searchVO) {
-		return (Integer) selectOne("IndvdlPge.selectIndvdlPgeListCnt", searchVO);
+		return egovIndvdlPgeMapper.selectIndvdlPgeListCnt(searchVO);
 	}
 
 	public IndvdlPgeVO selectIndvdlPgeDetail(IndvdlPgeVO indvdlPgeVO) {
-		return (IndvdlPgeVO) selectOne("IndvdlPge.selectIndvdlPgeDetail", indvdlPgeVO);
+		return egovIndvdlPgeMapper.selectIndvdlPgeDetail(indvdlPgeVO);
 	}
 
 	public void insertIndvdlPge(IndvdlPgeVO indvdlPgeVO) {
-		insert("IndvdlPge.insertIndvdlPge", indvdlPgeVO);
+		egovIndvdlPgeMapper.insertIndvdlPge(indvdlPgeVO);
 	}
 
 	public void updateIndvdlPge(IndvdlPgeVO indvdlPgeVO) {
-		update("IndvdlPge.updateIndvdlPge", indvdlPgeVO);
+		egovIndvdlPgeMapper.updateIndvdlPge(indvdlPgeVO);
 	}
 
 }

--- a/src/main/java/egovframework/com/uss/mpe/service/impl/EgovIndvdlPgeMapper.java
+++ b/src/main/java/egovframework/com/uss/mpe/service/impl/EgovIndvdlPgeMapper.java
@@ -1,0 +1,41 @@
+package egovframework.com.uss.mpe.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.uss.mpe.service.IndvdlPgeVO;
+
+/**
+ * 개인페이지 관리에 대한 Mapper 인터페이스
+ * @version 1.0
+ */
+@EgovMapper("egovIndvdlPgeMapper")
+public interface EgovIndvdlPgeMapper {
+
+	/**
+	 * 개인페이지 목록을 조회한다.
+	 */
+	List<IndvdlPgeVO> selectIndvdlPgeList(IndvdlPgeVO searchVO);
+
+	/**
+	 * 개인페이지 목록 총 개수를 조회한다.
+	 */
+	int selectIndvdlPgeListCnt(IndvdlPgeVO searchVO);
+
+	/**
+	 * 개인페이지 상세 정보를 조회한다.
+	 */
+	IndvdlPgeVO selectIndvdlPgeDetail(IndvdlPgeVO indvdlPgeVO);
+
+	/**
+	 * 개인페이지를 등록한다.
+	 */
+	void insertIndvdlPge(IndvdlPgeVO indvdlPgeVO);
+
+	/**
+	 * 개인페이지를 수정한다.
+	 */
+	void updateIndvdlPge(IndvdlPgeVO indvdlPgeVO);
+
+}

--- a/src/main/java/egovframework/com/uss/olp/cns/service/impl/CnsltManageDAO.java
+++ b/src/main/java/egovframework/com/uss/olp/cns/service/impl/CnsltManageDAO.java
@@ -5,11 +5,9 @@ import java.util.List;
 import org.egovframe.rte.psl.dataaccess.util.EgovMap;
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.uss.olp.cns.service.CnsltManageDefaultVO;
 import egovframework.com.uss.olp.cns.service.CnsltManageVO;
-
-
+import jakarta.annotation.Resource;
 
 /**
  *
@@ -29,146 +27,121 @@ import egovframework.com.uss.olp.cns.service.CnsltManageVO;
  * </pre>
  */
 @Repository("CnsltManageDAO")
-public class CnsltManageDAO extends EgovComAbstractDAO {
+public class CnsltManageDAO {
 
+	@Resource(name = "cnsltManageMapper")
+	private CnsltManageMapper cnsltManageMapper;
 
-    /**
+	/**
 	 * 상담내용 글 목록에 대한 상세내용을 조회한다.
 	 * @param vo
 	 * @return 조회한 글
 	 * @exception Exception
 	 */
-    public CnsltManageVO selectCnsltListDetail(CnsltManageVO vo) throws Exception {
-
-        return (CnsltManageVO) selectOne("CnsltManageDAO.selectCnsltListDetail", vo);
-
-    }
+	public CnsltManageVO selectCnsltListDetail(CnsltManageVO vo) throws Exception {
+		return cnsltManageMapper.selectCnsltListDetail(vo);
+	}
 
 	/**
 	 * 상담내용 글을 수정한다.(조회수를 수정)
 	 * @param vo
 	 * @exception Exception
 	 */
-    public void updateCnsltInqireCo(CnsltManageVO vo) throws Exception {
+	public void updateCnsltInqireCo(CnsltManageVO vo) throws Exception {
+		cnsltManageMapper.updateCnsltInqireCo(vo);
+	}
 
-        update("CnsltManageDAO.updateCnsltInqireCo", vo);
-
-    }
-
-    /**
+	/**
 	 * 상담내용 글 목록을 조회한다.
 	 * @param searchVO
 	 * @return 글 목록
 	 * @exception Exception
 	 */
-    public List<EgovMap> selectCnsltList(CnsltManageDefaultVO searchVO) throws Exception {
+	public List<EgovMap> selectCnsltList(CnsltManageDefaultVO searchVO) throws Exception {
+		return cnsltManageMapper.selectCnsltList(searchVO);
+	}
 
-    	return selectList("CnsltManageDAO.selectCnsltList", searchVO);
-
-    }
-
-    /**
+	/**
 	 * 상담내용 글 총 개수를 조회한다.
 	 * @param searchVO
 	 * @return 글 총 개수
 	 */
-    public int selectCnsltListTotCnt(CnsltManageDefaultVO searchVO) {
-
-        return (Integer)selectOne("CnsltManageDAO.selectCnsltListTotCnt", searchVO);
-
-    }
+	public int selectCnsltListTotCnt(CnsltManageDefaultVO searchVO) {
+		return cnsltManageMapper.selectCnsltListTotCnt(searchVO);
+	}
 
 	/**
 	 * 상담내용 글을 등록한다.
 	 * @param vo
 	 * @exception Exception
 	 */
-    public void insertCnsltDtls(CnsltManageVO vo) throws Exception {
+	public void insertCnsltDtls(CnsltManageVO vo) throws Exception {
+		cnsltManageMapper.insertCnsltDtls(vo);
+	}
 
-        insert("CnsltManageDAO.insertCnsltDtls", vo);
-
-    }
-
-    /**
+	/**
 	 * 작성비밀번호를 확인한다.
 	 * @param vo
 	 * @return 글 총 개수
 	 */
-    public int selectCnsltPasswordConfirmCnt(CnsltManageVO vo) {
-
-        return (Integer)selectOne("CnsltManageDAO.selectCnsltPasswordConfirmCnt", vo);
-
-    }
+	public int selectCnsltPasswordConfirmCnt(CnsltManageVO vo) {
+		return cnsltManageMapper.selectCnsltPasswordConfirmCnt(vo);
+	}
 
 	/**
 	 * 상담내용 글을 수정한다.
 	 * @param vo
 	 * @exception Exception
 	 */
-    public void updateCnsltDtls(CnsltManageVO vo) throws Exception {
-
-        update("CnsltManageDAO.updateCnsltDtls", vo);
-
-    }
+	public void updateCnsltDtls(CnsltManageVO vo) throws Exception {
+		cnsltManageMapper.updateCnsltDtls(vo);
+	}
 
 	/**
 	 * 상담내용 글을 삭제한다.
 	 * @param vo
 	 * @exception Exception
 	 */
-    public void deleteCnsltDtls(CnsltManageVO vo) throws Exception {
+	public void deleteCnsltDtls(CnsltManageVO vo) throws Exception {
+		cnsltManageMapper.deleteCnsltDtls(vo);
+	}
 
-        delete("CnsltManageDAO.deleteCnsltDtls", vo);
-
-    }
-
-
-    /**
+	/**
 	 * 상담답변 글 목록에 대한 상세내용을 조회한다.
 	 * @param vo
 	 * @return 조회한 글
 	 * @exception Exception
 	 */
-    public CnsltManageVO selectCnsltAnswerListDetail(CnsltManageVO vo) throws Exception {
+	public CnsltManageVO selectCnsltAnswerListDetail(CnsltManageVO vo) throws Exception {
+		return cnsltManageMapper.selectCnsltAnswerDetail(vo);
+	}
 
-        return (CnsltManageVO) selectOne("CnsltManageDAO.selectCnsltAnswerListDetail", vo);
-
-    }
-
-
-    /**
+	/**
 	 * 상담답변 글 목록을 조회한다.
 	 * @param searchVO
 	 * @return 글 목록
 	 * @exception Exception
 	 */
-    public List<EgovMap> selectCnsltAnswerList(CnsltManageDefaultVO searchVO) throws Exception {
+	public List<EgovMap> selectCnsltAnswerList(CnsltManageDefaultVO searchVO) throws Exception {
+		return cnsltManageMapper.selectCnsltAnswerList(searchVO);
+	}
 
-    	return selectList("CnsltManageDAO.selectCnsltAnswerList", searchVO);
-
-    }
-
-    /**
+	/**
 	 * 상담답변 글 총 개수를 조회한다.
 	 * @param searchVO
 	 * @return 글 총 개수
 	 */
-    public int selectCnsltAnswerListTotCnt(CnsltManageDefaultVO searchVO) {
-
-        return (Integer)selectOne("CnsltManageDAO.selectCnsltAnswerListTotCnt", searchVO);
-
-    }
+	public int selectCnsltAnswerListTotCnt(CnsltManageDefaultVO searchVO) {
+		return cnsltManageMapper.selectCnsltAnswerListTotCnt(searchVO);
+	}
 
 	/**
 	 * 상담답변 글을 수정한다.
 	 * @param vo
 	 * @exception Exception
 	 */
-    public void updateCnsltDtlsAnswer(CnsltManageVO vo) throws Exception {
-
-        update("CnsltManageDAO.updateCnsltDtlsAnswer", vo);
-
-    }
-
+	public void updateCnsltDtlsAnswer(CnsltManageVO vo) throws Exception {
+		cnsltManageMapper.updateCnsltDtlsAnswer(vo);
+	}
 
 }

--- a/src/main/java/egovframework/com/uss/olp/cns/service/impl/CnsltManageMapper.java
+++ b/src/main/java/egovframework/com/uss/olp/cns/service/impl/CnsltManageMapper.java
@@ -1,0 +1,80 @@
+package egovframework.com.uss.olp.cns.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+import org.egovframe.rte.psl.dataaccess.util.EgovMap;
+
+import egovframework.com.uss.olp.cns.service.CnsltManageDefaultVO;
+import egovframework.com.uss.olp.cns.service.CnsltManageVO;
+
+/**
+ * 상담내용을 처리하는 Mapper 인터페이스
+ * @author 공통서비스 개발팀 박정규
+ * @since 2009.04.01
+ * @version 1.0
+ */
+@EgovMapper("cnsltManageMapper")
+public interface CnsltManageMapper {
+
+	/**
+	 * 상담내용 글 목록에 대한 상세내용을 조회한다.
+	 */
+	CnsltManageVO selectCnsltListDetail(CnsltManageVO vo);
+
+	/**
+	 * 상담내용 글을 수정한다.(조회수를 수정)
+	 */
+	void updateCnsltInqireCo(CnsltManageVO vo);
+
+	/**
+	 * 상담내용 글 목록을 조회한다.
+	 */
+	List<EgovMap> selectCnsltList(CnsltManageDefaultVO searchVO);
+
+	/**
+	 * 상담내용 글 총 개수를 조회한다.
+	 */
+	int selectCnsltListTotCnt(CnsltManageDefaultVO searchVO);
+
+	/**
+	 * 상담내용 글을 등록한다.
+	 */
+	void insertCnsltDtls(CnsltManageVO vo);
+
+	/**
+	 * 작성비밀번호를 확인한다.
+	 */
+	int selectCnsltPasswordConfirmCnt(CnsltManageVO vo);
+
+	/**
+	 * 상담내용 글을 수정한다.
+	 */
+	void updateCnsltDtls(CnsltManageVO vo);
+
+	/**
+	 * 상담내용 글을 삭제한다.
+	 */
+	void deleteCnsltDtls(CnsltManageVO vo);
+
+	/**
+	 * 상담답변 글 목록에 대한 상세내용을 조회한다.
+	 */
+	CnsltManageVO selectCnsltAnswerDetail(CnsltManageVO vo);
+
+	/**
+	 * 상담답변 글 목록을 조회한다.
+	 */
+	List<EgovMap> selectCnsltAnswerList(CnsltManageDefaultVO searchVO);
+
+	/**
+	 * 상담답변 글 총 개수를 조회한다.
+	 */
+	int selectCnsltAnswerListTotCnt(CnsltManageDefaultVO searchVO);
+
+	/**
+	 * 상담답변 글을 수정한다.
+	 */
+	void updateCnsltDtlsAnswer(CnsltManageVO vo);
+
+}

--- a/src/main/resources/egovframework/mapper/com/cop/tpl/EgovTemplate_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/tpl/EgovTemplate_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="TemplateManageDAO">
+<mapper namespace="egovframework.com.cop.tpl.service.impl.TemplateManageMapper">
 
 	<resultMap id="tmplatList" type="egovframework.com.cop.tpl.service.TemplateInfVO">
 		<result property="tmplatId" column="TMPLAT_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/tpl/EgovTemplate_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/tpl/EgovTemplate_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="TemplateManageDAO">
+<mapper namespace="egovframework.com.cop.tpl.service.impl.TemplateManageMapper">
 
 	<resultMap id="tmplatList" type="egovframework.com.cop.tpl.service.TemplateInfVO">
 		<result property="tmplatId" column="TMPLAT_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/tpl/EgovTemplate_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/tpl/EgovTemplate_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="TemplateManageDAO">
+<mapper namespace="egovframework.com.cop.tpl.service.impl.TemplateManageMapper">
 
 	<resultMap id="tmplatList" type="egovframework.com.cop.tpl.service.TemplateInfVO">
 		<result property="tmplatId" column="TMPLAT_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/tpl/EgovTemplate_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/tpl/EgovTemplate_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="TemplateManageDAO">
+<mapper namespace="egovframework.com.cop.tpl.service.impl.TemplateManageMapper">
 
 	<resultMap id="tmplatList" type="egovframework.com.cop.tpl.service.TemplateInfVO">
 		<result property="tmplatId" column="TMPLAT_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/tpl/EgovTemplate_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/tpl/EgovTemplate_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="TemplateManageDAO">
+<mapper namespace="egovframework.com.cop.tpl.service.impl.TemplateManageMapper">
 
 	<resultMap id="tmplatList" type="egovframework.com.cop.tpl.service.TemplateInfVO">
 		<result property="tmplatId" column="TMPLAT_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/tpl/EgovTemplate_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/tpl/EgovTemplate_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="TemplateManageDAO">
+<mapper namespace="egovframework.com.cop.tpl.service.impl.TemplateManageMapper">
 
 	<resultMap id="tmplatList" type="egovframework.com.cop.tpl.service.TemplateInfVO">
 		<result property="tmplatId" column="TMPLAT_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/tpl/EgovTemplate_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/tpl/EgovTemplate_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="TemplateManageDAO">
+<mapper namespace="egovframework.com.cop.tpl.service.impl.TemplateManageMapper">
 
 	<resultMap id="tmplatList" type="egovframework.com.cop.tpl.service.TemplateInfVO">
 		<result property="tmplatId" column="TMPLAT_ID"/>

--- a/src/main/resources/egovframework/mapper/com/cop/tpl/EgovTemplate_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/tpl/EgovTemplate_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="TemplateManageDAO">
+<mapper namespace="egovframework.com.cop.tpl.service.impl.TemplateManageMapper">
 
 	<resultMap id="tmplatList" type="egovframework.com.cop.tpl.service.TemplateInfVO">
 		<result property="tmplatId" column="TMPLAT_ID"/>

--- a/src/main/resources/egovframework/mapper/com/dam/map/mat/EgovDamMapTeamMapMaterial_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/dam/map/mat/EgovDamMapTeamMapMaterial_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="MapMaterialDAO">
+<mapper namespace="egovframework.com.dam.map.mat.service.impl.MapMaterialMapper">
 	
 	<resultMap id="MapMaterialList" type="egovframework.com.dam.map.mat.service.MapMaterialVO">
 		<result property="orgnztNm" column="ORGNZT_NM"/>	

--- a/src/main/resources/egovframework/mapper/com/dam/map/mat/EgovDamMapTeamMapMaterial_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/dam/map/mat/EgovDamMapTeamMapMaterial_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="MapMaterialDAO">
+<mapper namespace="egovframework.com.dam.map.mat.service.impl.MapMaterialMapper">
 	
 	<resultMap id="MapMaterialList" type="egovframework.com.dam.map.mat.service.MapMaterialVO">
 		<result property="orgnztNm" column="ORGNZT_NM"/>	

--- a/src/main/resources/egovframework/mapper/com/dam/map/mat/EgovDamMapTeamMapMaterial_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/dam/map/mat/EgovDamMapTeamMapMaterial_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="MapMaterialDAO">
+<mapper namespace="egovframework.com.dam.map.mat.service.impl.MapMaterialMapper">
 	
 	<resultMap id="MapMaterialList" type="egovframework.com.dam.map.mat.service.MapMaterialVO">
 		<result property="orgnztNm" column="ORGNZT_NM"/>	

--- a/src/main/resources/egovframework/mapper/com/dam/map/mat/EgovDamMapTeamMapMaterial_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/dam/map/mat/EgovDamMapTeamMapMaterial_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="MapMaterialDAO">
+<mapper namespace="egovframework.com.dam.map.mat.service.impl.MapMaterialMapper">
 
 	<select id="selectMapMaterialList" parameterType="egovframework.com.dam.map.mat.service.MapMaterialVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/dam/map/mat/EgovDamMapTeamMapMaterial_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/dam/map/mat/EgovDamMapTeamMapMaterial_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="MapMaterialDAO">
+<mapper namespace="egovframework.com.dam.map.mat.service.impl.MapMaterialMapper">
 
 	<select id="selectMapMaterialList" parameterType="egovframework.com.dam.map.mat.service.MapMaterialVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/dam/map/mat/EgovDamMapTeamMapMaterial_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/dam/map/mat/EgovDamMapTeamMapMaterial_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="MapMaterialDAO">
+<mapper namespace="egovframework.com.dam.map.mat.service.impl.MapMaterialMapper">
 	
 	<resultMap id="MapMaterialList" type="egovframework.com.dam.map.mat.service.MapMaterialVO">
 		<result property="orgnztNm" column="ORGNZT_NM"/>	

--- a/src/main/resources/egovframework/mapper/com/dam/map/mat/EgovDamMapTeamMapMaterial_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/dam/map/mat/EgovDamMapTeamMapMaterial_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="MapMaterialDAO">
+<mapper namespace="egovframework.com.dam.map.mat.service.impl.MapMaterialMapper">
 
 	<select id="selectMapMaterialList" parameterType="egovframework.com.dam.map.mat.service.MapMaterialVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/dam/map/mat/EgovDamMapTeamMapMaterial_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/dam/map/mat/EgovDamMapTeamMapMaterial_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="MapMaterialDAO">
+<mapper namespace="egovframework.com.dam.map.mat.service.impl.MapMaterialMapper">
 	
 	<resultMap id="MapMaterialList" type="egovframework.com.dam.map.mat.service.MapMaterialVO">
 		<result property="orgnztNm" column="ORGNZT_NM"/>	

--- a/src/main/resources/egovframework/mapper/com/dam/map/tea/EgovDamMapTeamMapTeam_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/dam/map/tea/EgovDamMapTeamMapTeam_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="MapTeamDAO">
+<mapper namespace="egovframework.com.dam.map.tea.service.impl.MapTeamMapper">
 	
 	<resultMap id="MapTeamList" type="egovframework.com.dam.map.tea.service.MapTeamVO">
 		<result property="orgnztId" column="ORGNZT_ID"/>	

--- a/src/main/resources/egovframework/mapper/com/dam/map/tea/EgovDamMapTeamMapTeam_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/dam/map/tea/EgovDamMapTeamMapTeam_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="MapTeamDAO">
+<mapper namespace="egovframework.com.dam.map.tea.service.impl.MapTeamMapper">
 	
 	<resultMap id="MapTeamList" type="egovframework.com.dam.map.tea.service.MapTeamVO">
 		<result property="orgnztId" column="ORGNZT_ID"/>	

--- a/src/main/resources/egovframework/mapper/com/dam/map/tea/EgovDamMapTeamMapTeam_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/dam/map/tea/EgovDamMapTeamMapTeam_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="MapTeamDAO">
+<mapper namespace="egovframework.com.dam.map.tea.service.impl.MapTeamMapper">
 	
 	<resultMap id="MapTeamList" type="egovframework.com.dam.map.tea.service.MapTeamVO">
 		<result property="orgnztId" column="ORGNZT_ID"/>	

--- a/src/main/resources/egovframework/mapper/com/dam/map/tea/EgovDamMapTeamMapTeam_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/dam/map/tea/EgovDamMapTeamMapTeam_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="MapTeamDAO">
+<mapper namespace="egovframework.com.dam.map.tea.service.impl.MapTeamMapper">
 
 	<select id="selectMapTeamList" parameterType="egovframework.com.dam.map.tea.service.MapTeamVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/dam/map/tea/EgovDamMapTeamMapTeam_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/dam/map/tea/EgovDamMapTeamMapTeam_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="MapTeamDAO">
+<mapper namespace="egovframework.com.dam.map.tea.service.impl.MapTeamMapper">
 
 	<select id="selectMapTeamList" parameterType="egovframework.com.dam.map.tea.service.MapTeamVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/dam/map/tea/EgovDamMapTeamMapTeam_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/dam/map/tea/EgovDamMapTeamMapTeam_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="MapTeamDAO">
+<mapper namespace="egovframework.com.dam.map.tea.service.impl.MapTeamMapper">
 	
 	<resultMap id="MapTeamList" type="egovframework.com.dam.map.tea.service.MapTeamVO">
 		<result property="orgnztId" column="ORGNZT_ID"/>	

--- a/src/main/resources/egovframework/mapper/com/dam/map/tea/EgovDamMapTeamMapTeam_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/dam/map/tea/EgovDamMapTeamMapTeam_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="MapTeamDAO">
+<mapper namespace="egovframework.com.dam.map.tea.service.impl.MapTeamMapper">
 
 	<select id="selectMapTeamList" parameterType="egovframework.com.dam.map.tea.service.MapTeamVO" resultType="egovMap">
 		

--- a/src/main/resources/egovframework/mapper/com/dam/map/tea/EgovDamMapTeamMapTeam_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/dam/map/tea/EgovDamMapTeamMapTeam_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="MapTeamDAO">
+<mapper namespace="egovframework.com.dam.map.tea.service.impl.MapTeamMapper">
 	
 	<resultMap id="MapTeamList" type="egovframework.com.dam.map.tea.service.MapTeamVO">
 		<result property="orgnztId" column="ORGNZT_ID"/>	

--- a/src/main/resources/egovframework/mapper/com/dam/spe/spe/EgovDamKnoSpecialistList_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/dam/spe/spe/EgovDamKnoSpecialistList_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="KnoSpecialistDAO">
+<mapper namespace="egovframework.com.dam.spe.spe.service.impl.KnoSpecialistMapper">
 	
 	<resultMap id="KnoSpecialistList" type="egovframework.com.dam.spe.spe.service.KnoSpecialistVO">
 		<result property="orgnztNm" column="ORGNZT_NM"/>	

--- a/src/main/resources/egovframework/mapper/com/dam/spe/spe/EgovDamKnoSpecialistList_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/dam/spe/spe/EgovDamKnoSpecialistList_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="KnoSpecialistDAO">
+<mapper namespace="egovframework.com.dam.spe.spe.service.impl.KnoSpecialistMapper">
 	
 	<resultMap id="KnoSpecialistList" type="egovframework.com.dam.spe.spe.service.KnoSpecialistVO">
 		<result property="orgnztNm" column="ORGNZT_NM"/>	

--- a/src/main/resources/egovframework/mapper/com/dam/spe/spe/EgovDamKnoSpecialistList_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/dam/spe/spe/EgovDamKnoSpecialistList_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="KnoSpecialistDAO">
+<mapper namespace="egovframework.com.dam.spe.spe.service.impl.KnoSpecialistMapper">
 	
 	<resultMap id="KnoSpecialistList" type="egovframework.com.dam.spe.spe.service.KnoSpecialistVO">
 		<result property="orgnztNm" column="ORGNZT_NM"/>	

--- a/src/main/resources/egovframework/mapper/com/dam/spe/spe/EgovDamKnoSpecialistList_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/dam/spe/spe/EgovDamKnoSpecialistList_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="KnoSpecialistDAO">
+<mapper namespace="egovframework.com.dam.spe.spe.service.impl.KnoSpecialistMapper">
 
 	<resultMap id="KnoSpecialistList" type="egovframework.com.dam.spe.spe.service.KnoSpecialistVO">
         <result property="orgnztNm" column="ORGNZT_NM"/>    

--- a/src/main/resources/egovframework/mapper/com/dam/spe/spe/EgovDamKnoSpecialistList_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/dam/spe/spe/EgovDamKnoSpecialistList_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="KnoSpecialistDAO">
+<mapper namespace="egovframework.com.dam.spe.spe.service.impl.KnoSpecialistMapper">
 
 	<resultMap id="KnoSpecialistList" type="egovframework.com.dam.spe.spe.service.KnoSpecialistVO">
         <result property="orgnztNm" column="ORGNZT_NM"/>    

--- a/src/main/resources/egovframework/mapper/com/dam/spe/spe/EgovDamKnoSpecialistList_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/dam/spe/spe/EgovDamKnoSpecialistList_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="KnoSpecialistDAO">
+<mapper namespace="egovframework.com.dam.spe.spe.service.impl.KnoSpecialistMapper">
 	
 	<resultMap id="KnoSpecialistList" type="egovframework.com.dam.spe.spe.service.KnoSpecialistVO">
 		<result property="orgnztNm" column="ORGNZT_NM"/>	

--- a/src/main/resources/egovframework/mapper/com/dam/spe/spe/EgovDamKnoSpecialistList_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/dam/spe/spe/EgovDamKnoSpecialistList_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="KnoSpecialistDAO">
+<mapper namespace="egovframework.com.dam.spe.spe.service.impl.KnoSpecialistMapper">
 
 	<resultMap id="KnoSpecialistList" type="egovframework.com.dam.spe.spe.service.KnoSpecialistVO">
         <result property="orgnztNm" column="ORGNZT_NM"/>    

--- a/src/main/resources/egovframework/mapper/com/dam/spe/spe/EgovDamKnoSpecialistList_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/dam/spe/spe/EgovDamKnoSpecialistList_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="KnoSpecialistDAO">
+<mapper namespace="egovframework.com.dam.spe.spe.service.impl.KnoSpecialistMapper">
 	
 	<resultMap id="KnoSpecialistList" type="egovframework.com.dam.spe.spe.service.KnoSpecialistVO">
 		<result property="orgnztNm" column="ORGNZT_NM"/>	

--- a/src/main/resources/egovframework/mapper/com/uss/cmt/EgovCmtManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/cmt/EgovCmtManage_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:51:00 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="cmtManageDAO">
+<mapper namespace="egovframework.com.uss.cmt.service.impl.EgovCmtManageMapper">
 
     <insert id="insertWrkStartCmtInfo_S">
         

--- a/src/main/resources/egovframework/mapper/com/uss/cmt/EgovCmtManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/cmt/EgovCmtManage_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:51:00 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="cmtManageDAO">
+<mapper namespace="egovframework.com.uss.cmt.service.impl.EgovCmtManageMapper">
 
     <insert id="insertWrkStartCmtInfo_S">
         

--- a/src/main/resources/egovframework/mapper/com/uss/cmt/EgovCmtManage_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/cmt/EgovCmtManage_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:51:00 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="cmtManageDAO">
+<mapper namespace="egovframework.com.uss.cmt.service.impl.EgovCmtManageMapper">
 
     <insert id="insertWrkStartCmtInfo_S">
         

--- a/src/main/resources/egovframework/mapper/com/uss/cmt/EgovCmtManage_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/cmt/EgovCmtManage_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:51:00 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="cmtManageDAO">
+<mapper namespace="egovframework.com.uss.cmt.service.impl.EgovCmtManageMapper">
   
     
     <insert id="insertWrkStartCmtInfo_S">

--- a/src/main/resources/egovframework/mapper/com/uss/cmt/EgovCmtManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/cmt/EgovCmtManage_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:51:00 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="cmtManageDAO">
+<mapper namespace="egovframework.com.uss.cmt.service.impl.EgovCmtManageMapper">
   
     
     <insert id="insertWrkStartCmtInfo_S">

--- a/src/main/resources/egovframework/mapper/com/uss/cmt/EgovCmtManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/cmt/EgovCmtManage_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:51:00 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="cmtManageDAO">
+<mapper namespace="egovframework.com.uss.cmt.service.impl.EgovCmtManageMapper">
 
     
     <insert id="insertWrkStartCmtInfo_S">

--- a/src/main/resources/egovframework/mapper/com/uss/cmt/EgovCmtManage_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/cmt/EgovCmtManage_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:51:00 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="cmtManageDAO">
+<mapper namespace="egovframework.com.uss.cmt.service.impl.EgovCmtManageMapper">
   
     
     <insert id="insertWrkStartCmtInfo_S">

--- a/src/main/resources/egovframework/mapper/com/uss/cmt/EgovCmtManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/cmt/EgovCmtManage_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:51:01 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="cmtManageDAO">
+<mapper namespace="egovframework.com.uss.cmt.service.impl.EgovCmtManageMapper">
     
     <insert id="insertWrkStartCmtInfo_S">
         

--- a/src/main/resources/egovframework/mapper/com/uss/mpe/EgovIndvdlPge_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/mpe/EgovIndvdlPge_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="IndvdlPge">
+<mapper namespace="egovframework.com.uss.mpe.service.impl.EgovIndvdlPgeMapper">
 
     <resultMap id="indvdlPgeMap" type="egovframework.com.uss.mpe.service.IndvdlPgeVO">
         <result property="cntntsId" column="CNTNTS_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/mpe/EgovIndvdlPge_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/mpe/EgovIndvdlPge_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="IndvdlPge">
+<mapper namespace="egovframework.com.uss.mpe.service.impl.EgovIndvdlPgeMapper">
 
     <resultMap id="indvdlPgeMap" type="egovframework.com.uss.mpe.service.IndvdlPgeVO">
         <result property="cntntsId" column="CNTNTS_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/mpe/EgovIndvdlPge_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/mpe/EgovIndvdlPge_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="IndvdlPge">
+<mapper namespace="egovframework.com.uss.mpe.service.impl.EgovIndvdlPgeMapper">
 
     <resultMap id="indvdlPgeMap" type="egovframework.com.uss.mpe.service.IndvdlPgeVO">
         <result property="cntntsId" column="CNTNTS_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/mpe/EgovIndvdlPge_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/mpe/EgovIndvdlPge_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="IndvdlPge">
+<mapper namespace="egovframework.com.uss.mpe.service.impl.EgovIndvdlPgeMapper">
 
     <resultMap id="indvdlPgeMap" type="egovframework.com.uss.mpe.service.IndvdlPgeVO">
         <result property="cntntsId" column="CNTNTS_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/mpe/EgovIndvdlPge_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/mpe/EgovIndvdlPge_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="IndvdlPge">
+<mapper namespace="egovframework.com.uss.mpe.service.impl.EgovIndvdlPgeMapper">
 
     <resultMap id="indvdlPgeMap" type="egovframework.com.uss.mpe.service.IndvdlPgeVO">
         <result property="cntntsId" column="CNTNTS_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/mpe/EgovIndvdlPge_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/mpe/EgovIndvdlPge_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="IndvdlPge">
+<mapper namespace="egovframework.com.uss.mpe.service.impl.EgovIndvdlPgeMapper">
 
     <resultMap id="indvdlPgeMap" type="egovframework.com.uss.mpe.service.IndvdlPgeVO">
         <result property="cntntsId" column="CNTNTS_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/mpe/EgovIndvdlPge_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/mpe/EgovIndvdlPge_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="IndvdlPge">
+<mapper namespace="egovframework.com.uss.mpe.service.impl.EgovIndvdlPgeMapper">
 
     <resultMap id="indvdlPgeMap" type="egovframework.com.uss.mpe.service.IndvdlPgeVO">
         <result property="cntntsId" column="CNTNTS_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/mpe/EgovIndvdlPge_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/mpe/EgovIndvdlPge_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="IndvdlPge">
+<mapper namespace="egovframework.com.uss.mpe.service.impl.EgovIndvdlPgeMapper">
 
     <resultMap id="indvdlPgeMap" type="egovframework.com.uss.mpe.service.IndvdlPgeVO">
         <result property="cntntsId" column="CNTNTS_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/olp/cns/EgovCnsltManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/cns/EgovCnsltManage_SQL_altibase.xml
@@ -6,7 +6,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CnsltManageDAO">
+<mapper namespace="egovframework.com.uss.olp.cns.service.impl.CnsltManageMapper">
 
 	<resultMap id="CnsltManage" type="egovframework.com.uss.olp.cns.service.CnsltManageVO">
 		<result property="cnsltId" column="CNSLT_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/olp/cns/EgovCnsltManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/cns/EgovCnsltManage_SQL_cubrid.xml
@@ -6,7 +6,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CnsltManageDAO">
+<mapper namespace="egovframework.com.uss.olp.cns.service.impl.CnsltManageMapper">
 
 	<resultMap id="CnsltManage" type="egovframework.com.uss.olp.cns.service.CnsltManageVO">
 		<result property="cnsltId" column="CNSLT_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/olp/cns/EgovCnsltManage_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/cns/EgovCnsltManage_SQL_goldilocks.xml
@@ -6,7 +6,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CnsltManageDAO">
+<mapper namespace="egovframework.com.uss.olp.cns.service.impl.CnsltManageMapper">
 
 	<resultMap id="CnsltManage" type="egovframework.com.uss.olp.cns.service.CnsltManageVO">
 		<result property="cnsltId" column="CNSLT_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/olp/cns/EgovCnsltManage_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/cns/EgovCnsltManage_SQL_maria.xml
@@ -6,7 +6,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CnsltManageDAO">
+<mapper namespace="egovframework.com.uss.olp.cns.service.impl.CnsltManageMapper">
 
 	<resultMap id="CnsltManage" type="egovframework.com.uss.olp.cns.service.CnsltManageVO">
 		<result property="cnsltId" column="CNSLT_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/olp/cns/EgovCnsltManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/cns/EgovCnsltManage_SQL_mysql.xml
@@ -6,7 +6,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CnsltManageDAO">
+<mapper namespace="egovframework.com.uss.olp.cns.service.impl.CnsltManageMapper">
 
 	<resultMap id="CnsltManage" type="egovframework.com.uss.olp.cns.service.CnsltManageVO">
 		<result property="cnsltId" column="CNSLT_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/olp/cns/EgovCnsltManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/cns/EgovCnsltManage_SQL_oracle.xml
@@ -6,7 +6,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CnsltManageDAO">
+<mapper namespace="egovframework.com.uss.olp.cns.service.impl.CnsltManageMapper">
 
 	<resultMap id="CnsltManage" type="egovframework.com.uss.olp.cns.service.CnsltManageVO">
 		<result property="cnsltId" column="CNSLT_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/olp/cns/EgovCnsltManage_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/cns/EgovCnsltManage_SQL_postgres.xml
@@ -6,7 +6,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CnsltManageDAO">
+<mapper namespace="egovframework.com.uss.olp.cns.service.impl.CnsltManageMapper">
 
 	<resultMap id="CnsltManage" type="egovframework.com.uss.olp.cns.service.CnsltManageVO">
 		<result property="cnsltId" column="CNSLT_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/olp/cns/EgovCnsltManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/cns/EgovCnsltManage_SQL_tibero.xml
@@ -6,7 +6,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CnsltManageDAO">
+<mapper namespace="egovframework.com.uss.olp.cns.service.impl.CnsltManageMapper">
 
 	<resultMap id="CnsltManage" type="egovframework.com.uss.olp.cns.service.CnsltManageVO">
 		<result property="cnsltId" column="CNSLT_ID"/>

--- a/src/main/resources/egovframework/spring/com/context-mapper.xml
+++ b/src/main/resources/egovframework/spring/com/context-mapper.xml
@@ -21,5 +21,10 @@
 	<bean id="egov.sqlSessionTemplate" class="org.mybatis.spring.SqlSessionTemplate">
 		<constructor-arg ref="egov.sqlSession"/>
 	</bean>
-	
+
+	<bean class="org.mybatis.spring.mapper.MapperScannerConfigurer">
+		<property name="basePackage" value="egovframework.com" />
+		<property name="annotationClass" value="org.egovframe.rte.psl.dataaccess.mapper.EgovMapper" />
+	</bean>
+
 </beans>


### PR DESCRIPTION
## 변경 사유
기존 XML namespace 기반 DAO를 eGovFrame 5.0 신규 `@EgovMapper` 인터페이스 방식으로 전환합니다.

## 변경 내용
- 대상: dam/map·spe, cop/tpl, uss/cmt·mpe, uss/olp/cns 7개 DAO
- 각 DAO에 대응하는 Mapper 인터페이스(`@EgovMapper`) 신규 추가
- DAO를 mapper 위임 구조로 리팩토링 (EgovComAbstractDAO 상속 제거, @Resource 주입, @Repository bean name 유지)
- XML mapper namespace를 mapper 인터페이스 FQN으로 변경
- context-mapper.xml에 MapperScannerConfigurer(annotationClass=EgovMapper) 추가

## 영향 범위
- 해당 모듈만 영향, 서비스 레이어 호출 시그니처 변경 없음

## 참고
- 빌드 검증을 위해 #891(Lombok annotationProcessorPaths 빌드 수정) 선행 머지 권장
- context-mapper.xml MapperScannerConfigurer는 동일 시리즈 PR과 한 줄 중복될 수 있어, 선행 PR 머지 후 rebase로 정리 가능

## 체크리스트
- [x] 단일 주제만 다룸
- [x] 컴파일 검증(해당 모듈 신규 오류 0)
- [x] 기존 동작 호환
