### PR TITLE
[refactor][5.0.x][공통컴포넌트] uss/olp 투표·회의 및 dam/spe/req 5개 DAO @EgovMapper 인터페이스 전환

### DIFF
--- a/src/main/java/egovframework/com/dam/spe/req/service/impl/RequestOfferDao.java
+++ b/src/main/java/egovframework/com/dam/spe/req/service/impl/RequestOfferDao.java
@@ -9,8 +9,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.dam.spe.req.service.RequestOfferVO;
+import jakarta.annotation.Resource;
+
 /**
  * 지식정보제공/지식정보요청를 처리하는 Dao Class 구현
  * @author 공통콤포넌트 장동한
@@ -22,33 +23,36 @@ import egovframework.com.dam.spe.req.service.RequestOfferVO;
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2010.08.30  장동한          최초 생성
+ *   2026.05.28  dasomel         @EgovMapper 인터페이스 방식으로 전환
  *
  * </pre>
  */
 @Repository("RequestOfferDao")
-public class RequestOfferDao extends EgovComAbstractDAO {
-	
+public class RequestOfferDao {
+
 	private static final Logger LOGGER = LoggerFactory.getLogger(RequestOfferDao.class);
+
+	@Resource(name = "requestOfferMapper")
+	private RequestOfferMapper requestOfferMapper;
 
     /**
      * 삭제시 하위 답변 건수를 조회한다.
-     * @param RequestOfferVO  조회할 정보가 담긴 객체
+     * @param map  조회할 정보가 담긴 객체
      * @return int
      * @throws Exception
      */
     public int selectRequestOfferDelCnt(Map<?, ?> map) throws Exception {
-    	return (Integer)selectOne("RequestOffer.selectRequestOfferDelCnt", map);
+    	return requestOfferMapper.selectRequestOfferDelCnt(map);
     }
-
 
     /**
      * 등록된 지식전문가 건수를 조회한다.
-     * @param RequestOfferVO  조회할 정보가 담긴 객체
+     * @param map  조회할 정보가 담긴 객체
      * @return int
      * @throws Exception
      */
     public int selectRequestOfferSpeCnt(Map<?, ?> map) throws Exception {
-    	return (Integer)selectOne("RequestOffer.selectRequestOfferSpeCnt", map);
+    	return requestOfferMapper.selectRequestOfferSpeCnt(map);
     }
 
     /**
@@ -58,8 +62,7 @@ public class RequestOfferDao extends EgovComAbstractDAO {
      * @throws Exception
      */
     public List<EgovMap> selectRequestOfferList(RequestOfferVO requestOfferVO) throws Exception {
-    	return selectList("RequestOffer.selectRequestOffer",requestOfferVO);
-
+    	return requestOfferMapper.selectRequestOffer(requestOfferVO);
     }
 
     /**
@@ -69,7 +72,7 @@ public class RequestOfferDao extends EgovComAbstractDAO {
      * @throws Exception
      */
     public int selectRequestOfferListCnt(RequestOfferVO requestOfferVO) throws Exception {
-    	return (Integer)selectOne("RequestOffer.selectRequestOfferCnt", requestOfferVO);
+    	return requestOfferMapper.selectRequestOfferCnt(requestOfferVO);
     }
 
     /**
@@ -79,59 +82,54 @@ public class RequestOfferDao extends EgovComAbstractDAO {
      * @throws Exception
      */
     public RequestOfferVO selectRequestOfferDetail(RequestOfferVO requestOfferVO) throws Exception {
-    	return (RequestOfferVO)selectOne("RequestOffer.selectRequestOfferDetail", requestOfferVO);
+    	return requestOfferMapper.selectRequestOfferDetail(requestOfferVO);
     }
 
     /**
      * 지식정보제공/지식정보요청를(을) 등록한다.
-     * @param qindvdlInfoPolicy  지식정보제공/지식정보요청 정보가 담김 객체
+     * @param requestOfferVO  지식정보제공/지식정보요청 정보가 담김 객체
      * @throws Exception
      */
     @SuppressWarnings("unused")
 	public void insertRequestOffer(RequestOfferVO requestOfferVO) throws Exception {
-    	if(requestOfferVO.getCmd().equals("save")){
-    		insert("RequestOffer.insertRequestOfferSave", requestOfferVO);
-    	}else if(requestOfferVO.getCmd().equals("reply")){
-    		int nSeq = (Integer)selectOne("RequestOffer.selectRequestOfferReplySeq", requestOfferVO);
+    	if (requestOfferVO.getCmd().equals("save")) {
+    		requestOfferMapper.insertRequestOfferSave(requestOfferVO);
+    	} else if (requestOfferVO.getCmd().equals("reply")) {
+    		int nSeq = requestOfferMapper.selectRequestOfferReplySeq(requestOfferVO);
 
-    		Map<?, ?> mapAnsParents = (Map<?, ?>)selectOne("RequestOffer.selectRequestOfferReplyaAnsParents", requestOfferVO);
+    		Map<?, ?> mapAnsParents = requestOfferMapper.selectRequestOfferReplyaAnsParents(requestOfferVO);
 
     		//단말노드가 아닐때 탐색
-    		if(mapAnsParents != null){
-	    		Map<?, ?> mapAnsParentsSearch = null;
-	    		String sAnsParents = (String)mapAnsParents.get("knoId");
+    		if (mapAnsParents != null) {
+	    		String sAnsParents = (String) mapAnsParents.get("knoId");
 
 	    		LOGGER.info("sAnsParents>" + sAnsParents);
 
 	    		//단말노드 검사
-	    		while(true){
+	    		while (true) {
 	    			HashMap<String, String> hmParam = new HashMap<>();
 	    			hmParam.put("ansParents", sAnsParents);
-	    			mapAnsParents = (Map<?, ?>)selectOne("RequestOffer.selectRequestOfferReplyaAnsParentsSearch", hmParam);
+	    			mapAnsParents = requestOfferMapper.selectRequestOfferReplyaAnsParentsSearch(hmParam);
 	    			LOGGER.info("mapAnsParentsSearch>" + mapAnsParents);
 
-	    			if(mapAnsParents == null){
+	    			if (mapAnsParents == null) {
 	    				break;
-	    			//1레벨 일때 처리
-	    			//}else if(mapAnsParents == null){
-	    			}else{
-	    				sAnsParents = (String)mapAnsParents.get("knoId");
-	    				nSeq=(Integer)mapAnsParents.get("ansSeq") + 1;
+	    			} else {
+	    				sAnsParents = (String) mapAnsParents.get("knoId");
+	    				nSeq = (Integer) mapAnsParents.get("ansSeq") + 1;
 	    			}
 	    		}
     		}
 
     		//단말노드가 없으면
-    		if( nSeq != 1){
+    		if (nSeq != 1) {
     			requestOfferVO.setAnsSeq(nSeq);
     		}
     		LOGGER.info("LastSeq>" + nSeq);
 
-    		update("RequestOffer.updateRequestOfferReply", requestOfferVO);
-    		insert("RequestOffer.insertRequestOfferReply", requestOfferVO);
-
+    		requestOfferMapper.updateRequestOfferReply(requestOfferVO);
+    		requestOfferMapper.insertRequestOfferReply(requestOfferVO);
     	}
-
     }
 
     /**
@@ -140,7 +138,7 @@ public class RequestOfferDao extends EgovComAbstractDAO {
      * @throws Exception
      */
     public void updateRequestOffer(RequestOfferVO requestOfferVO) throws Exception {
-    	 update("RequestOffer.updateRequestOffer", requestOfferVO);
+    	requestOfferMapper.updateRequestOffer(requestOfferVO);
     }
 
     /**
@@ -149,7 +147,7 @@ public class RequestOfferDao extends EgovComAbstractDAO {
      * @throws Exception
      */
     public void deleteRequestOffer(RequestOfferVO requestOfferVO) throws Exception {
-    	delete("RequestOffer.deleteRequestOffer", requestOfferVO);
+    	requestOfferMapper.deleteRequestOffer(requestOfferVO);
     }
 
 }

--- a/src/main/java/egovframework/com/dam/spe/req/service/impl/RequestOfferMapper.java
+++ b/src/main/java/egovframework/com/dam/spe/req/service/impl/RequestOfferMapper.java
@@ -1,0 +1,112 @@
+package egovframework.com.dam.spe.req.service.impl;
+
+import java.util.List;
+import java.util.Map;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+import org.egovframe.rte.psl.dataaccess.util.EgovMap;
+
+import egovframework.com.dam.spe.req.service.RequestOfferVO;
+
+/**
+ * 지식정보제공/지식정보요청를 위한 Mapper 인터페이스
+ *
+ * <pre>
+ *  == 개정이력(Modification Information) ==
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2026.05.28  dasomel     @EgovMapper 인터페이스 방식으로 전환
+ *
+ * </pre>
+ */
+@EgovMapper
+public interface RequestOfferMapper {
+
+	/**
+	 * 삭제시 하위 답변 건수를 조회한다.
+	 * @param map - 조회 조건 Map
+	 * @return int
+	 */
+	int selectRequestOfferDelCnt(Map<?, ?> map);
+
+	/**
+	 * 등록된 지식전문가 건수를 조회한다.
+	 * @param map - 조회 조건 Map
+	 * @return int
+	 */
+	int selectRequestOfferSpeCnt(Map<?, ?> map);
+
+	/**
+	 * 지식정보제공/지식정보요청 목록을 조회한다.
+	 * @param requestOfferVO - 지식정보 VO
+	 * @return List
+	 */
+	List<EgovMap> selectRequestOffer(RequestOfferVO requestOfferVO);
+
+	/**
+	 * 지식정보제공/지식정보요청 목록 총 건수를 조회한다.
+	 * @param requestOfferVO - 지식정보 VO
+	 * @return int
+	 */
+	int selectRequestOfferCnt(RequestOfferVO requestOfferVO);
+
+	/**
+	 * 지식정보제공/지식정보요청 상세 정보를 조회한다.
+	 * @param requestOfferVO - 지식정보 VO
+	 * @return RequestOfferVO
+	 */
+	RequestOfferVO selectRequestOfferDetail(RequestOfferVO requestOfferVO);
+
+	/**
+	 * 지식정보제공/지식정보요청을 저장 등록한다.
+	 * @param requestOfferVO - 지식정보 VO
+	 */
+	void insertRequestOfferSave(RequestOfferVO requestOfferVO);
+
+	/**
+	 * 답변 순번을 조회한다.
+	 * @param requestOfferVO - 지식정보 VO
+	 * @return int
+	 */
+	int selectRequestOfferReplySeq(RequestOfferVO requestOfferVO);
+
+	/**
+	 * 부모 답변 정보를 조회한다.
+	 * @param requestOfferVO - 지식정보 VO
+	 * @return Map
+	 */
+	Map<?, ?> selectRequestOfferReplyaAnsParents(RequestOfferVO requestOfferVO);
+
+	/**
+	 * 부모 답변 탐색 정보를 조회한다.
+	 * @param hmParam - 조회 조건 Map
+	 * @return Map
+	 */
+	Map<?, ?> selectRequestOfferReplyaAnsParentsSearch(Map<?, ?> hmParam);
+
+	/**
+	 * 답변 순서를 업데이트한다.
+	 * @param requestOfferVO - 지식정보 VO
+	 */
+	void updateRequestOfferReply(RequestOfferVO requestOfferVO);
+
+	/**
+	 * 답변을 등록한다.
+	 * @param requestOfferVO - 지식정보 VO
+	 */
+	void insertRequestOfferReply(RequestOfferVO requestOfferVO);
+
+	/**
+	 * 지식정보제공/지식정보요청을 수정한다.
+	 * @param requestOfferVO - 지식정보 VO
+	 */
+	void updateRequestOffer(RequestOfferVO requestOfferVO);
+
+	/**
+	 * 지식정보제공/지식정보요청을 삭제한다.
+	 * @param requestOfferVO - 지식정보 VO
+	 */
+	void deleteRequestOffer(RequestOfferVO requestOfferVO);
+
+}

--- a/src/main/java/egovframework/com/uss/olp/mgt/service/impl/MeetingManageDao.java
+++ b/src/main/java/egovframework/com/uss/olp/mgt/service/impl/MeetingManageDao.java
@@ -6,8 +6,9 @@ import org.egovframe.rte.psl.dataaccess.util.EgovMap;
 import org.springframework.stereotype.Repository;
 
 import egovframework.com.cmm.ComDefaultVO;
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.uss.olp.mgt.service.MeetingManageVO;
+import jakarta.annotation.Resource;
+
 /**
  * 회의관리를 처리하기 위한 Dao 구현 Class
  * @author 공통서비스 장동한
@@ -21,86 +22,82 @@ import egovframework.com.uss.olp.mgt.service.MeetingManageVO;
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.03.20  장동한          최초 생성
+ *   2026.05.28  dasomel         @EgovMapper 인터페이스 방식으로 전환
  *
  * </pre>
  */
 @Repository("meetingManageDao")
-public class MeetingManageDao extends EgovComAbstractDAO {
+public class MeetingManageDao {
+
+    @Resource(name = "meetingManageMapper")
+    private MeetingManageMapper meetingManageMapper;
 
     /**
-	 * 부서 목록을 조회한다.
-	 * @param searchVO - 조회할 정보가 담긴 VO
-	 * @return List
-	 * @throws Exception
-	 */
-	public List<EgovMap> egovMeetingManageLisAuthorGroupPopup(ComDefaultVO searchVO){
-		return selectList("MeetingManage.EgovMeetingManageLisAuthorGroupPopup", searchVO);
-	}
+     * 부서 목록을 조회한다.
+     * @param searchVO - 조회할 정보가 담긴 VO
+     * @return List
+     */
+    public List<EgovMap> egovMeetingManageLisAuthorGroupPopup(ComDefaultVO searchVO) {
+        return meetingManageMapper.EgovMeetingManageLisAuthorGroupPopup(searchVO);
+    }
 
     /**
-	 * 아이디 목록을 조회한다.
-	 * @param searchVO - 조회할 정보가 담긴 VO
-	 * @return List
-	 * @throws Exception
-	 */
-	public List<EgovMap> egovMeetingManageLisEmpLyrPopup(ComDefaultVO searchVO){
-		return selectList("MeetingManage.EgovMeetingManageLisEmpLyrPopup", searchVO);
-	}
+     * 아이디 목록을 조회한다.
+     * @param searchVO - 조회할 정보가 담긴 VO
+     * @return List
+     */
+    public List<EgovMap> egovMeetingManageLisEmpLyrPopup(ComDefaultVO searchVO) {
+        return meetingManageMapper.EgovMeetingManageLisEmpLyrPopup(searchVO);
+    }
 
     /**
-	 * 회의정보 목록을 조회한다.
-	 * @param searchVO - 조회할 정보가 담긴 VO
-	 * @return List
-	 * @throws Exception
-	 */
-	public List<EgovMap> selectMeetingManageList(ComDefaultVO searchVO){
-		return selectList("MeetingManage.selectMeetingManage", searchVO);
-	}
+     * 회의정보 목록을 조회한다.
+     * @param searchVO - 조회할 정보가 담긴 VO
+     * @return List
+     */
+    public List<EgovMap> selectMeetingManageList(ComDefaultVO searchVO) {
+        return meetingManageMapper.selectMeetingManage(searchVO);
+    }
 
     /**
-	 * 회의정보를 상세조회 한다.
-	 * @param MeetingManageVO - 회정정보가 담김 VO
-	 * @return List
-	 * @throws Exception
-	 */
-	public List<EgovMap> selectMeetingManageDetail(MeetingManageVO meetingManageVO){
-		return selectList("MeetingManage.selectMeetingManageDetail", meetingManageVO);
-	}
+     * 회의정보를 상세조회 한다.
+     * @param meetingManageVO - 회정정보가 담김 VO
+     * @return List
+     */
+    public List<EgovMap> selectMeetingManageDetail(MeetingManageVO meetingManageVO) {
+        return meetingManageMapper.selectMeetingManageDetail(meetingManageVO);
+    }
 
     /**
-	 * 회의정보를 목록 전체 건수를 조회한다.
-	 * @param searchVO - 조회할 정보가 담긴 VO
-	 * @return int
-	 * @throws Exception
-	 */
-	public int selectMeetingManageListCnt(ComDefaultVO searchVO){
-		return (Integer)selectOne("MeetingManage.selectMeetingManageCnt", searchVO);
-	}
+     * 회의정보를 목록 전체 건수를 조회한다.
+     * @param searchVO - 조회할 정보가 담긴 VO
+     * @return int
+     */
+    public int selectMeetingManageListCnt(ComDefaultVO searchVO) {
+        return meetingManageMapper.selectMeetingManageCnt(searchVO);
+    }
 
     /**
-	 * 회의정보를 등록한다.
-	 * @param searchVO - 조회할 정보가 담긴 VO
-	 * @throws Exception
-	 */
-	public void insertMeetingManage(MeetingManageVO meetingManageVO){
-		insert("MeetingManage.insertMeetingManage", meetingManageVO);
-	}
+     * 회의정보를 등록한다.
+     * @param meetingManageVO - 회의정보가 담긴 VO
+     */
+    public void insertMeetingManage(MeetingManageVO meetingManageVO) {
+        meetingManageMapper.insertMeetingManage(meetingManageVO);
+    }
 
     /**
-	 * 회의정보를 수정한다.
-	 * @param searchVO - 조회할 정보가 담긴 VO
-	 * @throws Exception
-	 */
-	public void updateMeetingManage(MeetingManageVO meetingManageVO){
-		insert("MeetingManage.updateMeetingManage", meetingManageVO);
-	}
+     * 회의정보를 수정한다.
+     * @param meetingManageVO - 회의정보가 담긴 VO
+     */
+    public void updateMeetingManage(MeetingManageVO meetingManageVO) {
+        meetingManageMapper.updateMeetingManage(meetingManageVO);
+    }
 
     /**
-	 * 회의정보를 삭제한다.
-	 * @param searchVO - 조회할 정보가 담긴 VO
-	 * @throws Exception
-	 */
-	public void deleteMeetingManage(MeetingManageVO meetingManageVO){
-		insert("MeetingManage.deleteMeetingManage", meetingManageVO);
-	}
+     * 회의정보를 삭제한다.
+     * @param meetingManageVO - 회의정보가 담긴 VO
+     */
+    public void deleteMeetingManage(MeetingManageVO meetingManageVO) {
+        meetingManageMapper.deleteMeetingManage(meetingManageVO);
+    }
 }

--- a/src/main/java/egovframework/com/uss/olp/mgt/service/impl/MeetingManageMapper.java
+++ b/src/main/java/egovframework/com/uss/olp/mgt/service/impl/MeetingManageMapper.java
@@ -1,0 +1,79 @@
+package egovframework.com.uss.olp.mgt.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+import org.egovframe.rte.psl.dataaccess.util.EgovMap;
+
+import egovframework.com.cmm.ComDefaultVO;
+import egovframework.com.uss.olp.mgt.service.MeetingManageVO;
+
+/**
+ * 회의관리를 위한 Mapper 인터페이스
+ *
+ * <pre>
+ *  == 개정이력(Modification Information) ==
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2026.05.28  dasomel     @EgovMapper 인터페이스 방식으로 전환
+ *
+ * </pre>
+ */
+@EgovMapper
+public interface MeetingManageMapper {
+
+	/**
+	 * 부서 목록을 조회한다.
+	 * @param searchVO - 조회 조건 VO
+	 * @return List
+	 */
+	List<EgovMap> EgovMeetingManageLisAuthorGroupPopup(ComDefaultVO searchVO);
+
+	/**
+	 * 아이디 목록을 조회한다.
+	 * @param searchVO - 조회 조건 VO
+	 * @return List
+	 */
+	List<EgovMap> EgovMeetingManageLisEmpLyrPopup(ComDefaultVO searchVO);
+
+	/**
+	 * 회의정보 목록을 조회한다.
+	 * @param searchVO - 조회 조건 VO
+	 * @return List
+	 */
+	List<EgovMap> selectMeetingManage(ComDefaultVO searchVO);
+
+	/**
+	 * 회의정보 상세를 조회한다.
+	 * @param meetingManageVO - 회의정보 VO
+	 * @return List
+	 */
+	List<EgovMap> selectMeetingManageDetail(MeetingManageVO meetingManageVO);
+
+	/**
+	 * 회의정보 목록 총 건수를 조회한다.
+	 * @param searchVO - 조회 조건 VO
+	 * @return int
+	 */
+	int selectMeetingManageCnt(ComDefaultVO searchVO);
+
+	/**
+	 * 회의정보를 등록한다.
+	 * @param meetingManageVO - 회의정보 VO
+	 */
+	void insertMeetingManage(MeetingManageVO meetingManageVO);
+
+	/**
+	 * 회의정보를 수정한다.
+	 * @param meetingManageVO - 회의정보 VO
+	 */
+	void updateMeetingManage(MeetingManageVO meetingManageVO);
+
+	/**
+	 * 회의정보를 삭제한다.
+	 * @param meetingManageVO - 회의정보 VO
+	 */
+	void deleteMeetingManage(MeetingManageVO meetingManageVO);
+
+}

--- a/src/main/java/egovframework/com/uss/olp/opm/service/impl/OnlinePollManageDao.java
+++ b/src/main/java/egovframework/com/uss/olp/opm/service/impl/OnlinePollManageDao.java
@@ -6,9 +6,9 @@ import org.egovframe.rte.psl.dataaccess.util.EgovMap;
 import org.springframework.stereotype.Repository;
 
 import egovframework.com.cmm.ComDefaultVO;
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.uss.olp.opm.service.OnlinePollItem;
 import egovframework.com.uss.olp.opm.service.OnlinePollManage;
+import jakarta.annotation.Resource;
 
 /**
  * 온라인POLL관리를 처리하는 Dao Class 구현
@@ -21,40 +21,44 @@ import egovframework.com.uss.olp.opm.service.OnlinePollManage;
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.07.03  장동한          최초 생성
+ *   2026.05.28  dasomel         @EgovMapper 인터페이스 방식으로 전환
  *
  * </pre>
  */
 @Repository("onlinePollManageDao")
-public class OnlinePollManageDao extends EgovComAbstractDAO {
+public class OnlinePollManageDao {
+
+    @Resource(name = "onlinePollManageMapper")
+    private OnlinePollManageMapper onlinePollManageMapper;
 
     /**
      * 온라인POLL관리를(을) 목록을 한다.
-     * @param onlinePollVO  온라인POLL관리 정보 담김 VO
+     * @param searchVO  온라인POLL관리 정보 담김 VO
      * @return List
      * @throws Exception
      */
     public List<EgovMap> selectOnlinePollManageList(ComDefaultVO searchVO) throws Exception {
-        return selectList("OnlinePollManage.selectOnlinePollManage", searchVO);
+        return onlinePollManageMapper.selectOnlinePollManage(searchVO);
     }
 
     /**
      * 온라인POLL관리를(을) 상세조회 한다.
      * @param onlinePollManage 온라인POLL관리 정보가 담김 VO
-     * @return List
+     * @return OnlinePollManage
      * @throws Exception
      */
     public OnlinePollManage selectOnlinePollManageDetail(OnlinePollManage onlinePollManage) throws Exception {
-        return (OnlinePollManage)selectOne("OnlinePollManage.selectOnlinePollManageDetail", onlinePollManage);
+        return onlinePollManageMapper.selectOnlinePollManageDetail(onlinePollManage);
     }
 
     /**
      * 온라인POLL관리를(을) 목록 전체 건수를(을) 조회한다.
-     * @param onlinePollManage 온라인POLL관리 정보가 담김 VO
+     * @param searchVO 온라인POLL관리 정보가 담김 VO
      * @return int
      * @throws Exception
      */
     public int selectOnlinePollManageListCnt(ComDefaultVO searchVO) throws Exception {
-        return (Integer)selectOne("OnlinePollManage.selectOnlinePollManageCnt", searchVO);
+        return onlinePollManageMapper.selectOnlinePollManageCnt(searchVO);
     }
 
     /**
@@ -63,7 +67,7 @@ public class OnlinePollManageDao extends EgovComAbstractDAO {
      * @throws Exception
      */
     public void insertOnlinePollManage(OnlinePollManage onlinePollManage) throws Exception {
-        insert("OnlinePollManage.insertOnlinePollManage", onlinePollManage);
+        onlinePollManageMapper.insertOnlinePollManage(onlinePollManage);
     }
 
     /**
@@ -72,7 +76,7 @@ public class OnlinePollManageDao extends EgovComAbstractDAO {
      * @throws Exception
      */
     public void updateOnlinePollManage(OnlinePollManage onlinePollManage) throws Exception {
-        update("OnlinePollManage.updateOnlinePollManage", onlinePollManage);
+        onlinePollManageMapper.updateOnlinePollManage(onlinePollManage);
     }
 
     /**
@@ -82,29 +86,31 @@ public class OnlinePollManageDao extends EgovComAbstractDAO {
      */
     public void deleteOnlinePollManage(OnlinePollManage onlinePollManage) throws Exception {
         //온라인POLL 결과 정보 삭제
-        delete("OnlinePollManage.deleteOnlinePollResultAll", onlinePollManage);
+        onlinePollManageMapper.deleteOnlinePollResultAll(onlinePollManage);
         //온라인POLL 항목 정보 삭제
-        delete("OnlinePollManage.deleteOnlinePollItemAll", onlinePollManage);
+        onlinePollManageMapper.deleteOnlinePollItemAll(onlinePollManage);
         //온라인POLL 관리 정보 삭제
-        delete("OnlinePollManage.deleteOnlinePollManage", onlinePollManage);
+        onlinePollManageMapper.deleteOnlinePollManage(onlinePollManage);
     }
 
     /**
      * 온라인POLL관리를(을) 통계를 조회 한다.
      * @param onlinePollManage 온라인POLL관리 정보가 담김 VO
+     * @return List
      * @throws Exception
      */
     public List<OnlinePollManage> selectOnlinePollManageStatistics(OnlinePollManage onlinePollManage) throws Exception {
-        return selectList("OnlinePollManage.selectOnlinePollManageDetail", onlinePollManage);
+        return onlinePollManageMapper.selectOnlinePollManageStatistics(onlinePollManage);
     }
 
     /**
      * 온라인POLL항목를(을) 조회한다.
      * @param onlinePollItem  온라인POLL항목 정보가 담김 VO
+     * @return List
      * @throws Exception
      */
     public List<EgovMap> selectOnlinePollItemList(OnlinePollItem onlinePollItem) throws Exception {
-        return selectList("OnlinePollManage.selectOnlinePollItem", onlinePollItem);
+        return onlinePollManageMapper.selectOnlinePollItem(onlinePollItem);
     }
 
     /**
@@ -113,7 +119,7 @@ public class OnlinePollManageDao extends EgovComAbstractDAO {
      * @throws Exception
      */
     public void insertOnlinePollItem(OnlinePollItem onlinePollItem) throws Exception {
-        insert("OnlinePollManage.insertOnlinePollItem", onlinePollItem);
+        onlinePollManageMapper.insertOnlinePollItem(onlinePollItem);
     }
 
     /**
@@ -122,7 +128,7 @@ public class OnlinePollManageDao extends EgovComAbstractDAO {
      * @throws Exception
      */
     public void updateOnlinePollItem(OnlinePollItem onlinePollItem) throws Exception {
-        update("OnlinePollManage.updateOnlinePollIteme", onlinePollItem);
+        onlinePollManageMapper.updateOnlinePollIteme(onlinePollItem);
     }
 
     /**
@@ -132,8 +138,8 @@ public class OnlinePollManageDao extends EgovComAbstractDAO {
      */
     public void deleteOnlinePollItem(OnlinePollItem onlinePollItem) throws Exception {
         //온라인POLL 결과 삭제
-        delete("OnlinePollManage.deleteOnlinePollResultIemid", onlinePollItem);
+        onlinePollManageMapper.deleteOnlinePollResultIemid(onlinePollItem);
         //온라인POLL 항목 삭제
-        delete("OnlinePollManage.deleteOnlinePollItem", onlinePollItem);
+        onlinePollManageMapper.deleteOnlinePollItem(onlinePollItem);
     }
 }

--- a/src/main/java/egovframework/com/uss/olp/opm/service/impl/OnlinePollManageMapper.java
+++ b/src/main/java/egovframework/com/uss/olp/opm/service/impl/OnlinePollManageMapper.java
@@ -1,0 +1,116 @@
+package egovframework.com.uss.olp.opm.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+import org.egovframe.rte.psl.dataaccess.util.EgovMap;
+
+import egovframework.com.cmm.ComDefaultVO;
+import egovframework.com.uss.olp.opm.service.OnlinePollItem;
+import egovframework.com.uss.olp.opm.service.OnlinePollManage;
+
+/**
+ * 온라인POLL관리를 위한 Mapper 인터페이스
+ *
+ * <pre>
+ *  == 개정이력(Modification Information) ==
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2026.05.28  dasomel     @EgovMapper 인터페이스 방식으로 전환
+ *
+ * </pre>
+ */
+@EgovMapper
+public interface OnlinePollManageMapper {
+
+	/**
+	 * 온라인POLL관리 목록을 조회한다.
+	 * @param searchVO - 조회 조건 VO
+	 * @return List
+	 */
+	List<EgovMap> selectOnlinePollManage(ComDefaultVO searchVO);
+
+	/**
+	 * 온라인POLL관리 상세 정보를 조회한다.
+	 * @param onlinePollManage - 온라인POLL관리 VO
+	 * @return OnlinePollManage
+	 */
+	OnlinePollManage selectOnlinePollManageDetail(OnlinePollManage onlinePollManage);
+
+	/**
+	 * 온라인POLL관리 목록 총 건수를 조회한다.
+	 * @param searchVO - 조회 조건 VO
+	 * @return int
+	 */
+	int selectOnlinePollManageCnt(ComDefaultVO searchVO);
+
+	/**
+	 * 온라인POLL관리를 등록한다.
+	 * @param onlinePollManage - 온라인POLL관리 VO
+	 */
+	void insertOnlinePollManage(OnlinePollManage onlinePollManage);
+
+	/**
+	 * 온라인POLL관리를 수정한다.
+	 * @param onlinePollManage - 온라인POLL관리 VO
+	 */
+	void updateOnlinePollManage(OnlinePollManage onlinePollManage);
+
+	/**
+	 * 온라인POLL관리 통계를 조회한다.
+	 * @param onlinePollManage - 온라인POLL관리 VO
+	 * @return List
+	 */
+	List<OnlinePollManage> selectOnlinePollManageStatistics(OnlinePollManage onlinePollManage);
+
+	/**
+	 * 온라인POLL결과를 전체 삭제한다(POLL ID 기준).
+	 * @param onlinePollManage - 온라인POLL관리 VO
+	 */
+	void deleteOnlinePollResultAll(OnlinePollManage onlinePollManage);
+
+	/**
+	 * 온라인POLL항목을 전체 삭제한다(POLL ID 기준).
+	 * @param onlinePollManage - 온라인POLL관리 VO
+	 */
+	void deleteOnlinePollItemAll(OnlinePollManage onlinePollManage);
+
+	/**
+	 * 온라인POLL관리를 삭제한다.
+	 * @param onlinePollManage - 온라인POLL관리 VO
+	 */
+	void deleteOnlinePollManage(OnlinePollManage onlinePollManage);
+
+	/**
+	 * 온라인POLL항목 목록을 조회한다.
+	 * @param onlinePollItem - 온라인POLL항목 VO
+	 * @return List
+	 */
+	List<EgovMap> selectOnlinePollItem(OnlinePollItem onlinePollItem);
+
+	/**
+	 * 온라인POLL항목을 등록한다.
+	 * @param onlinePollItem - 온라인POLL항목 VO
+	 */
+	void insertOnlinePollItem(OnlinePollItem onlinePollItem);
+
+	/**
+	 * 온라인POLL항목을 수정한다.
+	 * @param onlinePollItem - 온라인POLL항목 VO
+	 */
+	void updateOnlinePollIteme(OnlinePollItem onlinePollItem);
+
+	/**
+	 * 온라인POLL결과를 삭제한다(항목 ID 기준).
+	 * @param onlinePollItem - 온라인POLL항목 VO
+	 */
+	void deleteOnlinePollResultIemid(OnlinePollItem onlinePollItem);
+
+	/**
+	 * 온라인POLL항목을 삭제한다.
+	 * @param onlinePollItem - 온라인POLL항목 VO
+	 */
+	void deleteOnlinePollItem(OnlinePollItem onlinePollItem);
+
+}

--- a/src/main/java/egovframework/com/uss/olp/opp/service/impl/OnlinePollPartcptnDao.java
+++ b/src/main/java/egovframework/com/uss/olp/opp/service/impl/OnlinePollPartcptnDao.java
@@ -6,8 +6,8 @@ import org.egovframe.rte.psl.dataaccess.util.EgovMap;
 import org.springframework.stereotype.Repository;
 
 import egovframework.com.cmm.ComDefaultVO;
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.uss.olp.opp.service.OnlinePollPartcptn;
+import jakarta.annotation.Resource;
 
 /**
  * 온라인POLL참여를 처리하는 Dao Class 구현
@@ -21,11 +21,15 @@ import egovframework.com.uss.olp.opp.service.OnlinePollPartcptn;
  *  -------    --------    ---------------------------
  *   2009.07.03  장동한          최초 생성
  *   2011.10.27  서준식          온라인 POLL 중복 투표 방지 기능 추가
+ *   2026.05.28  dasomel         @EgovMapper 인터페이스 방식으로 전환
  *
  * </pre>
  */
 @Repository("onlinePollPartcptnDao")
-public class OnlinePollPartcptnDao extends EgovComAbstractDAO {
+public class OnlinePollPartcptnDao {
+
+    @Resource(name = "onlinePollPartcptnMapper")
+    private OnlinePollPartcptnMapper onlinePollPartcptnMapper;
 
     /**
      * 온라인POLL관리를(을) 목록을 한다.
@@ -34,7 +38,7 @@ public class OnlinePollPartcptnDao extends EgovComAbstractDAO {
      * @throws Exception
      */
     public List<EgovMap> selectOnlinePollManageList(ComDefaultVO searchVO) throws Exception {
-        return selectList("OnlinePollPartcptn.selectOnlinePollManageList", searchVO);
+        return onlinePollPartcptnMapper.selectOnlinePollManageList(searchVO);
     }
 
     /**
@@ -44,7 +48,7 @@ public class OnlinePollPartcptnDao extends EgovComAbstractDAO {
      * @throws Exception
      */
     public int selectOnlinePollManageListCnt(ComDefaultVO searchVO) throws Exception {
-        return (Integer)selectOne("OnlinePollPartcptn.selectOnlinePollManageListCnt", searchVO);
+        return onlinePollPartcptnMapper.selectOnlinePollManageListCnt(searchVO);
     }
 
     /**
@@ -54,7 +58,7 @@ public class OnlinePollPartcptnDao extends EgovComAbstractDAO {
      * @throws Exception
      */
     public List<EgovMap> selectOnlinePollManageDetail(OnlinePollPartcptn onlinePollPartcptn) throws Exception {
-        return selectList("OnlinePollPartcptn.selectOnlinePollManageDetail", onlinePollPartcptn);
+        return onlinePollPartcptnMapper.selectOnlinePollManageDetail(onlinePollPartcptn);
     }
 
     /**
@@ -64,26 +68,26 @@ public class OnlinePollPartcptnDao extends EgovComAbstractDAO {
      * @throws Exception
      */
     public List<EgovMap> selectOnlinePollItemDetail(OnlinePollPartcptn onlinePollPartcptn) throws Exception {
-        return selectList("OnlinePollPartcptn.selectOnlinePollItem", onlinePollPartcptn);
+        return onlinePollPartcptnMapper.selectOnlinePollItem(onlinePollPartcptn);
     }
-
 
     /**
      * 온라인POLL참여를(을) 등록한다.
-     * @param qonlinePollPartcptn  온라인POLL 정보가 담김 VO
+     * @param onlinePollPartcptn  온라인POLL 정보가 담김 VO
      * @throws Exception
      */
     public void insertOnlinePollResult(OnlinePollPartcptn onlinePollPartcptn) throws Exception {
-        insert("OnlinePollPartcptn.insertOnlinePollResult", onlinePollPartcptn);
+        onlinePollPartcptnMapper.insertOnlinePollResult(onlinePollPartcptn);
     }
 
     /**
-     * 온라인POLL통계를(을) 등록한다.
-     * @param qonlinePollPartcptn  온라인POLL 정보가 담김 VO
+     * 온라인POLL통계를(을) 조회한다.
+     * @param onlinePollPartcptn  온라인POLL 정보가 담김 VO
+     * @return List
      * @throws Exception
      */
     public List<EgovMap> selectOnlinePollManageStatistics(OnlinePollPartcptn onlinePollPartcptn) throws Exception {
-        return selectList("OnlinePollPartcptn.selectOnlinePollPartcptnStatistics", onlinePollPartcptn);
+        return onlinePollPartcptnMapper.selectOnlinePollPartcptnStatistics(onlinePollPartcptn);
     }
 
     /**
@@ -92,10 +96,8 @@ public class OnlinePollPartcptnDao extends EgovComAbstractDAO {
      * @return int
      * @throws Exception
      */
-    public int selectOnlinePollResult( OnlinePollPartcptn onlinePollPartcptn) throws Exception{
-    	return (Integer)selectOne("OnlinePollPartcptn.selectOnlinePollResult", onlinePollPartcptn);
+    public int selectOnlinePollResult(OnlinePollPartcptn onlinePollPartcptn) throws Exception {
+        return onlinePollPartcptnMapper.selectOnlinePollResult(onlinePollPartcptn);
     }
-
-
 
 }

--- a/src/main/java/egovframework/com/uss/olp/opp/service/impl/OnlinePollPartcptnMapper.java
+++ b/src/main/java/egovframework/com/uss/olp/opp/service/impl/OnlinePollPartcptnMapper.java
@@ -1,0 +1,74 @@
+package egovframework.com.uss.olp.opp.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+import org.egovframe.rte.psl.dataaccess.util.EgovMap;
+
+import egovframework.com.cmm.ComDefaultVO;
+import egovframework.com.uss.olp.opp.service.OnlinePollPartcptn;
+
+/**
+ * 온라인POLL참여를 위한 Mapper 인터페이스
+ *
+ * <pre>
+ *  == 개정이력(Modification Information) ==
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2026.05.28  dasomel     @EgovMapper 인터페이스 방식으로 전환
+ *
+ * </pre>
+ */
+@EgovMapper
+public interface OnlinePollPartcptnMapper {
+
+	/**
+	 * 온라인POLL관리 목록을 조회한다.
+	 * @param searchVO - 조회 조건 VO
+	 * @return List
+	 */
+	List<EgovMap> selectOnlinePollManageList(ComDefaultVO searchVO);
+
+	/**
+	 * 온라인POLL관리 목록 총 건수를 조회한다.
+	 * @param searchVO - 조회 조건 VO
+	 * @return int
+	 */
+	int selectOnlinePollManageListCnt(ComDefaultVO searchVO);
+
+	/**
+	 * 온라인POLL관리 상세 정보를 조회한다.
+	 * @param onlinePollPartcptn - 온라인POLL 참여 VO
+	 * @return List
+	 */
+	List<EgovMap> selectOnlinePollManageDetail(OnlinePollPartcptn onlinePollPartcptn);
+
+	/**
+	 * 온라인POLL항목 상세 정보를 조회한다.
+	 * @param onlinePollPartcptn - 온라인POLL 참여 VO
+	 * @return List
+	 */
+	List<EgovMap> selectOnlinePollItem(OnlinePollPartcptn onlinePollPartcptn);
+
+	/**
+	 * 온라인POLL참여 결과를 등록한다.
+	 * @param onlinePollPartcptn - 온라인POLL 참여 VO
+	 */
+	void insertOnlinePollResult(OnlinePollPartcptn onlinePollPartcptn);
+
+	/**
+	 * 온라인POLL참여 통계를 조회한다.
+	 * @param onlinePollPartcptn - 온라인POLL 참여 VO
+	 * @return List
+	 */
+	List<EgovMap> selectOnlinePollPartcptnStatistics(OnlinePollPartcptn onlinePollPartcptn);
+
+	/**
+	 * 온라인POLL참여 여부를 조회한다.
+	 * @param onlinePollPartcptn - 온라인POLL 참여 VO
+	 * @return int
+	 */
+	int selectOnlinePollResult(OnlinePollPartcptn onlinePollPartcptn);
+
+}

--- a/src/main/java/egovframework/com/uss/olp/opr/service/impl/OnlinePollResultDao.java
+++ b/src/main/java/egovframework/com/uss/olp/opr/service/impl/OnlinePollResultDao.java
@@ -4,8 +4,8 @@ import java.util.List;
 
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.uss.olp.opr.service.OnlinePollResult;
+import jakarta.annotation.Resource;
 
 /**
  * 온라인POLL결과를 처리하는 Dao Class 구현
@@ -18,11 +18,15 @@ import egovframework.com.uss.olp.opr.service.OnlinePollResult;
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.07.03  장동한          최초 생성
+ *   2026.05.28  dasomel         @EgovMapper 인터페이스 방식으로 전환
  *
  * </pre>
  */
 @Repository("onlinePollResultDao")
-public class OnlinePollResultDao extends EgovComAbstractDAO {
+public class OnlinePollResultDao {
+
+    @Resource(name = "onlinePollResultMapper")
+    private OnlinePollResultMapper onlinePollResultMapper;
 
     /**
      * 온라인POLL결과를(을) 목록을 한다.
@@ -31,18 +35,16 @@ public class OnlinePollResultDao extends EgovComAbstractDAO {
      * @throws Exception
      */
     public List<?> selectOnlinePollResultList(OnlinePollResult onlinePollResult) throws Exception {
-        return selectList("OnlinePollResult.selectOnlinePollResult", onlinePollResult);
+        return onlinePollResultMapper.selectOnlinePollResult(onlinePollResult);
     }
 
     /**
      * 온라인POLL결과를(을) 삭제 한다.
      * @param onlinePollResult  온라인POLL결과 정보가 담김 VO
-     * @return void
      * @throws Exception
      */
     public void deleteOnlinePollResult(OnlinePollResult onlinePollResult) throws Exception {
-        delete("OnlinePollResult.deleteOnlinePollResult", onlinePollResult);
+        onlinePollResultMapper.deleteOnlinePollResult(onlinePollResult);
     }
-
 
 }

--- a/src/main/java/egovframework/com/uss/olp/opr/service/impl/OnlinePollResultMapper.java
+++ b/src/main/java/egovframework/com/uss/olp/opr/service/impl/OnlinePollResultMapper.java
@@ -1,0 +1,46 @@
+package egovframework.com.uss.olp.opr.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+import org.egovframe.rte.psl.dataaccess.util.EgovMap;
+
+import egovframework.com.uss.olp.opr.service.OnlinePollResult;
+
+
+/**
+ * 온라인POLL결과를 위한 Mapper 인터페이스
+ *
+ * <pre>
+ *  == 개정이력(Modification Information) ==
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2026.05.28  dasomel     @EgovMapper 인터페이스 방식으로 전환
+ *
+ * </pre>
+ */
+@EgovMapper
+public interface OnlinePollResultMapper {
+
+	/**
+	 * 온라인POLL관리 목록을 조회한다.
+	 * @param onlinePollResult - 온라인POLL결과 VO
+	 * @return List
+	 */
+	List<EgovMap> selectOnlinePollManageList(OnlinePollResult onlinePollResult);
+
+	/**
+	 * 온라인POLL결과 목록을 조회한다.
+	 * @param onlinePollResult - 온라인POLL결과 VO
+	 * @return List
+	 */
+	List<EgovMap> selectOnlinePollResult(OnlinePollResult onlinePollResult);
+
+	/**
+	 * 온라인POLL결과를 삭제한다.
+	 * @param onlinePollResult - 온라인POLL결과 VO
+	 */
+	void deleteOnlinePollResult(OnlinePollResult onlinePollResult);
+
+}

--- a/src/main/resources/egovframework/mapper/com/dam/spe/req/EgovDamRequestOffer_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/dam/spe/req/EgovDamRequestOffer_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="RequestOffer">
+<mapper namespace="egovframework.com.dam.spe.req.service.impl.RequestOfferMapper">
 
 	<!-- ::ResultMap 선언 -->
 	<resultMap id="RequestOfferVOs" type="egovframework.com.dam.spe.req.service.RequestOfferVO">

--- a/src/main/resources/egovframework/mapper/com/dam/spe/req/EgovDamRequestOffer_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/dam/spe/req/EgovDamRequestOffer_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="RequestOffer">
+<mapper namespace="egovframework.com.dam.spe.req.service.impl.RequestOfferMapper">
 
 	<!-- ::ResultMap 선언 -->
 	<resultMap id="RequestOfferVOs" type="egovframework.com.dam.spe.req.service.RequestOfferVO">

--- a/src/main/resources/egovframework/mapper/com/dam/spe/req/EgovDamRequestOffer_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/dam/spe/req/EgovDamRequestOffer_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="RequestOffer">
+<mapper namespace="egovframework.com.dam.spe.req.service.impl.RequestOfferMapper">
 
 	<!-- ::ResultMap 선언 -->
 	<resultMap id="RequestOfferVOs" type="egovframework.com.dam.spe.req.service.RequestOfferVO">

--- a/src/main/resources/egovframework/mapper/com/dam/spe/req/EgovDamRequestOffer_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/dam/spe/req/EgovDamRequestOffer_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="RequestOffer">
+<mapper namespace="egovframework.com.dam.spe.req.service.impl.RequestOfferMapper">
 
 	<!-- ::ResultMap 선언 -->
 	<resultMap id="RequestOfferVOs" type="egovframework.com.dam.spe.req.service.RequestOfferVO">

--- a/src/main/resources/egovframework/mapper/com/dam/spe/req/EgovDamRequestOffer_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/dam/spe/req/EgovDamRequestOffer_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="RequestOffer">
+<mapper namespace="egovframework.com.dam.spe.req.service.impl.RequestOfferMapper">
 
 	<!-- ::ResultMap 선언 -->
 	<resultMap id="RequestOfferVOs" type="egovframework.com.dam.spe.req.service.RequestOfferVO">

--- a/src/main/resources/egovframework/mapper/com/dam/spe/req/EgovDamRequestOffer_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/dam/spe/req/EgovDamRequestOffer_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="RequestOffer">
+<mapper namespace="egovframework.com.dam.spe.req.service.impl.RequestOfferMapper">
 
 	<!-- ::ResultMap 선언 -->
 	<resultMap id="RequestOfferVOs" type="egovframework.com.dam.spe.req.service.RequestOfferVO">

--- a/src/main/resources/egovframework/mapper/com/dam/spe/req/EgovDamRequestOffer_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/dam/spe/req/EgovDamRequestOffer_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="RequestOffer">
+<mapper namespace="egovframework.com.dam.spe.req.service.impl.RequestOfferMapper">
 
 	<!-- ::ResultMap 선언 -->
 	<resultMap id="RequestOfferVOs" type="egovframework.com.dam.spe.req.service.RequestOfferVO">

--- a/src/main/resources/egovframework/mapper/com/dam/spe/req/EgovDamRequestOffer_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/dam/spe/req/EgovDamRequestOffer_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="RequestOffer">
+<mapper namespace="egovframework.com.dam.spe.req.service.impl.RequestOfferMapper">
 
 	<!-- ::ResultMap 선언 -->
 	<resultMap id="RequestOfferVOs" type="egovframework.com.dam.spe.req.service.RequestOfferVO">

--- a/src/main/resources/egovframework/mapper/com/uss/olp/mgt/EgovMeetingManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/mgt/EgovMeetingManage_SQL_altibase.xml
@@ -5,7 +5,7 @@
 --><!--Converted at: Wed May 11 15:51:34 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="MeetingManage">
+<mapper namespace="egovframework.com.uss.olp.mgt.service.impl.MeetingManageMapper">
 
 	<resultMap id="MeetingManageListMap" type="java.util.HashMap">
 		<result property="mtgId" column="MTG_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/olp/mgt/EgovMeetingManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/mgt/EgovMeetingManage_SQL_cubrid.xml
@@ -5,7 +5,7 @@
 --><!--Converted at: Wed May 11 15:51:35 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="MeetingManage">
+<mapper namespace="egovframework.com.uss.olp.mgt.service.impl.MeetingManageMapper">
 
 	<resultMap id="MeetingManageListMap" type="java.util.HashMap">
 		<result property="mtgId" column="MTG_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/olp/mgt/EgovMeetingManage_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/mgt/EgovMeetingManage_SQL_goldilocks.xml
@@ -5,7 +5,7 @@
 --><!--Converted at: Wed May 11 15:51:34 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="MeetingManage">
+<mapper namespace="egovframework.com.uss.olp.mgt.service.impl.MeetingManageMapper">
 
 	<resultMap id="MeetingManageListMap" type="java.util.HashMap">
 		<result property="mtgId" column="MTG_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/olp/mgt/EgovMeetingManage_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/mgt/EgovMeetingManage_SQL_maria.xml
@@ -5,7 +5,7 @@
 --><!--Converted at: Wed May 11 15:51:35 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="MeetingManage">
+<mapper namespace="egovframework.com.uss.olp.mgt.service.impl.MeetingManageMapper">
 
 	<resultMap id="MeetingManageListMap" type="java.util.HashMap">
 		<result property="mtgId" column="MTG_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/olp/mgt/EgovMeetingManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/mgt/EgovMeetingManage_SQL_mysql.xml
@@ -5,7 +5,7 @@
 --><!--Converted at: Wed May 11 15:51:35 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="MeetingManage">
+<mapper namespace="egovframework.com.uss.olp.mgt.service.impl.MeetingManageMapper">
 
 	<resultMap id="MeetingManageListMap" type="java.util.HashMap">
 		<result property="mtgId" column="MTG_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/olp/mgt/EgovMeetingManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/mgt/EgovMeetingManage_SQL_oracle.xml
@@ -5,7 +5,7 @@
 --><!--Converted at: Wed May 11 15:51:35 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="MeetingManage">
+<mapper namespace="egovframework.com.uss.olp.mgt.service.impl.MeetingManageMapper">
 
 	<resultMap id="MeetingManageListMap" type="java.util.HashMap">
 		<result property="mtgId" column="MTG_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/olp/mgt/EgovMeetingManage_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/mgt/EgovMeetingManage_SQL_postgres.xml
@@ -6,7 +6,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="MeetingManage">
+<mapper namespace="egovframework.com.uss.olp.mgt.service.impl.MeetingManageMapper">
 
 	<resultMap id="MeetingManageListMap" type="java.util.HashMap">
 		<result property="mtgId" column="MTG_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/olp/mgt/EgovMeetingManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/mgt/EgovMeetingManage_SQL_tibero.xml
@@ -5,7 +5,7 @@
 --><!--Converted at: Wed May 11 15:51:35 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="MeetingManage">
+<mapper namespace="egovframework.com.uss.olp.mgt.service.impl.MeetingManageMapper">
 
 	<resultMap id="MeetingManageListMap" type="java.util.HashMap">
 		<result property="mtgId" column="MTG_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/olp/opm/EgovOnlinePollManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/opm/EgovOnlinePollManage_SQL_altibase.xml
@@ -5,7 +5,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="OnlinePollManage">
+<mapper namespace="egovframework.com.uss.olp.opm.service.impl.OnlinePollManageMapper">
 
 	<!-- 온라인POLL관리::ResultMap 선언 -->
 	<resultMap id="OnlinePollManageVO" type="egovframework.com.uss.olp.opm.service.OnlinePollManage">
@@ -237,4 +237,13 @@
 			WHERE POLL_IEM_ID=#{pollIemId}
 		
 	</delete>
+	<!-- 온라인POLL관리::통계조회 (상세보기 SQL 재사용) -->
+	<select id="selectOnlinePollManageStatistics" resultMap="OnlinePollManageVO">
+	SELECT 
+		A.POLL_ID, A.POLL_NM, A.POLL_BGNDE, A.POLL_ENDDE, A.POLL_KND,
+		A.POLL_DSUSE_ENNC, A.POLL_ATMC_DSUSE_ENNC, A.FRST_REGISTER_ID,
+		A.FRST_REGIST_PNTTM, A.LAST_UPDT_PNTTM, A.LAST_UPDUSR_ID
+	FROM COMTNONLINEPOLLMANAGE A
+	WHERE A.POLL_ID = #{pollId}
+	</select>
 </mapper>

--- a/src/main/resources/egovframework/mapper/com/uss/olp/opm/EgovOnlinePollManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/opm/EgovOnlinePollManage_SQL_cubrid.xml
@@ -5,7 +5,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="OnlinePollManage">
+<mapper namespace="egovframework.com.uss.olp.opm.service.impl.OnlinePollManageMapper">
 
 	<!-- 온라인POLL관리::ResultMap 선언 -->
 	<resultMap id="OnlinePollManageVO" type="egovframework.com.uss.olp.opm.service.OnlinePollManage">
@@ -237,4 +237,13 @@
 			WHERE POLL_IEM_ID=#{pollIemId}
 		
 	</delete>
+	<!-- 온라인POLL관리::통계조회 (상세보기 SQL 재사용) -->
+	<select id="selectOnlinePollManageStatistics" resultMap="OnlinePollManageVO">
+	SELECT 
+		A.POLL_ID, A.POLL_NM, A.POLL_BGNDE, A.POLL_ENDDE, A.POLL_KND,
+		A.POLL_DSUSE_ENNC, A.POLL_ATMC_DSUSE_ENNC, A.FRST_REGISTER_ID,
+		A.FRST_REGIST_PNTTM, A.LAST_UPDT_PNTTM, A.LAST_UPDUSR_ID
+	FROM COMTNONLINEPOLLMANAGE A
+	WHERE A.POLL_ID = #{pollId}
+	</select>
 </mapper>

--- a/src/main/resources/egovframework/mapper/com/uss/olp/opm/EgovOnlinePollManage_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/opm/EgovOnlinePollManage_SQL_goldilocks.xml
@@ -5,7 +5,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="OnlinePollManage">
+<mapper namespace="egovframework.com.uss.olp.opm.service.impl.OnlinePollManageMapper">
 
 	<!-- 온라인POLL관리::ResultMap 선언 -->
 	<resultMap id="OnlinePollManageVO" type="egovframework.com.uss.olp.opm.service.OnlinePollManage">
@@ -237,4 +237,13 @@
 			WHERE POLL_IEM_ID=#{pollIemId}
 		
 	</delete>
+	<!-- 온라인POLL관리::통계조회 (상세보기 SQL 재사용) -->
+	<select id="selectOnlinePollManageStatistics" resultMap="OnlinePollManageVO">
+	SELECT 
+		A.POLL_ID, A.POLL_NM, A.POLL_BGNDE, A.POLL_ENDDE, A.POLL_KND,
+		A.POLL_DSUSE_ENNC, A.POLL_ATMC_DSUSE_ENNC, A.FRST_REGISTER_ID,
+		A.FRST_REGIST_PNTTM, A.LAST_UPDT_PNTTM, A.LAST_UPDUSR_ID
+	FROM COMTNONLINEPOLLMANAGE A
+	WHERE A.POLL_ID = #{pollId}
+	</select>
 </mapper>

--- a/src/main/resources/egovframework/mapper/com/uss/olp/opm/EgovOnlinePollManage_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/opm/EgovOnlinePollManage_SQL_maria.xml
@@ -5,7 +5,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="OnlinePollManage">
+<mapper namespace="egovframework.com.uss.olp.opm.service.impl.OnlinePollManageMapper">
 
 	<!-- 온라인POLL관리::ResultMap 선언 -->
 	<resultMap id="OnlinePollManageVO" type="egovframework.com.uss.olp.opm.service.OnlinePollManage">
@@ -225,4 +225,13 @@ WHERE POLL_ID=#{pollId}
 			WHERE POLL_IEM_ID=#{pollIemId}
 		
 	</delete>
+	<!-- 온라인POLL관리::통계조회 (상세보기 SQL 재사용) -->
+	<select id="selectOnlinePollManageStatistics" resultMap="OnlinePollManageVO">
+	SELECT 
+		A.POLL_ID, A.POLL_NM, A.POLL_BGNDE, A.POLL_ENDDE, A.POLL_KND,
+		A.POLL_DSUSE_ENNC, A.POLL_ATMC_DSUSE_ENNC, A.FRST_REGISTER_ID,
+		A.FRST_REGIST_PNTTM, A.LAST_UPDT_PNTTM, A.LAST_UPDUSR_ID
+	FROM COMTNONLINEPOLLMANAGE A
+	WHERE A.POLL_ID = #{pollId}
+	</select>
 </mapper>

--- a/src/main/resources/egovframework/mapper/com/uss/olp/opm/EgovOnlinePollManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/opm/EgovOnlinePollManage_SQL_mysql.xml
@@ -5,7 +5,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="OnlinePollManage">
+<mapper namespace="egovframework.com.uss.olp.opm.service.impl.OnlinePollManageMapper">
 
 	<!-- 온라인POLL관리::ResultMap 선언 -->
 	<resultMap id="OnlinePollManageVO" type="egovframework.com.uss.olp.opm.service.OnlinePollManage">
@@ -225,4 +225,13 @@ WHERE POLL_ID=#{pollId}
 			WHERE POLL_IEM_ID=#{pollIemId}
 		
 	</delete>
+	<!-- 온라인POLL관리::통계조회 (상세보기 SQL 재사용) -->
+	<select id="selectOnlinePollManageStatistics" resultMap="OnlinePollManageVO">
+	SELECT 
+		A.POLL_ID, A.POLL_NM, A.POLL_BGNDE, A.POLL_ENDDE, A.POLL_KND,
+		A.POLL_DSUSE_ENNC, A.POLL_ATMC_DSUSE_ENNC, A.FRST_REGISTER_ID,
+		A.FRST_REGIST_PNTTM, A.LAST_UPDT_PNTTM, A.LAST_UPDUSR_ID
+	FROM COMTNONLINEPOLLMANAGE A
+	WHERE A.POLL_ID = #{pollId}
+	</select>
 </mapper>

--- a/src/main/resources/egovframework/mapper/com/uss/olp/opm/EgovOnlinePollManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/opm/EgovOnlinePollManage_SQL_oracle.xml
@@ -5,7 +5,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="OnlinePollManage">
+<mapper namespace="egovframework.com.uss.olp.opm.service.impl.OnlinePollManageMapper">
 
 	<!-- 온라인POLL관리::ResultMap 선언 -->
 	<resultMap id="OnlinePollManageVO" type="egovframework.com.uss.olp.opm.service.OnlinePollManage">
@@ -237,4 +237,13 @@
 			WHERE POLL_IEM_ID=#{pollIemId}
 		
 	</delete>
+	<!-- 온라인POLL관리::통계조회 (상세보기 SQL 재사용) -->
+	<select id="selectOnlinePollManageStatistics" resultMap="OnlinePollManageVO">
+	SELECT 
+		A.POLL_ID, A.POLL_NM, A.POLL_BGNDE, A.POLL_ENDDE, A.POLL_KND,
+		A.POLL_DSUSE_ENNC, A.POLL_ATMC_DSUSE_ENNC, A.FRST_REGISTER_ID,
+		A.FRST_REGIST_PNTTM, A.LAST_UPDT_PNTTM, A.LAST_UPDUSR_ID
+	FROM COMTNONLINEPOLLMANAGE A
+	WHERE A.POLL_ID = #{pollId}
+	</select>
 </mapper>

--- a/src/main/resources/egovframework/mapper/com/uss/olp/opm/EgovOnlinePollManage_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/opm/EgovOnlinePollManage_SQL_postgres.xml
@@ -5,7 +5,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="OnlinePollManage">
+<mapper namespace="egovframework.com.uss.olp.opm.service.impl.OnlinePollManageMapper">
 
 	<!-- 온라인POLL관리::ResultMap 선언 -->
 	<resultMap id="OnlinePollManageVO" type="egovframework.com.uss.olp.opm.service.OnlinePollManage">
@@ -225,4 +225,13 @@ WHERE POLL_ID=#{pollId}
 			WHERE POLL_IEM_ID=#{pollIemId}
 		
 	</delete>
+	<!-- 온라인POLL관리::통계조회 (상세보기 SQL 재사용) -->
+	<select id="selectOnlinePollManageStatistics" resultMap="OnlinePollManageVO">
+	SELECT 
+		A.POLL_ID, A.POLL_NM, A.POLL_BGNDE, A.POLL_ENDDE, A.POLL_KND,
+		A.POLL_DSUSE_ENNC, A.POLL_ATMC_DSUSE_ENNC, A.FRST_REGISTER_ID,
+		A.FRST_REGIST_PNTTM, A.LAST_UPDT_PNTTM, A.LAST_UPDUSR_ID
+	FROM COMTNONLINEPOLLMANAGE A
+	WHERE A.POLL_ID = #{pollId}
+	</select>
 </mapper>

--- a/src/main/resources/egovframework/mapper/com/uss/olp/opm/EgovOnlinePollManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/opm/EgovOnlinePollManage_SQL_tibero.xml
@@ -5,7 +5,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="OnlinePollManage">
+<mapper namespace="egovframework.com.uss.olp.opm.service.impl.OnlinePollManageMapper">
 
 	<!-- 온라인POLL관리::ResultMap 선언 -->
 	<resultMap id="OnlinePollManageVO" type="egovframework.com.uss.olp.opm.service.OnlinePollManage">
@@ -237,4 +237,13 @@
 			WHERE POLL_IEM_ID=#{pollIemId}
 		
 	</delete>
+	<!-- 온라인POLL관리::통계조회 (상세보기 SQL 재사용) -->
+	<select id="selectOnlinePollManageStatistics" resultMap="OnlinePollManageVO">
+	SELECT 
+		A.POLL_ID, A.POLL_NM, A.POLL_BGNDE, A.POLL_ENDDE, A.POLL_KND,
+		A.POLL_DSUSE_ENNC, A.POLL_ATMC_DSUSE_ENNC, A.FRST_REGISTER_ID,
+		A.FRST_REGIST_PNTTM, A.LAST_UPDT_PNTTM, A.LAST_UPDUSR_ID
+	FROM COMTNONLINEPOLLMANAGE A
+	WHERE A.POLL_ID = #{pollId}
+	</select>
 </mapper>

--- a/src/main/resources/egovframework/mapper/com/uss/olp/opp/EgovOnlinePollPartcptn_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/opp/EgovOnlinePollPartcptn_SQL_altibase.xml
@@ -8,7 +8,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="OnlinePollPartcptn">
+<mapper namespace="egovframework.com.uss.olp.opp.service.impl.OnlinePollPartcptnMapper">
 
 	<!-- 온라인POLL참여::ResultMap 선언 -->
 	<resultMap id="OnlinePollManageVO" type="egovframework.com.uss.olp.opm.service.OnlinePollManage">

--- a/src/main/resources/egovframework/mapper/com/uss/olp/opp/EgovOnlinePollPartcptn_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/opp/EgovOnlinePollPartcptn_SQL_cubrid.xml
@@ -8,7 +8,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="OnlinePollPartcptn">
+<mapper namespace="egovframework.com.uss.olp.opp.service.impl.OnlinePollPartcptnMapper">
 
 	<!-- 온라인POLL참여::ResultMap 선언 -->
 	<resultMap id="OnlinePollManageVO" type="egovframework.com.uss.olp.opm.service.OnlinePollManage">

--- a/src/main/resources/egovframework/mapper/com/uss/olp/opp/EgovOnlinePollPartcptn_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/opp/EgovOnlinePollPartcptn_SQL_goldilocks.xml
@@ -8,7 +8,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="OnlinePollPartcptn">
+<mapper namespace="egovframework.com.uss.olp.opp.service.impl.OnlinePollPartcptnMapper">
 
 	<!-- 온라인POLL참여::ResultMap 선언 -->
 	<resultMap id="OnlinePollManageVO" type="egovframework.com.uss.olp.opm.service.OnlinePollManage">

--- a/src/main/resources/egovframework/mapper/com/uss/olp/opp/EgovOnlinePollPartcptn_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/opp/EgovOnlinePollPartcptn_SQL_maria.xml
@@ -8,7 +8,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="OnlinePollPartcptn">
+<mapper namespace="egovframework.com.uss.olp.opp.service.impl.OnlinePollPartcptnMapper">
 
 	<!-- 온라인POLL참여::ResultMap 선언 -->
 	<resultMap id="OnlinePollManageVO" type="egovframework.com.uss.olp.opm.service.OnlinePollManage">

--- a/src/main/resources/egovframework/mapper/com/uss/olp/opp/EgovOnlinePollPartcptn_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/opp/EgovOnlinePollPartcptn_SQL_mysql.xml
@@ -8,7 +8,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="OnlinePollPartcptn">
+<mapper namespace="egovframework.com.uss.olp.opp.service.impl.OnlinePollPartcptnMapper">
 
 	<!-- 온라인POLL참여::ResultMap 선언 -->
 	<resultMap id="OnlinePollManageVO" type="egovframework.com.uss.olp.opm.service.OnlinePollManage">

--- a/src/main/resources/egovframework/mapper/com/uss/olp/opp/EgovOnlinePollPartcptn_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/opp/EgovOnlinePollPartcptn_SQL_oracle.xml
@@ -8,7 +8,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="OnlinePollPartcptn">
+<mapper namespace="egovframework.com.uss.olp.opp.service.impl.OnlinePollPartcptnMapper">
 
 	<!-- 온라인POLL참여::ResultMap 선언 -->
 	<resultMap id="OnlinePollManageVO" type="egovframework.com.uss.olp.opm.service.OnlinePollManage">

--- a/src/main/resources/egovframework/mapper/com/uss/olp/opp/EgovOnlinePollPartcptn_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/opp/EgovOnlinePollPartcptn_SQL_postgres.xml
@@ -8,7 +8,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="OnlinePollPartcptn">
+<mapper namespace="egovframework.com.uss.olp.opp.service.impl.OnlinePollPartcptnMapper">
 
 	<!-- 온라인POLL참여::ResultMap 선언 -->
 	<resultMap id="OnlinePollManageVO" type="egovframework.com.uss.olp.opm.service.OnlinePollManage">

--- a/src/main/resources/egovframework/mapper/com/uss/olp/opp/EgovOnlinePollPartcptn_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/opp/EgovOnlinePollPartcptn_SQL_tibero.xml
@@ -8,7 +8,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="OnlinePollPartcptn">
+<mapper namespace="egovframework.com.uss.olp.opp.service.impl.OnlinePollPartcptnMapper">
 
 	<!-- 온라인POLL참여::ResultMap 선언 -->
 	<resultMap id="OnlinePollManageVO" type="egovframework.com.uss.olp.opm.service.OnlinePollManage">

--- a/src/main/resources/egovframework/mapper/com/uss/olp/opr/EgovOnlinePollResult_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/opr/EgovOnlinePollResult_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="OnlinePollResult">
+<mapper namespace="egovframework.com.uss.olp.opr.service.impl.OnlinePollResultMapper">
 	
 	<!-- 온라인POLL관리::목록조회 게시물정보 -->
 	<select id="selectOnlinePollManageList" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/com/uss/olp/opr/EgovOnlinePollResult_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/opr/EgovOnlinePollResult_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="OnlinePollResult">
+<mapper namespace="egovframework.com.uss.olp.opr.service.impl.OnlinePollResultMapper">
 
 	<!-- 온라인POLL관리::목록조회 게시물정보 -->
 	<select id="selectOnlinePollManageList" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/com/uss/olp/opr/EgovOnlinePollResult_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/opr/EgovOnlinePollResult_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="OnlinePollResult">
+<mapper namespace="egovframework.com.uss.olp.opr.service.impl.OnlinePollResultMapper">
 	
 	<!-- 온라인POLL관리::목록조회 게시물정보 -->
 	<select id="selectOnlinePollManageList" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/com/uss/olp/opr/EgovOnlinePollResult_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/opr/EgovOnlinePollResult_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="OnlinePollResult">
+<mapper namespace="egovframework.com.uss.olp.opr.service.impl.OnlinePollResultMapper">
 	
 	<!-- 온라인POLL관리::목록조회 게시물정보 -->
 	<select id="selectOnlinePollManageList" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/com/uss/olp/opr/EgovOnlinePollResult_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/opr/EgovOnlinePollResult_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="OnlinePollResult">
+<mapper namespace="egovframework.com.uss.olp.opr.service.impl.OnlinePollResultMapper">
 	
 	<!-- 온라인POLL관리::목록조회 게시물정보 -->
 	<select id="selectOnlinePollManageList" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/com/uss/olp/opr/EgovOnlinePollResult_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/opr/EgovOnlinePollResult_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="OnlinePollResult">
+<mapper namespace="egovframework.com.uss.olp.opr.service.impl.OnlinePollResultMapper">
 	
 	<!-- 온라인POLL관리::목록조회 게시물정보 -->
 	<select id="selectOnlinePollManageList" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/com/uss/olp/opr/EgovOnlinePollResult_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/opr/EgovOnlinePollResult_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="OnlinePollResult">
+<mapper namespace="egovframework.com.uss.olp.opr.service.impl.OnlinePollResultMapper">
 	
 	<!-- 온라인POLL관리::목록조회 게시물정보 -->
 	<select id="selectOnlinePollManageList" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/com/uss/olp/opr/EgovOnlinePollResult_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/opr/EgovOnlinePollResult_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="OnlinePollResult">
+<mapper namespace="egovframework.com.uss.olp.opr.service.impl.OnlinePollResultMapper">
 	
 	<!-- 온라인POLL관리::목록조회 게시물정보 -->
 	<select id="selectOnlinePollManageList" resultType="egovMap">

--- a/src/main/resources/egovframework/spring/com/context-mapper.xml
+++ b/src/main/resources/egovframework/spring/com/context-mapper.xml
@@ -21,5 +21,11 @@
 	<bean id="egov.sqlSessionTemplate" class="org.mybatis.spring.SqlSessionTemplate">
 		<constructor-arg ref="egov.sqlSession"/>
 	</bean>
-	
+
+	<!-- @EgovMapper 어노테이션 기반 MapperScannerConfigurer -->
+	<bean class="org.mybatis.spring.mapper.MapperScannerConfigurer">
+		<property name="basePackage" value="egovframework.com" />
+		<property name="annotationClass" value="org.egovframe.rte.psl.dataaccess.mapper.EgovMapper" />
+	</bean>
+
 </beans>


### PR DESCRIPTION
## 변경 사유
기존 XML namespace 기반 DAO를 eGovFrame 5.0 신규 `@EgovMapper` 인터페이스 방식으로 전환합니다.

## 변경 내용
- 대상: uss/olp(opm·opp·opr·mgt), dam/spe/req 5개 DAO
- 각 DAO에 대응하는 Mapper 인터페이스(`@EgovMapper`) 신규 추가
- DAO를 mapper 위임 구조로 리팩토링 (EgovComAbstractDAO 상속 제거, @Resource 주입, @Repository bean name 유지)
- XML mapper namespace를 mapper 인터페이스 FQN으로 변경
- context-mapper.xml에 MapperScannerConfigurer(annotationClass=EgovMapper) 추가

## 영향 범위
- 해당 모듈만 영향, 서비스 레이어 호출 시그니처 변경 없음

## 참고
- 빌드 검증을 위해 #891(Lombok annotationProcessorPaths 빌드 수정) 선행 머지 권장
- context-mapper.xml MapperScannerConfigurer는 동일 시리즈 PR과 한 줄 중복될 수 있어, 선행 PR 머지 후 rebase로 정리 가능

## 체크리스트
- [x] 단일 주제만 다룸
- [x] 컴파일 검증(해당 모듈 신규 오류 0)
- [x] 기존 동작 호환
