### PR TITLE
[test][5.0.x][공통컴포넌트] utl/fcc 포맷·계산 유틸 단위 테스트 추가

### DIFF
--- a/src/test/java/egovframework/com/utl/fcc/service/EgovEhgtCalcUtilTest.java
+++ b/src/test/java/egovframework/com/utl/fcc/service/EgovEhgtCalcUtilTest.java
@@ -1,0 +1,64 @@
+package egovframework.com.utl.fcc.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * EgovEhgtCalcUtil 단위 테스트
+ *
+ * EgovEhgtCalcUtil.getEhgtCalc()는 한국수출입은행 환율 API(네트워크)에 의존하므로
+ * 해당 메서드는 통합 테스트 대상이다. 본 테스트는 클래스에 정의된 통화 코드 상수와
+ * 클래스 로딩 가능 여부를 검증한다.
+ *
+ * @author 공통컴포넌트 개발팀
+ * @since 2025.05.28
+ */
+public class EgovEhgtCalcUtilTest {
+
+    @Test
+    void 통화코드_미국_USD() {
+        assertEquals('U', EgovEhgtCalcUtil.EGHT_USD);
+    }
+
+    @Test
+    void 통화코드_일본_JPY() {
+        assertEquals('J', EgovEhgtCalcUtil.EGHT_JPY);
+    }
+
+    @Test
+    void 통화코드_유럽_EUR() {
+        assertEquals('E', EgovEhgtCalcUtil.EGHT_EUR);
+    }
+
+    @Test
+    void 통화코드_중국_CNY() {
+        assertEquals('C', EgovEhgtCalcUtil.EGHT_CNY);
+    }
+
+    @Test
+    void 통화코드_대한민국_KRW() {
+        assertEquals('K', EgovEhgtCalcUtil.EGHT_KWR);
+    }
+
+    @Test
+    void 통화코드_값_중복없음() {
+        char[] codes = {
+            EgovEhgtCalcUtil.EGHT_USD,
+            EgovEhgtCalcUtil.EGHT_JPY,
+            EgovEhgtCalcUtil.EGHT_EUR,
+            EgovEhgtCalcUtil.EGHT_CNY,
+            EgovEhgtCalcUtil.EGHT_KWR
+        };
+        long distinct = new String(codes).chars().distinct().count();
+        assertEquals(5, distinct, "통화 코드는 모두 고유해야 한다");
+    }
+
+    @Test
+    void getEhgtCalc_네트워크없이_예외발생_확인() {
+        // 외부 API 호출 메서드는 네트워크 연결 없이 RuntimeException을 던진다
+        assertThrows(Exception.class, () ->
+            EgovEhgtCalcUtil.getEhgtCalc("KRW", 1000L, "USD")
+        );
+    }
+}

--- a/src/test/java/egovframework/com/utl/fcc/service/EgovFormatCheckUtilTest.java
+++ b/src/test/java/egovframework/com/utl/fcc/service/EgovFormatCheckUtilTest.java
@@ -1,0 +1,246 @@
+package egovframework.com.utl.fcc.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * EgovFormatCheckUtil 단위 테스트
+ *
+ * @author 공통컴포넌트 개발팀
+ * @since 2025.05.28
+ */
+public class EgovFormatCheckUtilTest {
+
+    // ─── checkFormatTell(String, String, String) ───────────────────────────
+
+    @Test
+    void 전화번호_3분할_서울_유효() {
+        assertTrue(EgovFormatCheckUtil.checkFormatTell("02", "123", "4567"));
+    }
+
+    @Test
+    void 전화번호_3분할_서울_중간4자리_유효() {
+        assertTrue(EgovFormatCheckUtil.checkFormatTell("02", "1234", "5678"));
+    }
+
+    @Test
+    void 전화번호_3분할_경기_031_유효() {
+        assertTrue(EgovFormatCheckUtil.checkFormatTell("031", "123", "4567"));
+    }
+
+    @Test
+    void 전화번호_3분할_070_유효() {
+        assertTrue(EgovFormatCheckUtil.checkFormatTell("070", "123", "4567"));
+    }
+
+    @Test
+    void 전화번호_3분할_0505_유효() {
+        assertTrue(EgovFormatCheckUtil.checkFormatTell("0505", "123", "4567"));
+    }
+
+    @Test
+    void 전화번호_3분할_미등록국번_무효() {
+        assertFalse(EgovFormatCheckUtil.checkFormatTell("099", "123", "4567"));
+    }
+
+    @Test
+    void 전화번호_3분할_중간번호_0으로시작_무효() {
+        assertFalse(EgovFormatCheckUtil.checkFormatTell("031", "023", "4567"));
+    }
+
+    @Test
+    void 전화번호_3분할_비숫자_포함_무효() {
+        assertFalse(EgovFormatCheckUtil.checkFormatTell("031", "12a", "4567"));
+    }
+
+    @Test
+    void 전화번호_3분할_서울_뒷번호_3자리_무효() {
+        assertFalse(EgovFormatCheckUtil.checkFormatTell("02", "123", "456"));
+    }
+
+    @Test
+    void 전화번호_3분할_비서울_중간3자리초과_무효() {
+        assertFalse(EgovFormatCheckUtil.checkFormatTell("031", "1234", "5678"));
+    }
+
+    // ─── checkFormatTell(String) ──────────────────────────────────────────
+
+    @Test
+    void 전화번호_통합_하이픈포함_유효() {
+        assertTrue(EgovFormatCheckUtil.checkFormatTell("031-123-4567"));
+    }
+
+    @Test
+    void 전화번호_통합_하이픈없음_유효() {
+        assertTrue(EgovFormatCheckUtil.checkFormatTell("0311234567"));
+    }
+
+    @Test
+    void 전화번호_통합_서울02_9자리_유효() {
+        assertTrue(EgovFormatCheckUtil.checkFormatTell("02-123-4567"));
+    }
+
+    @Test
+    void 전화번호_통합_서울02_10자리_유효() {
+        assertTrue(EgovFormatCheckUtil.checkFormatTell("02-1234-5678"));
+    }
+
+    @Test
+    void 전화번호_통합_0505_유효() {
+        assertTrue(EgovFormatCheckUtil.checkFormatTell("0505-123-4567"));
+    }
+
+    @Test
+    void 전화번호_통합_0으로시작하지않음_무효() {
+        assertFalse(EgovFormatCheckUtil.checkFormatTell("1234567890"));
+    }
+
+    @Test
+    void 전화번호_통합_8자리이하_무효() {
+        assertFalse(EgovFormatCheckUtil.checkFormatTell("02-12-345"));
+    }
+
+    @Test
+    void 전화번호_통합_12자리초과_무효() {
+        assertFalse(EgovFormatCheckUtil.checkFormatTell("031-1234-56789"));
+    }
+
+    @Test
+    void 전화번호_통합_서울_11자리_무효() {
+        assertFalse(EgovFormatCheckUtil.checkFormatTell("02123456789"));
+    }
+
+    // ─── checkFormatCell(String, String, String) ──────────────────────────
+
+    @Test
+    void 휴대폰_3분할_010_10자리_유효() {
+        assertTrue(EgovFormatCheckUtil.checkFormatCell("010", "123", "4567"));
+    }
+
+    @Test
+    void 휴대폰_3분할_010_11자리_유효() {
+        assertTrue(EgovFormatCheckUtil.checkFormatCell("010", "1234", "5678"));
+    }
+
+    @Test
+    void 휴대폰_3분할_011_유효() {
+        assertTrue(EgovFormatCheckUtil.checkFormatCell("011", "123", "4567"));
+    }
+
+    @Test
+    void 휴대폰_3분할_016_유효() {
+        assertTrue(EgovFormatCheckUtil.checkFormatCell("016", "123", "4567"));
+    }
+
+    @Test
+    void 휴대폰_3분할_미등록번호_무효() {
+        assertFalse(EgovFormatCheckUtil.checkFormatCell("020", "123", "4567"));
+    }
+
+    @Test
+    void 휴대폰_3분할_중간번호_0으로시작_무효() {
+        assertFalse(EgovFormatCheckUtil.checkFormatCell("010", "023", "4567"));
+    }
+
+    @Test
+    void 휴대폰_3분할_비숫자_포함_무효() {
+        assertFalse(EgovFormatCheckUtil.checkFormatCell("010", "12a", "4567"));
+    }
+
+    @Test
+    void 휴대폰_3분할_뒷번호_3자리_무효() {
+        assertFalse(EgovFormatCheckUtil.checkFormatCell("010", "123", "456"));
+    }
+
+    @Test
+    void 휴대폰_3분할_중간번호_5자리_무효() {
+        assertFalse(EgovFormatCheckUtil.checkFormatCell("010", "12345", "6789"));
+    }
+
+    // ─── checkFormatCell(String) ──────────────────────────────────────────
+
+    @Test
+    void 휴대폰_통합_하이픈포함_10자리_유효() {
+        assertTrue(EgovFormatCheckUtil.checkFormatCell("010-123-4567"));
+    }
+
+    @Test
+    void 휴대폰_통합_하이픈포함_11자리_유효() {
+        assertTrue(EgovFormatCheckUtil.checkFormatCell("010-1234-5678"));
+    }
+
+    @Test
+    void 휴대폰_통합_하이픈없음_11자리_유효() {
+        assertTrue(EgovFormatCheckUtil.checkFormatCell("01012345678"));
+    }
+
+    @Test
+    void 휴대폰_통합_0으로시작하지않음_무효() {
+        assertFalse(EgovFormatCheckUtil.checkFormatCell("1101234567"));
+    }
+
+    @Test
+    void 휴대폰_통합_9자리이하_무효() {
+        assertFalse(EgovFormatCheckUtil.checkFormatCell("010-12-345"));
+    }
+
+    @Test
+    void 휴대폰_통합_12자리초과_무효() {
+        assertFalse(EgovFormatCheckUtil.checkFormatCell("010-12345-6789"));
+    }
+
+    // ─── checkFormatMail(String, String) ─────────────────────────────────
+
+    @Test
+    void 이메일_2분할_유효() {
+        // mail2는 소문자 알파벳과 점(.)만 허용, 점은 정확히 1개여야 함
+        assertTrue(EgovFormatCheckUtil.checkFormatMail("user", "example.com"));
+    }
+
+    @Test
+    void 이메일_2분할_대문자포함_유효() {
+        // mail1은 대소문자 및 숫자 허용
+        assertTrue(EgovFormatCheckUtil.checkFormatMail("User123", "example.com"));
+    }
+
+    @Test
+    void 이메일_2분할_mail2_점_2개_무효() {
+        // 점이 2개이면 count != 1 이므로 false
+        assertFalse(EgovFormatCheckUtil.checkFormatMail("user", "mail.example.com"));
+    }
+
+    @Test
+    void 이메일_2분할_mail2_점_없음_무효() {
+        assertFalse(EgovFormatCheckUtil.checkFormatMail("user", "examplecom"));
+    }
+
+    @Test
+    void 이메일_2분할_mail2_대문자포함_무효() {
+        // mail2는 소문자만 허용
+        assertFalse(EgovFormatCheckUtil.checkFormatMail("user", "Example.com"));
+    }
+
+    @Test
+    void 이메일_2분할_mail2_숫자포함_무효() {
+        // mail2는 소문자와 점만 허용 (숫자 불가)
+        assertFalse(EgovFormatCheckUtil.checkFormatMail("user", "example1.com"));
+    }
+
+    // ─── checkFormatMail(String) ──────────────────────────────────────────
+
+    @Test
+    void 이메일_통합_유효() {
+        assertTrue(EgovFormatCheckUtil.checkFormatMail("user@example.com"));
+    }
+
+    @Test
+    void 이메일_통합_at없음_무효() {
+        assertFalse(EgovFormatCheckUtil.checkFormatMail("userexample.com"));
+    }
+
+    @Test
+    void 이메일_통합_at_2개_무효() {
+        assertFalse(EgovFormatCheckUtil.checkFormatMail("user@exam@ple.com"));
+    }
+}


### PR DESCRIPTION
## 변경 사유
순수 함수형 유틸리티 클래스에 단위 테스트가 없어 회귀 검증이 어렵습니다. 결정적(deterministic) 입출력 기반 JUnit5 테스트를 추가합니다.

## 변경 내용
- 대상: EgovFormatCheckUtil·EgovEhgtCalcUtil
- 정상/경계/예외 케이스 포함 총 50개 테스트 메서드 (JUnit 5)
- 테스트 소스만 추가, 운영 코드/빌드 설정 변경 없음

## 검증
- 50/50 통과 확인

## 체크리스트
- [x] 단일 주제만 다룸 (테스트 파일만)
- [x] 전체 통과 확인
