### PR TITLE
[refactor][5.0.x][공통컴포넌트] uss/olp 설문관리 6개 DAO @EgovMapper 인터페이스 전환

### DIFF
--- a/src/main/java/egovframework/com/uss/olp/qim/service/impl/QustnrItemManageDao.java
+++ b/src/main/java/egovframework/com/uss/olp/qim/service/impl/QustnrItemManageDao.java
@@ -2,12 +2,13 @@ package egovframework.com.uss.olp.qim.service.impl;
 
 import java.util.List;
 
+import jakarta.annotation.Resource;
 import org.egovframe.rte.psl.dataaccess.util.EgovMap;
 import org.springframework.stereotype.Repository;
 
 import egovframework.com.cmm.ComDefaultVO;
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.uss.olp.qim.service.QustnrItemManageVO;
+
 /**
  * 설문항목관리를 처리하는 Dao Class 구현
  * @author 공통서비스 장동한
@@ -26,78 +27,78 @@ import egovframework.com.uss.olp.qim.service.QustnrItemManageVO;
  * </pre>
  */
 @Repository("qustnrItemManageDao")
-public class QustnrItemManageDao extends EgovComAbstractDAO {
+public class QustnrItemManageDao {
 
+	@Resource(name = "qustnrItemManageMapper")
+	private QustnrItemManageMapper qustnrItemManageMapper;
 
-    /**
-	 * 설문템플릿(을)를  목록을 조회한다.
+	/**
+	 * 설문템플릿(을)를 목록을 조회한다.
 	 * @param qustnrItemManageVO - 설문항목 정보 담김 VO
 	 * @return List
 	 * @throws Exception
 	 */
-	public List<EgovMap> selectQustnrTmplatManageList(QustnrItemManageVO qustnrItemManageVO) throws Exception{
-		return selectList("QustnrItemManage.selectQustnrTmplatManage", qustnrItemManageVO);
+	public List<EgovMap> selectQustnrTmplatManageList(QustnrItemManageVO qustnrItemManageVO) throws Exception {
+		return qustnrItemManageMapper.selectQustnrTmplatManage(qustnrItemManageVO);
 	}
 
-    /**
+	/**
 	 * 설문항목 목록을 조회한다.
 	 * @param searchVO - 조회할 정보가 담긴 VO
 	 * @return List
 	 * @throws Exception
 	 */
-	public List<EgovMap> selectQustnrItemManageList(ComDefaultVO searchVO) throws Exception{
-		return selectList("QustnrItemManage.selectQustnrItemManage", searchVO);
+	public List<EgovMap> selectQustnrItemManageList(ComDefaultVO searchVO) throws Exception {
+		return qustnrItemManageMapper.selectQustnrItemManage(searchVO);
 	}
 
-    /**
+	/**
 	 * 설문항목를(을) 상세조회 한다.
 	 * @param qustnrItemManageVO - 설문항목 정보 담김 VO
 	 * @return List
 	 * @throws Exception
 	 */
-	public List<EgovMap> selectQustnrItemManageDetail(QustnrItemManageVO qustnrItemManageVO) throws Exception{
-		return selectList("QustnrItemManage.selectQustnrItemManageDetail", qustnrItemManageVO);
+	public List<EgovMap> selectQustnrItemManageDetail(QustnrItemManageVO qustnrItemManageVO) throws Exception {
+		return qustnrItemManageMapper.selectQustnrItemManageDetail(qustnrItemManageVO);
 	}
 
-    /**
+	/**
 	 * 설문항목를(을) 목록 전체 건수를(을) 조회한다.
 	 * @param searchVO - 조회할 정보가 담긴 VO
 	 * @return int
 	 * @throws Exception
 	 */
-	public int selectQustnrItemManageListCnt(ComDefaultVO searchVO) throws Exception{
-		return (Integer)selectOne("QustnrItemManage.selectQustnrItemManageCnt", searchVO);
+	public int selectQustnrItemManageListCnt(ComDefaultVO searchVO) throws Exception {
+		return qustnrItemManageMapper.selectQustnrItemManageCnt(searchVO);
 	}
 
-    /**
+	/**
 	 * 설문항목를(을) 등록한다.
-	 * @param qqustnrItemManageVO - 설문항목 정보 담김 VO
+	 * @param qustnrItemManageVO - 설문항목 정보 담김 VO
 	 * @throws Exception
 	 */
-	public void insertQustnrItemManage(QustnrItemManageVO qustnrItemManageVO) throws Exception{
-		insert("QustnrItemManage.insertQustnrItemManage", qustnrItemManageVO);
+	public void insertQustnrItemManage(QustnrItemManageVO qustnrItemManageVO) throws Exception {
+		qustnrItemManageMapper.insertQustnrItemManage(qustnrItemManageVO);
 	}
 
-    /**
+	/**
 	 * 설문항목를(을) 수정한다.
 	 * @param qustnrItemManageVO - 설문항목 정보 담김 VO
 	 * @throws Exception
 	 */
-	public void updateQustnrItemManage(QustnrItemManageVO qustnrItemManageVO) throws Exception{
-		insert("QustnrItemManage.updateQustnrItemManage", qustnrItemManageVO);
+	public void updateQustnrItemManage(QustnrItemManageVO qustnrItemManageVO) throws Exception {
+		qustnrItemManageMapper.updateQustnrItemManage(qustnrItemManageVO);
 	}
 
-    /**
+	/**
 	 * 설문항목를(을) 삭제한다.
 	 * @param qustnrItemManageVO - 설문항목 정보 담김 VO
 	 * @throws Exception
 	 */
-	public void deleteQustnrItemManage(QustnrItemManageVO qustnrItemManageVO) throws Exception{
+	public void deleteQustnrItemManage(QustnrItemManageVO qustnrItemManageVO) throws Exception {
 		//설문조사(설문결과) 삭제
-		delete("QustnrItemManage.deleteQustnrRespondInfo", qustnrItemManageVO);
-
+		qustnrItemManageMapper.deleteQustnrRespondInfo(qustnrItemManageVO);
 		//설문항목 삭제
-		insert("QustnrItemManage.deleteQustnrItemManage", qustnrItemManageVO);
-
+		qustnrItemManageMapper.deleteQustnrItemManage(qustnrItemManageVO);
 	}
 }

--- a/src/main/java/egovframework/com/uss/olp/qim/service/impl/QustnrItemManageMapper.java
+++ b/src/main/java/egovframework/com/uss/olp/qim/service/impl/QustnrItemManageMapper.java
@@ -1,0 +1,90 @@
+package egovframework.com.uss.olp.qim.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+import org.egovframe.rte.psl.dataaccess.util.EgovMap;
+
+import egovframework.com.cmm.ComDefaultVO;
+import egovframework.com.uss.olp.qim.service.QustnrItemManageVO;
+
+/**
+ * 설문항목관리를 처리하는 Mapper 인터페이스
+ * @author 공통서비스 장동한
+ * @since 2009.03.20
+ * @version 1.0
+ * @see
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2009.03.20  장동한          최초 생성
+ *
+ * </pre>
+ */
+@EgovMapper("qustnrItemManageMapper")
+public interface QustnrItemManageMapper {
+
+    /**
+     * 설문템플릿(을)를 목록을 조회한다.
+     * @param qustnrItemManageVO - 설문항목 정보 담김 VO
+     * @return List
+     * @throws Exception
+     */
+    List<EgovMap> selectQustnrTmplatManage(QustnrItemManageVO qustnrItemManageVO) throws Exception;
+
+    /**
+     * 설문항목 목록을 조회한다.
+     * @param searchVO - 조회할 정보가 담긴 VO
+     * @return List
+     * @throws Exception
+     */
+    List<EgovMap> selectQustnrItemManage(ComDefaultVO searchVO) throws Exception;
+
+    /**
+     * 설문항목를(을) 상세조회 한다.
+     * @param qustnrItemManageVO - 설문항목 정보 담김 VO
+     * @return List
+     * @throws Exception
+     */
+    List<EgovMap> selectQustnrItemManageDetail(QustnrItemManageVO qustnrItemManageVO) throws Exception;
+
+    /**
+     * 설문항목를(을) 목록 전체 건수를(을) 조회한다.
+     * @param searchVO - 조회할 정보가 담긴 VO
+     * @return int
+     * @throws Exception
+     */
+    int selectQustnrItemManageCnt(ComDefaultVO searchVO) throws Exception;
+
+    /**
+     * 설문항목를(을) 등록한다.
+     * @param qustnrItemManageVO - 설문항목 정보 담김 VO
+     * @throws Exception
+     */
+    void insertQustnrItemManage(QustnrItemManageVO qustnrItemManageVO) throws Exception;
+
+    /**
+     * 설문항목를(을) 수정한다.
+     * @param qustnrItemManageVO - 설문항목 정보 담김 VO
+     * @throws Exception
+     */
+    void updateQustnrItemManage(QustnrItemManageVO qustnrItemManageVO) throws Exception;
+
+    /**
+     * 설문조사(설문결과)를 삭제한다.
+     * @param qustnrItemManageVO - 설문항목 정보 담김 VO
+     * @throws Exception
+     */
+    void deleteQustnrRespondInfo(QustnrItemManageVO qustnrItemManageVO) throws Exception;
+
+    /**
+     * 설문항목를(을) 삭제한다.
+     * @param qustnrItemManageVO - 설문항목 정보 담김 VO
+     * @throws Exception
+     */
+    void deleteQustnrItemManage(QustnrItemManageVO qustnrItemManageVO) throws Exception;
+
+}

--- a/src/main/java/egovframework/com/uss/olp/qmc/service/impl/QustnrManageDao.java
+++ b/src/main/java/egovframework/com/uss/olp/qmc/service/impl/QustnrManageDao.java
@@ -2,12 +2,13 @@ package egovframework.com.uss.olp.qmc.service.impl;
 
 import java.util.List;
 
+import jakarta.annotation.Resource;
 import org.egovframe.rte.psl.dataaccess.util.EgovMap;
 import org.springframework.stereotype.Repository;
 
 import egovframework.com.cmm.ComDefaultVO;
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.uss.olp.qmc.service.QustnrManageVO;
+
 /**
  * 설문관리를 처리하는 Dao Class 구현
  * @author 공통서비스 장동한
@@ -26,92 +27,94 @@ import egovframework.com.uss.olp.qmc.service.QustnrManageVO;
  * </pre>
  */
 @Repository("qustnrManageDao")
-public class QustnrManageDao extends EgovComAbstractDAO {
+public class QustnrManageDao {
 
-    /**
+	@Resource(name = "qustnrManageMapper")
+	private QustnrManageMapper qustnrManageMapper;
+
+	/**
 	 * 설문템플릿 목록을 조회한다.
 	 * @param qustnrManageVO - 설문관리 정보 담김 VO
 	 * @return List
 	 * @throws Exception
 	 */
-	public List<EgovMap> selectQustnrTmplatManageList(QustnrManageVO qustnrManageVO) throws Exception{
-		return selectList("QustnrManage.selectQustnrTmplatManage", qustnrManageVO);
+	public List<EgovMap> selectQustnrTmplatManageList(QustnrManageVO qustnrManageVO) throws Exception {
+		return qustnrManageMapper.selectQustnrTmplatManage(qustnrManageVO);
 	}
 
-    /**
+	/**
 	 * 설문관리 목록을 조회한다.
 	 * @param searchVO - 조회할 정보가 담긴 VO
 	 * @return List
 	 * @throws Exception
 	 */
-	public List<EgovMap> selectQustnrManageList(ComDefaultVO searchVO) throws Exception{
-		return selectList("QustnrManage.selectQustnrManage", searchVO);
+	public List<EgovMap> selectQustnrManageList(ComDefaultVO searchVO) throws Exception {
+		return qustnrManageMapper.selectQustnrManage(searchVO);
 	}
 
-    /**
+	/**
 	 * 설문관리를 상세조회(Model) 한다.
 	 * @param qustnrManageVO - 설문관리 정보 담김 VO
-	 * @return List
+	 * @return QustnrManageVO
 	 * @throws Exception
 	 */
-    public QustnrManageVO selectQustnrManageDetailModel(QustnrManageVO qustnrManageVO) throws Exception {
-        return (QustnrManageVO) selectOne("QustnrManage.selectQustnrManageDetailModel", qustnrManageVO);
-    }
+	public QustnrManageVO selectQustnrManageDetailModel(QustnrManageVO qustnrManageVO) throws Exception {
+		return qustnrManageMapper.selectQustnrManageDetailModel(qustnrManageVO);
+	}
 
-    /**
+	/**
 	 * 설문관리를(을) 상세조회 한다.
 	 * @param qustnrManageVO - 설문관리 정보 담김 VO
 	 * @return List
 	 * @throws Exception
 	 */
-	public List<EgovMap> selectQustnrManageDetail(QustnrManageVO qustnrManageVO) throws Exception{
-		return selectList("QustnrManage.selectQustnrManageDetail", qustnrManageVO);
+	public List<EgovMap> selectQustnrManageDetail(QustnrManageVO qustnrManageVO) throws Exception {
+		return qustnrManageMapper.selectQustnrManageDetail(qustnrManageVO);
 	}
 
-    /**
+	/**
 	 * 설문관리를(을) 목록 전체 건수를(을) 조회한다.
 	 * @param searchVO - 조회할 정보가 담긴 VO
 	 * @return int
 	 * @throws Exception
 	 */
-	public int selectQustnrManageListCnt(ComDefaultVO searchVO) throws Exception{
-		return (Integer)selectOne("QustnrManage.selectQustnrManageCnt", searchVO);
+	public int selectQustnrManageListCnt(ComDefaultVO searchVO) throws Exception {
+		return qustnrManageMapper.selectQustnrManageCnt(searchVO);
 	}
 
-    /**
+	/**
 	 * 설문관리를(을) 등록한다.
-	 * @param qqustnrManageVO - 설문관리 정보 담김 VO
+	 * @param qustnrManageVO - 설문관리 정보 담김 VO
 	 * @throws Exception
 	 */
-	public void insertQustnrManage(QustnrManageVO qustnrManageVO) throws Exception{
-		insert("QustnrManage.insertQustnrManage", qustnrManageVO);
+	public void insertQustnrManage(QustnrManageVO qustnrManageVO) throws Exception {
+		qustnrManageMapper.insertQustnrManage(qustnrManageVO);
 	}
 
-    /**
+	/**
 	 * 설문관리를(을) 수정한다.
 	 * @param qustnrManageVO - 설문관리 정보 담김 VO
 	 * @throws Exception
 	 */
-	public void updateQustnrManage(QustnrManageVO qustnrManageVO) throws Exception{
-		insert("QustnrManage.updateQustnrManage", qustnrManageVO);
+	public void updateQustnrManage(QustnrManageVO qustnrManageVO) throws Exception {
+		qustnrManageMapper.updateQustnrManage(qustnrManageVO);
 	}
 
-    /**
+	/**
 	 * 설문관리를(을) 삭제한다.
 	 * @param qustnrManageVO - 설문관리 정보 담김 VO
 	 * @throws Exception
 	 */
-	public void deleteQustnrManage(QustnrManageVO qustnrManageVO) throws Exception{
+	public void deleteQustnrManage(QustnrManageVO qustnrManageVO) throws Exception {
 		//설문응답자 삭제
-		delete("QustnrManage.deleteQustnrRespondManage", qustnrManageVO);
+		qustnrManageMapper.deleteQustnrRespondManage(qustnrManageVO);
 		//설문조사(설문결과) 삭제
-		delete("QustnrManage.deleteQustnrRespondInfo", qustnrManageVO);
+		qustnrManageMapper.deleteQustnrRespondInfo(qustnrManageVO);
 		//설문항목 삭제
-		delete("QustnrManage.deleteQustnrItemManage", qustnrManageVO);
+		qustnrManageMapper.deleteQustnrItemManage(qustnrManageVO);
 		//설문문항 삭제
-		delete("QustnrManage.deleteQustnrQestnManage", qustnrManageVO);
-
+		qustnrManageMapper.deleteQustnrQestnManage(qustnrManageVO);
 		//설문관리 삭제
-		delete("QustnrManage.deleteQustnrManage", qustnrManageVO);
+		qustnrManageMapper.deleteQustnrManage(qustnrManageVO);
 	}
 }

--- a/src/main/java/egovframework/com/uss/olp/qmc/service/impl/QustnrManageMapper.java
+++ b/src/main/java/egovframework/com/uss/olp/qmc/service/impl/QustnrManageMapper.java
@@ -1,0 +1,119 @@
+package egovframework.com.uss.olp.qmc.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+import org.egovframe.rte.psl.dataaccess.util.EgovMap;
+
+import egovframework.com.cmm.ComDefaultVO;
+import egovframework.com.uss.olp.qmc.service.QustnrManageVO;
+
+/**
+ * 설문관리를 처리하는 Mapper 인터페이스
+ * @author 공통서비스 장동한
+ * @since 2009.03.20
+ * @version 1.0
+ * @see
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2009.03.20  장동한          최초 생성
+ *
+ * </pre>
+ */
+@EgovMapper("qustnrManageMapper")
+public interface QustnrManageMapper {
+
+    /**
+     * 설문템플릿 목록을 조회한다.
+     * @param qustnrManageVO - 설문관리 정보 담김 VO
+     * @return List
+     * @throws Exception
+     */
+    List<EgovMap> selectQustnrTmplatManage(QustnrManageVO qustnrManageVO) throws Exception;
+
+    /**
+     * 설문관리 목록을 조회한다.
+     * @param searchVO - 조회할 정보가 담긴 VO
+     * @return List
+     * @throws Exception
+     */
+    List<EgovMap> selectQustnrManage(ComDefaultVO searchVO) throws Exception;
+
+    /**
+     * 설문관리를 상세조회(Model) 한다.
+     * @param qustnrManageVO - 설문관리 정보 담김 VO
+     * @return QustnrManageVO
+     * @throws Exception
+     */
+    QustnrManageVO selectQustnrManageDetailModel(QustnrManageVO qustnrManageVO) throws Exception;
+
+    /**
+     * 설문관리를(을) 상세조회 한다.
+     * @param qustnrManageVO - 설문관리 정보 담김 VO
+     * @return List
+     * @throws Exception
+     */
+    List<EgovMap> selectQustnrManageDetail(QustnrManageVO qustnrManageVO) throws Exception;
+
+    /**
+     * 설문관리를(을) 목록 전체 건수를(을) 조회한다.
+     * @param searchVO - 조회할 정보가 담긴 VO
+     * @return int
+     * @throws Exception
+     */
+    int selectQustnrManageCnt(ComDefaultVO searchVO) throws Exception;
+
+    /**
+     * 설문관리를(을) 등록한다.
+     * @param qustnrManageVO - 설문관리 정보 담김 VO
+     * @throws Exception
+     */
+    void insertQustnrManage(QustnrManageVO qustnrManageVO) throws Exception;
+
+    /**
+     * 설문관리를(을) 수정한다.
+     * @param qustnrManageVO - 설문관리 정보 담김 VO
+     * @throws Exception
+     */
+    void updateQustnrManage(QustnrManageVO qustnrManageVO) throws Exception;
+
+    /**
+     * 설문응답자를 삭제한다.
+     * @param qustnrManageVO - 설문관리 정보 담김 VO
+     * @throws Exception
+     */
+    void deleteQustnrRespondManage(QustnrManageVO qustnrManageVO) throws Exception;
+
+    /**
+     * 설문조사(설문결과)를 삭제한다.
+     * @param qustnrManageVO - 설문관리 정보 담김 VO
+     * @throws Exception
+     */
+    void deleteQustnrRespondInfo(QustnrManageVO qustnrManageVO) throws Exception;
+
+    /**
+     * 설문항목을 삭제한다.
+     * @param qustnrManageVO - 설문관리 정보 담김 VO
+     * @throws Exception
+     */
+    void deleteQustnrItemManage(QustnrManageVO qustnrManageVO) throws Exception;
+
+    /**
+     * 설문문항을 삭제한다.
+     * @param qustnrManageVO - 설문관리 정보 담김 VO
+     * @throws Exception
+     */
+    void deleteQustnrQestnManage(QustnrManageVO qustnrManageVO) throws Exception;
+
+    /**
+     * 설문관리를(을) 삭제한다.
+     * @param qustnrManageVO - 설문관리 정보 담김 VO
+     * @throws Exception
+     */
+    void deleteQustnrManage(QustnrManageVO qustnrManageVO) throws Exception;
+
+}

--- a/src/main/java/egovframework/com/uss/olp/qqm/service/impl/QustnrQestnManageDao.java
+++ b/src/main/java/egovframework/com/uss/olp/qqm/service/impl/QustnrQestnManageDao.java
@@ -3,11 +3,11 @@ package egovframework.com.uss.olp.qqm.service.impl;
 import java.util.List;
 import java.util.Map;
 
+import jakarta.annotation.Resource;
 import org.egovframe.rte.psl.dataaccess.util.EgovMap;
 import org.springframework.stereotype.Repository;
 
 import egovframework.com.cmm.ComDefaultVO;
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.uss.olp.qqm.service.QustnrQestnManageVO;
 
 /**
@@ -28,100 +28,100 @@ import egovframework.com.uss.olp.qqm.service.QustnrQestnManageVO;
  * </pre>
  */
 @Repository("qustnrQestnManageDao")
-public class QustnrQestnManageDao extends EgovComAbstractDAO {
+public class QustnrQestnManageDao {
 
-    /**
+	@Resource(name = "qustnrQestnManageMapper")
+	private QustnrQestnManageMapper qustnrQestnManageMapper;
+
+	/**
 	 * 설문조사 응답자답변내용결과/기타답변내용결과 통계를 조회한다.
-	 * @param Map - 설문지 정보가 담김 Parameter
-	 * @return Map
+	 * @param map - 설문지 정보가 담김 Parameter
+	 * @return List
 	 * @throws Exception
 	 */
-	public List<EgovMap> selectQustnrManageStatistics2(Map<?, ?> map) throws Exception{
-		return selectList("QustnrQestnManage.selectQustnrManageStatistics2", map);
+	public List<EgovMap> selectQustnrManageStatistics2(Map<?, ?> map) throws Exception {
+		return qustnrQestnManageMapper.selectQustnrManageStatistics2(map);
 	}
 
-    /**
+	/**
 	 * 설문조사 통계를 조회한다.
-	 * @param Map - 설문지 정보가 담김 Parameter
-	 * @return Map
+	 * @param map - 설문지 정보가 담김 Parameter
+	 * @return List
 	 * @throws Exception
 	 */
-	public List<?> selectQustnrManageStatistics(Map<?, ?> map) throws Exception{
-		return selectList("QustnrQestnManage.selectQustnrManageStatistics", map);
+	public List<?> selectQustnrManageStatistics(Map<?, ?> map) throws Exception {
+		return qustnrQestnManageMapper.selectQustnrManageStatistics(map);
 	}
 
-    /**
+	/**
 	 * 설문지정보 설문제목을 조회한다.
-	 * @param Map - 설문지 정보가 담김 Parameter
+	 * @param map - 설문지 정보가 담김 Parameter
 	 * @return Map
 	 * @throws Exception
 	 */
-	public Map<?, ?> selectQustnrManageQestnrSj(Map<?, ?> map) throws Exception{
-		return (Map<?, ?>)selectOne("QustnrQestnManage.selectQustnrManageQestnrSj", map);
+	public Map<?, ?> selectQustnrManageQestnrSj(Map<?, ?> map) throws Exception {
+		return qustnrQestnManageMapper.selectQustnrManageQestnrSj(map);
 	}
 
-
-    /**
+	/**
 	 * 설문문항 목록을 조회한다.
 	 * @param searchVO - 조회할 정보가 담긴 VO
 	 * @return List
 	 * @throws Exception
 	 */
-	public List<?> selectQustnrQestnManageList(ComDefaultVO searchVO) throws Exception{
-		return selectList("QustnrQestnManage.selectQustnrQestnManage", searchVO);
+	public List<?> selectQustnrQestnManageList(ComDefaultVO searchVO) throws Exception {
+		return qustnrQestnManageMapper.selectQustnrQestnManage(searchVO);
 	}
 
-    /**
+	/**
 	 * 설문문항를(을) 상세조회 한다.
 	 * @param qustnrQestnManageVO - 설문문항 정보 담김 VO
 	 * @return List
 	 * @throws Exception
 	 */
-	public List<EgovMap> selectQustnrQestnManageDetail(QustnrQestnManageVO qustnrQestnManageVO) throws Exception{
-		return selectList("QustnrQestnManage.selectQustnrQestnManageDetail", qustnrQestnManageVO);
+	public List<EgovMap> selectQustnrQestnManageDetail(QustnrQestnManageVO qustnrQestnManageVO) throws Exception {
+		return qustnrQestnManageMapper.selectQustnrQestnManageDetail(qustnrQestnManageVO);
 	}
 
-    /**
+	/**
 	 * 설문문항를(을) 목록 전체 건수를(을) 조회한다.
 	 * @param searchVO - 조회할 정보가 담긴 VO
 	 * @return int
 	 * @throws Exception
 	 */
-	public int selectQustnrQestnManageListCnt(ComDefaultVO searchVO) throws Exception{
-		return (Integer)selectOne("QustnrQestnManage.selectQustnrQestnManageCnt", searchVO);
+	public int selectQustnrQestnManageListCnt(ComDefaultVO searchVO) throws Exception {
+		return qustnrQestnManageMapper.selectQustnrQestnManageCnt(searchVO);
 	}
 
-    /**
+	/**
 	 * 설문문항를(을) 등록한다.
-	 * @param qqustnrQestnManageVO - 설문문항 정보 담김 VO
+	 * @param qustnrQestnManageVO - 설문문항 정보 담김 VO
 	 * @throws Exception
 	 */
-	public void insertQustnrQestnManage(QustnrQestnManageVO qustnrQestnManageVO) throws Exception{
-		insert("QustnrQestnManage.insertQustnrQestnManage", qustnrQestnManageVO);
+	public void insertQustnrQestnManage(QustnrQestnManageVO qustnrQestnManageVO) throws Exception {
+		qustnrQestnManageMapper.insertQustnrQestnManage(qustnrQestnManageVO);
 	}
 
-    /**
+	/**
 	 * 설문문항를(을) 수정한다.
 	 * @param qustnrQestnManageVO - 설문문항 정보 담김 VO
 	 * @throws Exception
 	 */
-	public void updateQustnrQestnManage(QustnrQestnManageVO qustnrQestnManageVO) throws Exception{
-		insert("QustnrQestnManage.updateQustnrQestnManage", qustnrQestnManageVO);
+	public void updateQustnrQestnManage(QustnrQestnManageVO qustnrQestnManageVO) throws Exception {
+		qustnrQestnManageMapper.updateQustnrQestnManage(qustnrQestnManageVO);
 	}
 
-    /**
+	/**
 	 * 설문문항를(을) 삭제한다.
 	 * @param qustnrQestnManageVO - 설문문항 정보 담김 VO
 	 * @throws Exception
 	 */
-	public void deleteQustnrQestnManage(QustnrQestnManageVO qustnrQestnManageVO) throws Exception{
-
+	public void deleteQustnrQestnManage(QustnrQestnManageVO qustnrQestnManageVO) throws Exception {
 		//설문조사(설문결과) 삭제
-		delete("QustnrQestnManage.deleteQustnrRespondInfo", qustnrQestnManageVO);
+		qustnrQestnManageMapper.deleteQustnrRespondInfo(qustnrQestnManageVO);
 		//설문항목 삭제
-		delete("QustnrQestnManage.deleteQustnrItemManage", qustnrQestnManageVO);
-
+		qustnrQestnManageMapper.deleteQustnrItemManage(qustnrQestnManageVO);
 		//설문문항
-		delete("QustnrQestnManage.deleteQustnrQestnManage", qustnrQestnManageVO);
+		qustnrQestnManageMapper.deleteQustnrQestnManage(qustnrQestnManageVO);
 	}
 }

--- a/src/main/java/egovframework/com/uss/olp/qqm/service/impl/QustnrQestnManageMapper.java
+++ b/src/main/java/egovframework/com/uss/olp/qqm/service/impl/QustnrQestnManageMapper.java
@@ -1,0 +1,114 @@
+package egovframework.com.uss.olp.qqm.service.impl;
+
+import java.util.List;
+import java.util.Map;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+import org.egovframe.rte.psl.dataaccess.util.EgovMap;
+
+import egovframework.com.cmm.ComDefaultVO;
+import egovframework.com.uss.olp.qqm.service.QustnrQestnManageVO;
+
+/**
+ * 설문문항을 처리하는 Mapper 인터페이스
+ * @author 공통서비스 장동한
+ * @since 2009.03.20
+ * @version 1.0
+ * @see
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2009.03.20  장동한          최초 생성
+ *
+ * </pre>
+ */
+@EgovMapper("qustnrQestnManageMapper")
+public interface QustnrQestnManageMapper {
+
+    /**
+     * 설문조사 응답자답변내용결과/기타답변내용결과 통계를 조회한다.
+     * @param map - 설문지 정보가 담김 Parameter
+     * @return List
+     * @throws Exception
+     */
+    List<EgovMap> selectQustnrManageStatistics2(Map<?, ?> map) throws Exception;
+
+    /**
+     * 설문조사 통계를 조회한다.
+     * @param map - 설문지 정보가 담김 Parameter
+     * @return List
+     * @throws Exception
+     */
+    List<?> selectQustnrManageStatistics(Map<?, ?> map) throws Exception;
+
+    /**
+     * 설문지정보 설문제목을 조회한다.
+     * @param map - 설문지 정보가 담김 Parameter
+     * @return Map
+     * @throws Exception
+     */
+    Map<?, ?> selectQustnrManageQestnrSj(Map<?, ?> map) throws Exception;
+
+    /**
+     * 설문문항 목록을 조회한다.
+     * @param searchVO - 조회할 정보가 담긴 VO
+     * @return List
+     * @throws Exception
+     */
+    List<?> selectQustnrQestnManage(ComDefaultVO searchVO) throws Exception;
+
+    /**
+     * 설문문항를(을) 상세조회 한다.
+     * @param qustnrQestnManageVO - 설문문항 정보 담김 VO
+     * @return List
+     * @throws Exception
+     */
+    List<EgovMap> selectQustnrQestnManageDetail(QustnrQestnManageVO qustnrQestnManageVO) throws Exception;
+
+    /**
+     * 설문문항를(을) 목록 전체 건수를(을) 조회한다.
+     * @param searchVO - 조회할 정보가 담긴 VO
+     * @return int
+     * @throws Exception
+     */
+    int selectQustnrQestnManageCnt(ComDefaultVO searchVO) throws Exception;
+
+    /**
+     * 설문문항를(을) 등록한다.
+     * @param qustnrQestnManageVO - 설문문항 정보 담김 VO
+     * @throws Exception
+     */
+    void insertQustnrQestnManage(QustnrQestnManageVO qustnrQestnManageVO) throws Exception;
+
+    /**
+     * 설문문항를(을) 수정한다.
+     * @param qustnrQestnManageVO - 설문문항 정보 담김 VO
+     * @throws Exception
+     */
+    void updateQustnrQestnManage(QustnrQestnManageVO qustnrQestnManageVO) throws Exception;
+
+    /**
+     * 설문조사(설문결과)를 삭제한다.
+     * @param qustnrQestnManageVO - 설문문항 정보 담김 VO
+     * @throws Exception
+     */
+    void deleteQustnrRespondInfo(QustnrQestnManageVO qustnrQestnManageVO) throws Exception;
+
+    /**
+     * 설문항목을 삭제한다.
+     * @param qustnrQestnManageVO - 설문문항 정보 담김 VO
+     * @throws Exception
+     */
+    void deleteQustnrItemManage(QustnrQestnManageVO qustnrQestnManageVO) throws Exception;
+
+    /**
+     * 설문문항를(을) 삭제한다.
+     * @param qustnrQestnManageVO - 설문문항 정보 담김 VO
+     * @throws Exception
+     */
+    void deleteQustnrQestnManage(QustnrQestnManageVO qustnrQestnManageVO) throws Exception;
+
+}

--- a/src/main/java/egovframework/com/uss/olp/qri/service/impl/QustnrRespondInfoDao.java
+++ b/src/main/java/egovframework/com/uss/olp/qri/service/impl/QustnrRespondInfoDao.java
@@ -3,12 +3,13 @@ package egovframework.com.uss.olp.qri.service.impl;
 import java.util.List;
 import java.util.Map;
 
+import jakarta.annotation.Resource;
 import org.egovframe.rte.psl.dataaccess.util.EgovMap;
 import org.springframework.stereotype.Repository;
 
 import egovframework.com.cmm.ComDefaultVO;
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.uss.olp.qri.service.QustnrRespondInfoVO;
+
 /**
  * 설문조사 Dao Class 구현
  * @author 공통서비스 장동한
@@ -27,170 +28,163 @@ import egovframework.com.uss.olp.qri.service.QustnrRespondInfoVO;
  * </pre>
  */
 @Repository("qustnrRespondInfoDao")
-public class QustnrRespondInfoDao extends EgovComAbstractDAO {
+public class QustnrRespondInfoDao {
 
+	@Resource(name = "qustnrRespondInfoMapper")
+	private QustnrRespondInfoMapper qustnrRespondInfoMapper;
 
-    /**
+	/**
 	 * 설문템플릿을 조회한다.
 	 * @param map - 조회할 정보가 담긴 map
 	 * @return List
 	 * @throws Exception
 	 */
-	public List<?> selectQustnrTmplatManage(Map<?, ?> map) throws Exception{
-		return selectList("QustnrRespondInfo.selectQustnrTmplatManages", map);
+	public List<?> selectQustnrTmplatManage(Map<?, ?> map) throws Exception {
+		return qustnrRespondInfoMapper.selectQustnrTmplatManages(map);
 	}
 
 	/**
-	 * 객관식 통계를 조회 조회한다.
-	 *
+	 * 객관식 통계를 조회한다.
 	 * @param map - 조회할 정보가 담긴 map
 	 * @return List
 	 * @throws Exception
 	 */
 	public List<EgovMap> selectQustnrRespondInfoManageStatistics1(Map<?, ?> map) throws Exception {
-		return selectList("QustnrRespondInfo.selectQustnrRespondInfoManageStatistics1", map);
+		return qustnrRespondInfoMapper.selectQustnrRespondInfoManageStatistics1(map);
 	}
 
 	/**
-     * 주관식 통계를 조회 조회한다.
-     *
-     * @param map - 조회할 정보가 담긴 map
-     * @return List
-     * @throws Exception
-     */
-    public List<EgovMap> selectQustnrRespondInfoManageStatistics2(Map<?, ?> map) throws Exception {
-        return selectList("QustnrRespondInfo.selectQustnrRespondInfoManageStatistics2", map);
-    }
-
-    /**
-	 * 회원정보를 조회한다.
+	 * 주관식 통계를 조회한다.
 	 * @param map - 조회할 정보가 담긴 map
 	 * @return List
 	 * @throws Exception
 	 */
-	public Map<?, ?> selectQustnrRespondInfoManageEmplyrinfo(Map<?, ?> map) throws Exception{
-		return (Map<?, ?>)selectOne("QustnrRespondInfo.selectQustnrRespondInfoManageEmplyrinfo", map);
+	public List<EgovMap> selectQustnrRespondInfoManageStatistics2(Map<?, ?> map) throws Exception {
+		return qustnrRespondInfoMapper.selectQustnrRespondInfoManageStatistics2(map);
 	}
 
-    /**
-     * 설문정보를 조회한다.
-     *
-     * @param map - 조회할 정보가 담긴 map
-     * @return List
-     * @throws Exception
-     */
-    public List<EgovMap> selectQustnrRespondInfoManageComtnqestnrinfo(Map<?, ?> map) throws Exception {
-        return selectList("QustnrRespondInfo.selectQustnrRespondInfoManageComtnqestnrinfo", map);
-    }
+	/**
+	 * 회원정보를 조회한다.
+	 * @param map - 조회할 정보가 담긴 map
+	 * @return Map
+	 * @throws Exception
+	 */
+	public Map<?, ?> selectQustnrRespondInfoManageEmplyrinfo(Map<?, ?> map) throws Exception {
+		return qustnrRespondInfoMapper.selectQustnrRespondInfoManageEmplyrinfo(map);
+	}
 
-    /**
-     * 문항정보를 조회한다.
-     *
-     * @param map - 조회할 정보가 담긴 map
-     * @return List
-     * @throws Exception
-     */
-    public List<EgovMap> selectQustnrRespondInfoManageComtnqustnrqesitm(Map<?, ?> map) throws Exception {
-        return selectList("QustnrRespondInfo.selectQustnrRespondInfoManageComtnqustnrqesitm", map);
-    }
+	/**
+	 * 설문정보를 조회한다.
+	 * @param map - 조회할 정보가 담긴 map
+	 * @return List
+	 * @throws Exception
+	 */
+	public List<EgovMap> selectQustnrRespondInfoManageComtnqestnrinfo(Map<?, ?> map) throws Exception {
+		return qustnrRespondInfoMapper.selectQustnrRespondInfoManageComtnqestnrinfo(map);
+	}
 
-    /**
-     * 항목정보를 조회한다.
-     *
-     * @param map - 조회할 정보가 담긴 map
-     * @return List
-     * @throws Exception
-     */
-    public List<EgovMap> selectQustnrRespondInfoManageComtnqustnriem(Map<?, ?> map) throws Exception {
-        return selectList("QustnrRespondInfo.selectQustnrRespondInfoManageComtnqustnriem", map);
-    }
+	/**
+	 * 문항정보를 조회한다.
+	 * @param map - 조회할 정보가 담긴 map
+	 * @return List
+	 * @throws Exception
+	 */
+	public List<EgovMap> selectQustnrRespondInfoManageComtnqustnrqesitm(Map<?, ?> map) throws Exception {
+		return qustnrRespondInfoMapper.selectQustnrRespondInfoManageComtnqustnrqesitm(map);
+	}
 
-    /**
-     * 설문조사(설문등록)를(을) 목록을 조회한다.
-     *
-     * @param searchVO - 조회할 정보가 담긴 VO
-     * @return List
-     * @throws Exception
-     */
-    public List<EgovMap> selectQustnrRespondInfoManageList(ComDefaultVO searchVO){
-        return selectList("QustnrRespondInfo.selectQustnrRespondInfoManage", searchVO);
-    }
+	/**
+	 * 항목정보를 조회한다.
+	 * @param map - 조회할 정보가 담긴 map
+	 * @return List
+	 * @throws Exception
+	 */
+	public List<EgovMap> selectQustnrRespondInfoManageComtnqustnriem(Map<?, ?> map) throws Exception {
+		return qustnrRespondInfoMapper.selectQustnrRespondInfoManageComtnqustnriem(map);
+	}
 
-    /**
+	/**
+	 * 설문조사(설문등록)를(을) 목록을 조회한다.
+	 * @param searchVO - 조회할 정보가 담긴 VO
+	 * @return List
+	 */
+	public List<EgovMap> selectQustnrRespondInfoManageList(ComDefaultVO searchVO) {
+		return qustnrRespondInfoMapper.selectQustnrRespondInfoManage(searchVO);
+	}
+
+	/**
 	 * 설문조사(설문등록)를(을) 목록 전체 건수를(을) 조회한다.
 	 * @param searchVO - 조회할 정보가 담긴 VO
 	 * @return int
 	 * @throws Exception
 	 */
-	public int selectQustnrRespondInfoManageListCnt(ComDefaultVO searchVO) throws Exception{
-		return (Integer)selectOne("QustnrRespondInfo.selectQustnrRespondInfoManageCnt", searchVO);
+	public int selectQustnrRespondInfoManageListCnt(ComDefaultVO searchVO) throws Exception {
+		return qustnrRespondInfoMapper.selectQustnrRespondInfoManageCnt(searchVO);
 	}
 
-    /**
-     * 응답자결과(설문조사) 목록을 조회한다.
-     *
-     * @param searchVO - 조회할 정보가 담긴 VO
-     * @throws Exception
-     */
-    public List<EgovMap> selectQustnrRespondInfoList(ComDefaultVO searchVO) throws Exception {
-        return selectList("QustnrRespondInfo.selectQustnrRespondInfo", searchVO);
-    }
+	/**
+	 * 응답자결과(설문조사) 목록을 조회한다.
+	 * @param searchVO - 조회할 정보가 담긴 VO
+	 * @return List
+	 * @throws Exception
+	 */
+	public List<EgovMap> selectQustnrRespondInfoList(ComDefaultVO searchVO) throws Exception {
+		return qustnrRespondInfoMapper.selectQustnrRespondInfo(searchVO);
+	}
 
-    /**
-     * 응답자결과(설문조사)를(을) 상세조회 한다.
-     *
-     * @param qustnrRespondInfoVO - 응답자결과(설문조사) 정보 담김 VO
-     * @throws Exception
-     */
-    public List<EgovMap> selectQustnrRespondInfoDetail(QustnrRespondInfoVO qustnrRespondInfoVO) throws Exception {
-        return selectList("QustnrRespondInfo.selectQustnrRespondInfoDetail", qustnrRespondInfoVO);
-    }
+	/**
+	 * 응답자결과(설문조사)를(을) 상세조회 한다.
+	 * @param qustnrRespondInfoVO - 응답자결과(설문조사) 정보 담김 VO
+	 * @return List
+	 * @throws Exception
+	 */
+	public List<EgovMap> selectQustnrRespondInfoDetail(QustnrRespondInfoVO qustnrRespondInfoVO) throws Exception {
+		return qustnrRespondInfoMapper.selectQustnrRespondInfoDetail(qustnrRespondInfoVO);
+	}
 
-    /**
+	/**
 	 * 응답자결과(설문조사)를(을) 목록 전체 건수를(을) 조회한다.
 	 * @param searchVO - 조회할 정보가 담긴 VO
- 	 * @return int
+	 * @return int
 	 * @throws Exception
 	 */
-	public int selectQustnrRespondInfoListCnt(ComDefaultVO searchVO) throws Exception{
-		return (Integer)selectOne("QustnrRespondInfo.selectQustnrRespondInfoCnt", searchVO);
+	public int selectQustnrRespondInfoListCnt(ComDefaultVO searchVO) throws Exception {
+		return qustnrRespondInfoMapper.selectQustnrRespondInfoCnt(searchVO);
 	}
 
-    /**
+	/**
 	 * 응답자결과(설문조사)를(을) 등록한다.
-	 * @param qqustnrRespondInfoVO - 응답자결과(설문조사) 정보 담김 VO
+	 * @param qustnrRespondInfoVO - 응답자결과(설문조사) 정보 담김 VO
 	 * @throws Exception
 	 */
-	public void insertQustnrRespondInfo(QustnrRespondInfoVO qustnrRespondInfoVO) throws Exception{
-		insert("QustnrRespondInfo.insertQustnrRespondInfo", qustnrRespondInfoVO);
+	public void insertQustnrRespondInfo(QustnrRespondInfoVO qustnrRespondInfoVO) throws Exception {
+		qustnrRespondInfoMapper.insertQustnrRespondInfo(qustnrRespondInfoVO);
 	}
 
-    /**
+	/**
 	 * 응답자결과(설문조사)를(을) 수정한다.
 	 * @param qustnrRespondInfoVO - 응답자결과(설문조사) 정보 담김 VO
 	 * @throws Exception
 	 */
-	public void updateQustnrRespondInfo(QustnrRespondInfoVO qustnrRespondInfoVO) throws Exception{
-		insert("QustnrRespondInfo.updateQustnrRespondInfo", qustnrRespondInfoVO);
+	public void updateQustnrRespondInfo(QustnrRespondInfoVO qustnrRespondInfoVO) throws Exception {
+		qustnrRespondInfoMapper.updateQustnrRespondInfo(qustnrRespondInfoVO);
 	}
 
-    /**
+	/**
 	 * 응답자결과(설문조사)를(을) 삭제한다.
 	 * @param qustnrRespondInfoVO - 응답자결과(설문조사) 정보 담김 VO
 	 * @throws Exception
 	 */
-	public void deleteQustnrRespondInfo(QustnrRespondInfoVO qustnrRespondInfoVO) throws Exception{
-		insert("QustnrRespondInfo.deleteQustnrRespondInfo", qustnrRespondInfoVO);
+	public void deleteQustnrRespondInfo(QustnrRespondInfoVO qustnrRespondInfoVO) throws Exception {
+		qustnrRespondInfoMapper.deleteQustnrRespondInfo(qustnrRespondInfoVO);
 	}
 
-    /**
-     * 설문템플릿 화이트리스트를 조회한다.
-     *
-     * @param map - 조회할 정보가 담긴 map
-     * @return List
-     * @throws Exception
-     */
-    public List<EgovMap> selectQustnrTmplatWhiteList() throws Exception {
-        return selectList("QustnrRespondInfo.selectQustnrTmplatWhiteList");
-    }
+	/**
+	 * 설문템플릿 화이트리스트를 조회한다.
+	 * @return List
+	 * @throws Exception
+	 */
+	public List<EgovMap> selectQustnrTmplatWhiteList() throws Exception {
+		return qustnrRespondInfoMapper.selectQustnrTmplatWhiteList();
+	}
 }

--- a/src/main/java/egovframework/com/uss/olp/qri/service/impl/QustnrRespondInfoMapper.java
+++ b/src/main/java/egovframework/com/uss/olp/qri/service/impl/QustnrRespondInfoMapper.java
@@ -1,0 +1,154 @@
+package egovframework.com.uss.olp.qri.service.impl;
+
+import java.util.List;
+import java.util.Map;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+import org.egovframe.rte.psl.dataaccess.util.EgovMap;
+
+import egovframework.com.cmm.ComDefaultVO;
+import egovframework.com.uss.olp.qri.service.QustnrRespondInfoVO;
+
+/**
+ * 설문조사 Mapper 인터페이스
+ * @author 공통서비스 장동한
+ * @since 2009.03.20
+ * @version 1.0
+ * @see
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2009.03.20  장동한          최초 생성
+ *
+ * </pre>
+ */
+@EgovMapper("qustnrRespondInfoMapper")
+public interface QustnrRespondInfoMapper {
+
+    /**
+     * 설문템플릿을 조회한다.
+     * @param map - 조회할 정보가 담긴 map
+     * @return List
+     * @throws Exception
+     */
+    List<?> selectQustnrTmplatManages(Map<?, ?> map) throws Exception;
+
+    /**
+     * 설문템플릿 화이트리스트를 조회한다.
+     * @return List
+     * @throws Exception
+     */
+    List<EgovMap> selectQustnrTmplatWhiteList() throws Exception;
+
+    /**
+     * 객관식 통계를 조회한다.
+     * @param map - 조회할 정보가 담긴 map
+     * @return List
+     * @throws Exception
+     */
+    List<EgovMap> selectQustnrRespondInfoManageStatistics1(Map<?, ?> map) throws Exception;
+
+    /**
+     * 주관식 통계를 조회한다.
+     * @param map - 조회할 정보가 담긴 map
+     * @return List
+     * @throws Exception
+     */
+    List<EgovMap> selectQustnrRespondInfoManageStatistics2(Map<?, ?> map) throws Exception;
+
+    /**
+     * 회원정보를 조회한다.
+     * @param map - 조회할 정보가 담긴 map
+     * @return Map
+     * @throws Exception
+     */
+    Map<?, ?> selectQustnrRespondInfoManageEmplyrinfo(Map<?, ?> map) throws Exception;
+
+    /**
+     * 설문정보를 조회한다.
+     * @param map - 조회할 정보가 담긴 map
+     * @return List
+     * @throws Exception
+     */
+    List<EgovMap> selectQustnrRespondInfoManageComtnqestnrinfo(Map<?, ?> map) throws Exception;
+
+    /**
+     * 문항정보를 조회한다.
+     * @param map - 조회할 정보가 담긴 map
+     * @return List
+     * @throws Exception
+     */
+    List<EgovMap> selectQustnrRespondInfoManageComtnqustnrqesitm(Map<?, ?> map) throws Exception;
+
+    /**
+     * 항목정보를 조회한다.
+     * @param map - 조회할 정보가 담긴 map
+     * @return List
+     * @throws Exception
+     */
+    List<EgovMap> selectQustnrRespondInfoManageComtnqustnriem(Map<?, ?> map) throws Exception;
+
+    /**
+     * 설문조사(설문등록)를(을) 목록을 조회한다.
+     * @param searchVO - 조회할 정보가 담긴 VO
+     * @return List
+     */
+    List<EgovMap> selectQustnrRespondInfoManage(ComDefaultVO searchVO);
+
+    /**
+     * 설문조사(설문등록)를(을) 목록 전체 건수를(을) 조회한다.
+     * @param searchVO - 조회할 정보가 담긴 VO
+     * @return int
+     * @throws Exception
+     */
+    int selectQustnrRespondInfoManageCnt(ComDefaultVO searchVO) throws Exception;
+
+    /**
+     * 응답자결과(설문조사) 목록을 조회한다.
+     * @param searchVO - 조회할 정보가 담긴 VO
+     * @return List
+     * @throws Exception
+     */
+    List<EgovMap> selectQustnrRespondInfo(ComDefaultVO searchVO) throws Exception;
+
+    /**
+     * 응답자결과(설문조사)를(을) 상세조회 한다.
+     * @param qustnrRespondInfoVO - 응답자결과(설문조사) 정보 담김 VO
+     * @return List
+     * @throws Exception
+     */
+    List<EgovMap> selectQustnrRespondInfoDetail(QustnrRespondInfoVO qustnrRespondInfoVO) throws Exception;
+
+    /**
+     * 응답자결과(설문조사)를(을) 목록 전체 건수를(을) 조회한다.
+     * @param searchVO - 조회할 정보가 담긴 VO
+     * @return int
+     * @throws Exception
+     */
+    int selectQustnrRespondInfoCnt(ComDefaultVO searchVO) throws Exception;
+
+    /**
+     * 응답자결과(설문조사)를(을) 등록한다.
+     * @param qustnrRespondInfoVO - 응답자결과(설문조사) 정보 담김 VO
+     * @throws Exception
+     */
+    void insertQustnrRespondInfo(QustnrRespondInfoVO qustnrRespondInfoVO) throws Exception;
+
+    /**
+     * 응답자결과(설문조사)를(을) 수정한다.
+     * @param qustnrRespondInfoVO - 응답자결과(설문조사) 정보 담김 VO
+     * @throws Exception
+     */
+    void updateQustnrRespondInfo(QustnrRespondInfoVO qustnrRespondInfoVO) throws Exception;
+
+    /**
+     * 응답자결과(설문조사)를(을) 삭제한다.
+     * @param qustnrRespondInfoVO - 응답자결과(설문조사) 정보 담김 VO
+     * @throws Exception
+     */
+    void deleteQustnrRespondInfo(QustnrRespondInfoVO qustnrRespondInfoVO) throws Exception;
+
+}

--- a/src/main/java/egovframework/com/uss/olp/qrm/service/impl/QustnrRespondManageDao.java
+++ b/src/main/java/egovframework/com/uss/olp/qrm/service/impl/QustnrRespondManageDao.java
@@ -2,12 +2,13 @@ package egovframework.com.uss.olp.qrm.service.impl;
 
 import java.util.List;
 
+import jakarta.annotation.Resource;
 import org.egovframe.rte.psl.dataaccess.util.EgovMap;
 import org.springframework.stereotype.Repository;
 
 import egovframework.com.cmm.ComDefaultVO;
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.uss.olp.qrm.service.QustnrRespondManageVO;
+
 /**
  * 설문응답자관리 Dao Class 구현
  * @author 공통서비스 장동한
@@ -26,62 +27,65 @@ import egovframework.com.uss.olp.qrm.service.QustnrRespondManageVO;
  * </pre>
  */
 @Repository("qustnrRespondManageDao")
-public class QustnrRespondManageDao extends EgovComAbstractDAO {
+public class QustnrRespondManageDao {
 
-    /**
+	@Resource(name = "qustnrRespondManageMapper")
+	private QustnrRespondManageMapper qustnrRespondManageMapper;
+
+	/**
 	 * 응답자정보 목록을 조회한다.
 	 * @param searchVO - 조회할 정보가 담긴 VO
 	 * @return List
 	 * @throws Exception
 	 */
-	public List<EgovMap> selectQustnrRespondManageList(ComDefaultVO searchVO) throws Exception{
-		return selectList("QustnrRespondManage.selectQustnrRespondManage", searchVO);
+	public List<EgovMap> selectQustnrRespondManageList(ComDefaultVO searchVO) throws Exception {
+		return qustnrRespondManageMapper.selectQustnrRespondManage(searchVO);
 	}
 
-    /**
+	/**
 	 * 응답자정보를(을) 상세조회 한다.
 	 * @param qustnrRespondManageVO - 응답자정보 정보 담김 VO
 	 * @return List
 	 * @throws Exception
 	 */
-	public List<EgovMap> selectQustnrRespondManageDetail(QustnrRespondManageVO qustnrRespondManageVO) throws Exception{
-		return selectList("QustnrRespondManage.selectQustnrRespondManageDetail", qustnrRespondManageVO);
+	public List<EgovMap> selectQustnrRespondManageDetail(QustnrRespondManageVO qustnrRespondManageVO) throws Exception {
+		return qustnrRespondManageMapper.selectQustnrRespondManageDetail(qustnrRespondManageVO);
 	}
 
-    /**
+	/**
 	 * 응답자정보를(을) 목록 전체 건수를(을) 조회한다.
 	 * @param searchVO - 조회할 정보가 담긴 VO
 	 * @return int
 	 * @throws Exception
 	 */
-	public int selectQustnrRespondManageListCnt(ComDefaultVO searchVO) throws Exception{
-		return (Integer)selectOne("QustnrRespondManage.selectQustnrRespondManageCnt", searchVO);
+	public int selectQustnrRespondManageListCnt(ComDefaultVO searchVO) throws Exception {
+		return qustnrRespondManageMapper.selectQustnrRespondManageCnt(searchVO);
 	}
 
-    /**
+	/**
 	 * 응답자정보를(을) 등록한다.
-	 * @param qqustnrRespondManageVO - 응답자정보 정보 담김 VO
+	 * @param qustnrRespondManageVO - 응답자정보 정보 담김 VO
 	 * @throws Exception
 	 */
-	public void insertQustnrRespondManage(QustnrRespondManageVO qustnrRespondManageVO) throws Exception{
-		insert("QustnrRespondManage.insertQustnrRespondManage", qustnrRespondManageVO);
+	public void insertQustnrRespondManage(QustnrRespondManageVO qustnrRespondManageVO) throws Exception {
+		qustnrRespondManageMapper.insertQustnrRespondManage(qustnrRespondManageVO);
 	}
 
-    /**
+	/**
 	 * 응답자정보를(을) 수정한다.
 	 * @param qustnrRespondManageVO - 응답자정보 정보 담김 VO
 	 * @throws Exception
 	 */
-	public void updateQustnrRespondManage(QustnrRespondManageVO qustnrRespondManageVO) throws Exception{
-		insert("QustnrRespondManage.updateQustnrRespondManage", qustnrRespondManageVO);
+	public void updateQustnrRespondManage(QustnrRespondManageVO qustnrRespondManageVO) throws Exception {
+		qustnrRespondManageMapper.updateQustnrRespondManage(qustnrRespondManageVO);
 	}
 
-    /**
+	/**
 	 * 응답자정보를(을) 삭제한다.
 	 * @param qustnrRespondManageVO - 응답자정보 정보 담김 VO
 	 * @throws Exception
 	 */
-	public void deleteQustnrRespondManage(QustnrRespondManageVO qustnrRespondManageVO) throws Exception{
-		insert("QustnrRespondManage.deleteQustnrRespondManage", qustnrRespondManageVO);
+	public void deleteQustnrRespondManage(QustnrRespondManageVO qustnrRespondManageVO) throws Exception {
+		qustnrRespondManageMapper.deleteQustnrRespondManage(qustnrRespondManageVO);
 	}
 }

--- a/src/main/java/egovframework/com/uss/olp/qrm/service/impl/QustnrRespondManageMapper.java
+++ b/src/main/java/egovframework/com/uss/olp/qrm/service/impl/QustnrRespondManageMapper.java
@@ -1,0 +1,75 @@
+package egovframework.com.uss.olp.qrm.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+import org.egovframe.rte.psl.dataaccess.util.EgovMap;
+
+import egovframework.com.cmm.ComDefaultVO;
+import egovframework.com.uss.olp.qrm.service.QustnrRespondManageVO;
+
+/**
+ * 설문응답자관리 Mapper 인터페이스
+ * @author 공통서비스 장동한
+ * @since 2009.03.20
+ * @version 1.0
+ * @see
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2009.03.20  장동한          최초 생성
+ *
+ * </pre>
+ */
+@EgovMapper("qustnrRespondManageMapper")
+public interface QustnrRespondManageMapper {
+
+    /**
+     * 응답자정보 목록을 조회한다.
+     * @param searchVO - 조회할 정보가 담긴 VO
+     * @return List
+     * @throws Exception
+     */
+    List<EgovMap> selectQustnrRespondManage(ComDefaultVO searchVO) throws Exception;
+
+    /**
+     * 응답자정보를(을) 상세조회 한다.
+     * @param qustnrRespondManageVO - 응답자정보 정보 담김 VO
+     * @return List
+     * @throws Exception
+     */
+    List<EgovMap> selectQustnrRespondManageDetail(QustnrRespondManageVO qustnrRespondManageVO) throws Exception;
+
+    /**
+     * 응답자정보를(을) 목록 전체 건수를(을) 조회한다.
+     * @param searchVO - 조회할 정보가 담긴 VO
+     * @return int
+     * @throws Exception
+     */
+    int selectQustnrRespondManageCnt(ComDefaultVO searchVO) throws Exception;
+
+    /**
+     * 응답자정보를(을) 등록한다.
+     * @param qustnrRespondManageVO - 응답자정보 정보 담김 VO
+     * @throws Exception
+     */
+    void insertQustnrRespondManage(QustnrRespondManageVO qustnrRespondManageVO) throws Exception;
+
+    /**
+     * 응답자정보를(을) 수정한다.
+     * @param qustnrRespondManageVO - 응답자정보 정보 담김 VO
+     * @throws Exception
+     */
+    void updateQustnrRespondManage(QustnrRespondManageVO qustnrRespondManageVO) throws Exception;
+
+    /**
+     * 응답자정보를(을) 삭제한다.
+     * @param qustnrRespondManageVO - 응답자정보 정보 담김 VO
+     * @throws Exception
+     */
+    void deleteQustnrRespondManage(QustnrRespondManageVO qustnrRespondManageVO) throws Exception;
+
+}

--- a/src/main/java/egovframework/com/uss/olp/qtm/service/impl/QustnrTmplatManageDao.java
+++ b/src/main/java/egovframework/com/uss/olp/qtm/service/impl/QustnrTmplatManageDao.java
@@ -3,11 +3,11 @@ package egovframework.com.uss.olp.qtm.service.impl;
 import java.util.List;
 import java.util.Map;
 
+import jakarta.annotation.Resource;
 import org.egovframe.rte.psl.dataaccess.util.EgovMap;
 import org.springframework.stereotype.Repository;
 
 import egovframework.com.cmm.ComDefaultVO;
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.uss.olp.qtm.service.QustnrTmplatManageVO;
 
 /**
@@ -28,85 +28,79 @@ import egovframework.com.uss.olp.qtm.service.QustnrTmplatManageVO;
  * </pre>
  */
 @Repository("qustnrTmplatManageDao")
-public class QustnrTmplatManageDao extends EgovComAbstractDAO {
+public class QustnrTmplatManageDao {
 
-    /**
+	@Resource(name = "qustnrTmplatManageMapper")
+	private QustnrTmplatManageMapper qustnrTmplatManageMapper;
+
+	/**
 	 * 템플릿파일명을 조회한다.
 	 * @param qustnrTmplatManageVO - 조회할 정보가 담긴 VO
-	 * @return List
-	 * @throws Exception
+	 * @return Map
 	 */
-	public Map<?,?> selectQustnrTmplatManageTmplatImagepathnm(QustnrTmplatManageVO qustnrTmplatManageVO){
-		return (Map<?,?>)selectOne("QustnrTmplatManage.selectQustnrTmplatManageTmplatImagepathnm", qustnrTmplatManageVO);
+	public Map<?, ?> selectQustnrTmplatManageTmplatImagepathnm(QustnrTmplatManageVO qustnrTmplatManageVO) {
+		return qustnrTmplatManageMapper.selectQustnrTmplatManageTmplatImagepathnm(qustnrTmplatManageVO);
 	}
-
 
 	/**
 	 * 설문템플릿 목록을 조회한다.
 	 * @param searchVO - 조회할 정보가 담긴 VO
 	 * @return List
-	 * @throws Exception
 	 */
-	public List<EgovMap> selectQustnrTmplatManageList(ComDefaultVO searchVO){
-		return selectList("QustnrTmplatManage.selectQustnrTmplatManage", searchVO);
+	public List<EgovMap> selectQustnrTmplatManageList(ComDefaultVO searchVO) {
+		return qustnrTmplatManageMapper.selectQustnrTmplatManage(searchVO);
 	}
 
-    /**
+	/**
 	 * 설문템플릿를(을) 상세조회 한다.
-	 * @param QustnrTmplatManage - 회정정보가 담김 VO
+	 * @param qustnrTmplatManageVO - 설문템플릿 정보 담김 VO
 	 * @return List
-	 * @throws Exception
 	 */
-	public List<EgovMap> selectQustnrTmplatManageDetail(QustnrTmplatManageVO qustnrTmplatManageVO){
-		return selectList("QustnrTmplatManage.selectQustnrTmplatManageDetail", qustnrTmplatManageVO);
+	public List<EgovMap> selectQustnrTmplatManageDetail(QustnrTmplatManageVO qustnrTmplatManageVO) {
+		return qustnrTmplatManageMapper.selectQustnrTmplatManageDetail(qustnrTmplatManageVO);
 	}
 
-    /**
+	/**
 	 * 설문템플릿를(을) 목록 전체 건수를(을) 조회한다.
 	 * @param searchVO - 조회할 정보가 담긴 VO
 	 * @return int
-	 * @throws Exception
 	 */
-	public int selectQustnrTmplatManageListCnt(ComDefaultVO searchVO){
-		return (Integer)selectOne("QustnrTmplatManage.selectQustnrTmplatManageCnt", searchVO);
+	public int selectQustnrTmplatManageListCnt(ComDefaultVO searchVO) {
+		return qustnrTmplatManageMapper.selectQustnrTmplatManageCnt(searchVO);
 	}
 
-    /**
+	/**
 	 * 설문템플릿를(을) 등록한다.
-	 * @param searchVO - 조회할 정보가 담긴 VO
-	 * @throws Exception
+	 * @param qustnrTmplatManageVO - 설문템플릿 정보 담김 VO
 	 */
-	public void insertQustnrTmplatManage(QustnrTmplatManageVO qustnrTmplatManageVO){
-		insert("QustnrTmplatManage.insertQustnrTmplatManage", qustnrTmplatManageVO);
+	public void insertQustnrTmplatManage(QustnrTmplatManageVO qustnrTmplatManageVO) {
+		qustnrTmplatManageMapper.insertQustnrTmplatManage(qustnrTmplatManageVO);
 	}
 
-    /**
+	/**
 	 * 설문템플릿를(을) 수정한다.
-	 * @param searchVO - 조회할 정보가 담긴 VO
-	 * @throws Exception
+	 * @param qustnrTmplatManageVO - 설문템플릿 정보 담김 VO
 	 */
-	public void updateQustnrTmplatManage(QustnrTmplatManageVO qustnrTmplatManageVO){
-		update("QustnrTmplatManage.updateQustnrTmplatManage", qustnrTmplatManageVO);
+	public void updateQustnrTmplatManage(QustnrTmplatManageVO qustnrTmplatManageVO) {
+		qustnrTmplatManageMapper.updateQustnrTmplatManage(qustnrTmplatManageVO);
 	}
 
-    /**
+	/**
 	 * 설문템플릿를(을) 삭제한다.
-	 * @param searchVO - 조회할 정보가 담긴 VO
-	 * @throws Exception
+	 * @param qustnrTmplatManageVO - 설문템플릿 정보 담김 VO
 	 */
-	public void deleteQustnrTmplatManage(QustnrTmplatManageVO qustnrTmplatManageVO){
+	public void deleteQustnrTmplatManage(QustnrTmplatManageVO qustnrTmplatManageVO) {
 		//설문응답자 삭제
-		delete("QustnrTmplatManage.deleteQustnrRespondManage", qustnrTmplatManageVO);
+		qustnrTmplatManageMapper.deleteQustnrRespondManage(qustnrTmplatManageVO);
 		//설문조사(설문결과) 삭제
-		delete("QustnrTmplatManage.deleteQustnrRespondInfo", qustnrTmplatManageVO);
+		qustnrTmplatManageMapper.deleteQustnrRespondInfo(qustnrTmplatManageVO);
 		//설문항목 삭제
-		delete("QustnrTmplatManage.deleteQustnrItemManage", qustnrTmplatManageVO);
+		qustnrTmplatManageMapper.deleteQustnrItemManage(qustnrTmplatManageVO);
 		//설문문항 삭제
-		delete("QustnrTmplatManage.deleteQustnrQestnManage", qustnrTmplatManageVO);
+		qustnrTmplatManageMapper.deleteQustnrQestnManage(qustnrTmplatManageVO);
 		//설문관리 삭제
-		delete("QustnrTmplatManage.deleteQustnrManage", qustnrTmplatManageVO);
-
+		qustnrTmplatManageMapper.deleteQustnrManage(qustnrTmplatManageVO);
 		//설문템플릿삭제
-		delete("QustnrTmplatManage.deleteQustnrTmplatManage", qustnrTmplatManageVO);
+		qustnrTmplatManageMapper.deleteQustnrTmplatManage(qustnrTmplatManageVO);
 	}
 }

--- a/src/main/java/egovframework/com/uss/olp/qtm/service/impl/QustnrTmplatManageMapper.java
+++ b/src/main/java/egovframework/com/uss/olp/qtm/service/impl/QustnrTmplatManageMapper.java
@@ -1,0 +1,107 @@
+package egovframework.com.uss.olp.qtm.service.impl;
+
+import java.util.List;
+import java.util.Map;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+import org.egovframe.rte.psl.dataaccess.util.EgovMap;
+
+import egovframework.com.cmm.ComDefaultVO;
+import egovframework.com.uss.olp.qtm.service.QustnrTmplatManageVO;
+
+/**
+ * 설문템플릿 Mapper 인터페이스
+ * @author 공통서비스 장동한
+ * @since 2009.03.20
+ * @version 1.0
+ * @see
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2009.03.20  장동한          최초 생성
+ *
+ * </pre>
+ */
+@EgovMapper("qustnrTmplatManageMapper")
+public interface QustnrTmplatManageMapper {
+
+    /**
+     * 템플릿파일명을 조회한다.
+     * @param qustnrTmplatManageVO - 조회할 정보가 담긴 VO
+     * @return Map
+     */
+    Map<?, ?> selectQustnrTmplatManageTmplatImagepathnm(QustnrTmplatManageVO qustnrTmplatManageVO);
+
+    /**
+     * 설문템플릿 목록을 조회한다.
+     * @param searchVO - 조회할 정보가 담긴 VO
+     * @return List
+     */
+    List<EgovMap> selectQustnrTmplatManage(ComDefaultVO searchVO);
+
+    /**
+     * 설문템플릿를(을) 상세조회 한다.
+     * @param qustnrTmplatManageVO - 설문템플릿 정보 담김 VO
+     * @return List
+     */
+    List<EgovMap> selectQustnrTmplatManageDetail(QustnrTmplatManageVO qustnrTmplatManageVO);
+
+    /**
+     * 설문템플릿를(을) 목록 전체 건수를(을) 조회한다.
+     * @param searchVO - 조회할 정보가 담긴 VO
+     * @return int
+     */
+    int selectQustnrTmplatManageCnt(ComDefaultVO searchVO);
+
+    /**
+     * 설문템플릿를(을) 등록한다.
+     * @param qustnrTmplatManageVO - 설문템플릿 정보 담김 VO
+     */
+    void insertQustnrTmplatManage(QustnrTmplatManageVO qustnrTmplatManageVO);
+
+    /**
+     * 설문템플릿를(을) 수정한다.
+     * @param qustnrTmplatManageVO - 설문템플릿 정보 담김 VO
+     */
+    void updateQustnrTmplatManage(QustnrTmplatManageVO qustnrTmplatManageVO);
+
+    /**
+     * 설문응답자를 삭제한다.
+     * @param qustnrTmplatManageVO - 설문템플릿 정보 담김 VO
+     */
+    void deleteQustnrRespondManage(QustnrTmplatManageVO qustnrTmplatManageVO);
+
+    /**
+     * 설문조사(설문결과)를 삭제한다.
+     * @param qustnrTmplatManageVO - 설문템플릿 정보 담김 VO
+     */
+    void deleteQustnrRespondInfo(QustnrTmplatManageVO qustnrTmplatManageVO);
+
+    /**
+     * 설문항목을 삭제한다.
+     * @param qustnrTmplatManageVO - 설문템플릿 정보 담김 VO
+     */
+    void deleteQustnrItemManage(QustnrTmplatManageVO qustnrTmplatManageVO);
+
+    /**
+     * 설문문항을 삭제한다.
+     * @param qustnrTmplatManageVO - 설문템플릿 정보 담김 VO
+     */
+    void deleteQustnrQestnManage(QustnrTmplatManageVO qustnrTmplatManageVO);
+
+    /**
+     * 설문관리를 삭제한다.
+     * @param qustnrTmplatManageVO - 설문템플릿 정보 담김 VO
+     */
+    void deleteQustnrManage(QustnrTmplatManageVO qustnrTmplatManageVO);
+
+    /**
+     * 설문템플릿를(을) 삭제한다.
+     * @param qustnrTmplatManageVO - 설문템플릿 정보 담김 VO
+     */
+    void deleteQustnrTmplatManage(QustnrTmplatManageVO qustnrTmplatManageVO);
+
+}

--- a/src/main/resources/egovframework/mapper/com/uss/olp/qim/EgovQustnrItemManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/qim/EgovQustnrItemManage_SQL_altibase.xml
@@ -13,7 +13,7 @@
 --><!--Converted at: Wed May 11 15:51:38 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QustnrItemManage">
+<mapper namespace="egovframework.com.uss.olp.qim.service.impl.QustnrItemManageMapper">
 
 	<!-- 설문정보::설문템플릿정보 -->
 	<select id="selectQustnrTmplatManage" parameterType="egovframework.com.uss.olp.qim.service.QustnrItemManageVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/com/uss/olp/qim/EgovQustnrItemManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/qim/EgovQustnrItemManage_SQL_cubrid.xml
@@ -13,7 +13,7 @@
 --><!--Converted at: Wed May 11 15:51:38 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QustnrItemManage">
+<mapper namespace="egovframework.com.uss.olp.qim.service.impl.QustnrItemManageMapper">
 	<!-- 설문정보::설문템플릿정보 -->
 	<select id="selectQustnrTmplatManage" parameterType="egovframework.com.uss.olp.qim.service.QustnrItemManageVO" resultType="egovMap">
 		<![CDATA[

--- a/src/main/resources/egovframework/mapper/com/uss/olp/qim/EgovQustnrItemManage_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/qim/EgovQustnrItemManage_SQL_goldilocks.xml
@@ -13,7 +13,7 @@
 --><!--Converted at: Wed May 11 15:51:38 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QustnrItemManage">
+<mapper namespace="egovframework.com.uss.olp.qim.service.impl.QustnrItemManageMapper">
 
 	<!-- 설문정보::설문템플릿정보 -->
 	<select id="selectQustnrTmplatManage" parameterType="egovframework.com.uss.olp.qim.service.QustnrItemManageVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/com/uss/olp/qim/EgovQustnrItemManage_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/qim/EgovQustnrItemManage_SQL_maria.xml
@@ -13,7 +13,7 @@
 --><!--Converted at: Wed May 11 15:51:38 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QustnrItemManage">
+<mapper namespace="egovframework.com.uss.olp.qim.service.impl.QustnrItemManageMapper">
 
 	<!-- 설문정보::설문템플릿정보 -->
 	<select id="selectQustnrTmplatManage" parameterType="egovframework.com.uss.olp.qim.service.QustnrItemManageVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/com/uss/olp/qim/EgovQustnrItemManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/qim/EgovQustnrItemManage_SQL_mysql.xml
@@ -13,7 +13,7 @@
 --><!--Converted at: Wed May 11 15:51:38 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QustnrItemManage">
+<mapper namespace="egovframework.com.uss.olp.qim.service.impl.QustnrItemManageMapper">
 
 	<!-- 설문정보::설문템플릿정보 -->
 	<select id="selectQustnrTmplatManage" parameterType="egovframework.com.uss.olp.qim.service.QustnrItemManageVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/com/uss/olp/qim/EgovQustnrItemManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/qim/EgovQustnrItemManage_SQL_oracle.xml
@@ -13,7 +13,7 @@
 --><!--Converted at: Wed May 11 15:51:38 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QustnrItemManage">
+<mapper namespace="egovframework.com.uss.olp.qim.service.impl.QustnrItemManageMapper">
 	<!-- 설문정보::설문템플릿정보 -->
 	<select id="selectQustnrTmplatManage" parameterType="egovframework.com.uss.olp.qim.service.QustnrItemManageVO" resultType="egovMap">
 		<![CDATA[

--- a/src/main/resources/egovframework/mapper/com/uss/olp/qim/EgovQustnrItemManage_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/qim/EgovQustnrItemManage_SQL_postgres.xml
@@ -13,7 +13,7 @@
 --><!--Converted at: Wed May 11 15:51:38 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QustnrItemManage">
+<mapper namespace="egovframework.com.uss.olp.qim.service.impl.QustnrItemManageMapper">
 
 	<!-- 설문정보::설문템플릿정보 -->
 	<select id="selectQustnrTmplatManage" parameterType="egovframework.com.uss.olp.qim.service.QustnrItemManageVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/com/uss/olp/qim/EgovQustnrItemManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/qim/EgovQustnrItemManage_SQL_tibero.xml
@@ -13,7 +13,7 @@
 --><!--Converted at: Wed May 11 15:51:39 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QustnrItemManage">
+<mapper namespace="egovframework.com.uss.olp.qim.service.impl.QustnrItemManageMapper">
 	<!-- 설문정보::설문템플릿정보 -->
 	<select id="selectQustnrTmplatManage" parameterType="egovframework.com.uss.olp.qim.service.QustnrItemManageVO" resultType="egovMap">
 		<![CDATA[

--- a/src/main/resources/egovframework/mapper/com/uss/olp/qmc/EgovQustnrManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/qmc/EgovQustnrManage_SQL_altibase.xml
@@ -14,7 +14,7 @@
 --><!--Converted at: Wed May 11 15:51:39 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QustnrManage">
+<mapper namespace="egovframework.com.uss.olp.qmc.service.impl.QustnrManageMapper">
 	<resultMap id="QustnrManage" type="egovframework.com.uss.olp.qmc.service.QustnrManageVO">
 		<result property="qestnrId" column="QESTNR_ID"/>
 		<result property="qestnrSj" column="QUSTNR_SJ"/>

--- a/src/main/resources/egovframework/mapper/com/uss/olp/qmc/EgovQustnrManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/qmc/EgovQustnrManage_SQL_cubrid.xml
@@ -14,7 +14,7 @@
 --><!--Converted at: Wed May 11 15:51:39 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QustnrManage">
+<mapper namespace="egovframework.com.uss.olp.qmc.service.impl.QustnrManageMapper">
 	<resultMap id="QustnrManage" type="egovframework.com.uss.olp.qmc.service.QustnrManageVO">
 		<result property="qestnrId" column="QESTNR_ID"/>
 		<result property="qestnrSj" column="QUSTNR_SJ"/>

--- a/src/main/resources/egovframework/mapper/com/uss/olp/qmc/EgovQustnrManage_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/qmc/EgovQustnrManage_SQL_goldilocks.xml
@@ -14,7 +14,7 @@
 --><!--Converted at: Wed May 11 15:51:39 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QustnrManage">
+<mapper namespace="egovframework.com.uss.olp.qmc.service.impl.QustnrManageMapper">
 	<resultMap id="QustnrManage" type="egovframework.com.uss.olp.qmc.service.QustnrManageVO">
 		<result property="qestnrId" column="QESTNR_ID"/>
 		<result property="qestnrSj" column="QUSTNR_SJ"/>

--- a/src/main/resources/egovframework/mapper/com/uss/olp/qmc/EgovQustnrManage_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/qmc/EgovQustnrManage_SQL_maria.xml
@@ -14,7 +14,7 @@
 --><!--Converted at: Wed May 11 15:51:39 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QustnrManage">
+<mapper namespace="egovframework.com.uss.olp.qmc.service.impl.QustnrManageMapper">
 
 	<resultMap id="QustnrManage" type="egovframework.com.uss.olp.qmc.service.QustnrManageVO">
 		<result property="qestnrId" column="QESTNR_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/olp/qmc/EgovQustnrManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/qmc/EgovQustnrManage_SQL_mysql.xml
@@ -14,7 +14,7 @@
 --><!--Converted at: Wed May 11 15:51:39 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QustnrManage">
+<mapper namespace="egovframework.com.uss.olp.qmc.service.impl.QustnrManageMapper">
 
 	<resultMap id="QustnrManage" type="egovframework.com.uss.olp.qmc.service.QustnrManageVO">
 		<result property="qestnrId" column="QESTNR_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/olp/qmc/EgovQustnrManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/qmc/EgovQustnrManage_SQL_oracle.xml
@@ -14,7 +14,7 @@
 --><!--Converted at: Wed May 11 15:51:39 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QustnrManage">
+<mapper namespace="egovframework.com.uss.olp.qmc.service.impl.QustnrManageMapper">
 	<resultMap id="QustnrManage" type="egovframework.com.uss.olp.qmc.service.QustnrManageVO">
 		<result property="qestnrId" column="QESTNR_ID"/>
 		<result property="qestnrSj" column="QUSTNR_SJ"/>

--- a/src/main/resources/egovframework/mapper/com/uss/olp/qmc/EgovQustnrManage_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/qmc/EgovQustnrManage_SQL_postgres.xml
@@ -14,7 +14,7 @@
 --><!--Converted at: Wed May 11 15:51:39 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QustnrManage">
+<mapper namespace="egovframework.com.uss.olp.qmc.service.impl.QustnrManageMapper">
 
 	<resultMap id="QustnrManage" type="egovframework.com.uss.olp.qmc.service.QustnrManageVO">
 		<result property="qestnrId" column="QESTNR_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/olp/qmc/EgovQustnrManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/qmc/EgovQustnrManage_SQL_tibero.xml
@@ -14,7 +14,7 @@
 --><!--Converted at: Wed May 11 15:51:39 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QustnrManage">
+<mapper namespace="egovframework.com.uss.olp.qmc.service.impl.QustnrManageMapper">
 	<resultMap id="QustnrManage" type="egovframework.com.uss.olp.qmc.service.QustnrManageVO">
 		<result property="qestnrId" column="QESTNR_ID"/>
 		<result property="qestnrSj" column="QUSTNR_SJ"/>

--- a/src/main/resources/egovframework/mapper/com/uss/olp/qqm/EgovQustnrQestnManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/qqm/EgovQustnrQestnManage_SQL_altibase.xml
@@ -14,7 +14,7 @@
 --><!--Converted at: Wed May 11 15:51:40 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QustnrQestnManage">
+<mapper namespace="egovframework.com.uss.olp.qqm.service.impl.QustnrQestnManageMapper">
 
 	<!-- 설문문항:: 객관식 통계  -->
 	<select id="selectQustnrManageStatistics" parameterType="java.util.Map" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/com/uss/olp/qqm/EgovQustnrQestnManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/qqm/EgovQustnrQestnManage_SQL_cubrid.xml
@@ -14,7 +14,7 @@
 --><!--Converted at: Wed May 11 15:51:40 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QustnrQestnManage">
+<mapper namespace="egovframework.com.uss.olp.qqm.service.impl.QustnrQestnManageMapper">
 
 	<!-- 설문문항:: 객관식 통계  -->
 	<select id="selectQustnrManageStatistics" parameterType="java.util.Map" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/com/uss/olp/qqm/EgovQustnrQestnManage_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/qqm/EgovQustnrQestnManage_SQL_goldilocks.xml
@@ -14,7 +14,7 @@
 --><!--Converted at: Wed May 11 15:51:40 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QustnrQestnManage">
+<mapper namespace="egovframework.com.uss.olp.qqm.service.impl.QustnrQestnManageMapper">
 
 	<!-- 설문문항:: 객관식 통계  -->
 	<select id="selectQustnrManageStatistics" parameterType="java.util.Map" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/com/uss/olp/qqm/EgovQustnrQestnManage_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/qqm/EgovQustnrQestnManage_SQL_maria.xml
@@ -14,7 +14,7 @@
 --><!--Converted at: Wed May 11 15:51:40 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QustnrQestnManage">
+<mapper namespace="egovframework.com.uss.olp.qqm.service.impl.QustnrQestnManageMapper">
 
 	<!-- 설문문항:: 객관식 통계  -->
 	<select id="selectQustnrManageStatistics" parameterType="java.util.Map" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/com/uss/olp/qqm/EgovQustnrQestnManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/qqm/EgovQustnrQestnManage_SQL_mysql.xml
@@ -14,7 +14,7 @@
 --><!--Converted at: Wed May 11 15:51:40 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QustnrQestnManage">
+<mapper namespace="egovframework.com.uss.olp.qqm.service.impl.QustnrQestnManageMapper">
 
 	<!-- 설문문항:: 객관식 통계  -->
 	<select id="selectQustnrManageStatistics" parameterType="java.util.Map" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/com/uss/olp/qqm/EgovQustnrQestnManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/qqm/EgovQustnrQestnManage_SQL_oracle.xml
@@ -14,7 +14,7 @@
 --><!--Converted at: Wed May 11 15:51:40 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QustnrQestnManage">
+<mapper namespace="egovframework.com.uss.olp.qqm.service.impl.QustnrQestnManageMapper">
 
 	<!-- 설문문항:: 객관식 통계  -->
 	<select id="selectQustnrManageStatistics" parameterType="java.util.Map" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/com/uss/olp/qqm/EgovQustnrQestnManage_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/qqm/EgovQustnrQestnManage_SQL_postgres.xml
@@ -14,7 +14,7 @@
 --><!--Converted at: Wed May 11 15:51:40 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QustnrQestnManage">
+<mapper namespace="egovframework.com.uss.olp.qqm.service.impl.QustnrQestnManageMapper">
 
 	<!-- 설문문항:: 객관식 통계  -->
 	<select id="selectQustnrManageStatistics" parameterType="java.util.Map" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/com/uss/olp/qqm/EgovQustnrQestnManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/qqm/EgovQustnrQestnManage_SQL_tibero.xml
@@ -14,7 +14,7 @@
 --><!--Converted at: Wed May 11 15:51:40 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QustnrQestnManage">
+<mapper namespace="egovframework.com.uss.olp.qqm.service.impl.QustnrQestnManageMapper">
 
 	<!-- 설문문항:: 객관식 통계  -->
 	<select id="selectQustnrManageStatistics" parameterType="java.util.Map" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/com/uss/olp/qri/EgovQustnrRespondInfo_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/qri/EgovQustnrRespondInfo_SQL_altibase.xml
@@ -12,7 +12,7 @@
 --><!--Converted at: Wed May 11 15:51:41 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QustnrRespondInfo">
+<mapper namespace="egovframework.com.uss.olp.qri.service.impl.QustnrRespondInfoMapper">
 
 	<!-- 설문등록:: 설문템플릿조회 -->
 	<select id="selectQustnrTmplatManages" parameterType="java.util.Map" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/com/uss/olp/qri/EgovQustnrRespondInfo_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/qri/EgovQustnrRespondInfo_SQL_cubrid.xml
@@ -12,7 +12,7 @@
 --><!--Converted at: Wed May 11 15:51:41 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QustnrRespondInfo">
+<mapper namespace="egovframework.com.uss.olp.qri.service.impl.QustnrRespondInfoMapper">
 
 	<!-- 설문등록:: 설문템플릿조회 -->
 	<select id="selectQustnrTmplatManages" parameterType="java.util.Map" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/com/uss/olp/qri/EgovQustnrRespondInfo_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/qri/EgovQustnrRespondInfo_SQL_goldilocks.xml
@@ -12,7 +12,7 @@
 --><!--Converted at: Wed May 11 15:51:41 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QustnrRespondInfo">
+<mapper namespace="egovframework.com.uss.olp.qri.service.impl.QustnrRespondInfoMapper">
 
 	<!-- 설문등록:: 설문템플릿조회 -->
 	<select id="selectQustnrTmplatManages" parameterType="java.util.Map" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/com/uss/olp/qri/EgovQustnrRespondInfo_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/qri/EgovQustnrRespondInfo_SQL_maria.xml
@@ -13,7 +13,7 @@
 --><!--Converted at: Wed May 11 15:51:41 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QustnrRespondInfo">
+<mapper namespace="egovframework.com.uss.olp.qri.service.impl.QustnrRespondInfoMapper">
 
 	<!-- 설문등록:: 설문템플릿조회 -->
 	<select id="selectQustnrTmplatManages" parameterType="java.util.Map" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/com/uss/olp/qri/EgovQustnrRespondInfo_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/qri/EgovQustnrRespondInfo_SQL_mysql.xml
@@ -13,7 +13,7 @@
 --><!--Converted at: Wed May 11 15:51:41 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QustnrRespondInfo">
+<mapper namespace="egovframework.com.uss.olp.qri.service.impl.QustnrRespondInfoMapper">
 
 	<!-- 설문등록:: 설문템플릿조회 -->
 	<select id="selectQustnrTmplatManages" parameterType="java.util.Map" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/com/uss/olp/qri/EgovQustnrRespondInfo_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/qri/EgovQustnrRespondInfo_SQL_oracle.xml
@@ -12,7 +12,7 @@
 --><!--Converted at: Wed May 11 15:51:41 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QustnrRespondInfo">
+<mapper namespace="egovframework.com.uss.olp.qri.service.impl.QustnrRespondInfoMapper">
 
 	<!-- 설문등록:: 설문템플릿조회 -->
 	<select id="selectQustnrTmplatManages" parameterType="java.util.Map" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/com/uss/olp/qri/EgovQustnrRespondInfo_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/qri/EgovQustnrRespondInfo_SQL_postgres.xml
@@ -13,7 +13,7 @@
 --><!--Converted at: Wed May 11 15:51:41 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QustnrRespondInfo">
+<mapper namespace="egovframework.com.uss.olp.qri.service.impl.QustnrRespondInfoMapper">
 
 	<!-- 설문등록:: 설문템플릿조회 -->
 	<select id="selectQustnrTmplatManages" parameterType="java.util.Map" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/com/uss/olp/qri/EgovQustnrRespondInfo_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/qri/EgovQustnrRespondInfo_SQL_tibero.xml
@@ -12,7 +12,7 @@
 --><!--Converted at: Wed May 11 15:51:41 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QustnrRespondInfo">
+<mapper namespace="egovframework.com.uss.olp.qri.service.impl.QustnrRespondInfoMapper">
 
 	<!-- 설문등록:: 설문템플릿조회 -->
 	<select id="selectQustnrTmplatManages" parameterType="java.util.Map" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/com/uss/olp/qrm/EgovQustnrRespondManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/qrm/EgovQustnrRespondManage_SQL_altibase.xml
@@ -13,7 +13,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QustnrRespondManage">
+<mapper namespace="egovframework.com.uss.olp.qrm.service.impl.QustnrRespondManageMapper">
 
 	<!-- 응답자결과(설문조사)::삭제  -->
 	<delete id="deleteQustnrRespondManage">

--- a/src/main/resources/egovframework/mapper/com/uss/olp/qrm/EgovQustnrRespondManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/qrm/EgovQustnrRespondManage_SQL_cubrid.xml
@@ -13,7 +13,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QustnrRespondManage">
+<mapper namespace="egovframework.com.uss.olp.qrm.service.impl.QustnrRespondManageMapper">
 
 	<!-- 응답자결과(설문조사)::삭제  -->
 	<delete id="deleteQustnrRespondManage">

--- a/src/main/resources/egovframework/mapper/com/uss/olp/qrm/EgovQustnrRespondManage_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/qrm/EgovQustnrRespondManage_SQL_goldilocks.xml
@@ -13,7 +13,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QustnrRespondManage">
+<mapper namespace="egovframework.com.uss.olp.qrm.service.impl.QustnrRespondManageMapper">
 
 	<!-- 응답자결과(설문조사)::삭제  -->
 	<delete id="deleteQustnrRespondManage">

--- a/src/main/resources/egovframework/mapper/com/uss/olp/qrm/EgovQustnrRespondManage_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/qrm/EgovQustnrRespondManage_SQL_maria.xml
@@ -13,7 +13,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QustnrRespondManage">
+<mapper namespace="egovframework.com.uss.olp.qrm.service.impl.QustnrRespondManageMapper">
 
 	<!-- 응답자결과(설문조사)::삭제  -->
 	<delete id="deleteQustnrRespondManage">

--- a/src/main/resources/egovframework/mapper/com/uss/olp/qrm/EgovQustnrRespondManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/qrm/EgovQustnrRespondManage_SQL_mysql.xml
@@ -13,7 +13,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QustnrRespondManage">
+<mapper namespace="egovframework.com.uss.olp.qrm.service.impl.QustnrRespondManageMapper">
 
 	<!-- 응답자결과(설문조사)::삭제  -->
 	<delete id="deleteQustnrRespondManage">

--- a/src/main/resources/egovframework/mapper/com/uss/olp/qrm/EgovQustnrRespondManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/qrm/EgovQustnrRespondManage_SQL_oracle.xml
@@ -13,7 +13,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QustnrRespondManage">
+<mapper namespace="egovframework.com.uss.olp.qrm.service.impl.QustnrRespondManageMapper">
 
 	<!-- 응답자결과(설문조사)::삭제  -->
 	<delete id="deleteQustnrRespondManage">

--- a/src/main/resources/egovframework/mapper/com/uss/olp/qrm/EgovQustnrRespondManage_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/qrm/EgovQustnrRespondManage_SQL_postgres.xml
@@ -13,7 +13,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QustnrRespondManage">
+<mapper namespace="egovframework.com.uss.olp.qrm.service.impl.QustnrRespondManageMapper">
 
 	<!-- 응답자결과(설문조사)::삭제  -->
 	<delete id="deleteQustnrRespondManage">

--- a/src/main/resources/egovframework/mapper/com/uss/olp/qrm/EgovQustnrRespondManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/qrm/EgovQustnrRespondManage_SQL_tibero.xml
@@ -13,7 +13,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QustnrRespondManage">
+<mapper namespace="egovframework.com.uss.olp.qrm.service.impl.QustnrRespondManageMapper">
 
 	<!-- 응답자결과(설문조사)::삭제  -->
 	<delete id="deleteQustnrRespondManage">

--- a/src/main/resources/egovframework/mapper/com/uss/olp/qtm/EgovQustnrTmplatManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/qtm/EgovQustnrTmplatManage_SQL_altibase.xml
@@ -15,7 +15,7 @@
 --><!--Converted at: Wed May 11 15:51:42 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QustnrTmplatManage">
+<mapper namespace="egovframework.com.uss.olp.qtm.service.impl.QustnrTmplatManageMapper">
 
  	<resultMap id="QustnrTmplatManageTmplatImagepathnm" type="java.util.HashMap">
         <result property="QUSTNR_TMPLAT_IMAGE_INFOPATHNM" column="QUSTNR_TMPLAT_IMAGE_INFOPATHNM" javaType="_byte[]" jdbcType="BLOB"/>

--- a/src/main/resources/egovframework/mapper/com/uss/olp/qtm/EgovQustnrTmplatManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/qtm/EgovQustnrTmplatManage_SQL_cubrid.xml
@@ -15,7 +15,7 @@
 --><!--Converted at: Wed May 11 15:51:42 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QustnrTmplatManage">
+<mapper namespace="egovframework.com.uss.olp.qtm.service.impl.QustnrTmplatManageMapper">
 
  	<resultMap id="QustnrTmplatManageTmplatImagepathnm" type="java.util.HashMap">
         <result property="QUSTNR_TMPLAT_IMAGE_INFOPATHNM" column="QUSTNR_TMPLAT_IMAGE_INFOPATHNM"/>

--- a/src/main/resources/egovframework/mapper/com/uss/olp/qtm/EgovQustnrTmplatManage_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/qtm/EgovQustnrTmplatManage_SQL_goldilocks.xml
@@ -15,7 +15,7 @@
 --><!--Converted at: Wed May 11 15:51:42 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QustnrTmplatManage">
+<mapper namespace="egovframework.com.uss.olp.qtm.service.impl.QustnrTmplatManageMapper">
 
  	<resultMap id="QustnrTmplatManageTmplatImagepathnm" type="java.util.HashMap">
         <result property="QUSTNR_TMPLAT_IMAGE_INFOPATHNM" column="QUSTNR_TMPLAT_IMAGE_INFOPATHNM" javaType="_byte[]"/>

--- a/src/main/resources/egovframework/mapper/com/uss/olp/qtm/EgovQustnrTmplatManage_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/qtm/EgovQustnrTmplatManage_SQL_maria.xml
@@ -15,7 +15,7 @@
 --><!--Converted at: Wed May 11 15:51:43 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QustnrTmplatManage">
+<mapper namespace="egovframework.com.uss.olp.qtm.service.impl.QustnrTmplatManageMapper">
 
  	<resultMap id="QustnrTmplatManageTmplatImagepathnm" type="java.util.HashMap">
         <result property="QUSTNR_TMPLAT_IMAGE_INFOPATHNM" column="QUSTNR_TMPLAT_IMAGE_INFOPATHNM" javaType="_byte[]" jdbcType="BLOB"/>

--- a/src/main/resources/egovframework/mapper/com/uss/olp/qtm/EgovQustnrTmplatManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/qtm/EgovQustnrTmplatManage_SQL_mysql.xml
@@ -15,7 +15,7 @@
 --><!--Converted at: Wed May 11 15:51:43 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QustnrTmplatManage">
+<mapper namespace="egovframework.com.uss.olp.qtm.service.impl.QustnrTmplatManageMapper">
 
  	<resultMap id="QustnrTmplatManageTmplatImagepathnm" type="java.util.HashMap">
         <result property="QUSTNR_TMPLAT_IMAGE_INFOPATHNM" column="QUSTNR_TMPLAT_IMAGE_INFOPATHNM" javaType="_byte[]" jdbcType="BLOB"/>

--- a/src/main/resources/egovframework/mapper/com/uss/olp/qtm/EgovQustnrTmplatManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/qtm/EgovQustnrTmplatManage_SQL_oracle.xml
@@ -15,7 +15,7 @@
 --><!--Converted at: Wed May 11 15:51:43 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QustnrTmplatManage">
+<mapper namespace="egovframework.com.uss.olp.qtm.service.impl.QustnrTmplatManageMapper">
 
  	<resultMap id="QustnrTmplatManageTmplatImagepathnm" type="java.util.HashMap">
         <result property="QUSTNR_TMPLAT_IMAGE_INFOPATHNM" column="QUSTNR_TMPLAT_IMAGE_INFOPATHNM" javaType="_byte[]" jdbcType="BLOB"/>

--- a/src/main/resources/egovframework/mapper/com/uss/olp/qtm/EgovQustnrTmplatManage_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/qtm/EgovQustnrTmplatManage_SQL_postgres.xml
@@ -15,7 +15,7 @@
 --><!--Converted at: Wed May 11 15:51:43 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QustnrTmplatManage">
+<mapper namespace="egovframework.com.uss.olp.qtm.service.impl.QustnrTmplatManageMapper">
 
  	<resultMap id="QustnrTmplatManageTmplatImagepathnm" type="java.util.HashMap">
         <result property="QUSTNR_TMPLAT_IMAGE_INFOPATHNM" column="QUSTNR_TMPLAT_IMAGE_INFOPATHNM" jdbcType="BLOB"/>

--- a/src/main/resources/egovframework/mapper/com/uss/olp/qtm/EgovQustnrTmplatManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/qtm/EgovQustnrTmplatManage_SQL_tibero.xml
@@ -15,7 +15,7 @@
 --><!--Converted at: Wed May 11 15:51:43 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QustnrTmplatManage">
+<mapper namespace="egovframework.com.uss.olp.qtm.service.impl.QustnrTmplatManageMapper">
 
  	<resultMap id="QustnrTmplatManageTmplatImagepathnm" type="java.util.HashMap">
         <result property="QUSTNR_TMPLAT_IMAGE_INFOPATHNM" column="QUSTNR_TMPLAT_IMAGE_INFOPATHNM" javaType="_byte[]" jdbcType="BLOB"/>

--- a/src/main/resources/egovframework/spring/com/context-mapper.xml
+++ b/src/main/resources/egovframework/spring/com/context-mapper.xml
@@ -21,5 +21,12 @@
 	<bean id="egov.sqlSessionTemplate" class="org.mybatis.spring.SqlSessionTemplate">
 		<constructor-arg ref="egov.sqlSession"/>
 	</bean>
-	
+
+	<!-- @EgovMapper 어노테이션 기반 Mapper 스캔 -->
+	<bean class="org.mybatis.spring.mapper.MapperScannerConfigurer">
+		<property name="basePackage" value="egovframework.com"/>
+		<property name="annotationClass" value="org.egovframe.rte.psl.dataaccess.mapper.EgovMapper"/>
+		<property name="sqlSessionFactoryBeanName" value="egov.sqlSession"/>
+	</bean>
+
 </beans>


### PR DESCRIPTION
## 변경 사유
기존 XML namespace 기반 DAO를 eGovFrame 5.0 신규 `@EgovMapper` 인터페이스 방식으로 전환합니다.

## 변경 내용
- 대상: uss/olp 설문(qmc·qqm·qim·qrm·qtm·qri) 6개 DAO
- 각 DAO에 대응하는 Mapper 인터페이스(`@EgovMapper`) 신규 추가
- DAO를 mapper 위임 구조로 리팩토링 (EgovComAbstractDAO 상속 제거, @Resource 주입, @Repository bean name 유지)
- XML mapper namespace를 mapper 인터페이스 FQN으로 변경
- context-mapper.xml에 MapperScannerConfigurer(annotationClass=EgovMapper) 추가

## 영향 범위
- 해당 모듈만 영향, 서비스 레이어 호출 시그니처 변경 없음

## 참고
- 빌드 검증을 위해 #891(Lombok annotationProcessorPaths 빌드 수정) 선행 머지 권장
- context-mapper.xml MapperScannerConfigurer는 동일 시리즈 PR과 한 줄 중복될 수 있어, 선행 PR 머지 후 rebase로 정리 가능

## 체크리스트
- [x] 단일 주제만 다룸
- [x] 컴파일 검증(해당 모듈 신규 오류 0)
- [x] 기존 동작 호환
