### PR TITLE
[refactor][5.0.x][공통컴포넌트] uss/ion 잔여 8개 DAO @EgovMapper 인터페이스 전환

### DIFF
--- a/src/main/java/egovframework/com/uss/ion/ntm/service/impl/NoteManageDao.java
+++ b/src/main/java/egovframework/com/uss/ion/ntm/service/impl/NoteManageDao.java
@@ -7,8 +7,9 @@ import org.egovframe.rte.psl.dataaccess.util.EgovMap;
 import org.springframework.stereotype.Repository;
 
 import egovframework.com.cmm.ComDefaultVO;
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.uss.ion.ntm.service.NoteManageVO;
+import jakarta.annotation.Resource;
+
 /**
  * 쪽지 관리(보내기)를 처리하는 Dao Class 구현
  * @author 공통콤포넌트 장동한
@@ -21,11 +22,15 @@ import egovframework.com.uss.ion.ntm.service.NoteManageVO;
  *  -------    --------    ---------------------------
  *   2009.07.03  장동한           최초 생성
  *   2017.06.05   최두영          공통컴포넌트 3.7 개발
+ *   2026.05.28  dasomel         @EgovMapper 인터페이스 위임 방식으로 전환
  *
  * </pre>
  */
 @Repository("noteManageDao")
-public class NoteManageDao extends EgovComAbstractDAO {
+public class NoteManageDao {
+
+    @Resource(name = "noteManageMapper")
+    private NoteManageMapper mapper;
 
     /**
      * 쪽지관리 정보를 조회한다.
@@ -33,7 +38,7 @@ public class NoteManageDao extends EgovComAbstractDAO {
      * @throws Exception
      */
     public Map<?, ?> selectNoteManage(NoteManageVO noteManage) throws Exception {
-    	return (Map<?, ?>)selectOne("NoteManage.selectNoteManage", noteManage);
+        return mapper.selectNoteManage(noteManage);
     }
 
     /**
@@ -42,9 +47,8 @@ public class NoteManageDao extends EgovComAbstractDAO {
      * @throws Exception
      */
     public void insertNoteManage(NoteManageVO noteManage) throws Exception {
-    	insert("NoteManage.insertNoteManage", noteManage);
+        mapper.insertNoteManage(noteManage);
     }
-
 
     /**
      * 보낸쪽지를 등록한다.
@@ -52,9 +56,8 @@ public class NoteManageDao extends EgovComAbstractDAO {
      * @throws Exception
      */
     public void insertNoteTrnsmit(NoteManageVO noteManage) throws Exception {
-    	insert("NoteManage.insertNoteTrnsmit", noteManage);
+        mapper.insertNoteTrnsmit(noteManage);
     }
-
 
     /**
      * 받은쪽지를 등록한다.
@@ -62,26 +65,26 @@ public class NoteManageDao extends EgovComAbstractDAO {
      * @throws Exception
      */
     public void insertNoteRecptn(NoteManageVO noteManage) throws Exception {
-    	insert("NoteManage.insertNoteRecptn", noteManage);
+        mapper.insertNoteRecptn(noteManage);
     }
 
     /**
-	 * 수신자/참조자선택팝업 목록을 조회한다.
-	 * @param searchVO -조회할 정보가 담긴 VO
-	 * @return List -회원정보 리스트
-	 * @throws Exception
-	 */
-	public List<EgovMap> selectNoteEmpListPopup(ComDefaultVO searchVO) throws Exception {
-		return selectList("NoteManage.EovNoteEmpListPopup", searchVO);
-	}
+     * 수신자/참조자선택팝업 목록을 조회한다.
+     * @param searchVO -조회할 정보가 담긴 VO
+     * @return List -회원정보 리스트
+     * @throws Exception
+     */
+    public List<EgovMap> selectNoteEmpListPopup(ComDefaultVO searchVO) throws Exception {
+        return mapper.EovNoteEmpListPopup(searchVO);
+    }
 
     /**
-	 * 수신자/참조자선택팝업 건수를 조회한다.
-	 * @param searchVO -조회할 정보가 담긴 VO
-	 * @return int -조회된 데이터 개수
-	 * @throws Exception
-	 */
-	public int selectNoteEmpListPopupCnt(ComDefaultVO searchVO) throws Exception{
-		 return (Integer)selectOne("NoteManage.EovNoteEmpListPopupCnt", searchVO);
-	}
+     * 수신자/참조자선택팝업 건수를 조회한다.
+     * @param searchVO -조회할 정보가 담긴 VO
+     * @return int -조회된 데이터 개수
+     * @throws Exception
+     */
+    public int selectNoteEmpListPopupCnt(ComDefaultVO searchVO) throws Exception {
+        return mapper.EovNoteEmpListPopupCnt(searchVO);
+    }
 }

--- a/src/main/java/egovframework/com/uss/ion/ntm/service/impl/NoteManageMapper.java
+++ b/src/main/java/egovframework/com/uss/ion/ntm/service/impl/NoteManageMapper.java
@@ -1,0 +1,37 @@
+package egovframework.com.uss.ion.ntm.service.impl;
+
+import java.util.List;
+import java.util.Map;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+import org.egovframe.rte.psl.dataaccess.util.EgovMap;
+
+import egovframework.com.cmm.ComDefaultVO;
+import egovframework.com.uss.ion.ntm.service.NoteManageVO;
+
+/**
+ * 쪽지 관리(보내기)에 대한 Mapper 인터페이스
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2026.05.28  dasomel         XML 기반 DAO → @EgovMapper 인터페이스로 전환
+ * </pre>
+ */
+@EgovMapper("noteManageMapper")
+public interface NoteManageMapper {
+
+	Map<?, ?> selectNoteManage(NoteManageVO noteManage);
+
+	void insertNoteManage(NoteManageVO noteManage);
+
+	void insertNoteTrnsmit(NoteManageVO noteManage);
+
+	void insertNoteRecptn(NoteManageVO noteManage);
+
+	List<EgovMap> EovNoteEmpListPopup(ComDefaultVO searchVO);
+
+	int EovNoteEmpListPopupCnt(ComDefaultVO searchVO);
+}

--- a/src/main/java/egovframework/com/uss/ion/ntr/service/impl/NoteRecptnDao.java
+++ b/src/main/java/egovframework/com/uss/ion/ntr/service/impl/NoteRecptnDao.java
@@ -6,8 +6,9 @@ import java.util.Map;
 import org.egovframe.rte.psl.dataaccess.util.EgovMap;
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.uss.ion.ntr.service.NoteRecptn;
+import jakarta.annotation.Resource;
+
 /**
  * 받은쪽지함관리를 처리하는 Dao Class 구현
  * @author 공통콤포넌트 장동한
@@ -20,11 +21,15 @@ import egovframework.com.uss.ion.ntr.service.NoteRecptn;
  *  -------    --------    ---------------------------
  *   2009.07.03  장동한          최초 생성
  *   2017.09.14	 장동한		   표준프레임워크 3.7 개선
+ *   2026.05.28  dasomel         @EgovMapper 인터페이스 위임 방식으로 전환
  *
  * </pre>
  */
 @Repository("noteRecptnDao")
-public class NoteRecptnDao extends EgovComAbstractDAO {
+public class NoteRecptnDao {
+
+    @Resource(name = "noteRecptnMapper")
+    private NoteRecptnMapper mapper;
 
     /**
      * 받은쪽지함관리를(을) 목록을 한다.
@@ -33,7 +38,7 @@ public class NoteRecptnDao extends EgovComAbstractDAO {
      * @throws Exception
      */
     public List<EgovMap> selectNoteRecptnList(NoteRecptn noteRecptn) throws Exception {
-    	return selectList("NoteRecptn.selectNoteRecptn", noteRecptn);
+        return mapper.selectNoteRecptn(noteRecptn);
     }
 
     /**
@@ -43,7 +48,7 @@ public class NoteRecptnDao extends EgovComAbstractDAO {
      * @throws Exception
      */
     public int selectNoteRecptnListCnt(NoteRecptn noteRecptn) throws Exception {
-    	return (Integer)selectOne("NoteRecptn.selectNoteRecptnCnt", noteRecptn);
+        return mapper.selectNoteRecptnCnt(noteRecptn);
     }
 
     /**
@@ -52,7 +57,7 @@ public class NoteRecptnDao extends EgovComAbstractDAO {
      * @throws Exception
      */
     public void updateNoteRecptnRelationOpenYn(NoteRecptn noteRecptn) throws Exception {
-    	update("NoteRecptn.updateNoteRecptnRelationOpenYn" , noteRecptn);
+    	mapper.updateNoteRecptnRelationOpenYn(noteRecptn);
     }
 
     /**
@@ -62,7 +67,7 @@ public class NoteRecptnDao extends EgovComAbstractDAO {
      * @throws Exception
      */
     public Map<?, ?> selectNoteRecptnDetail(NoteRecptn noteRecptn) throws Exception {
-    	return (Map<?, ?>)selectOne("NoteRecptn.selectNoteRecptnDetail", noteRecptn);
+    	return mapper.selectNoteRecptnDetail(noteRecptn);
     }
 
     /**
@@ -71,7 +76,7 @@ public class NoteRecptnDao extends EgovComAbstractDAO {
      * @throws Exception
      */
     public void deleteNoteRecptnRelation(NoteRecptn noteRecptn) throws Exception {
-        delete("NoteRecptn.deleteNoteRecptnRelation" , noteRecptn);
+        mapper.deleteNoteRecptnRelation(noteRecptn);
     }
 
     /**
@@ -80,7 +85,7 @@ public class NoteRecptnDao extends EgovComAbstractDAO {
      * @throws Exception
      */
     public void deleteNoteRecptn(NoteRecptn noteRecptn) throws Exception {
-    	delete("NoteRecptn.deleteNoteRecptn" , noteRecptn);
+    	mapper.deleteNoteRecptn(noteRecptn);
     }
 
     /**
@@ -89,7 +94,7 @@ public class NoteRecptnDao extends EgovComAbstractDAO {
      * @throws Exception
      */
     public void deleteNoteTrnsmit(NoteRecptn noteRecptn) throws Exception {
-        delete("NoteRecptn.deleteNoteTrnsmit" , noteRecptn);
+        mapper.deleteNoteTrnsmit(noteRecptn);
     }
 
     /**
@@ -98,7 +103,7 @@ public class NoteRecptnDao extends EgovComAbstractDAO {
      * @throws Exception
      */
     public void deleteNoteManage(NoteRecptn noteRecptn) throws Exception {
-        delete("NoteRecptn.deleteNoteManage" , noteRecptn);
+        mapper.deleteNoteManage(noteRecptn);
     }
 
     /**
@@ -108,7 +113,7 @@ public class NoteRecptnDao extends EgovComAbstractDAO {
      * @throws Exception
      */
     public int selectNoteTrnsmitRelationCnt(NoteRecptn noteRecptn) throws Exception {
-    	return (Integer)selectOne("NoteRecptn.selectNoteTrnsmitRelationCnt", noteRecptn);
+    	return mapper.selectNoteTrnsmitRelationCnt(noteRecptn);
     }
 
     /**
@@ -118,6 +123,6 @@ public class NoteRecptnDao extends EgovComAbstractDAO {
      * @throws Exception
      */
     public int selectNoteRecptnRelationCnt(NoteRecptn noteRecptn) throws Exception {
-    	return (Integer)selectOne("NoteRecptn.selectNoteRecptnRelationCnt", noteRecptn);
+    	return mapper.selectNoteRecptnRelationCnt(noteRecptn);
     }
 }

--- a/src/main/java/egovframework/com/uss/ion/ntr/service/impl/NoteRecptnMapper.java
+++ b/src/main/java/egovframework/com/uss/ion/ntr/service/impl/NoteRecptnMapper.java
@@ -1,0 +1,44 @@
+package egovframework.com.uss.ion.ntr.service.impl;
+
+import java.util.List;
+import java.util.Map;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+import org.egovframe.rte.psl.dataaccess.util.EgovMap;
+
+import egovframework.com.uss.ion.ntr.service.NoteRecptn;
+
+/**
+ * 받은쪽지함관리에 대한 Mapper 인터페이스
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2026.05.28  dasomel         XML 기반 DAO → @EgovMapper 인터페이스로 전환
+ * </pre>
+ */
+@EgovMapper("noteRecptnMapper")
+public interface NoteRecptnMapper {
+
+	List<EgovMap> selectNoteRecptn(NoteRecptn noteRecptn);
+
+	int selectNoteRecptnCnt(NoteRecptn noteRecptn);
+
+	void updateNoteRecptnRelationOpenYn(NoteRecptn noteRecptn);
+
+	Map<?, ?> selectNoteRecptnDetail(NoteRecptn noteRecptn);
+
+	void deleteNoteRecptnRelation(NoteRecptn noteRecptn);
+
+	void deleteNoteRecptn(NoteRecptn noteRecptn);
+
+	void deleteNoteTrnsmit(NoteRecptn noteRecptn);
+
+	void deleteNoteManage(NoteRecptn noteRecptn);
+
+	int selectNoteTrnsmitRelationCnt(NoteRecptn noteRecptn);
+
+	int selectNoteRecptnRelationCnt(NoteRecptn noteRecptn);
+}

--- a/src/main/java/egovframework/com/uss/ion/rsm/service/impl/RecentSrchwrdDao.java
+++ b/src/main/java/egovframework/com/uss/ion/rsm/service/impl/RecentSrchwrdDao.java
@@ -5,8 +5,8 @@ import java.util.List;
 import org.egovframe.rte.psl.dataaccess.util.EgovMap;
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.uss.ion.rsm.service.RecentSrchwrd;
+import jakarta.annotation.Resource;
 
 /**
  * 최근검색어를 처리하는 Dao Class 구현
@@ -19,11 +19,15 @@ import egovframework.com.uss.ion.rsm.service.RecentSrchwrd;
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.07.03  장동한          최초 생성
+ *   2026.05.28  dasomel         @EgovMapper 인터페이스 위임 방식으로 전환
  *
  * </pre>
  */
 @Repository("onlineRecentSrchwrdDao")
-public class RecentSrchwrdDao extends EgovComAbstractDAO {
+public class RecentSrchwrdDao {
+
+    @Resource(name = "onlineRecentSrchwrdMapper")
+    private RecentSrchwrdMapper mapper;
 
     /**
      * 최근검색어관리를(을) 목록을 한다.
@@ -32,7 +36,7 @@ public class RecentSrchwrdDao extends EgovComAbstractDAO {
      * @throws Exception
      */
     public List<EgovMap> selectRecentSrchwrdList(RecentSrchwrd searchVO) throws Exception {
-        return selectList("RecentSrchwrd.selectRecentSrchwrd", searchVO);
+        return mapper.selectRecentSrchwrd(searchVO);
     }
 
     /**
@@ -42,7 +46,7 @@ public class RecentSrchwrdDao extends EgovComAbstractDAO {
      * @throws Exception
      */
     public int selectRecentSrchwrdListCnt(RecentSrchwrd searchVO) throws Exception {
-        return (Integer)selectOne("RecentSrchwrd.selectRecentSrchwrdCnt", searchVO);
+        return mapper.selectRecentSrchwrdCnt(searchVO);
     }
 
     /**
@@ -52,7 +56,7 @@ public class RecentSrchwrdDao extends EgovComAbstractDAO {
      * @throws Exception
      */
     public RecentSrchwrd selectRecentSrchwrdDetail(RecentSrchwrd recentSrchwrd) throws Exception {
-        return (RecentSrchwrd)selectOne("RecentSrchwrd.selectRecentSrchwrdDetail", recentSrchwrd);
+        return mapper.selectRecentSrchwrdDetail(recentSrchwrd);
     }
 
     /**
@@ -61,7 +65,7 @@ public class RecentSrchwrdDao extends EgovComAbstractDAO {
      * @throws Exception
      */
     public void insertRecentSrchwrd(RecentSrchwrd recentSrchwrd) throws Exception {
-        insert("RecentSrchwrd.insertRecentSrchwrd", recentSrchwrd);
+        mapper.insertRecentSrchwrd(recentSrchwrd);
     }
 
     /**
@@ -70,7 +74,7 @@ public class RecentSrchwrdDao extends EgovComAbstractDAO {
      * @throws Exception
      */
     public void updateRecentSrchwrd(RecentSrchwrd recentSrchwrd) throws Exception {
-        update("RecentSrchwrd.updateRecentSrchwrd", recentSrchwrd);
+        mapper.updateRecentSrchwrd(recentSrchwrd);
     }
 
     /**
@@ -79,7 +83,7 @@ public class RecentSrchwrdDao extends EgovComAbstractDAO {
      * @throws Exception
      */
     public void deleteRecentSrchwrd(RecentSrchwrd recentSrchwrd) throws Exception {
-        delete("RecentSrchwrd.deleteRecentSrchwrd", recentSrchwrd);
+        mapper.deleteRecentSrchwrd(recentSrchwrd);
     }
 
     /**
@@ -89,7 +93,7 @@ public class RecentSrchwrdDao extends EgovComAbstractDAO {
      * @throws Exception
      */
     public List<EgovMap> selectRecentSrchwrdResultInquire(RecentSrchwrd recentSrchwrd) throws Exception {
-        return selectList("RecentSrchwrd.selectRecentSrchwrdResultInquire", recentSrchwrd);
+        return mapper.selectRecentSrchwrdResultInquire(recentSrchwrd);
     }
 
     /**
@@ -99,7 +103,7 @@ public class RecentSrchwrdDao extends EgovComAbstractDAO {
      * @throws Exception
      */
     public List<?> selectRecentSrchwrdResultList(RecentSrchwrd searchVO) throws Exception {
-        return selectList("RecentSrchwrd.selectRecentSrchwrdResult", searchVO);
+        return mapper.selectRecentSrchwrdResult(searchVO);
     }
 
     /**
@@ -109,7 +113,7 @@ public class RecentSrchwrdDao extends EgovComAbstractDAO {
      * @throws Exception
      */
     public int selectRecentSrchwrdResultListCnt(RecentSrchwrd searchVO) throws Exception {
-        return (Integer)selectOne("RecentSrchwrd.selectRecentSrchwrdCntResult", searchVO);
+        return mapper.selectRecentSrchwrdCntResult(searchVO);
     }
 
     /**
@@ -118,7 +122,7 @@ public class RecentSrchwrdDao extends EgovComAbstractDAO {
      * @throws Exception
      */
     public void insertRecentSrchwrdResult(RecentSrchwrd recentSrchwrd) throws Exception {
-        insert("RecentSrchwrd.insertRecentSrchwrdResult", recentSrchwrd);
+        mapper.insertRecentSrchwrdResult(recentSrchwrd);
     }
 
     /**
@@ -127,7 +131,7 @@ public class RecentSrchwrdDao extends EgovComAbstractDAO {
      * @throws Exception
      */
     public void deleteRecentSrchwrdResult(RecentSrchwrd recentSrchwrd) throws Exception {
-        delete("RecentSrchwrd.deleteRecentSrchwrdResult", recentSrchwrd);
+        mapper.deleteRecentSrchwrdResult(recentSrchwrd);
     }
 
     /**
@@ -136,7 +140,7 @@ public class RecentSrchwrdDao extends EgovComAbstractDAO {
      * @throws Exception
      */
     public void deleteRecentSrchwrdResultAll(RecentSrchwrd recentSrchwrd) throws Exception {
-        delete("RecentSrchwrd.deleteRecentSrchwrdResultAll", recentSrchwrd);
+        mapper.deleteRecentSrchwrdResultAll(recentSrchwrd);
     }
 
 }

--- a/src/main/java/egovframework/com/uss/ion/rsm/service/impl/RecentSrchwrdMapper.java
+++ b/src/main/java/egovframework/com/uss/ion/rsm/service/impl/RecentSrchwrdMapper.java
@@ -1,0 +1,47 @@
+package egovframework.com.uss.ion.rsm.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+import org.egovframe.rte.psl.dataaccess.util.EgovMap;
+
+import egovframework.com.uss.ion.rsm.service.RecentSrchwrd;
+
+/**
+ * 최근검색어에 대한 Mapper 인터페이스
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2026.05.28  dasomel         XML 기반 DAO → @EgovMapper 인터페이스로 전환
+ * </pre>
+ */
+@EgovMapper("onlineRecentSrchwrdMapper")
+public interface RecentSrchwrdMapper {
+
+	List<EgovMap> selectRecentSrchwrd(RecentSrchwrd searchVO);
+
+	int selectRecentSrchwrdCnt(RecentSrchwrd searchVO);
+
+	RecentSrchwrd selectRecentSrchwrdDetail(RecentSrchwrd recentSrchwrd);
+
+	void insertRecentSrchwrd(RecentSrchwrd recentSrchwrd);
+
+	void updateRecentSrchwrd(RecentSrchwrd recentSrchwrd);
+
+	void deleteRecentSrchwrd(RecentSrchwrd recentSrchwrd);
+
+	List<EgovMap> selectRecentSrchwrdResultInquire(RecentSrchwrd recentSrchwrd);
+
+	List<?> selectRecentSrchwrdResult(RecentSrchwrd searchVO);
+
+	int selectRecentSrchwrdCntResult(RecentSrchwrd searchVO);
+
+	void insertRecentSrchwrdResult(RecentSrchwrd recentSrchwrd);
+
+	void deleteRecentSrchwrdResult(RecentSrchwrd recentSrchwrd);
+
+	void deleteRecentSrchwrdResultAll(RecentSrchwrd recentSrchwrd);
+}

--- a/src/main/java/egovframework/com/uss/ion/rsn/service/impl/RssDao.java
+++ b/src/main/java/egovframework/com/uss/ion/rsn/service/impl/RssDao.java
@@ -5,8 +5,8 @@ import java.util.Map;
 
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.uss.ion.rsn.service.RssInfo;
+import jakarta.annotation.Resource;
 /**
  * RSS서비스를 처리하는 Dao Class 구현
  * @author 공통콤포넌트 장동한
@@ -18,11 +18,15 @@ import egovframework.com.uss.ion.rsn.service.RssInfo;
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.07.03  장동한          최초 생성
+ *   2026.05.28  dasomel         @EgovMapper 인터페이스 위임 방식으로 전환
  *
  * </pre>
  */
 @Repository("rssInfoDao")
-public class RssDao extends EgovComAbstractDAO {
+public class RssDao {
+
+    @Resource(name = "rssInfoMapper")
+    private RssMapper mapper;
 
     /**
      * RSS서비스 테이블을 조회 한다.
@@ -31,7 +35,7 @@ public class RssDao extends EgovComAbstractDAO {
      * @throws Exception
      */
     public List<?> selectRssTagServiceTable(Map<?, ?> param) throws Exception {
-    	return selectList("RssTagService.selectRssTagServiceTable",param);
+    	return mapper.selectRssTagServiceTable(param);
     }
 
     /**
@@ -41,7 +45,7 @@ public class RssDao extends EgovComAbstractDAO {
      * @throws Exception
      */
     public List<?> selectRssTagServiceList(RssInfo rssInfo) throws Exception {
-    	return selectList("RssTagService.selectRssTagService",rssInfo);
+    	return mapper.selectRssTagService(rssInfo);
     }
 
     /**
@@ -51,7 +55,7 @@ public class RssDao extends EgovComAbstractDAO {
      * @throws Exception
      */
     public int selectRssTagServiceListCnt(RssInfo rssInfo) throws Exception {
-    	return (Integer)selectOne("RssTagService.selectRssTagServiceCnt", rssInfo);
+    	return mapper.selectRssTagServiceCnt(rssInfo);
     }
 
     /**
@@ -61,7 +65,7 @@ public class RssDao extends EgovComAbstractDAO {
      * @throws Exception
      */
     public Map<?, ?> selectRssTagServiceDetail(RssInfo rssInfo) throws Exception {
-    	return (Map<?, ?>)selectOne("RssTagService.selectRssTagServiceDetail", rssInfo);
+    	return mapper.selectRssTagServiceDetail(rssInfo);
     }
 
 

--- a/src/main/java/egovframework/com/uss/ion/rsn/service/impl/RssMapper.java
+++ b/src/main/java/egovframework/com/uss/ion/rsn/service/impl/RssMapper.java
@@ -1,0 +1,31 @@
+package egovframework.com.uss.ion.rsn.service.impl;
+
+import java.util.List;
+import java.util.Map;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.uss.ion.rsn.service.RssInfo;
+
+/**
+ * RSS서비스에 대한 Mapper 인터페이스
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2026.05.28  dasomel         XML 기반 DAO → @EgovMapper 인터페이스로 전환
+ * </pre>
+ */
+@EgovMapper("rssInfoMapper")
+public interface RssMapper {
+
+	List<?> selectRssTagServiceTable(Map<?, ?> param);
+
+	List<?> selectRssTagService(RssInfo rssInfo);
+
+	int selectRssTagServiceCnt(RssInfo rssInfo);
+
+	Map<?, ?> selectRssTagServiceDetail(RssInfo rssInfo);
+}

--- a/src/main/java/egovframework/com/uss/ion/rss/service/impl/RssTagManageDao.java
+++ b/src/main/java/egovframework/com/uss/ion/rss/service/impl/RssTagManageDao.java
@@ -11,12 +11,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.ibatis.session.SqlSession;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Repository;
 
 import egovframework.com.cmm.ComDefaultCodeVO;
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.uss.ion.rss.service.RssManage;
 import egovframework.com.utl.fcc.service.EgovStringUtil;
 import jakarta.annotation.Resource;
@@ -42,11 +42,18 @@ import jakarta.annotation.Resource;
  *   2025.08.14  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-LocalVariableNamingConventions(final이 아닌 변수는 밑줄을 포함할 수 없음)
  *   2025.08.14  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-CloseResource(부적절한 자원 해제)
  *   2025.08.14  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-SimplifyBooleanExpressions(boolean 사용 시 불필요한 비교 연산을 피하도록 함)
+ *   2026.05.28  dasomel         @EgovMapper 인터페이스 위임 방식으로 전환
  *
  *      </pre>
  */
 @Repository("rssManageDao")
-public class RssTagManageDao extends EgovComAbstractDAO {
+public class RssTagManageDao {
+
+	@Resource(name = "rssTagManageMapper")
+	private RssTagManageMapper mapper;
+
+	@Resource(name = "egov.sqlSessionTemplate")
+	private SqlSession sqlSession;
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(RssTagManageDao.class);
 
@@ -74,7 +81,7 @@ public class RssTagManageDao extends EgovComAbstractDAO {
 		try {
 			// Spring 트랜잭션 관리자가 관리하는 Connection을 사용
 			// Connection을 닫지 않음 (트랜잭션 관리자가 관리)
-			conn = getSqlSession().getConnection();
+			conn = sqlSession.getConnection();
 			dbmd = conn.getMetaData();
 			tables = dbmd.getTables(null, null, null, types);
 
@@ -129,7 +136,7 @@ public class RssTagManageDao extends EgovComAbstractDAO {
 		try {
 			// Spring 트랜잭션 관리자가 관리하는 Connection을 사용
 			// Connection을 닫지 않음 (트랜잭션 관리자가 관리)
-			conn = getSqlSession().getConnection();
+			conn = sqlSession.getConnection();
 
 			// KISA 보안약점 조치 (2018-12-05, 신용호)
 			// WhiteList 기능 보완 (2019-05-10, 신용호)
@@ -195,7 +202,7 @@ public class RssTagManageDao extends EgovComAbstractDAO {
 	 * @throws Exception
 	 */
 	public List<?> selectRssTagManageList(RssManage rssManage) throws Exception {
-		return selectList("RssTagManage.selectRssTagManage", rssManage);
+		return mapper.selectRssTagManage(rssManage);
 
 	}
 
@@ -207,7 +214,7 @@ public class RssTagManageDao extends EgovComAbstractDAO {
 	 * @throws Exception
 	 */
 	public int selectRssTagManageListCnt(RssManage rssManage) throws Exception {
-		return (Integer) selectOne("RssTagManage.selectRssTagManageCnt", rssManage);
+		return mapper.selectRssTagManageCnt(rssManage);
 	}
 
 	/**
@@ -218,7 +225,7 @@ public class RssTagManageDao extends EgovComAbstractDAO {
 	 * @throws Exception
 	 */
 	public RssManage selectRssTagManageDetail(RssManage rssManage) throws Exception {
-		return (RssManage) selectOne("RssTagManage.selectRssTagManageDetail", rssManage);
+		return mapper.selectRssTagManageDetail(rssManage);
 	}
 
 	/**
@@ -228,7 +235,7 @@ public class RssTagManageDao extends EgovComAbstractDAO {
 	 * @throws Exception
 	 */
 	public void insertRssTagManage(RssManage rssManage) throws Exception {
-		insert("RssTagManage.insertRssTagManage", rssManage);
+		mapper.insertRssTagManage(rssManage);
 	}
 
 	/**
@@ -238,7 +245,7 @@ public class RssTagManageDao extends EgovComAbstractDAO {
 	 * @throws Exception
 	 */
 	public void updateRssTagManage(RssManage rssManage) throws Exception {
-		update("RssTagManage.updateRssTagManage", rssManage);
+		mapper.updateRssTagManage(rssManage);
 	}
 
 	/**
@@ -248,7 +255,7 @@ public class RssTagManageDao extends EgovComAbstractDAO {
 	 * @throws Exception
 	 */
 	public void deleteRssTagManage(RssManage rssManage) throws Exception {
-		delete("RssTagManage.deleteRssTagManage", rssManage);
+		mapper.deleteRssTagManage(rssManage);
 	}
 
 }

--- a/src/main/java/egovframework/com/uss/ion/rss/service/impl/RssTagManageMapper.java
+++ b/src/main/java/egovframework/com/uss/ion/rss/service/impl/RssTagManageMapper.java
@@ -1,0 +1,34 @@
+package egovframework.com.uss.ion.rss.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.uss.ion.rss.service.RssManage;
+
+/**
+ * RSS태그관리에 대한 Mapper 인터페이스
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2026.05.28  dasomel         XML 기반 DAO → @EgovMapper 인터페이스로 전환
+ * </pre>
+ */
+@EgovMapper("rssTagManageMapper")
+public interface RssTagManageMapper {
+
+	List<?> selectRssTagManage(RssManage rssManage);
+
+	int selectRssTagManageCnt(RssManage rssManage);
+
+	RssManage selectRssTagManageDetail(RssManage rssManage);
+
+	void insertRssTagManage(RssManage rssManage);
+
+	void updateRssTagManage(RssManage rssManage);
+
+	void deleteRssTagManage(RssManage rssManage);
+}

--- a/src/main/java/egovframework/com/uss/ion/tir/service/impl/EgovTwitterDao.java
+++ b/src/main/java/egovframework/com/uss/ion/tir/service/impl/EgovTwitterDao.java
@@ -4,7 +4,7 @@ import java.util.Map;
 
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
+import jakarta.annotation.Resource;
 /**
  * RSS태그관리를 처리하는 Dao Class 구현
  * @author 공통콤포넌트 장동한
@@ -16,11 +16,15 @@ import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2010.10.04  장동한          최초 생성
+ *   2026.05.28  dasomel         @EgovMapper 인터페이스 위임 방식으로 전환
  *
  * </pre>
  */
 @Repository("twitterDao")
-public class EgovTwitterDao extends EgovComAbstractDAO {
+public class EgovTwitterDao {
+
+    @Resource(name = "twitterMapper")
+    private EgovTwitterMapper mapper;
 
     /**
      * 트위터 계정을 조회 한다.
@@ -29,7 +33,7 @@ public class EgovTwitterDao extends EgovComAbstractDAO {
      * @throws Exception
      */
     public Map<?, ?> selectTwitterAccount(Map<?, ?> param) throws Exception {
-    	return (Map<?, ?>)selectOne("Twitter.selectTwitterAccount",param);
+    	return mapper.selectTwitterAccount(param);
     }
 
 
@@ -40,7 +44,7 @@ public class EgovTwitterDao extends EgovComAbstractDAO {
      * @throws Exception
      */
     public int selectTwitterAccountCheck(Map<?, ?> param) throws Exception {
-    	return (Integer)selectOne("Twitter.selectTwitterAccountCheck",param);
+    	return mapper.selectTwitterAccountCheck(param);
     }
 
 	/**
@@ -48,7 +52,7 @@ public class EgovTwitterDao extends EgovComAbstractDAO {
 	 * @param param - 조회할 정보가 담긴 Map
 	 */
 	public void insertTwitterAccount(Map<?, ?> param) throws Exception {
-		insert("Twitter.insertTwitterAccount", param);
+		mapper.insertTwitterAccount(param);
 	}
 
 	/**
@@ -56,7 +60,7 @@ public class EgovTwitterDao extends EgovComAbstractDAO {
 	 * @param param - 조회할 정보가 담긴 Map
 	 */
 	public void updtTwitterAccount(Map<?, ?> param) throws Exception {
-		update("Twitter.updateTwitterAccount", param);
+		mapper.updateTwitterAccount(param);
 	}
 
 	/**
@@ -64,6 +68,6 @@ public class EgovTwitterDao extends EgovComAbstractDAO {
 	 * @param param - 조회할 정보가 담긴 Map
 	 */
 	public void deleteTwitterAccount(Map<?, ?> param) throws Exception {
-        delete("Twitter.deleteTwitterAccount",param);
+        mapper.deleteTwitterAccount(param);
 	}
 }

--- a/src/main/java/egovframework/com/uss/ion/tir/service/impl/EgovTwitterMapper.java
+++ b/src/main/java/egovframework/com/uss/ion/tir/service/impl/EgovTwitterMapper.java
@@ -1,0 +1,30 @@
+package egovframework.com.uss.ion.tir.service.impl;
+
+import java.util.Map;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+/**
+ * 트위터 계정관리에 대한 Mapper 인터페이스
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2026.05.28  dasomel         XML 기반 DAO → @EgovMapper 인터페이스로 전환
+ * </pre>
+ */
+@EgovMapper("twitterMapper")
+public interface EgovTwitterMapper {
+
+	Map<?, ?> selectTwitterAccount(Map<?, ?> param);
+
+	int selectTwitterAccountCheck(Map<?, ?> param);
+
+	void insertTwitterAccount(Map<?, ?> param);
+
+	void updateTwitterAccount(Map<?, ?> param);
+
+	void deleteTwitterAccount(Map<?, ?> param);
+}

--- a/src/main/java/egovframework/com/uss/ion/ulm/service/impl/UnityLinkDao.java
+++ b/src/main/java/egovframework/com/uss/ion/ulm/service/impl/UnityLinkDao.java
@@ -4,8 +4,8 @@ import java.util.List;
 
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.uss.ion.ulm.service.UnityLink;
+import jakarta.annotation.Resource;
 
 /**
  * 통합링크관리를 처리하는 Dao Class 구현
@@ -18,11 +18,15 @@ import egovframework.com.uss.ion.ulm.service.UnityLink;
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.07.03  장동한          최초 생성
+ *   2026.05.28  dasomel         @EgovMapper 인터페이스 위임 방식으로 전환
  *
  * </pre>
  */
 @Repository("onlineUnityLinkDao")
-public class UnityLinkDao extends EgovComAbstractDAO {
+public class UnityLinkDao {
+
+    @Resource(name = "onlineUnityLinkMapper")
+    private UnityLinkMapper mapper;
 
     /**
      * 통합링크관리 메인 셈플 목록을 조회한다.
@@ -30,7 +34,7 @@ public class UnityLinkDao extends EgovComAbstractDAO {
      * @return List - 통합링크관리 목록
      */
     public List<?> selectUnityLinkSample(UnityLink unityLink) throws Exception {
-        return selectList("UnityLink.selectUnityLinkSample", unityLink);
+        return mapper.selectUnityLinkSample(unityLink);
     }
 
     /**
@@ -40,7 +44,7 @@ public class UnityLinkDao extends EgovComAbstractDAO {
      * @throws Exception
      */
     public List<?> selectUnityLinkList(UnityLink unityLink) throws Exception {
-        return selectList("UnityLink.selectUnityLink", unityLink);
+        return mapper.selectUnityLink(unityLink);
     }
 
     /**
@@ -50,7 +54,7 @@ public class UnityLinkDao extends EgovComAbstractDAO {
      * @throws Exception
      */
     public int selectUnityLinkListCnt(UnityLink unityLink) throws Exception {
-        return (Integer)selectOne("UnityLink.selectUnityLinkCnt", unityLink);
+        return mapper.selectUnityLinkCnt(unityLink);
     }
 
     /**
@@ -60,7 +64,7 @@ public class UnityLinkDao extends EgovComAbstractDAO {
      * @throws Exception
      */
     public UnityLink selectUnityLinkDetail(UnityLink unityLink) throws Exception {
-        return (UnityLink)selectOne("UnityLink.selectUnityLinkDetail", unityLink);
+        return mapper.selectUnityLinkDetail(unityLink);
     }
 
     /**
@@ -69,7 +73,7 @@ public class UnityLinkDao extends EgovComAbstractDAO {
      * @throws Exception
      */
     public void insertUnityLink(UnityLink unityLink) throws Exception {
-        insert("UnityLink.insertUnityLink", unityLink);
+        mapper.insertUnityLink(unityLink);
     }
 
     /**
@@ -78,7 +82,7 @@ public class UnityLinkDao extends EgovComAbstractDAO {
      * @throws Exception
      */
     public void updateUnityLink(UnityLink unityLink) throws Exception {
-        update("UnityLink.updateUnityLink", unityLink);
+        mapper.updateUnityLink(unityLink);
     }
 
     /**
@@ -87,7 +91,7 @@ public class UnityLinkDao extends EgovComAbstractDAO {
      * @throws Exception
      */
     public void deleteUnityLink(UnityLink unityLink) throws Exception {
-        delete("UnityLink.deleteUnityLink", unityLink);
+        mapper.deleteUnityLink(unityLink);
     }
 
 }

--- a/src/main/java/egovframework/com/uss/ion/ulm/service/impl/UnityLinkMapper.java
+++ b/src/main/java/egovframework/com/uss/ion/ulm/service/impl/UnityLinkMapper.java
@@ -1,0 +1,36 @@
+package egovframework.com.uss.ion.ulm.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.uss.ion.ulm.service.UnityLink;
+
+/**
+ * 통합링크관리에 대한 Mapper 인터페이스
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2026.05.28  dasomel         XML 기반 DAO → @EgovMapper 인터페이스로 전환
+ * </pre>
+ */
+@EgovMapper("onlineUnityLinkMapper")
+public interface UnityLinkMapper {
+
+	List<?> selectUnityLinkSample(UnityLink unityLink);
+
+	List<?> selectUnityLink(UnityLink unityLink);
+
+	int selectUnityLinkCnt(UnityLink unityLink);
+
+	UnityLink selectUnityLinkDetail(UnityLink unityLink);
+
+	void insertUnityLink(UnityLink unityLink);
+
+	void updateUnityLink(UnityLink unityLink);
+
+	void deleteUnityLink(UnityLink unityLink);
+}

--- a/src/main/java/egovframework/com/uss/ion/wik/bmk/service/impl/WikiBookmarkDao.java
+++ b/src/main/java/egovframework/com/uss/ion/wik/bmk/service/impl/WikiBookmarkDao.java
@@ -4,8 +4,8 @@ import java.util.List;
 
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.uss.ion.wik.bmk.service.WikiBookmark;
+import jakarta.annotation.Resource;
 
 /**
  * 위키북마크를 처리하는 Dao Class 구현
@@ -18,11 +18,15 @@ import egovframework.com.uss.ion.wik.bmk.service.WikiBookmark;
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2010.10.20  장동한          최초 생성
+ *   2026.05.28  dasomel         @EgovMapper 인터페이스 위임 방식으로 전환
  *
  * </pre>
  */
 @Repository("wikiBookmarkDao")
-public class WikiBookmarkDao extends EgovComAbstractDAO {
+public class WikiBookmarkDao {
+
+    @Resource(name = "wikiBookmarkMapper")
+    private WikiBookmarkMapper mapper;
     /**
 	 * 위키북마크 목록을 조회한다.
 	 * @param wikiBookmark -조회할 정보가 담긴 객체
@@ -30,7 +34,7 @@ public class WikiBookmarkDao extends EgovComAbstractDAO {
 	 * @throws Exception
 	 */
 	public List<?> selectWikiBookmarkList(WikiBookmark wikiBookmark) throws Exception{
-		return selectList("WikiBookmark.selectWikiBookmarkList", wikiBookmark);
+		return mapper.selectWikiBookmarkList(wikiBookmark);
 	}
 
     /**
@@ -40,7 +44,7 @@ public class WikiBookmarkDao extends EgovComAbstractDAO {
      * @throws Exception
      */
     public int selectWikiBookmarkDuplicationCnt(WikiBookmark wikiBookmark) throws Exception{
-    	return (Integer)selectOne("WikiBookmark.selectWikiBookmarkDuplicationCnt", wikiBookmark);
+    	return mapper.selectWikiBookmarkDuplicationCnt(wikiBookmark);
     }
 
     /**
@@ -50,7 +54,7 @@ public class WikiBookmarkDao extends EgovComAbstractDAO {
      * @throws Exception
      */
     public int selectWikiBookmarkListCnt(WikiBookmark wikiBookmark) throws Exception{
-    	return (Integer)selectOne("WikiBookmark.selectWikiBookmarkListCnt", wikiBookmark);
+    	return mapper.selectWikiBookmarkListCnt(wikiBookmark);
     }
 
     /**
@@ -60,7 +64,7 @@ public class WikiBookmarkDao extends EgovComAbstractDAO {
      * @throws Exception
      */
     public String selectWikiBookmarkEmpUniqId(WikiBookmark wikiBookmark) throws Exception{
-    	return (String)selectOne("WikiBookmark.selectWikiBookmarkEmpUniqId", wikiBookmark);
+    	return mapper.selectWikiBookmarkEmpUniqId(wikiBookmark);
     }
 
 
@@ -69,8 +73,8 @@ public class WikiBookmarkDao extends EgovComAbstractDAO {
 	 * @param wikiBookmark -위키북마크 정보 담김 객체
 	 * @throws Exception
 	 */
-	void insertWikiBookmark(WikiBookmark wikiBookmark) throws Exception{
-		insert("WikiBookmark.insertWikiBookmark",wikiBookmark);
+	public void insertWikiBookmark(WikiBookmark wikiBookmark) throws Exception{
+		mapper.insertWikiBookmark(wikiBookmark);
 	}
 
      /**
@@ -78,7 +82,7 @@ public class WikiBookmarkDao extends EgovComAbstractDAO {
 	 * @param wikiBookmark -위키북마크 정보 담김 객체
 	 * @throws Exception
 	 */
-	void deleteWikiBookmark(WikiBookmark wikiBookmark) throws Exception{
-		delete("WikiBookmark.deleteWikiBookmark", wikiBookmark);
+	public void deleteWikiBookmark(WikiBookmark wikiBookmark) throws Exception{
+		mapper.deleteWikiBookmark(wikiBookmark);
 	}
 }

--- a/src/main/java/egovframework/com/uss/ion/wik/bmk/service/impl/WikiBookmarkMapper.java
+++ b/src/main/java/egovframework/com/uss/ion/wik/bmk/service/impl/WikiBookmarkMapper.java
@@ -1,0 +1,34 @@
+package egovframework.com.uss.ion.wik.bmk.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.uss.ion.wik.bmk.service.WikiBookmark;
+
+/**
+ * 위키북마크에 대한 Mapper 인터페이스
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2026.05.28  dasomel         XML 기반 DAO → @EgovMapper 인터페이스로 전환
+ * </pre>
+ */
+@EgovMapper("wikiBookmarkMapper")
+public interface WikiBookmarkMapper {
+
+	List<?> selectWikiBookmarkList(WikiBookmark wikiBookmark);
+
+	int selectWikiBookmarkListCnt(WikiBookmark wikiBookmark);
+
+	int selectWikiBookmarkDuplicationCnt(WikiBookmark wikiBookmark);
+
+	String selectWikiBookmarkEmpUniqId(WikiBookmark wikiBookmark);
+
+	void insertWikiBookmark(WikiBookmark wikiBookmark);
+
+	void deleteWikiBookmark(WikiBookmark wikiBookmark);
+}

--- a/src/main/resources/egovframework/mapper/com/uss/ion/ntm/EgovNoteManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/ntm/EgovNoteManage_SQL_altibase.xml
@@ -6,7 +6,7 @@
   2011.8.12   	안민정     	 	테이블 표준화에 따른 수정사항 반영
 							DELETE_YN	->	DELETE_AT
 -->
-<mapper namespace="NoteManage">
+<mapper namespace="egovframework.com.uss.ion.ntm.service.impl.NoteManageMapper">
 	
 	<!-- 쪽지관리::쪽지관리 조회(답변처리시) -->
 	<select id="selectNoteManage" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/ntm/EgovNoteManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/ntm/EgovNoteManage_SQL_cubrid.xml
@@ -6,7 +6,7 @@
   2011.8.12   	안민정     	 	테이블 표준화에 따른 수정사항 반영
 							DELETE_YN	->	DELETE_AT
 -->
-<mapper namespace="NoteManage">
+<mapper namespace="egovframework.com.uss.ion.ntm.service.impl.NoteManageMapper">
 	
 	<!-- 쪽지관리::쪽지관리 조회(답변처리시) -->
 	<select id="selectNoteManage" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/ntm/EgovNoteManage_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/ntm/EgovNoteManage_SQL_goldilocks.xml
@@ -6,7 +6,7 @@
   2011.8.12   	안민정     	 	테이블 표준화에 따른 수정사항 반영
 							DELETE_YN	->	DELETE_AT
 -->
-<mapper namespace="NoteManage">
+<mapper namespace="egovframework.com.uss.ion.ntm.service.impl.NoteManageMapper">
 	
 	<!-- 쪽지관리::쪽지관리 조회(답변처리시) -->
 	<select id="selectNoteManage" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/ntm/EgovNoteManage_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/ntm/EgovNoteManage_SQL_maria.xml
@@ -8,7 +8,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="NoteManage">
+<mapper namespace="egovframework.com.uss.ion.ntm.service.impl.NoteManageMapper">
 	
 	<!-- 쪽지관리::쪽지관리 조회(답변처리시) -->
 	<select id="selectNoteManage" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/ntm/EgovNoteManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/ntm/EgovNoteManage_SQL_mysql.xml
@@ -8,7 +8,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="NoteManage">
+<mapper namespace="egovframework.com.uss.ion.ntm.service.impl.NoteManageMapper">
 	
 	<!-- 쪽지관리::쪽지관리 조회(답변처리시) -->
 	<select id="selectNoteManage" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/ntm/EgovNoteManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/ntm/EgovNoteManage_SQL_oracle.xml
@@ -6,7 +6,7 @@
   2011.8.12   	안민정     	 	테이블 표준화에 따른 수정사항 반영
 							DELETE_YN	->	DELETE_AT
 -->
-<mapper namespace="NoteManage">
+<mapper namespace="egovframework.com.uss.ion.ntm.service.impl.NoteManageMapper">
 	
 	<!-- 쪽지관리::쪽지관리 조회(답변처리시) -->
 	<select id="selectNoteManage" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/ntm/EgovNoteManage_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/ntm/EgovNoteManage_SQL_postgres.xml
@@ -8,7 +8,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="NoteManage">
+<mapper namespace="egovframework.com.uss.ion.ntm.service.impl.NoteManageMapper">
 	
 	<!-- 쪽지관리::쪽지관리 조회(답변처리시) -->
 	<select id="selectNoteManage" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/ntm/EgovNoteManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/ntm/EgovNoteManage_SQL_tibero.xml
@@ -6,7 +6,7 @@
   2011.8.12   	안민정     	 	테이블 표준화에 따른 수정사항 반영
 							DELETE_YN	->	DELETE_AT
 -->
-<mapper namespace="NoteManage">
+<mapper namespace="egovframework.com.uss.ion.ntm.service.impl.NoteManageMapper">
 	
 	<!-- 쪽지관리::쪽지관리 조회(답변처리시) -->
 	<select id="selectNoteManage" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/ntr/EgovNoteRecptn_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/ntr/EgovNoteRecptn_SQL_altibase.xml
@@ -6,7 +6,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="NoteRecptn">
+<mapper namespace="egovframework.com.uss.ion.ntr.service.impl.NoteRecptnMapper">
 	
 	<!-- 받은편지함관리::개봉으로 업데이트 -->
 	<update id="updateNoteRecptnRelationOpenYn">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/ntr/EgovNoteRecptn_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/ntr/EgovNoteRecptn_SQL_cubrid.xml
@@ -6,7 +6,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="NoteRecptn">
+<mapper namespace="egovframework.com.uss.ion.ntr.service.impl.NoteRecptnMapper">
 	
 	<!-- 받은편지함관리::개봉으로 업데이트 -->
 	<update id="updateNoteRecptnRelationOpenYn">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/ntr/EgovNoteRecptn_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/ntr/EgovNoteRecptn_SQL_goldilocks.xml
@@ -6,7 +6,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="NoteRecptn">
+<mapper namespace="egovframework.com.uss.ion.ntr.service.impl.NoteRecptnMapper">
 	
 	<!-- 받은편지함관리::개봉으로 업데이트 -->
 	<update id="updateNoteRecptnRelationOpenYn">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/ntr/EgovNoteRecptn_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/ntr/EgovNoteRecptn_SQL_maria.xml
@@ -6,7 +6,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="NoteRecptn">
+<mapper namespace="egovframework.com.uss.ion.ntr.service.impl.NoteRecptnMapper">
 
 	<!-- 받은편지함관리::개봉으로 업데이트 -->
 	<update id="updateNoteRecptnRelationOpenYn">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/ntr/EgovNoteRecptn_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/ntr/EgovNoteRecptn_SQL_mysql.xml
@@ -6,7 +6,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="NoteRecptn">
+<mapper namespace="egovframework.com.uss.ion.ntr.service.impl.NoteRecptnMapper">
 
 	<!-- 받은편지함관리::개봉으로 업데이트 -->
 	<update id="updateNoteRecptnRelationOpenYn">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/ntr/EgovNoteRecptn_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/ntr/EgovNoteRecptn_SQL_oracle.xml
@@ -6,7 +6,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="NoteRecptn">
+<mapper namespace="egovframework.com.uss.ion.ntr.service.impl.NoteRecptnMapper">
 	
 	<!-- 받은편지함관리::개봉으로 업데이트 -->
 	<update id="updateNoteRecptnRelationOpenYn">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/ntr/EgovNoteRecptn_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/ntr/EgovNoteRecptn_SQL_postgres.xml
@@ -6,7 +6,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="NoteRecptn">
+<mapper namespace="egovframework.com.uss.ion.ntr.service.impl.NoteRecptnMapper">
 
 	<!-- 받은편지함관리::개봉으로 업데이트 -->
 	<update id="updateNoteRecptnRelationOpenYn">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/ntr/EgovNoteRecptn_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/ntr/EgovNoteRecptn_SQL_tibero.xml
@@ -6,7 +6,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="NoteRecptn">
+<mapper namespace="egovframework.com.uss.ion.ntr.service.impl.NoteRecptnMapper">
 	
 	<!-- 받은편지함관리::개봉으로 업데이트 -->
 	<update id="updateNoteRecptnRelationOpenYn">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/rsm/EgovRecentSrchwrd_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/rsm/EgovRecentSrchwrd_SQL_altibase.xml
@@ -7,7 +7,7 @@
 --><!--Converted at: Wed May 11 15:51:18 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="RecentSrchwrd">
+<mapper namespace="egovframework.com.uss.ion.rsm.service.impl.RecentSrchwrdMapper">
 
 	<!-- 최근검색어조회::ResultMap 선언 -->
 	<resultMap id="RecentSrchwrdVO" type="egovframework.com.uss.ion.rsm.service.RecentSrchwrd">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/rsm/EgovRecentSrchwrd_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/rsm/EgovRecentSrchwrd_SQL_cubrid.xml
@@ -5,7 +5,7 @@
 --><!--Converted at: Wed May 11 15:51:18 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="RecentSrchwrd">
+<mapper namespace="egovframework.com.uss.ion.rsm.service.impl.RecentSrchwrdMapper">
 
 	<!-- 최근검색어조회::ResultMap 선언 -->
 	<resultMap id="RecentSrchwrdVO" type="egovframework.com.uss.ion.rsm.service.RecentSrchwrd">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/rsm/EgovRecentSrchwrd_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/rsm/EgovRecentSrchwrd_SQL_goldilocks.xml
@@ -7,7 +7,7 @@
 --><!--Converted at: Wed May 11 15:51:18 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="RecentSrchwrd">
+<mapper namespace="egovframework.com.uss.ion.rsm.service.impl.RecentSrchwrdMapper">
 
 	<!-- 최근검색어조회::ResultMap 선언 -->
 	<resultMap id="RecentSrchwrdVO" type="egovframework.com.uss.ion.rsm.service.RecentSrchwrd">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/rsm/EgovRecentSrchwrd_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/rsm/EgovRecentSrchwrd_SQL_maria.xml
@@ -7,7 +7,7 @@
 --><!--Converted at: Wed May 11 15:51:18 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="RecentSrchwrd">
+<mapper namespace="egovframework.com.uss.ion.rsm.service.impl.RecentSrchwrdMapper">
 
 	<!-- 최근검색어조회::ResultMap 선언 -->
 	<resultMap id="RecentSrchwrdVO" type="egovframework.com.uss.ion.rsm.service.RecentSrchwrd">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/rsm/EgovRecentSrchwrd_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/rsm/EgovRecentSrchwrd_SQL_mysql.xml
@@ -7,7 +7,7 @@
 --><!--Converted at: Wed May 11 15:51:18 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="RecentSrchwrd">
+<mapper namespace="egovframework.com.uss.ion.rsm.service.impl.RecentSrchwrdMapper">
 
 	<!-- 최근검색어조회::ResultMap 선언 -->
 	<resultMap id="RecentSrchwrdVO" type="egovframework.com.uss.ion.rsm.service.RecentSrchwrd">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/rsm/EgovRecentSrchwrd_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/rsm/EgovRecentSrchwrd_SQL_oracle.xml
@@ -7,7 +7,7 @@
 --><!--Converted at: Wed May 11 15:51:18 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="RecentSrchwrd">
+<mapper namespace="egovframework.com.uss.ion.rsm.service.impl.RecentSrchwrdMapper">
 
 	<!-- 최근검색어조회::ResultMap 선언 -->
 	<resultMap id="RecentSrchwrdVO" type="egovframework.com.uss.ion.rsm.service.RecentSrchwrd">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/rsm/EgovRecentSrchwrd_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/rsm/EgovRecentSrchwrd_SQL_postgres.xml
@@ -7,7 +7,7 @@
 --><!--Converted at: Wed May 11 15:51:18 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="RecentSrchwrd">
+<mapper namespace="egovframework.com.uss.ion.rsm.service.impl.RecentSrchwrdMapper">
 
 	<!-- 최근검색어조회::ResultMap 선언 -->
 	<resultMap id="RecentSrchwrdVO" type="egovframework.com.uss.ion.rsm.service.RecentSrchwrd">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/rsm/EgovRecentSrchwrd_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/rsm/EgovRecentSrchwrd_SQL_tibero.xml
@@ -7,7 +7,7 @@
 --><!--Converted at: Wed May 11 15:51:18 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="RecentSrchwrd">
+<mapper namespace="egovframework.com.uss.ion.rsm.service.impl.RecentSrchwrdMapper">
 
 	<!-- 최근검색어조회::ResultMap 선언 -->
 	<resultMap id="RecentSrchwrdVO" type="egovframework.com.uss.ion.rsm.service.RecentSrchwrd">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/rsn/EgovRssTagService_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/rsn/EgovRssTagService_SQL_altibase.xml
@@ -5,7 +5,7 @@
 --><!--Converted at: Wed May 11 15:51:18 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="RssTagService">
+<mapper namespace="egovframework.com.uss.ion.rsn.service.impl.RssMapper">
 
 	<!-- RSS서비스::해당RSS서비스 조회 --> 
 	<select id="selectRssTagServiceTable" parameterType="java.util.Map" resultType="java.util.HashMap">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/rsn/EgovRssTagService_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/rsn/EgovRssTagService_SQL_cubrid.xml
@@ -5,7 +5,7 @@
 --><!--Converted at: Wed May 11 15:51:19 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="RssTagService">
+<mapper namespace="egovframework.com.uss.ion.rsn.service.impl.RssMapper">
 
 	<!-- RSS서비스::해당RSS서비스 조회 --> 
 	<select id="selectRssTagServiceTable" parameterType="java.util.Map" resultType="java.util.HashMap">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/rsn/EgovRssTagService_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/rsn/EgovRssTagService_SQL_goldilocks.xml
@@ -5,7 +5,7 @@
 --><!--Converted at: Wed May 11 15:51:18 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="RssTagService">
+<mapper namespace="egovframework.com.uss.ion.rsn.service.impl.RssMapper">
 
 	<!-- RSS서비스::해당RSS서비스 조회 --> 
 	<select id="selectRssTagServiceTable" parameterType="java.util.Map" resultType="java.util.HashMap">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/rsn/EgovRssTagService_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/rsn/EgovRssTagService_SQL_maria.xml
@@ -5,7 +5,7 @@
 --><!--Converted at: Wed May 11 15:51:19 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="RssTagService">
+<mapper namespace="egovframework.com.uss.ion.rsn.service.impl.RssMapper">
 
 	<!-- RSS서비스::해당RSS서비스 조회 --> 
 	<select id="selectRssTagServiceTable" parameterType="java.util.Map" resultType="java.util.HashMap">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/rsn/EgovRssTagService_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/rsn/EgovRssTagService_SQL_mysql.xml
@@ -5,7 +5,7 @@
 --><!--Converted at: Wed May 11 15:51:19 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="RssTagService">
+<mapper namespace="egovframework.com.uss.ion.rsn.service.impl.RssMapper">
 
 	<!-- RSS서비스::해당RSS서비스 조회 --> 
 	<select id="selectRssTagServiceTable" parameterType="java.util.Map" resultType="java.util.HashMap">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/rsn/EgovRssTagService_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/rsn/EgovRssTagService_SQL_oracle.xml
@@ -5,7 +5,7 @@
 --><!--Converted at: Wed May 11 15:51:19 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="RssTagService">
+<mapper namespace="egovframework.com.uss.ion.rsn.service.impl.RssMapper">
 
 	<!-- RSS서비스::해당RSS서비스 조회 --> 
 	<select id="selectRssTagServiceTable" parameterType="java.util.Map" resultType="java.util.HashMap">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/rsn/EgovRssTagService_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/rsn/EgovRssTagService_SQL_postgres.xml
@@ -5,7 +5,7 @@
 --><!--Converted at: Wed May 11 15:51:19 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="RssTagService">
+<mapper namespace="egovframework.com.uss.ion.rsn.service.impl.RssMapper">
 
 	<!-- RSS서비스::해당RSS서비스 조회 --> 
 	<select id="selectRssTagServiceTable" parameterType="java.util.Map" resultType="java.util.HashMap">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/rsn/EgovRssTagService_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/rsn/EgovRssTagService_SQL_tibero.xml
@@ -5,7 +5,7 @@
 --><!--Converted at: Wed May 11 15:51:19 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="RssTagService">
+<mapper namespace="egovframework.com.uss.ion.rsn.service.impl.RssMapper">
 
 	<!-- RSS서비스::해당RSS서비스 조회 --> 
 	<select id="selectRssTagServiceTable" parameterType="java.util.Map" resultType="java.util.HashMap">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/rss/EgovRssTagManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/rss/EgovRssTagManage_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:51:19 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="RssTagManage">
+<mapper namespace="egovframework.com.uss.ion.rss.service.impl.RssTagManageMapper">
 
 	<!-- ::ResultMap 선언 -->
 	<resultMap id="RssManageVO" type="egovframework.com.uss.ion.rss.service.RssManage">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/rss/EgovRssTagManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/rss/EgovRssTagManage_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:51:20 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="RssTagManage">
+<mapper namespace="egovframework.com.uss.ion.rss.service.impl.RssTagManageMapper">
 
 	<!-- ::ResultMap 선언 -->
 	<resultMap id="RssManageVO" type="egovframework.com.uss.ion.rss.service.RssManage">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/rss/EgovRssTagManage_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/rss/EgovRssTagManage_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:51:19 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="RssTagManage">
+<mapper namespace="egovframework.com.uss.ion.rss.service.impl.RssTagManageMapper">
 
 	<!-- ::ResultMap 선언 -->
 	<resultMap id="RssManageVO" type="egovframework.com.uss.ion.rss.service.RssManage">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/rss/EgovRssTagManage_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/rss/EgovRssTagManage_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:51:20 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="RssTagManage">
+<mapper namespace="egovframework.com.uss.ion.rss.service.impl.RssTagManageMapper">
 
 	<!-- ::ResultMap 선언 -->
 	<resultMap id="RssManageVO" type="egovframework.com.uss.ion.rss.service.RssManage">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/rss/EgovRssTagManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/rss/EgovRssTagManage_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:51:20 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="RssTagManage">
+<mapper namespace="egovframework.com.uss.ion.rss.service.impl.RssTagManageMapper">
 
 	<!-- ::ResultMap 선언 -->
 	<resultMap id="RssManageVO" type="egovframework.com.uss.ion.rss.service.RssManage">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/rss/EgovRssTagManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/rss/EgovRssTagManage_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:51:20 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="RssTagManage">
+<mapper namespace="egovframework.com.uss.ion.rss.service.impl.RssTagManageMapper">
 
 	<!-- ::ResultMap 선언 -->
 	<resultMap id="RssManageVO" type="egovframework.com.uss.ion.rss.service.RssManage">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/rss/EgovRssTagManage_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/rss/EgovRssTagManage_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:51:20 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="RssTagManage">
+<mapper namespace="egovframework.com.uss.ion.rss.service.impl.RssTagManageMapper">
 
 	<!-- ::ResultMap 선언 -->
 	<resultMap id="RssManageVO" type="egovframework.com.uss.ion.rss.service.RssManage">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/rss/EgovRssTagManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/rss/EgovRssTagManage_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!--Converted at: Wed May 11 15:51:20 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="RssTagManage">
+<mapper namespace="egovframework.com.uss.ion.rss.service.impl.RssTagManageMapper">
 
 	<!-- ::ResultMap 선언 -->
 	<resultMap id="RssManageVO" type="egovframework.com.uss.ion.rss.service.RssManage">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/tir/EgovTwitter_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/tir/EgovTwitter_SQL_altibase.xml
@@ -8,7 +8,7 @@
 --><!--Converted at: Wed May 11 15:51:22 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="Twitter">
+<mapper namespace="egovframework.com.uss.ion.tir.service.impl.EgovTwitterMapper">
 
 	<!-- 트위터::개정설정 검색 -->
 	<select id="selectTwitterAccount" resultType="java.util.HashMap">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/tir/EgovTwitter_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/tir/EgovTwitter_SQL_cubrid.xml
@@ -8,7 +8,7 @@
 --><!--Converted at: Wed May 11 15:51:22 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="Twitter">
+<mapper namespace="egovframework.com.uss.ion.tir.service.impl.EgovTwitterMapper">
 
 	<!-- 트위터::개정설정 검색 -->
 	<select id="selectTwitterAccount" resultType="java.util.HashMap">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/tir/EgovTwitter_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/tir/EgovTwitter_SQL_goldilocks.xml
@@ -8,7 +8,7 @@
 --><!--Converted at: Wed May 11 15:51:22 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="Twitter">
+<mapper namespace="egovframework.com.uss.ion.tir.service.impl.EgovTwitterMapper">
 
 	<!-- 트위터::개정설정 검색 -->
 	<select id="selectTwitterAccount" resultType="java.util.HashMap">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/tir/EgovTwitter_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/tir/EgovTwitter_SQL_maria.xml
@@ -8,7 +8,7 @@
 --><!--Converted at: Wed May 11 15:51:22 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="Twitter">
+<mapper namespace="egovframework.com.uss.ion.tir.service.impl.EgovTwitterMapper">
 
 	<!-- 트위터::개정설정 검색 -->
 	<select id="selectTwitterAccount" resultType="java.util.HashMap">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/tir/EgovTwitter_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/tir/EgovTwitter_SQL_mysql.xml
@@ -8,7 +8,7 @@
 --><!--Converted at: Wed May 11 15:51:22 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="Twitter">
+<mapper namespace="egovframework.com.uss.ion.tir.service.impl.EgovTwitterMapper">
 
 	<!-- 트위터::개정설정 검색 -->
 	<select id="selectTwitterAccount" resultType="java.util.HashMap">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/tir/EgovTwitter_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/tir/EgovTwitter_SQL_oracle.xml
@@ -8,7 +8,7 @@
 --><!--Converted at: Wed May 11 15:51:22 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="Twitter">
+<mapper namespace="egovframework.com.uss.ion.tir.service.impl.EgovTwitterMapper">
 
 	<!-- 트위터::개정설정 검색 -->
 	<select id="selectTwitterAccount" resultType="java.util.HashMap">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/tir/EgovTwitter_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/tir/EgovTwitter_SQL_postgres.xml
@@ -8,7 +8,7 @@
 --><!--Converted at: Wed May 11 15:51:22 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="Twitter">
+<mapper namespace="egovframework.com.uss.ion.tir.service.impl.EgovTwitterMapper">
 
 	<!-- 트위터::개정설정 검색 -->
 	<select id="selectTwitterAccount" resultType="java.util.HashMap">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/tir/EgovTwitter_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/tir/EgovTwitter_SQL_tibero.xml
@@ -8,7 +8,7 @@
 --><!--Converted at: Wed May 11 15:51:23 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="Twitter">
+<mapper namespace="egovframework.com.uss.ion.tir.service.impl.EgovTwitterMapper">
 
 	<!-- 트위터::개정설정 검색 -->
 	<select id="selectTwitterAccount" resultType="java.util.HashMap">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/ulm/EgovUnityLink_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/ulm/EgovUnityLink_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="UnityLink">
+<mapper namespace="egovframework.com.uss.ion.ulm.service.impl.UnityLinkMapper">
 
 	<!-- ::ResultMap 선언 -->
 	<resultMap id="UnityLink" type="egovframework.com.uss.ion.ulm.service.UnityLink">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/ulm/EgovUnityLink_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/ulm/EgovUnityLink_SQL_cubrid.xml
@@ -5,7 +5,7 @@
 --><!--Converted at: Wed May 11 15:51:24 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="UnityLink">
+<mapper namespace="egovframework.com.uss.ion.ulm.service.impl.UnityLinkMapper">
 
 	<!-- ::ResultMap 선언 -->
 	<resultMap id="UnityLink" type="egovframework.com.uss.ion.ulm.service.UnityLink">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/ulm/EgovUnityLink_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/ulm/EgovUnityLink_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="UnityLink">
+<mapper namespace="egovframework.com.uss.ion.ulm.service.impl.UnityLinkMapper">
 
 	<!-- ::ResultMap 선언 -->
 	<resultMap id="UnityLink" type="egovframework.com.uss.ion.ulm.service.UnityLink">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/ulm/EgovUnityLink_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/ulm/EgovUnityLink_SQL_maria.xml
@@ -5,7 +5,7 @@
 --><!--Converted at: Wed May 11 15:51:24 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="UnityLink">
+<mapper namespace="egovframework.com.uss.ion.ulm.service.impl.UnityLinkMapper">
 
 	<!-- ::ResultMap 선언 -->
 	<resultMap id="UnityLink" type="egovframework.com.uss.ion.ulm.service.UnityLink">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/ulm/EgovUnityLink_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/ulm/EgovUnityLink_SQL_mysql.xml
@@ -5,7 +5,7 @@
 --><!--Converted at: Wed May 11 15:51:24 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="UnityLink">
+<mapper namespace="egovframework.com.uss.ion.ulm.service.impl.UnityLinkMapper">
 
 	<!-- ::ResultMap 선언 -->
 	<resultMap id="UnityLink" type="egovframework.com.uss.ion.ulm.service.UnityLink">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/ulm/EgovUnityLink_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/ulm/EgovUnityLink_SQL_oracle.xml
@@ -5,7 +5,7 @@
 --><!--Converted at: Wed May 11 15:51:24 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="UnityLink">
+<mapper namespace="egovframework.com.uss.ion.ulm.service.impl.UnityLinkMapper">
 
 	<!-- ::ResultMap 선언 -->
 	<resultMap id="UnityLink" type="egovframework.com.uss.ion.ulm.service.UnityLink">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/ulm/EgovUnityLink_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/ulm/EgovUnityLink_SQL_postgres.xml
@@ -5,7 +5,7 @@
 --><!--Converted at: Wed May 11 15:51:24 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="UnityLink">
+<mapper namespace="egovframework.com.uss.ion.ulm.service.impl.UnityLinkMapper">
 
 	<!-- ::ResultMap 선언 -->
 	<resultMap id="UnityLink" type="egovframework.com.uss.ion.ulm.service.UnityLink">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/ulm/EgovUnityLink_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/ulm/EgovUnityLink_SQL_tibero.xml
@@ -5,7 +5,7 @@
 --><!--Converted at: Wed May 11 15:51:24 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="UnityLink">
+<mapper namespace="egovframework.com.uss.ion.ulm.service.impl.UnityLinkMapper">
 
 	<!-- ::ResultMap 선언 -->
 	<resultMap id="UnityLink" type="egovframework.com.uss.ion.ulm.service.UnityLink">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/wik/bmk/EgovWikiBookmark_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/wik/bmk/EgovWikiBookmark_SQL_altibase.xml
@@ -9,7 +9,7 @@
 --><!--Converted at: Wed May 11 15:51:25 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="WikiBookmark">
+<mapper namespace="egovframework.com.uss.ion.wik.bmk.service.impl.WikiBookmarkMapper">
 
 	<!-- 위키북마크::목록조회 게시물정보 -->
 	<select id="selectWikiBookmarkList" parameterType="comDefaultVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/wik/bmk/EgovWikiBookmark_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/wik/bmk/EgovWikiBookmark_SQL_cubrid.xml
@@ -9,7 +9,7 @@
 --><!--Converted at: Wed May 11 15:51:26 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="WikiBookmark">
+<mapper namespace="egovframework.com.uss.ion.wik.bmk.service.impl.WikiBookmarkMapper">
 
 	<!-- 위키북마크::목록조회 게시물정보 -->
 	<select id="selectWikiBookmarkList" parameterType="comDefaultVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/wik/bmk/EgovWikiBookmark_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/wik/bmk/EgovWikiBookmark_SQL_goldilocks.xml
@@ -9,7 +9,7 @@
 --><!--Converted at: Wed May 11 15:51:25 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="WikiBookmark">
+<mapper namespace="egovframework.com.uss.ion.wik.bmk.service.impl.WikiBookmarkMapper">
 
 	<!-- 위키북마크::목록조회 게시물정보 -->
 	<select id="selectWikiBookmarkList" parameterType="comDefaultVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/wik/bmk/EgovWikiBookmark_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/wik/bmk/EgovWikiBookmark_SQL_maria.xml
@@ -9,7 +9,7 @@
 --><!--Converted at: Wed May 11 15:51:26 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="WikiBookmark">
+<mapper namespace="egovframework.com.uss.ion.wik.bmk.service.impl.WikiBookmarkMapper">
 
 	<!-- 위키북마크::목록조회 게시물정보 -->
 	<select id="selectWikiBookmarkList" parameterType="comDefaultVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/wik/bmk/EgovWikiBookmark_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/wik/bmk/EgovWikiBookmark_SQL_mysql.xml
@@ -9,7 +9,7 @@
 --><!--Converted at: Wed May 11 15:51:26 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="WikiBookmark">
+<mapper namespace="egovframework.com.uss.ion.wik.bmk.service.impl.WikiBookmarkMapper">
 
 	<!-- 위키북마크::목록조회 게시물정보 -->
 	<select id="selectWikiBookmarkList" parameterType="comDefaultVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/wik/bmk/EgovWikiBookmark_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/wik/bmk/EgovWikiBookmark_SQL_oracle.xml
@@ -9,7 +9,7 @@
 --><!--Converted at: Wed May 11 15:51:26 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="WikiBookmark">
+<mapper namespace="egovframework.com.uss.ion.wik.bmk.service.impl.WikiBookmarkMapper">
 
 	<!-- 위키북마크::목록조회 게시물정보 -->
 	<select id="selectWikiBookmarkList" parameterType="comDefaultVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/wik/bmk/EgovWikiBookmark_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/wik/bmk/EgovWikiBookmark_SQL_postgres.xml
@@ -9,7 +9,7 @@
 --><!--Converted at: Wed May 11 15:51:26 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="WikiBookmark">
+<mapper namespace="egovframework.com.uss.ion.wik.bmk.service.impl.WikiBookmarkMapper">
 
 	<!-- 위키북마크::목록조회 게시물정보 -->
 	<select id="selectWikiBookmarkList" parameterType="comDefaultVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/com/uss/ion/wik/bmk/EgovWikiBookmark_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/wik/bmk/EgovWikiBookmark_SQL_tibero.xml
@@ -9,7 +9,7 @@
 --><!--Converted at: Wed May 11 15:51:26 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="WikiBookmark">
+<mapper namespace="egovframework.com.uss.ion.wik.bmk.service.impl.WikiBookmarkMapper">
 
 	<!-- 위키북마크::목록조회 게시물정보 -->
 	<select id="selectWikiBookmarkList" parameterType="comDefaultVO" resultType="egovMap">

--- a/src/main/resources/egovframework/spring/com/context-mapper.xml
+++ b/src/main/resources/egovframework/spring/com/context-mapper.xml
@@ -21,5 +21,12 @@
 	<bean id="egov.sqlSessionTemplate" class="org.mybatis.spring.SqlSessionTemplate">
 		<constructor-arg ref="egov.sqlSession"/>
 	</bean>
-	
+
+	<!-- @EgovMapper 어노테이션이 붙은 인터페이스를 자동으로 스캔하여 빈으로 등록 -->
+	<bean class="org.mybatis.spring.mapper.MapperScannerConfigurer">
+		<property name="basePackage" value="egovframework.com"/>
+		<property name="annotationClass" value="org.egovframe.rte.psl.dataaccess.mapper.EgovMapper"/>
+		<property name="sqlSessionFactoryBeanName" value="egov.sqlSession"/>
+	</bean>
+
 </beans>


### PR DESCRIPTION
## 변경 사유
기존 XML namespace 기반 DAO를 eGovFrame 5.0 신규 `@EgovMapper` 인터페이스 방식으로 전환합니다.

## 변경 내용
- 대상: uss/ion(ntm·ntr·rsm·rsn·rss·tir·ulm·wik/bmk) 8개 DAO
- 각 DAO에 대응하는 Mapper 인터페이스(`@EgovMapper`) 신규 추가
- DAO를 mapper 위임 구조로 리팩토링 (EgovComAbstractDAO 상속 제거, @Resource 주입, @Repository bean name 유지)
- XML mapper namespace를 mapper 인터페이스 FQN으로 변경
- context-mapper.xml에 MapperScannerConfigurer(annotationClass=EgovMapper) 추가

## 영향 범위
- 해당 모듈만 영향, 서비스 레이어 호출 시그니처 변경 없음

## 참고
- 빌드 검증을 위해 #891(Lombok annotationProcessorPaths 빌드 수정) 선행 머지 권장
- context-mapper.xml MapperScannerConfigurer는 동일 시리즈 PR과 한 줄 중복될 수 있어, 선행 PR 머지 후 rebase로 정리 가능

## 체크리스트
- [x] 단일 주제만 다룸
- [x] 컴파일 검증(해당 모듈 신규 오류 0)
- [x] 기존 동작 호환
