### PR TITLE
[refactor][5.0.x][공통컴포넌트] uss/sam/ipm 및 utl/sys 잔여 3개 DAO @EgovMapper 인터페이스 전환

### DIFF
--- a/src/main/java/egovframework/com/uss/sam/ipm/service/impl/IndvdlInfoPolicyDao.java
+++ b/src/main/java/egovframework/com/uss/sam/ipm/service/impl/IndvdlInfoPolicyDao.java
@@ -6,90 +6,95 @@ import org.egovframe.rte.psl.dataaccess.util.EgovMap;
 import org.springframework.stereotype.Repository;
 
 import egovframework.com.cmm.ComDefaultVO;
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.uss.sam.ipm.service.IndvdlInfoPolicy;
+
+import jakarta.annotation.Resource;
 
 /**
  * 개인정보보호정책를 처리하는 Dao Class 구현
- * 
+ *
  * @author 공통서비스 장동한
  * @since 2009.07.03
  * @version 1.0
  * @see
- * 
+ *
  *      <pre>
  * &lt;&lt; 개정이력(Modification Information) &gt;&gt;
  *
  *   수정일          수정자       수정내용
  *  -----------    --------    ---------------------------
  *   2009.07.03     장동한       최초 생성
+ *   2026.05.28     dasomel     @EgovMapper 인터페이스 방식으로 전환
  *
  *      </pre>
  */
 @Repository("onlineIndvdlInfoPolicyDao")
-public class IndvdlInfoPolicyDao extends EgovComAbstractDAO {
+public class IndvdlInfoPolicyDao {
+
+	@Resource(name = "indvdlInfoPolicyMapper")
+	private IndvdlInfoPolicyMapper indvdlInfoPolicyMapper;
 
 	/**
 	 * 개인정보보호정책를(을) 목록을 한다.
-	 * 
+	 *
 	 * @param searchVO 조회할 정보가 담긴 VO
 	 * @return List
 	 * @throws Exception
 	 */
 	public List<EgovMap> selectIndvdlInfoPolicyList(ComDefaultVO searchVO) throws Exception {
-		return selectList("IndvdlInfoPolicy.selectIndvdlInfoPolicy", searchVO);
+		return indvdlInfoPolicyMapper.selectIndvdlInfoPolicy(searchVO);
 	}
 
 	/**
 	 * 개인정보보호정책를(을) 목록 전체 건수를(을) 조회한다.
-	 * 
+	 *
 	 * @param searchVO 조회할 정보가 담긴 VO
 	 * @return int
 	 * @throws Exception
 	 */
 	public int selectIndvdlInfoPolicyListCnt(ComDefaultVO searchVO) throws Exception {
-		return (Integer) selectOne("IndvdlInfoPolicy.selectIndvdlInfoPolicyCnt", searchVO);
+		return indvdlInfoPolicyMapper.selectIndvdlInfoPolicyCnt(searchVO);
 	}
 
 	/**
 	 * 개인정보보호정책를(을) 상세조회 한다.
-	 * 
+	 *
 	 * @param indvdlInfoPolicy 개인정보보호정책 정보가 담김 VO
 	 * @return IndvdlInfoPolicy
 	 * @throws Exception
 	 */
 	public IndvdlInfoPolicy selectIndvdlInfoPolicyDetail(IndvdlInfoPolicy indvdlInfoPolicy) throws Exception {
-		return (IndvdlInfoPolicy) selectOne("IndvdlInfoPolicy.selectIndvdlInfoPolicyDetail", indvdlInfoPolicy);
+		return indvdlInfoPolicyMapper.selectIndvdlInfoPolicyDetail(indvdlInfoPolicy);
 	}
 
 	/**
 	 * 개인정보보호정책를(을) 등록한다.
-	 * 
-	 * @param qindvdlInfoPolicy 개인정보보호정책 정보가 담김 VO
+	 *
+	 * @param indvdlInfoPolicy 개인정보보호정책 정보가 담김 VO
 	 * @throws Exception
 	 */
 	public void insertIndvdlInfoPolicy(IndvdlInfoPolicy indvdlInfoPolicy) throws Exception {
-		insert("IndvdlInfoPolicy.insertIndvdlInfoPolicy", indvdlInfoPolicy);
+		indvdlInfoPolicyMapper.insertIndvdlInfoPolicy(indvdlInfoPolicy);
 	}
 
 	/**
 	 * 개인정보보호정책를(을) 수정한다.
-	 * 
+	 *
 	 * @param indvdlInfoPolicy 개인정보보호정책 정보가 담김 VO
 	 * @throws Exception
 	 */
 	public void updateIndvdlInfoPolicy(IndvdlInfoPolicy indvdlInfoPolicy) throws Exception {
-		update("IndvdlInfoPolicy.updateIndvdlInfoPolicy", indvdlInfoPolicy);
+		indvdlInfoPolicyMapper.updateIndvdlInfoPolicy(indvdlInfoPolicy);
 	}
 
 	/**
 	 * 개인정보보호정책를(을) 삭제한다.
-	 * 
+	 *
 	 * @param indvdlInfoPolicy 개인정보보호정책 정보가 담김 VO
 	 * @throws Exception
 	 */
 	public void deleteIndvdlInfoPolicy(IndvdlInfoPolicy indvdlInfoPolicy) throws Exception {
-		delete("IndvdlInfoPolicy.deleteIndvdlInfoPolicy", indvdlInfoPolicy);
+		indvdlInfoPolicyMapper.deleteIndvdlInfoPolicy(indvdlInfoPolicy);
 	}
 
 }

--- a/src/main/java/egovframework/com/uss/sam/ipm/service/impl/IndvdlInfoPolicyMapper.java
+++ b/src/main/java/egovframework/com/uss/sam/ipm/service/impl/IndvdlInfoPolicyMapper.java
@@ -1,0 +1,44 @@
+package egovframework.com.uss.sam.ipm.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+import org.egovframe.rte.psl.dataaccess.util.EgovMap;
+
+import egovframework.com.cmm.ComDefaultVO;
+import egovframework.com.uss.sam.ipm.service.IndvdlInfoPolicy;
+
+/**
+ * 개인정보보호정책에 대한 데이터 접근 Mapper 인터페이스를 정의한다.
+ *
+ * @author 공통서비스 장동한
+ * @since 2009.07.03
+ * @version 1.0
+ * @see
+ *
+ *      <pre>
+ * &lt;&lt; 개정이력(Modification Information) &gt;&gt;
+ *
+ *   수정일          수정자       수정내용
+ *  -----------    --------    ---------------------------
+ *   2009.07.03     장동한       최초 생성
+ *   2026.05.28     dasomel     XML 기반 DAO → @EgovMapper 인터페이스로 전환
+ *
+ *      </pre>
+ */
+@EgovMapper("indvdlInfoPolicyMapper")
+public interface IndvdlInfoPolicyMapper {
+
+	List<EgovMap> selectIndvdlInfoPolicy(ComDefaultVO searchVO);
+
+	int selectIndvdlInfoPolicyCnt(ComDefaultVO searchVO);
+
+	IndvdlInfoPolicy selectIndvdlInfoPolicyDetail(IndvdlInfoPolicy indvdlInfoPolicy);
+
+	void insertIndvdlInfoPolicy(IndvdlInfoPolicy indvdlInfoPolicy);
+
+	void updateIndvdlInfoPolicy(IndvdlInfoPolicy indvdlInfoPolicy);
+
+	void deleteIndvdlInfoPolicy(IndvdlInfoPolicy indvdlInfoPolicy);
+
+}

--- a/src/main/java/egovframework/com/utl/sys/dbm/service/impl/DbMntrngDao.java
+++ b/src/main/java/egovframework/com/utl/sys/dbm/service/impl/DbMntrngDao.java
@@ -3,9 +3,10 @@ import java.util.List;
 
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.utl.sys.dbm.service.DbMntrng;
 import egovframework.com.utl.sys.dbm.service.DbMntrngLog;
+
+import jakarta.annotation.Resource;
 
 /**
  * DB서비스모니터링관리에 대한 DAO 클래스를 정의한다.
@@ -21,10 +22,14 @@ import egovframework.com.utl.sys.dbm.service.DbMntrngLog;
  *   수정일       수정자           수정내용
  *  -------     --------    ---------------------------
  *  2010.06.21   김진만     최초 생성
+ *  2026.05.28   dasomel    @EgovMapper 인터페이스 방식으로 전환
  * </pre>
  */
 @Repository("dbMntrngDao")
-public class DbMntrngDao extends EgovComAbstractDAO {
+public class DbMntrngDao {
+
+	@Resource(name = "dbMntrngMapper")
+	private DbMntrngMapper dbMntrngMapper;
 
 	/**
 	 * DB서비스모니터링을 삭제한다.
@@ -34,7 +39,7 @@ public class DbMntrngDao extends EgovComAbstractDAO {
 	 */
 	public void deleteDbMntrng(DbMntrng dbMntrng)
 	  throws Exception{
-		delete("DbMntrngDao.deleteDbMntrng", dbMntrng);
+		dbMntrngMapper.deleteDbMntrng(dbMntrng);
 	}
 
 	/**
@@ -45,7 +50,7 @@ public class DbMntrngDao extends EgovComAbstractDAO {
 	 */
 	public void insertDbMntrng(DbMntrng dbMntrng)
 	  throws Exception{
-		insert("DbMntrngDao.insertDbMntrng", dbMntrng);
+		dbMntrngMapper.insertDbMntrng(dbMntrng);
 	}
 
 	/**
@@ -56,7 +61,7 @@ public class DbMntrngDao extends EgovComAbstractDAO {
 	 */
 	public void insertDbMntrngLog(DbMntrngLog dbMntrngLog)
 	  throws Exception{
-		insert("DbMntrngDao.insertDbMntrngLog", dbMntrngLog);
+		dbMntrngMapper.insertDbMntrngLog(dbMntrngLog);
 	}
 
 	/**
@@ -68,7 +73,7 @@ public class DbMntrngDao extends EgovComAbstractDAO {
 	 */
 	public DbMntrng selectDbMntrng(DbMntrng dbMntrng)
 	  throws Exception{
-		return (DbMntrng)selectOne("DbMntrngDao.selectDbMntrng", dbMntrng);
+		return dbMntrngMapper.selectDbMntrng(dbMntrng);
 	}
 
 	/**
@@ -80,7 +85,7 @@ public class DbMntrngDao extends EgovComAbstractDAO {
 	 */
 	public DbMntrngLog selectDbMntrngLog(DbMntrngLog dbMntrngLog)
 	  throws Exception{
-		return (DbMntrngLog)selectOne("DbMntrngDao.selectDbMntrngLog", dbMntrngLog);
+		return dbMntrngMapper.selectDbMntrngLog(dbMntrngLog);
 	}
 
 	/**
@@ -91,7 +96,7 @@ public class DbMntrngDao extends EgovComAbstractDAO {
 	 * @exception Exception Exception
 	 */
 	public List<DbMntrng> selectDbMntrngList(DbMntrng searchVO) throws Exception{
-		return selectList("DbMntrngDao.selectDbMntrngList", searchVO);
+		return dbMntrngMapper.selectDbMntrngList(searchVO);
 	}
 
 	/**
@@ -103,7 +108,7 @@ public class DbMntrngDao extends EgovComAbstractDAO {
 	 */
 	public int selectDbMntrngListCnt(DbMntrng searchVO)
 	  throws Exception{
-		return (Integer)selectOne("DbMntrngDao.selectDbMntrngListCnt", searchVO);
+		return dbMntrngMapper.selectDbMntrngListCnt(searchVO);
 	}
 
 	/**
@@ -115,7 +120,7 @@ public class DbMntrngDao extends EgovComAbstractDAO {
 	 */
 	public List<DbMntrngLog> selectDbMntrngLogList(DbMntrngLog searchVO)
 	  throws Exception{
-		return selectList("DbMntrngDao.selectDbMntrngLogList", searchVO);
+		return dbMntrngMapper.selectDbMntrngLogList(searchVO);
 	}
 
 	/**
@@ -127,7 +132,7 @@ public class DbMntrngDao extends EgovComAbstractDAO {
 	 */
 	public int selectDbMntrngLogListCnt(DbMntrngLog searchVO)
 	  throws Exception{
-		return (Integer)selectOne("DbMntrngDao.selectDbMntrngLogListCnt", searchVO);
+		return dbMntrngMapper.selectDbMntrngLogListCnt(searchVO);
 	}
 
 	/**
@@ -138,7 +143,7 @@ public class DbMntrngDao extends EgovComAbstractDAO {
 	 */
 	public void updateDbMntrng(DbMntrng dbMntrng)
 	  throws Exception{
-		update("DbMntrngDao.updateDbMntrng", dbMntrng);
+		dbMntrngMapper.updateDbMntrng(dbMntrng);
 	}
 
 }

--- a/src/main/java/egovframework/com/utl/sys/dbm/service/impl/DbMntrngMapper.java
+++ b/src/main/java/egovframework/com/utl/sys/dbm/service/impl/DbMntrngMapper.java
@@ -1,0 +1,49 @@
+package egovframework.com.utl.sys.dbm.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.utl.sys.dbm.service.DbMntrng;
+import egovframework.com.utl.sys.dbm.service.DbMntrngLog;
+
+/**
+ * DB서비스모니터링관리에 대한 Mapper 인터페이스를 정의한다.
+ *
+ * @author 김진만
+ * @since 2010.06.21
+ * @version 1.0
+ * @see
+ * <pre>
+ * == 개정이력(Modification Information) ==
+ *
+ *   수정일       수정자           수정내용
+ *  -------     --------    ---------------------------
+ *  2010.06.21   김진만     최초 생성
+ *  2026.05.28   dasomel    @EgovMapper 인터페이스 방식으로 전환
+ * </pre>
+ */
+@EgovMapper("dbMntrngMapper")
+public interface DbMntrngMapper {
+
+	void deleteDbMntrng(DbMntrng dbMntrng);
+
+	void insertDbMntrng(DbMntrng dbMntrng);
+
+	void insertDbMntrngLog(DbMntrngLog dbMntrngLog);
+
+	DbMntrng selectDbMntrng(DbMntrng dbMntrng);
+
+	DbMntrngLog selectDbMntrngLog(DbMntrngLog dbMntrngLog);
+
+	List<DbMntrng> selectDbMntrngList(DbMntrng searchVO);
+
+	int selectDbMntrngListCnt(DbMntrng searchVO);
+
+	List<DbMntrngLog> selectDbMntrngLogList(DbMntrngLog searchVO);
+
+	int selectDbMntrngLogListCnt(DbMntrngLog searchVO);
+
+	void updateDbMntrng(DbMntrng dbMntrng);
+
+}

--- a/src/main/java/egovframework/com/utl/sys/trm/service/impl/TrsmrcvMntrngDao.java
+++ b/src/main/java/egovframework/com/utl/sys/trm/service/impl/TrsmrcvMntrngDao.java
@@ -4,10 +4,11 @@ import java.util.List;
 
 import org.springframework.stereotype.Repository;
 
-import egovframework.com.cmm.service.impl.EgovComAbstractDAO;
 import egovframework.com.utl.sys.trm.service.CntcVO;
 import egovframework.com.utl.sys.trm.service.TrsmrcvMntrng;
 import egovframework.com.utl.sys.trm.service.TrsmrcvMntrngLog;
+
+import jakarta.annotation.Resource;
 
 /**
  * 송수신모니터링관리에 대한 DAO 클래스를 정의한다.
@@ -23,10 +24,14 @@ import egovframework.com.utl.sys.trm.service.TrsmrcvMntrngLog;
  *   수정일       수정자           수정내용
  *  -------     --------    ---------------------------
  *  2010.06.21   김진만     최초 생성
+ *  2026.05.28   dasomel    @EgovMapper 인터페이스 방식으로 전환
  * </pre>
  */
 @Repository("trsmrcvMntrngDao")
-public class TrsmrcvMntrngDao extends EgovComAbstractDAO {
+public class TrsmrcvMntrngDao {
+
+	@Resource(name = "trsmrcvMntrngMapper")
+	private TrsmrcvMntrngMapper trsmrcvMntrngMapper;
 
 	/**
 	 * 송수신모니터링을 삭제한다.
@@ -35,7 +40,7 @@ public class TrsmrcvMntrngDao extends EgovComAbstractDAO {
 	 * @exception Exception Exception
 	 */
 	public void deleteTrsmrcvMntrng(TrsmrcvMntrng trsmrcvMntrng) throws Exception {
-		delete("TrsmrcvMntrngDao.deleteTrsmrcvMntrng", trsmrcvMntrng);
+		trsmrcvMntrngMapper.deleteTrsmrcvMntrng(trsmrcvMntrng);
 	}
 
 	/**
@@ -45,7 +50,7 @@ public class TrsmrcvMntrngDao extends EgovComAbstractDAO {
 	 * @exception Exception Exception
 	 */
 	public void insertTrsmrcvMntrng(TrsmrcvMntrng trsmrcvMntrng) throws Exception {
-		insert("TrsmrcvMntrngDao.insertTrsmrcvMntrng", trsmrcvMntrng);
+		trsmrcvMntrngMapper.insertTrsmrcvMntrng(trsmrcvMntrng);
 	}
 
 	/**
@@ -55,7 +60,7 @@ public class TrsmrcvMntrngDao extends EgovComAbstractDAO {
 	 * @exception Exception Exception
 	 */
 	public void insertTrsmrcvMntrngLog(TrsmrcvMntrngLog trsmrcvMntrngLog) throws Exception {
-		insert("TrsmrcvMntrngDao.insertTrsmrcvMntrngLog", trsmrcvMntrngLog);
+		trsmrcvMntrngMapper.insertTrsmrcvMntrngLog(trsmrcvMntrngLog);
 	}
 
 	/**
@@ -66,7 +71,7 @@ public class TrsmrcvMntrngDao extends EgovComAbstractDAO {
 	 * @exception Exception Exception
 	 */
 	public TrsmrcvMntrng selectTrsmrcvMntrng(TrsmrcvMntrng trsmrcvMntrng) throws Exception {
-		return (TrsmrcvMntrng) selectOne("TrsmrcvMntrngDao.selectTrsmrcvMntrng", trsmrcvMntrng);
+		return trsmrcvMntrngMapper.selectTrsmrcvMntrng(trsmrcvMntrng);
 	}
 
 	/**
@@ -77,7 +82,7 @@ public class TrsmrcvMntrngDao extends EgovComAbstractDAO {
 	 * @exception Exception Exception
 	 */
 	public TrsmrcvMntrngLog selectTrsmrcvMntrngLog(TrsmrcvMntrngLog trsmrcvMntrngLog) throws Exception {
-		return (TrsmrcvMntrngLog) selectOne("TrsmrcvMntrngDao.selectTrsmrcvMntrngLog", trsmrcvMntrngLog);
+		return trsmrcvMntrngMapper.selectTrsmrcvMntrngLog(trsmrcvMntrngLog);
 	}
 
 	/**
@@ -88,7 +93,7 @@ public class TrsmrcvMntrngDao extends EgovComAbstractDAO {
 	 * @exception Exception Exception
 	 */
 	public List<TrsmrcvMntrng> selectTrsmrcvMntrngList(TrsmrcvMntrng searchVO) throws Exception {
-		return selectList("TrsmrcvMntrngDao.selectTrsmrcvMntrngList", searchVO);
+		return trsmrcvMntrngMapper.selectTrsmrcvMntrngList(searchVO);
 	}
 
 	/**
@@ -99,7 +104,7 @@ public class TrsmrcvMntrngDao extends EgovComAbstractDAO {
 	 * @exception Exception Exception
 	 */
 	public int selectTrsmrcvMntrngListCnt(TrsmrcvMntrng searchVO) throws Exception {
-		return (Integer) selectOne("TrsmrcvMntrngDao.selectTrsmrcvMntrngListCnt", searchVO);
+		return trsmrcvMntrngMapper.selectTrsmrcvMntrngListCnt(searchVO);
 	}
 
 	/**
@@ -110,7 +115,7 @@ public class TrsmrcvMntrngDao extends EgovComAbstractDAO {
 	 * @exception Exception Exception
 	 */
 	public List<TrsmrcvMntrngLog> selectTrsmrcvMntrngLogList(TrsmrcvMntrngLog searchVO) throws Exception {
-		return selectList("TrsmrcvMntrngDao.selectTrsmrcvMntrngLogList", searchVO);
+		return trsmrcvMntrngMapper.selectTrsmrcvMntrngLogList(searchVO);
 	}
 
 	/**
@@ -121,7 +126,7 @@ public class TrsmrcvMntrngDao extends EgovComAbstractDAO {
 	 * @exception Exception Exception
 	 */
 	public int selectTrsmrcvMntrngLogListCnt(TrsmrcvMntrngLog searchVO) throws Exception {
-		return (Integer) selectOne("TrsmrcvMntrngDao.selectTrsmrcvMntrngLogListCnt", searchVO);
+		return trsmrcvMntrngMapper.selectTrsmrcvMntrngLogListCnt(searchVO);
 	}
 
 	/**
@@ -131,7 +136,7 @@ public class TrsmrcvMntrngDao extends EgovComAbstractDAO {
 	 * @exception Exception Exception
 	 */
 	public void updateTrsmrcvMntrng(TrsmrcvMntrng trsmrcvMntrng) throws Exception {
-		update("TrsmrcvMntrngDao.updateTrsmrcvMntrng", trsmrcvMntrng);
+		trsmrcvMntrngMapper.updateTrsmrcvMntrng(trsmrcvMntrng);
 	}
 
 	/**
@@ -142,7 +147,7 @@ public class TrsmrcvMntrngDao extends EgovComAbstractDAO {
 	 * @exception Exception Exception
 	 */
 	public List<CntcVO> selectCntcList(CntcVO searchVO) throws Exception {
-		return selectList("TrsmrcvMntrngDao.selectCntcList", searchVO);
+		return trsmrcvMntrngMapper.selectCntcList(searchVO);
 	}
 
 	/**
@@ -153,7 +158,7 @@ public class TrsmrcvMntrngDao extends EgovComAbstractDAO {
 	 * @exception Exception Exception
 	 */
 	public int selectCntcListCnt(CntcVO searchVO) throws Exception {
-		return (Integer) selectOne("TrsmrcvMntrngDao.selectCntcListCnt", searchVO);
+		return trsmrcvMntrngMapper.selectCntcListCnt(searchVO);
 	}
 
 }

--- a/src/main/java/egovframework/com/utl/sys/trm/service/impl/TrsmrcvMntrngMapper.java
+++ b/src/main/java/egovframework/com/utl/sys/trm/service/impl/TrsmrcvMntrngMapper.java
@@ -1,0 +1,54 @@
+package egovframework.com.utl.sys.trm.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.utl.sys.trm.service.CntcVO;
+import egovframework.com.utl.sys.trm.service.TrsmrcvMntrng;
+import egovframework.com.utl.sys.trm.service.TrsmrcvMntrngLog;
+
+/**
+ * 송수신모니터링관리에 대한 Mapper 인터페이스를 정의한다.
+ *
+ * @author 김진만
+ * @since 2010.06.21
+ * @version 1.0
+ * @see
+ * <pre>
+ * == 개정이력(Modification Information) ==
+ *
+ *   수정일       수정자           수정내용
+ *  -------     --------    ---------------------------
+ *  2010.06.21   김진만     최초 생성
+ *  2026.05.28   dasomel    @EgovMapper 인터페이스 방식으로 전환
+ * </pre>
+ */
+@EgovMapper("trsmrcvMntrngMapper")
+public interface TrsmrcvMntrngMapper {
+
+	void deleteTrsmrcvMntrng(TrsmrcvMntrng trsmrcvMntrng);
+
+	void insertTrsmrcvMntrng(TrsmrcvMntrng trsmrcvMntrng);
+
+	void insertTrsmrcvMntrngLog(TrsmrcvMntrngLog trsmrcvMntrngLog);
+
+	TrsmrcvMntrng selectTrsmrcvMntrng(TrsmrcvMntrng trsmrcvMntrng);
+
+	TrsmrcvMntrngLog selectTrsmrcvMntrngLog(TrsmrcvMntrngLog trsmrcvMntrngLog);
+
+	List<TrsmrcvMntrng> selectTrsmrcvMntrngList(TrsmrcvMntrng searchVO);
+
+	int selectTrsmrcvMntrngListCnt(TrsmrcvMntrng searchVO);
+
+	List<TrsmrcvMntrngLog> selectTrsmrcvMntrngLogList(TrsmrcvMntrngLog searchVO);
+
+	int selectTrsmrcvMntrngLogListCnt(TrsmrcvMntrngLog searchVO);
+
+	void updateTrsmrcvMntrng(TrsmrcvMntrng trsmrcvMntrng);
+
+	List<CntcVO> selectCntcList(CntcVO searchVO);
+
+	int selectCntcListCnt(CntcVO searchVO);
+
+}

--- a/src/main/resources/egovframework/mapper/com/uss/sam/ipm/EgovIndvdlInfoPolicy_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/sam/ipm/EgovIndvdlInfoPolicy_SQL_altibase.xml
@@ -7,7 +7,7 @@
 --><!--Converted at: Wed May 11 15:51:44 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="IndvdlInfoPolicy">
+<mapper namespace="egovframework.com.uss.sam.ipm.service.impl.IndvdlInfoPolicyMapper">
 
 	<!-- ::ResultMap 선언 -->
 	<resultMap id="IndvdlInfoPolicyVO" type="egovframework.com.uss.sam.ipm.service.IndvdlInfoPolicy">

--- a/src/main/resources/egovframework/mapper/com/uss/sam/ipm/EgovIndvdlInfoPolicy_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/sam/ipm/EgovIndvdlInfoPolicy_SQL_cubrid.xml
@@ -7,7 +7,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="IndvdlInfoPolicy">
+<mapper namespace="egovframework.com.uss.sam.ipm.service.impl.IndvdlInfoPolicyMapper">
 
 	<!-- ::ResultMap 선언 -->
 	<resultMap id="IndvdlInfoPolicyVO" type="egovframework.com.uss.sam.ipm.service.IndvdlInfoPolicy">

--- a/src/main/resources/egovframework/mapper/com/uss/sam/ipm/EgovIndvdlInfoPolicy_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/sam/ipm/EgovIndvdlInfoPolicy_SQL_goldilocks.xml
@@ -7,7 +7,7 @@
 --><!--Converted at: Wed May 11 15:51:44 KST 2016-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="IndvdlInfoPolicy">
+<mapper namespace="egovframework.com.uss.sam.ipm.service.impl.IndvdlInfoPolicyMapper">
 
 	<!-- ::ResultMap 선언 -->
 	<resultMap id="IndvdlInfoPolicyVO" type="egovframework.com.uss.sam.ipm.service.IndvdlInfoPolicy">

--- a/src/main/resources/egovframework/mapper/com/uss/sam/ipm/EgovIndvdlInfoPolicy_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/sam/ipm/EgovIndvdlInfoPolicy_SQL_maria.xml
@@ -7,7 +7,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="IndvdlInfoPolicy">
+<mapper namespace="egovframework.com.uss.sam.ipm.service.impl.IndvdlInfoPolicyMapper">
 
 	<!-- ::ResultMap 선언 -->
 	<resultMap id="IndvdlInfoPolicyVO" type="egovframework.com.uss.sam.ipm.service.IndvdlInfoPolicy">

--- a/src/main/resources/egovframework/mapper/com/uss/sam/ipm/EgovIndvdlInfoPolicy_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/sam/ipm/EgovIndvdlInfoPolicy_SQL_mysql.xml
@@ -7,7 +7,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="IndvdlInfoPolicy">
+<mapper namespace="egovframework.com.uss.sam.ipm.service.impl.IndvdlInfoPolicyMapper">
 
 	<!-- ::ResultMap 선언 -->
 	<resultMap id="IndvdlInfoPolicyVO" type="egovframework.com.uss.sam.ipm.service.IndvdlInfoPolicy">

--- a/src/main/resources/egovframework/mapper/com/uss/sam/ipm/EgovIndvdlInfoPolicy_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/sam/ipm/EgovIndvdlInfoPolicy_SQL_oracle.xml
@@ -7,7 +7,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="IndvdlInfoPolicy">
+<mapper namespace="egovframework.com.uss.sam.ipm.service.impl.IndvdlInfoPolicyMapper">
 
 	<!-- ::ResultMap 선언 -->
 	<resultMap id="IndvdlInfoPolicyVO" type="egovframework.com.uss.sam.ipm.service.IndvdlInfoPolicy">

--- a/src/main/resources/egovframework/mapper/com/uss/sam/ipm/EgovIndvdlInfoPolicy_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/sam/ipm/EgovIndvdlInfoPolicy_SQL_postgres.xml
@@ -7,7 +7,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="IndvdlInfoPolicy">
+<mapper namespace="egovframework.com.uss.sam.ipm.service.impl.IndvdlInfoPolicyMapper">
 
 	<!-- ::ResultMap 선언 -->
 	<resultMap id="IndvdlInfoPolicyVO" type="egovframework.com.uss.sam.ipm.service.IndvdlInfoPolicy">

--- a/src/main/resources/egovframework/mapper/com/uss/sam/ipm/EgovIndvdlInfoPolicy_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/sam/ipm/EgovIndvdlInfoPolicy_SQL_tibero.xml
@@ -7,7 +7,7 @@
 -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="IndvdlInfoPolicy">
+<mapper namespace="egovframework.com.uss.sam.ipm.service.impl.IndvdlInfoPolicyMapper">
 
 	<!-- ::ResultMap 선언 -->
 	<resultMap id="IndvdlInfoPolicyVO" type="egovframework.com.uss.sam.ipm.service.IndvdlInfoPolicy">

--- a/src/main/resources/egovframework/mapper/com/utl/sys/dbm/EgovDbMntrng_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/dbm/EgovDbMntrng_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="DbMntrngDao">
+<mapper namespace="egovframework.com.utl.sys.dbm.service.impl.DbMntrngMapper">
 
     <resultMap id="dbMntrngResult" type="egovframework.com.utl.sys.dbm.service.DbMntrng">
         <result property="dataSourcNm" column="DATA_SOURC_NM"/>

--- a/src/main/resources/egovframework/mapper/com/utl/sys/dbm/EgovDbMntrng_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/dbm/EgovDbMntrng_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="DbMntrngDao">
+<mapper namespace="egovframework.com.utl.sys.dbm.service.impl.DbMntrngMapper">
 
     <resultMap id="dbMntrngResult" type="egovframework.com.utl.sys.dbm.service.DbMntrng">
         <result property="dataSourcNm" column="DATA_SOURC_NM"/>

--- a/src/main/resources/egovframework/mapper/com/utl/sys/dbm/EgovDbMntrng_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/dbm/EgovDbMntrng_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="DbMntrngDao">
+<mapper namespace="egovframework.com.utl.sys.dbm.service.impl.DbMntrngMapper">
 
     <resultMap id="dbMntrngResult" type="egovframework.com.utl.sys.dbm.service.DbMntrng">
         <result property="dataSourcNm" column="DATA_SOURC_NM"/>

--- a/src/main/resources/egovframework/mapper/com/utl/sys/dbm/EgovDbMntrng_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/dbm/EgovDbMntrng_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="DbMntrngDao">
+<mapper namespace="egovframework.com.utl.sys.dbm.service.impl.DbMntrngMapper">
 
 	<resultMap id="dbMntrngResult" type="egovframework.com.utl.sys.dbm.service.DbMntrng">
 		<result property="dataSourcNm" column="DATA_SOURC_NM"/>

--- a/src/main/resources/egovframework/mapper/com/utl/sys/dbm/EgovDbMntrng_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/dbm/EgovDbMntrng_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="DbMntrngDao">
+<mapper namespace="egovframework.com.utl.sys.dbm.service.impl.DbMntrngMapper">
 
 	<resultMap id="dbMntrngResult" type="egovframework.com.utl.sys.dbm.service.DbMntrng">
 		<result property="dataSourcNm" column="DATA_SOURC_NM"/>

--- a/src/main/resources/egovframework/mapper/com/utl/sys/dbm/EgovDbMntrng_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/dbm/EgovDbMntrng_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="DbMntrngDao">
+<mapper namespace="egovframework.com.utl.sys.dbm.service.impl.DbMntrngMapper">
 
     <resultMap id="dbMntrngResult" type="egovframework.com.utl.sys.dbm.service.DbMntrng">
         <result property="dataSourcNm" column="DATA_SOURC_NM"/>

--- a/src/main/resources/egovframework/mapper/com/utl/sys/dbm/EgovDbMntrng_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/dbm/EgovDbMntrng_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="DbMntrngDao">
+<mapper namespace="egovframework.com.utl.sys.dbm.service.impl.DbMntrngMapper">
 
 	<resultMap id="dbMntrngResult" type="egovframework.com.utl.sys.dbm.service.DbMntrng">
 		<result property="dataSourcNm" column="DATA_SOURC_NM"/>

--- a/src/main/resources/egovframework/mapper/com/utl/sys/dbm/EgovDbMntrng_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/dbm/EgovDbMntrng_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="DbMntrngDao">
+<mapper namespace="egovframework.com.utl.sys.dbm.service.impl.DbMntrngMapper">
 
     <resultMap id="dbMntrngResult" type="egovframework.com.utl.sys.dbm.service.DbMntrng">
         <result property="dataSourcNm" column="DATA_SOURC_NM"/>

--- a/src/main/resources/egovframework/mapper/com/utl/sys/trm/EgovTrsmrcvMntrng_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/trm/EgovTrsmrcvMntrng_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="TrsmrcvMntrngDao">
+<mapper namespace="egovframework.com.utl.sys.trm.service.impl.TrsmrcvMntrngMapper">
 
 	<resultMap id="trsmrcvMntrngResult" type="egovframework.com.utl.sys.trm.service.TrsmrcvMntrng">
 		<result property="cntcId" column="CNTC_ID"/>

--- a/src/main/resources/egovframework/mapper/com/utl/sys/trm/EgovTrsmrcvMntrng_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/trm/EgovTrsmrcvMntrng_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="TrsmrcvMntrngDao">
+<mapper namespace="egovframework.com.utl.sys.trm.service.impl.TrsmrcvMntrngMapper">
 
 	<resultMap id="trsmrcvMntrngResult" type="egovframework.com.utl.sys.trm.service.TrsmrcvMntrng">
 		<result property="cntcId" column="CNTC_ID"/>

--- a/src/main/resources/egovframework/mapper/com/utl/sys/trm/EgovTrsmrcvMntrng_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/trm/EgovTrsmrcvMntrng_SQL_goldilocks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="TrsmrcvMntrngDao">
+<mapper namespace="egovframework.com.utl.sys.trm.service.impl.TrsmrcvMntrngMapper">
 
 	<resultMap id="trsmrcvMntrngResult" type="egovframework.com.utl.sys.trm.service.TrsmrcvMntrng">
 		<result property="cntcId" column="CNTC_ID"/>

--- a/src/main/resources/egovframework/mapper/com/utl/sys/trm/EgovTrsmrcvMntrng_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/trm/EgovTrsmrcvMntrng_SQL_maria.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="TrsmrcvMntrngDao">
+<mapper namespace="egovframework.com.utl.sys.trm.service.impl.TrsmrcvMntrngMapper">
 
 	<resultMap id="trsmrcvMntrngResult" type="egovframework.com.utl.sys.trm.service.TrsmrcvMntrng">
 		<result property="cntcId" column="CNTC_ID"/>

--- a/src/main/resources/egovframework/mapper/com/utl/sys/trm/EgovTrsmrcvMntrng_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/trm/EgovTrsmrcvMntrng_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="TrsmrcvMntrngDao">
+<mapper namespace="egovframework.com.utl.sys.trm.service.impl.TrsmrcvMntrngMapper">
 
 	<resultMap id="trsmrcvMntrngResult" type="egovframework.com.utl.sys.trm.service.TrsmrcvMntrng">
 		<result property="cntcId" column="CNTC_ID"/>

--- a/src/main/resources/egovframework/mapper/com/utl/sys/trm/EgovTrsmrcvMntrng_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/trm/EgovTrsmrcvMntrng_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="TrsmrcvMntrngDao">
+<mapper namespace="egovframework.com.utl.sys.trm.service.impl.TrsmrcvMntrngMapper">
 
 	<resultMap id="trsmrcvMntrngResult" type="egovframework.com.utl.sys.trm.service.TrsmrcvMntrng">
 		<result property="cntcId" column="CNTC_ID"/>

--- a/src/main/resources/egovframework/mapper/com/utl/sys/trm/EgovTrsmrcvMntrng_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/trm/EgovTrsmrcvMntrng_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="TrsmrcvMntrngDao">
+<mapper namespace="egovframework.com.utl.sys.trm.service.impl.TrsmrcvMntrngMapper">
 
 	<resultMap id="trsmrcvMntrngResult" type="egovframework.com.utl.sys.trm.service.TrsmrcvMntrng">
 		<result property="cntcId" column="CNTC_ID"/>

--- a/src/main/resources/egovframework/mapper/com/utl/sys/trm/EgovTrsmrcvMntrng_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/trm/EgovTrsmrcvMntrng_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="TrsmrcvMntrngDao">
+<mapper namespace="egovframework.com.utl.sys.trm.service.impl.TrsmrcvMntrngMapper">
 
 	<resultMap id="trsmrcvMntrngResult" type="egovframework.com.utl.sys.trm.service.TrsmrcvMntrng">
 		<result property="cntcId" column="CNTC_ID"/>

--- a/src/main/resources/egovframework/spring/com/context-mapper.xml
+++ b/src/main/resources/egovframework/spring/com/context-mapper.xml
@@ -21,5 +21,10 @@
 	<bean id="egov.sqlSessionTemplate" class="org.mybatis.spring.SqlSessionTemplate">
 		<constructor-arg ref="egov.sqlSession"/>
 	</bean>
-	
+
+	<bean class="org.mybatis.spring.mapper.MapperScannerConfigurer">
+		<property name="basePackage" value="egovframework.com" />
+		<property name="annotationClass" value="org.egovframe.rte.psl.dataaccess.mapper.EgovMapper" />
+	</bean>
+
 </beans>


### PR DESCRIPTION
## 변경 사유
기존 XML namespace 기반 DAO를 eGovFrame 5.0 신규 `@EgovMapper` 인터페이스 방식으로 전환합니다.

## 변경 내용
- 대상: uss/sam/ipm, utl/sys(dbm·trm) 3개 DAO
- 각 DAO에 대응하는 Mapper 인터페이스(`@EgovMapper`) 신규 추가
- DAO를 mapper 위임 구조로 리팩토링 (EgovComAbstractDAO 상속 제거, @Resource 주입, @Repository bean name 유지)
- XML mapper namespace를 mapper 인터페이스 FQN으로 변경
- context-mapper.xml에 MapperScannerConfigurer(annotationClass=EgovMapper) 추가

## 영향 범위
- 해당 모듈만 영향, 서비스 레이어 호출 시그니처 변경 없음

## 참고
- 빌드 검증을 위해 #891(Lombok annotationProcessorPaths 빌드 수정) 선행 머지 권장
- context-mapper.xml MapperScannerConfigurer는 동일 시리즈 PR과 한 줄 중복될 수 있어, 선행 PR 머지 후 rebase로 정리 가능

## 체크리스트
- [x] 단일 주제만 다룸
- [x] 컴파일 검증(해당 모듈 신규 오류 0)
- [x] 기존 동작 호환
