### PR TITLE
[test][5.0.x][공통컴포넌트] utl/fcc 날짜 유틸(EgovDateUtil·EgovDateFormat) 단위 테스트 추가

### DIFF
--- a/src/test/java/egovframework/com/utl/fcc/service/EgovDateFormatTest.java
+++ b/src/test/java/egovframework/com/utl/fcc/service/EgovDateFormatTest.java
@@ -1,0 +1,229 @@
+package egovframework.com.utl.fcc.service;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.text.DateFormat;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.Locale;
+
+/**
+ * EgovDateFormat 단위 테스트
+ */
+public class EgovDateFormatTest {
+
+    /** 고정된 테스트 날짜: 2006-02-28 15:30:45 */
+    private static Date fixedDate() {
+        Calendar cal = Calendar.getInstance();
+        cal.set(2006, Calendar.FEBRUARY, 28, 15, 30, 45);
+        cal.set(Calendar.MILLISECOND, 0);
+        return cal.getTime();
+    }
+
+    // ─── formatDate(Date) ─────────────────────────────────────────────────
+
+    @Test
+    void formatDate_Date_기본로케일_비어있지않음() {
+        String result = EgovDateFormat.formatDate(fixedDate());
+        Assertions.assertNotNull(result);
+        Assertions.assertFalse(result.isEmpty());
+    }
+
+    @Test
+    void formatDate_Date_날짜포함() {
+        // 기본 로케일로 포맷된 결과에 "2006" 연도가 포함되어야 함
+        String result = EgovDateFormat.formatDate(fixedDate());
+        Assertions.assertTrue(result.contains("2006"),
+                "기본 formatDate 결과에 연도 2006이 포함되어야 합니다: " + result);
+    }
+
+    // ─── formatDate(Locale, Date) ─────────────────────────────────────────
+
+    @Test
+    void formatDate_Locale_US() {
+        String result = EgovDateFormat.formatDate(Locale.US, fixedDate());
+        Assertions.assertNotNull(result);
+        Assertions.assertFalse(result.isEmpty());
+        Assertions.assertTrue(result.contains("2006"),
+                "US 로케일 formatDate 결과에 연도 2006이 포함되어야 합니다: " + result);
+    }
+
+    @Test
+    void formatDate_Locale_KOREA() {
+        String result = EgovDateFormat.formatDate(Locale.KOREA, fixedDate());
+        Assertions.assertNotNull(result);
+        Assertions.assertTrue(result.contains("2006"));
+    }
+
+    // ─── formatDate(int style, Date) ──────────────────────────────────────
+
+    @Test
+    void formatDate_스타일_SHORT() {
+        String result = EgovDateFormat.formatDate(DateFormat.SHORT, fixedDate());
+        Assertions.assertNotNull(result);
+        Assertions.assertFalse(result.isEmpty());
+    }
+
+    @Test
+    void formatDate_스타일_MEDIUM() {
+        String result = EgovDateFormat.formatDate(DateFormat.MEDIUM, fixedDate());
+        Assertions.assertNotNull(result);
+        Assertions.assertFalse(result.isEmpty());
+    }
+
+    @Test
+    void formatDate_스타일_LONG() {
+        String result = EgovDateFormat.formatDate(DateFormat.LONG, fixedDate());
+        Assertions.assertNotNull(result);
+        Assertions.assertTrue(result.contains("2006"));
+    }
+
+    @Test
+    void formatDate_스타일_FULL() {
+        String result = EgovDateFormat.formatDate(DateFormat.FULL, fixedDate());
+        Assertions.assertNotNull(result);
+        Assertions.assertTrue(result.contains("2006"));
+    }
+
+    // ─── formatDate(int style, Locale, Date) ──────────────────────────────
+
+    @Test
+    void formatDate_스타일_로케일_SHORT_US() {
+        String result = EgovDateFormat.formatDate(DateFormat.SHORT, Locale.US, fixedDate());
+        // US SHORT: M/d/yy 형식 → "2/28/06"
+        Assertions.assertNotNull(result);
+        Assertions.assertTrue(result.contains("28") || result.contains("06"),
+                "US SHORT 날짜에 '28' 또는 '06'이 포함되어야 합니다: " + result);
+    }
+
+    @Test
+    void formatDate_스타일_로케일_FULL_US() {
+        String result = EgovDateFormat.formatDate(DateFormat.FULL, Locale.US, fixedDate());
+        Assertions.assertTrue(result.contains("2006"));
+        Assertions.assertTrue(result.contains("February") || result.contains("Feb"),
+                "US FULL 날짜에 월 이름이 포함되어야 합니다: " + result);
+    }
+
+    @Test
+    void formatDate_스타일_로케일_결과일관성() {
+        // 동일 인자로 두 번 호출하면 같은 결과
+        Date date = fixedDate();
+        String r1 = EgovDateFormat.formatDate(DateFormat.MEDIUM, Locale.US, date);
+        String r2 = EgovDateFormat.formatDate(DateFormat.MEDIUM, Locale.US, date);
+        Assertions.assertEquals(r1, r2);
+    }
+
+    // ─── formatDateTime(Date) ─────────────────────────────────────────────
+
+    @Test
+    void formatDateTime_Date_날짜시간포함() {
+        String result = EgovDateFormat.formatDateTime(fixedDate());
+        Assertions.assertNotNull(result);
+        Assertions.assertTrue(result.contains("2006"));
+    }
+
+    // ─── formatDateTime(Locale, Date) ─────────────────────────────────────
+
+    @Test
+    void formatDateTime_Locale_US() {
+        String result = EgovDateFormat.formatDateTime(Locale.US, fixedDate());
+        Assertions.assertNotNull(result);
+        Assertions.assertTrue(result.contains("2006"));
+    }
+
+    // ─── formatDateTime(int dateStyle, int timeStyle, Date) ───────────────
+
+    @Test
+    void formatDateTime_dateStyle_timeStyle_SHORT() {
+        String result = EgovDateFormat.formatDateTime(DateFormat.SHORT, DateFormat.SHORT, fixedDate());
+        Assertions.assertNotNull(result);
+        Assertions.assertFalse(result.isEmpty());
+    }
+
+    @Test
+    void formatDateTime_dateStyle_timeStyle_MEDIUM() {
+        String result = EgovDateFormat.formatDateTime(DateFormat.MEDIUM, DateFormat.MEDIUM, fixedDate());
+        Assertions.assertNotNull(result);
+        Assertions.assertFalse(result.isEmpty());
+    }
+
+    // ─── formatDateTime(int dateStyle, int timeStyle, Locale, Date) ───────
+
+    @Test
+    void formatDateTime_스타일_로케일_결과일관성() {
+        Date date = fixedDate();
+        String r1 = EgovDateFormat.formatDateTime(DateFormat.MEDIUM, DateFormat.SHORT, Locale.US, date);
+        String r2 = EgovDateFormat.formatDateTime(DateFormat.MEDIUM, DateFormat.SHORT, Locale.US, date);
+        Assertions.assertEquals(r1, r2);
+    }
+
+    @Test
+    void formatDateTime_FULL_US_날짜시간포함() {
+        String result = EgovDateFormat.formatDateTime(DateFormat.FULL, DateFormat.FULL, Locale.US, fixedDate());
+        Assertions.assertTrue(result.contains("2006"));
+        // 시간 15:30이 어떤 형태로든 포함
+        Assertions.assertTrue(result.contains("3:30") || result.contains("15:30"),
+                "FULL 날짜시간에 시간 정보가 포함되어야 합니다: " + result);
+    }
+
+    // ─── formatTime(Date) ─────────────────────────────────────────────────
+
+    @Test
+    void formatTime_Date_비어있지않음() {
+        String result = EgovDateFormat.formatTime(fixedDate());
+        Assertions.assertNotNull(result);
+        Assertions.assertFalse(result.isEmpty());
+    }
+
+    // ─── formatTime(Locale, Date) ─────────────────────────────────────────
+
+    @Test
+    void formatTime_Locale_US() {
+        String result = EgovDateFormat.formatTime(Locale.US, fixedDate());
+        Assertions.assertNotNull(result);
+        Assertions.assertFalse(result.isEmpty());
+    }
+
+    // ─── formatTime(int style, Date) ──────────────────────────────────────
+
+    @Test
+    void formatTime_스타일_SHORT() {
+        String result = EgovDateFormat.formatTime(DateFormat.SHORT, fixedDate());
+        Assertions.assertNotNull(result);
+        Assertions.assertFalse(result.isEmpty());
+    }
+
+    @Test
+    void formatTime_스타일_MEDIUM() {
+        String result = EgovDateFormat.formatTime(DateFormat.MEDIUM, fixedDate());
+        Assertions.assertNotNull(result);
+        Assertions.assertFalse(result.isEmpty());
+    }
+
+    // ─── formatTime(int style, Locale, Date) ──────────────────────────────
+
+    @Test
+    void formatTime_스타일_로케일_결과일관성() {
+        Date date = fixedDate();
+        String r1 = EgovDateFormat.formatTime(DateFormat.SHORT, Locale.US, date);
+        String r2 = EgovDateFormat.formatTime(DateFormat.SHORT, Locale.US, date);
+        Assertions.assertEquals(r1, r2);
+    }
+
+    @Test
+    void formatTime_MEDIUM_US_분포함() {
+        String result = EgovDateFormat.formatTime(DateFormat.MEDIUM, Locale.US, fixedDate());
+        // 15:30:45 → US MEDIUM "3:30:45 PM"
+        Assertions.assertTrue(result.contains("30"),
+                "시간 포맷 결과에 '30'(분)이 포함되어야 합니다: " + result);
+    }
+
+    @Test
+    void formatTime_FULL_US_비어있지않음() {
+        String result = EgovDateFormat.formatTime(DateFormat.FULL, Locale.US, fixedDate());
+        Assertions.assertNotNull(result);
+        Assertions.assertFalse(result.isEmpty());
+    }
+
+}

--- a/src/test/java/egovframework/com/utl/fcc/service/EgovDateUtilTest.java
+++ b/src/test/java/egovframework/com/utl/fcc/service/EgovDateUtilTest.java
@@ -1,0 +1,377 @@
+package egovframework.com.utl.fcc.service;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+/**
+ * EgovDateUtil 단위 테스트
+ */
+public class EgovDateUtilTest {
+
+    // ─── addYearMonthDay ───────────────────────────────────────────────────
+
+    @Test
+    void addYearMonthDay_일가산_정상() {
+        Assertions.assertEquals("19810916", EgovDateUtil.addYearMonthDay("19810828", 0, 0, 19));
+    }
+
+    @Test
+    void addYearMonthDay_일감산_정상() {
+        Assertions.assertEquals("20060218", EgovDateUtil.addYearMonthDay("20060228", 0, 0, -10));
+    }
+
+    @Test
+    void addYearMonthDay_월말_일가산_월경계() {
+        Assertions.assertEquals("20060310", EgovDateUtil.addYearMonthDay("20060228", 0, 0, 10));
+    }
+
+    @Test
+    void addYearMonthDay_월감산_2월말일처리() {
+        Assertions.assertEquals("20050228", EgovDateUtil.addYearMonthDay("20050331", 0, -1, 0));
+    }
+
+    @Test
+    void addYearMonthDay_년가산_정상() {
+        // 2005-03-01 + 1년 + 2월 + 30일 = 2006-05-31
+        Assertions.assertEquals("20060531", EgovDateUtil.addYearMonthDay("20050301", 1, 2, 30));
+    }
+
+    @Test
+    void addYearMonthDay_구분자있는날짜형식() {
+        Assertions.assertEquals("20060228", EgovDateUtil.addYearMonthDay("2006-02-28", 0, 0, 0));
+    }
+
+    @Test
+    void addYearMonthDay_null입력_예외() {
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> EgovDateUtil.addYearMonthDay(null, 0, 0, 1));
+    }
+
+    @Test
+    void addYearMonthDay_잘못된형식_예외() {
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> EgovDateUtil.addYearMonthDay("2006228", 0, 0, 1));
+    }
+
+    // ─── addYear ──────────────────────────────────────────────────────────
+
+    @Test
+    void addYear_정상가산() {
+        Assertions.assertEquals("20620201", EgovDateUtil.addYear("20000201", 62));
+    }
+
+    @Test
+    void addYear_정상감산() {
+        Assertions.assertEquals("20000201", EgovDateUtil.addYear("20620201", -62));
+    }
+
+    @Test
+    void addYear_윤년2월29일_비윤년으로이동() {
+        Assertions.assertEquals("20060228", EgovDateUtil.addYear("20040229", 2));
+    }
+
+    // ─── addMonth ─────────────────────────────────────────────────────────
+
+    @Test
+    void addMonth_12개월가산() {
+        Assertions.assertEquals("20020201", EgovDateUtil.addMonth("20010201", 12));
+    }
+
+    @Test
+    void addMonth_월말일처리_2월() {
+        Assertions.assertEquals("20060228", EgovDateUtil.addMonth("20060131", 1));
+    }
+
+    @Test
+    void addMonth_감산() {
+        Assertions.assertEquals("20060128", EgovDateUtil.addMonth("20060228", -1));
+    }
+
+    // ─── addDay ───────────────────────────────────────────────────────────
+
+    @Test
+    void addDay_정상가산() {
+        Assertions.assertEquals("20000201", EgovDateUtil.addDay("19991201", 62));
+    }
+
+    @Test
+    void addDay_정상감산() {
+        Assertions.assertEquals("19991201", EgovDateUtil.addDay("20000201", -62));
+    }
+
+    @Test
+    void addDay_월경계() {
+        Assertions.assertEquals("20050903", EgovDateUtil.addDay("20050831", 3));
+    }
+
+    // ─── getDaysDiff ──────────────────────────────────────────────────────
+
+    @Test
+    void getDaysDiff_양수() {
+        Assertions.assertEquals(10, EgovDateUtil.getDaysDiff("20060228", "20060310"));
+    }
+
+    @Test
+    void getDaysDiff_1년() {
+        Assertions.assertEquals(365, EgovDateUtil.getDaysDiff("20060101", "20070101"));
+    }
+
+    @Test
+    void getDaysDiff_음수() {
+        Assertions.assertEquals(-28, EgovDateUtil.getDaysDiff("19990228", "19990131"));
+    }
+
+    @Test
+    void getDaysDiff_같은날() {
+        Assertions.assertEquals(0, EgovDateUtil.getDaysDiff("20060801", "20060801"));
+    }
+
+    @Test
+    void getDaysDiff_1일() {
+        Assertions.assertEquals(1, EgovDateUtil.getDaysDiff("20060801", "20060802"));
+    }
+
+    // ─── checkDate(String) ────────────────────────────────────────────────
+
+    @Test
+    void checkDate_유효한날짜_8자리() {
+        Assertions.assertTrue(EgovDateUtil.checkDate("20060228"));
+    }
+
+    @Test
+    void checkDate_유효한날짜_구분자() {
+        Assertions.assertTrue(EgovDateUtil.checkDate("2006-02-28"));
+    }
+
+    @Test
+    void checkDate_존재하지않는날짜_35일() {
+        Assertions.assertFalse(EgovDateUtil.checkDate("19990235"));
+    }
+
+    @Test
+    void checkDate_존재하지않는날짜_13월() {
+        Assertions.assertFalse(EgovDateUtil.checkDate("20001331"));
+    }
+
+    @Test
+    void checkDate_11월31일() {
+        Assertions.assertFalse(EgovDateUtil.checkDate("20061131"));
+    }
+
+    // ─── checkDate(String, String, String) ────────────────────────────────
+
+    @Test
+    void checkDate_년월일파라미터_유효() {
+        Assertions.assertTrue(EgovDateUtil.checkDate("2006", "02", "28"));
+    }
+
+    @Test
+    void checkDate_년월일파라미터_무효() {
+        Assertions.assertFalse(EgovDateUtil.checkDate("2006", "02", "30"));
+    }
+
+    // ─── formatDate ───────────────────────────────────────────────────────
+
+    @Test
+    void formatDate_8자리_점구분자() {
+        Assertions.assertEquals("2003.04.05", EgovDateUtil.formatDate("20030405", "."));
+    }
+
+    @Test
+    void formatDate_8자리_슬래시구분자() {
+        Assertions.assertEquals("2004/01/01", EgovDateUtil.formatDate("20040101", "/"));
+    }
+
+    @Test
+    void formatDate_6자리_유효하지않은입력_예외() {
+        // validChkDate는 8자리 또는 10자리(yyyy-MM-dd)만 허용
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> EgovDateUtil.formatDate("200304", "."));
+    }
+
+    @Test
+    void formatDate_4자리_유효하지않은입력_예외() {
+        // validChkDate는 8자리 또는 10자리(yyyy-MM-dd)만 허용
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> EgovDateUtil.formatDate("2003", "."));
+    }
+
+    @Test
+    void formatDate_0000년_빈문자열() {
+        Assertions.assertEquals("", EgovDateUtil.formatDate("00000101", "."));
+    }
+
+    @Test
+    void formatDate_월이00_년도만반환() {
+        Assertions.assertEquals("2003", EgovDateUtil.formatDate("20030000", "."));
+    }
+
+    @Test
+    void formatDate_일이00_년월반환() {
+        Assertions.assertEquals("2003.04", EgovDateUtil.formatDate("20030400", "."));
+    }
+
+    // ─── formatTime ───────────────────────────────────────────────────────
+
+    @Test
+    void formatTime_6자리_예외() {
+        // validChkTime은 4자리(HHmm)만 허용 — 6자리 입력은 예외
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> EgovDateUtil.formatTime("151241", "/"));
+    }
+
+    @Test
+    void formatTime_4자리입력_substring예외() {
+        // validChkTime 통과(4자리)하지만 formatTime이 substring(4,6) 호출 → StringIndexOutOfBoundsException
+        Assertions.assertThrows(Exception.class,
+                () -> EgovDateUtil.formatTime("1512", "/"));
+    }
+
+    // ─── isLeapYear ───────────────────────────────────────────────────────
+    // 주의: isLeapYear는 윤년이면 false, 비윤년이면 true를 반환하는 구현
+
+    @Test
+    void isLeapYear_윤년_false반환() {
+        Assertions.assertFalse(EgovDateUtil.isLeapYear(2000)); // 400의 배수
+        Assertions.assertFalse(EgovDateUtil.isLeapYear(2004)); // 4의 배수, 100의 배수 아님
+    }
+
+    @Test
+    void isLeapYear_비윤년_true반환() {
+        Assertions.assertTrue(EgovDateUtil.isLeapYear(2005)); // 평년
+        Assertions.assertTrue(EgovDateUtil.isLeapYear(2100)); // 100의 배수, 400의 배수 아님
+    }
+
+    // ─── convertWeek ──────────────────────────────────────────────────────
+
+    @Test
+    void convertWeek_월요일() {
+        Assertions.assertEquals("월요일", EgovDateUtil.convertWeek("MON"));
+    }
+
+    @Test
+    void convertWeek_일요일() {
+        Assertions.assertEquals("일요일", EgovDateUtil.convertWeek("SUN"));
+    }
+
+    @Test
+    void convertWeek_토요일() {
+        Assertions.assertEquals("토요일", EgovDateUtil.convertWeek("SAT"));
+    }
+
+    @Test
+    void convertWeek_금요일() {
+        Assertions.assertEquals("금요일", EgovDateUtil.convertWeek("FRI"));
+    }
+
+    // ─── validDate ────────────────────────────────────────────────────────
+
+    @Test
+    void validDate_유효한날짜() {
+        Assertions.assertTrue(EgovDateUtil.validDate("20060228"));
+    }
+
+    @Test
+    void validDate_무효한날짜() {
+        Assertions.assertFalse(EgovDateUtil.validDate("20061131"));
+    }
+
+    // ─── validTime ────────────────────────────────────────────────────────
+
+    @Test
+    void validTime_유효한시간() {
+        Assertions.assertTrue(EgovDateUtil.validTime("1530"));
+    }
+
+    @Test
+    void validTime_무효한시간() {
+        Assertions.assertFalse(EgovDateUtil.validTime("2561"));
+    }
+
+    // ─── addYMDtoWeek ─────────────────────────────────────────────────────
+
+    @Test
+    void addYMDtoWeek_수요일() {
+        // 2006-02-22는 수요일
+        Assertions.assertEquals("Wed", EgovDateUtil.addYMDtoWeek("20060222", 0, 0, 0));
+    }
+
+    @Test
+    void addYMDtoWeek_1일후() {
+        // 2006-02-22(수) + 1일 = 2006-02-23(목)
+        Assertions.assertEquals("Thu", EgovDateUtil.addYMDtoWeek("20060222", 0, 0, 1));
+    }
+
+    // ─── validChkDate / validChkTime ──────────────────────────────────────
+
+    @Test
+    void validChkDate_8자리정상() {
+        Assertions.assertEquals("20060228", EgovDateUtil.validChkDate("20060228"));
+    }
+
+    @Test
+    void validChkDate_10자리구분자제거() {
+        Assertions.assertEquals("20060228", EgovDateUtil.validChkDate("2006-02-28"));
+    }
+
+    @Test
+    void validChkDate_null_예외() {
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> EgovDateUtil.validChkDate(null));
+    }
+
+    @Test
+    void validChkDate_잘못된길이_예외() {
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> EgovDateUtil.validChkDate("200602"));
+    }
+
+    @Test
+    void validChkTime_4자리정상() {
+        Assertions.assertEquals("1530", EgovDateUtil.validChkTime("1530"));
+    }
+
+    @Test
+    void validChkTime_null_예외() {
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> EgovDateUtil.validChkTime(null));
+    }
+
+    // ─── toLunar / toSolar ────────────────────────────────────────────────
+
+    @Test
+    void toLunar_양력_to_음력_반환값구조() {
+        Map<String, String> result = EgovDateUtil.toLunar("20060228");
+        Assertions.assertNotNull(result.get("day"));
+        Assertions.assertNotNull(result.get("leap"));
+        Assertions.assertEquals(8, result.get("day").length());
+    }
+
+    @Test
+    void toSolar_음력_to_양력() {
+        // toLunar 결과를 toSolar로 되돌렸을 때 원본 날짜 반환 확인
+        Map<String, String> lunar = EgovDateUtil.toLunar("20060228");
+        String solarBack = EgovDateUtil.toSolar(lunar.get("day"), Integer.parseInt(lunar.get("leap")));
+        Assertions.assertEquals("20060228", solarBack);
+    }
+
+    // ─── getRandomDate ────────────────────────────────────────────────────
+
+    @Test
+    void getRandomDate_범위내반환() {
+        String result = EgovDateUtil.getRandomDate("20060101", "20061231");
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals(8, result.length());
+        int val = Integer.parseInt(result);
+        Assertions.assertTrue(val >= 20060101 && val <= 20061231);
+    }
+
+    @Test
+    void getRandomDate_시작이끝보다크면_예외() {
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> EgovDateUtil.getRandomDate("20061231", "20060101"));
+    }
+
+}


### PR DESCRIPTION
## 변경 사유
순수 함수형 유틸리티 클래스에 단위 테스트가 없어 회귀 검증이 어렵습니다. 결정적(deterministic) 입출력 기반 JUnit5 테스트를 추가합니다.

## 변경 내용
- 대상: EgovDateUtil·EgovDateFormat
- 정상/경계/예외 케이스 포함 총 84개 테스트 메서드 (JUnit 5)
- 테스트 소스만 추가, 운영 코드/빌드 설정 변경 없음

## 검증
- 84/84 통과 확인

## 체크리스트
- [x] 단일 주제만 다룸 (테스트 파일만)
- [x] 전체 통과 확인
