### PR TITLE
[test][5.0.x][공통컴포넌트] utl/fcc 숫자 유틸(EgovNumberUtil·EgovNumberFormat) 단위 테스트 추가

### DIFF
--- a/src/test/java/egovframework/com/utl/fcc/service/EgovNumberFormatTest.java
+++ b/src/test/java/egovframework/com/utl/fcc/service/EgovNumberFormatTest.java
@@ -1,0 +1,196 @@
+package egovframework.com.utl.fcc.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Locale;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * EgovNumberFormat 단위 테스트
+ */
+public class EgovNumberFormatTest {
+
+    // -----------------------------------------------------------------------
+    // formatNumber (기본 Locale)
+    // -----------------------------------------------------------------------
+
+    @Test
+    void testFormatNumber_integer_grouping() {
+        String result = EgovNumberFormat.formatNumber(1000000);
+        // 기본 Locale(한국 JVM 환경) 기준 그룹 구분자 포함
+        assertTrue(result.contains("1") && result.endsWith("000"),
+                "1000000 포맷 결과에 자릿수 표기 포함: " + result);
+    }
+
+    @Test
+    void testFormatNumber_noGrouping() {
+        String result = EgovNumberFormat.formatNumber(1000000, false);
+        assertFalse(result.contains(",") || result.contains(".") && result.length() < 8,
+                "그룹 구분자 없이 숫자만 포함: " + result);
+        assertTrue(result.replace(",", "").replace(".", "").contains("1000000")
+                || result.contains("1000000"),
+                "1000000 숫자값 포함: " + result);
+    }
+
+    @Test
+    void testFormatNumber_decimalTruncation() {
+        // 소수점 3자리까지만 (MAX_FRACTION_DIGIT=3)
+        String result = EgovNumberFormat.formatNumber(3.14159265);
+        // 소수점 이하 최대 3자리로 잘림
+        String[] parts = result.split("[,.]");
+        // 마지막 파트(소수점 이하)가 3자리 이하
+        if (result.contains(".")) {
+            String decimalPart = result.substring(result.lastIndexOf('.') + 1);
+            assertTrue(decimalPart.length() <= 3,
+                    "소수점 3자리 초과하지 않아야 함: " + result);
+        }
+    }
+
+    @Test
+    void testFormatNumber_maxFractionDigits_zero() {
+        String result = EgovNumberFormat.formatNumber(3.99, 0);
+        assertFalse(result.contains("."), "소수점 0자리: 소수점 없어야 함: " + result);
+    }
+
+    @Test
+    void testFormatNumber_negative() {
+        String result = EgovNumberFormat.formatNumber(-500);
+        assertTrue(result.contains("-"), "음수 표기 포함: " + result);
+    }
+
+    // -----------------------------------------------------------------------
+    // formatNumber (Locale 지정)
+    // -----------------------------------------------------------------------
+
+    @Test
+    void testFormatNumber_localeUS_groupingComma() {
+        String result = EgovNumberFormat.formatNumber(Locale.US, 1234567);
+        assertEquals("1,234,567", result, "US Locale 그룹 구분자 쉼표");
+    }
+
+    @Test
+    void testFormatNumber_localeUS_decimal() {
+        String result = EgovNumberFormat.formatNumber(Locale.US, 1234.5678, 2);
+        assertEquals("1,234.57", result, "US Locale 소수 2자리 반올림");
+    }
+
+    @Test
+    void testFormatNumber_localeUS_noGrouping() {
+        String result = EgovNumberFormat.formatNumber(Locale.US, 1234567, false);
+        assertEquals("1234567", result, "US Locale 그룹 구분자 없음");
+    }
+
+    @Test
+    void testFormatNumber_localeUS_noGrouping_decimal() {
+        String result = EgovNumberFormat.formatNumber(Locale.US, 1234.5, false, 1);
+        assertEquals("1234.5", result, "US Locale 그룹 없음, 소수 1자리");
+    }
+
+    @Test
+    void testFormatNumber_localeUS_zero() {
+        String result = EgovNumberFormat.formatNumber(Locale.US, 0);
+        assertEquals("0", result, "0 포맷");
+    }
+
+    // -----------------------------------------------------------------------
+    // formatCurrency (기본 Locale)
+    // -----------------------------------------------------------------------
+
+    @Test
+    void testFormatCurrency_containsNumber() {
+        String result = EgovNumberFormat.formatCurrency(1000);
+        // 통화 기호 포함 여부와 무관하게 숫자 1000 포함
+        assertTrue(result.replace(",", "").contains("1000"),
+                "통화 포맷에 1000 포함: " + result);
+    }
+
+    @Test
+    void testFormatCurrency_noGrouping_containsNumber() {
+        String result = EgovNumberFormat.formatCurrency(2000, false);
+        assertTrue(result.replace(",", "").contains("2000"),
+                "그룹 없는 통화 포맷에 2000 포함: " + result);
+    }
+
+    // -----------------------------------------------------------------------
+    // formatCurrency (Locale 지정)
+    // -----------------------------------------------------------------------
+
+    @Test
+    void testFormatCurrency_localeUS() {
+        String result = EgovNumberFormat.formatCurrency(Locale.US, 1234);
+        assertTrue(result.contains("$") && result.contains("1,234"),
+                "US 통화 기호 $ 와 1,234 포함: " + result);
+    }
+
+    @Test
+    void testFormatCurrency_localeUS_noGrouping() {
+        String result = EgovNumberFormat.formatCurrency(Locale.US, 5000, false);
+        assertTrue(result.contains("$"), "US 통화 기호 $ 포함: " + result);
+        assertFalse(result.contains(","), "그룹 구분자 없음: " + result);
+    }
+
+    // -----------------------------------------------------------------------
+    // formatPercent (기본 Locale)
+    // -----------------------------------------------------------------------
+
+    @Test
+    void testFormatPercent_half() {
+        String result = EgovNumberFormat.formatPercent(0.5);
+        assertTrue(result.contains("50") && result.contains("%"),
+                "0.5 → 50% 포함: " + result);
+    }
+
+    @Test
+    void testFormatPercent_one() {
+        String result = EgovNumberFormat.formatPercent(1.0);
+        assertTrue(result.contains("100") && result.contains("%"),
+                "1.0 → 100% 포함: " + result);
+    }
+
+    @Test
+    void testFormatPercent_noGrouping() {
+        String result = EgovNumberFormat.formatPercent(0.5, false);
+        assertTrue(result.contains("%"), "% 기호 포함: " + result);
+    }
+
+    @Test
+    void testFormatPercent_maxFractionDigits() {
+        String result = EgovNumberFormat.formatPercent(0.5, 0);
+        assertTrue(result.contains("50") && result.contains("%"),
+                "소수 0자리 퍼센트: " + result);
+        assertFalse(result.contains("."), "소수점 없음: " + result);
+    }
+
+    // -----------------------------------------------------------------------
+    // formatPercent (Locale 지정)
+    // -----------------------------------------------------------------------
+
+    @Test
+    void testFormatPercent_localeUS() {
+        String result = EgovNumberFormat.formatPercent(Locale.US, 0.25);
+        assertTrue(result.contains("25") && result.contains("%"),
+                "US 25% 포함: " + result);
+    }
+
+    @Test
+    void testFormatPercent_localeUS_noGrouping() {
+        String result = EgovNumberFormat.formatPercent(Locale.US, 0.75, false);
+        assertTrue(result.contains("75") && result.contains("%"),
+                "US 75% 포함: " + result);
+    }
+
+    @Test
+    void testFormatPercent_localeUS_maxFraction() {
+        String result = EgovNumberFormat.formatPercent(Locale.US, 0.333, 1);
+        assertTrue(result.contains("%"), "% 포함: " + result);
+        // 33.3% 근처 값
+        assertTrue(result.contains("33"), "33 포함: " + result);
+    }
+
+    @Test
+    void testFormatPercent_localeUS_noGrouping_maxFraction() {
+        String result = EgovNumberFormat.formatPercent(Locale.US, 0.5, false, 0);
+        assertEquals("50%", result, "US 50% (그룹 없음, 소수 0자리)");
+    }
+}

--- a/src/test/java/egovframework/com/utl/fcc/service/EgovNumberUtilTest.java
+++ b/src/test/java/egovframework/com/utl/fcc/service/EgovNumberUtilTest.java
@@ -1,0 +1,195 @@
+package egovframework.com.utl.fcc.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+
+/**
+ * EgovNumberUtil 단위 테스트
+ */
+public class EgovNumberUtilTest {
+
+    // -----------------------------------------------------------------------
+    // getRandomNum
+    // -----------------------------------------------------------------------
+
+    @RepeatedTest(20)
+    void testGetRandomNum_resultInRange() {
+        int result = EgovNumberUtil.getRandomNum(3, 7);
+        assertTrue(result >= 3 && result <= 7,
+                "결과는 시작숫자 이상, 종료숫자 이하여야 한다");
+    }
+
+    @Test
+    void testGetRandomNum_sameStartEnd() {
+        int result = EgovNumberUtil.getRandomNum(5, 5);
+        assertEquals(5, result, "시작과 종료가 같으면 항상 해당 값 반환");
+    }
+
+    // -----------------------------------------------------------------------
+    // getNumSearchCheck
+    // -----------------------------------------------------------------------
+
+    @Test
+    void testGetNumSearchCheck_found() {
+        assertTrue(EgovNumberUtil.getNumSearchCheck(12345678, 7),
+                "12345678 에 7이 포함됨");
+    }
+
+    @Test
+    void testGetNumSearchCheck_notFound() {
+        assertFalse(EgovNumberUtil.getNumSearchCheck(12345678, 9),
+                "12345678 에 9가 없음");
+    }
+
+    @Test
+    void testGetNumSearchCheck_multiDigitSearch() {
+        assertTrue(EgovNumberUtil.getNumSearchCheck(12345678, 234),
+                "12345678 에 234가 포함됨");
+    }
+
+    @Test
+    void testGetNumSearchCheck_sameNumber() {
+        assertTrue(EgovNumberUtil.getNumSearchCheck(999, 999),
+                "동일 숫자는 항상 존재");
+    }
+
+    // -----------------------------------------------------------------------
+    // getNumToStrCnvr
+    // -----------------------------------------------------------------------
+
+    @Test
+    void testGetNumToStrCnvr_positive() {
+        assertEquals("20081212", EgovNumberUtil.getNumToStrCnvr(20081212));
+    }
+
+    @Test
+    void testGetNumToStrCnvr_zero() {
+        assertEquals("0", EgovNumberUtil.getNumToStrCnvr(0));
+    }
+
+    @Test
+    void testGetNumToStrCnvr_negative() {
+        assertEquals("-1", EgovNumberUtil.getNumToStrCnvr(-1));
+    }
+
+    // -----------------------------------------------------------------------
+    // getNumToDateCnvr
+    // -----------------------------------------------------------------------
+
+    @Test
+    void testGetNumToDateCnvr_eightDigit() {
+        String result = EgovNumberUtil.getNumToDateCnvr(20081212);
+        assertEquals("2008-12-12", result);
+    }
+
+    @Test
+    void testGetNumToDateCnvr_eightDigitAnother() {
+        String result = EgovNumberUtil.getNumToDateCnvr(20230101);
+        assertEquals("2023-01-01", result);
+    }
+
+    @Test
+    void testGetNumToDateCnvr_invalidLength_throws() {
+        // 8자리·14자리 외에는 IllegalArgumentException
+        assertThrows(IllegalArgumentException.class,
+                () -> EgovNumberUtil.getNumToDateCnvr(2008121));
+    }
+
+    @Test
+    void testGetNumToDateCnvr_sevenDigit_throws() {
+        assertThrows(IllegalArgumentException.class,
+                () -> EgovNumberUtil.getNumToDateCnvr(1234567));
+    }
+
+    // -----------------------------------------------------------------------
+    // getNumberValidCheck
+    // -----------------------------------------------------------------------
+
+    @Test
+    void testGetNumberValidCheck_allDigits() {
+        assertTrue(EgovNumberUtil.getNumberValidCheck("12345"));
+    }
+
+    @Test
+    void testGetNumberValidCheck_singleDigit() {
+        assertTrue(EgovNumberUtil.getNumberValidCheck("0"));
+    }
+
+    @Test
+    void testGetNumberValidCheck_containsLetter() {
+        assertFalse(EgovNumberUtil.getNumberValidCheck("123a5"));
+    }
+
+    @Test
+    void testGetNumberValidCheck_negativeSign() {
+        // '-' 는 숫자가 아니므로 false
+        assertFalse(EgovNumberUtil.getNumberValidCheck("-123"));
+    }
+
+    @Test
+    void testGetNumberValidCheck_decimal() {
+        // '.' 는 숫자가 아니므로 false
+        assertFalse(EgovNumberUtil.getNumberValidCheck("3.14"));
+    }
+
+    // -----------------------------------------------------------------------
+    // getNumberCnvr
+    // -----------------------------------------------------------------------
+
+    @Test
+    void testGetNumberCnvr_basic() {
+        // 12345678 에서 123을 999로 치환 → 99945678
+        assertEquals(99945678, EgovNumberUtil.getNumberCnvr(12345678, 123, 999));
+    }
+
+    @Test
+    void testGetNumberCnvr_noMatch() {
+        // 치환 대상이 없으면 원본 반환
+        assertEquals(12345678, EgovNumberUtil.getNumberCnvr(12345678, 999, 111));
+    }
+
+    @Test
+    void testGetNumberCnvr_multipleOccurrences() {
+        // 111111 에서 11을 22로 치환 → 222211? 로직 추적:
+        // source="111111", subject="11"
+        // 1회: pre="", next="1111", rtn="22"
+        // 2회: pre="", next="11",   rtn="2222"
+        // 3회: pre="", next="",     rtn="222222"
+        // append nextStr("") → "222222"
+        assertEquals(222222, EgovNumberUtil.getNumberCnvr(111111, 11, 22));
+    }
+
+    // -----------------------------------------------------------------------
+    // checkRlnoInteger
+    // -----------------------------------------------------------------------
+
+    @Test
+    void testCheckRlnoInteger_negative() {
+        assertEquals(-1, EgovNumberUtil.checkRlnoInteger(-1.5));
+    }
+
+    @Test
+    void testCheckRlnoInteger_negativeInt() {
+        assertEquals(-1, EgovNumberUtil.checkRlnoInteger(-3));
+    }
+
+    @Test
+    void testCheckRlnoInteger_positiveDouble() {
+        // String.valueOf(3.14) = "3.14" -> '.' 포함 -> 1
+        assertEquals(1, EgovNumberUtil.checkRlnoInteger(3.14));
+    }
+
+    @Test
+    void testCheckRlnoInteger_positiveIntAsDouble() {
+        // double 파라미터로 5 전달 시 String.valueOf(5.0) = "5.0" -> '.' 포함 -> 1
+        assertEquals(1, EgovNumberUtil.checkRlnoInteger(5));
+    }
+
+    @Test
+    void testCheckRlnoInteger_zero() {
+        // String.valueOf(0.0) = "0.0" -> '.' 포함 -> 1
+        assertEquals(1, EgovNumberUtil.checkRlnoInteger(0));
+    }
+}


### PR DESCRIPTION
## 변경 사유
순수 함수형 유틸리티 클래스에 단위 테스트가 없어 회귀 검증이 어렵습니다. 결정적(deterministic) 입출력 기반 JUnit5 테스트를 추가합니다.

## 변경 내용
- 대상: EgovNumberUtil·EgovNumberFormat
- 정상/경계/예외 케이스 포함 총 67개 테스트 메서드 (JUnit 5)
- 테스트 소스만 추가, 운영 코드/빌드 설정 변경 없음

## 검증
- 67/67 통과 확인

## 체크리스트
- [x] 단일 주제만 다룸 (테스트 파일만)
- [x] 전체 통과 확인
