### PR TITLE
[test][5.0.x] EgovXMLConstants, EgovResourceCloseHelper, EgovDoubleSubmitHelper 단위 테스트 추가

### DIFF
--- a/src/test/java/egovframework/com/cmm/util/EgovDoubleSubmitHelperTest.java
+++ b/src/test/java/egovframework/com/cmm/util/EgovDoubleSubmitHelperTest.java
@@ -1,0 +1,57 @@
+package egovframework.com.cmm.util;
+
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * EgovDoubleSubmitHelper UUID 생성 메서드 테스트
+ */
+public class EgovDoubleSubmitHelperTest {
+
+	@Test
+	void testGetNewUuid_notNull() {
+		String uuid = EgovDoubleSubmitHelper.getNewUUID();
+		assertNotNull(uuid);
+	}
+
+	@Test
+	void testGetNewUuid_upperCase() {
+		String uuid = EgovDoubleSubmitHelper.getNewUUID();
+		assertTrue(uuid.equals(uuid.toUpperCase()), "UUID should be upper case");
+	}
+
+	@Test
+	void testGetNewUuid_uuidFormat() {
+		String uuid = EgovDoubleSubmitHelper.getNewUUID();
+		assertTrue(uuid.matches("[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}"),
+				"UUID format should match standard pattern");
+	}
+
+	@Test
+	void testGetNewUuid_uniqueness() {
+		String uuid1 = EgovDoubleSubmitHelper.getNewUUID();
+		String uuid2 = EgovDoubleSubmitHelper.getNewUUID();
+		assertNotEquals(uuid1, uuid2, "Each call should return a different UUID");
+	}
+
+	@Test
+	void testSessionTokenKey_notEmpty() {
+		assertNotNull(EgovDoubleSubmitHelper.SESSION_TOKEN_KEY);
+		assertTrue(EgovDoubleSubmitHelper.SESSION_TOKEN_KEY.length() > 0);
+	}
+
+	@Test
+	void testParameterName_notEmpty() {
+		assertNotNull(EgovDoubleSubmitHelper.PARAMETER_NAME);
+		assertTrue(EgovDoubleSubmitHelper.PARAMETER_NAME.length() > 0);
+	}
+
+	@Test
+	void testDefaultTokenKey_value() {
+		assertNotNull(EgovDoubleSubmitHelper.DEFAULT_TOKEN_KEY);
+		assertTrue(EgovDoubleSubmitHelper.DEFAULT_TOKEN_KEY.equals("DEFAULT"));
+	}
+}

--- a/src/test/java/egovframework/com/cmm/util/EgovResourceCloseHelperTest.java
+++ b/src/test/java/egovframework/com/cmm/util/EgovResourceCloseHelperTest.java
@@ -1,0 +1,46 @@
+package egovframework.com.cmm.util;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import java.io.ByteArrayInputStream;
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * EgovResourceCloseHelper 리소스 닫기 유틸 테스트
+ */
+public class EgovResourceCloseHelperTest {
+
+	@Test
+	void testClose_nullResource() {
+		assertDoesNotThrow(() -> EgovResourceCloseHelper.close((Closeable) null));
+	}
+
+	@Test
+	void testClose_validStream() {
+		InputStream in = new ByteArrayInputStream(new byte[0]);
+		assertDoesNotThrow(() -> EgovResourceCloseHelper.close(in));
+	}
+
+	@Test
+	void testClose_multipleResources() {
+		InputStream in1 = new ByteArrayInputStream(new byte[0]);
+		InputStream in2 = new ByteArrayInputStream(new byte[0]);
+		assertDoesNotThrow(() -> EgovResourceCloseHelper.close(in1, in2));
+	}
+
+	@Test
+	void testClose_nullAmongResources() {
+		InputStream in1 = new ByteArrayInputStream(new byte[0]);
+		assertDoesNotThrow(() -> EgovResourceCloseHelper.close(in1, null));
+	}
+
+	@Test
+	void testClose_throwingResource() {
+		Closeable throwingResource = () -> { throw new IOException("close error"); };
+		assertDoesNotThrow(() -> EgovResourceCloseHelper.close(throwingResource));
+	}
+}

--- a/src/test/java/egovframework/com/utl/sim/service/EgovXMLConstantsTest.java
+++ b/src/test/java/egovframework/com/utl/sim/service/EgovXMLConstantsTest.java
@@ -1,0 +1,73 @@
+package egovframework.com.utl.sim.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * EgovXMLConstants 상수 값 검증 테스트
+ */
+public class EgovXMLConstantsTest {
+
+	@Test
+	void testNullNsUri() {
+		assertEquals("", EgovXMLConstants.NULL_NS_URI);
+	}
+
+	@Test
+	void testDefaultNsPrefix() {
+		assertEquals("", EgovXMLConstants.DEFAULT_NS_PREFIX);
+	}
+
+	@Test
+	void testXmlNsUri() {
+		assertEquals("http://www.w3.org/XML/1998/namespace", EgovXMLConstants.XML_NS_URI);
+	}
+
+	@Test
+	void testXmlNsPrefix() {
+		assertEquals("xml", EgovXMLConstants.XML_NS_PREFIX);
+	}
+
+	@Test
+	void testXmlnsAttributeNsUri() {
+		assertEquals("http://www.w3.org/2000/xmlns/", EgovXMLConstants.XMLNS_ATTRIBUTE_NS_URI);
+	}
+
+	@Test
+	void testXmlnsAttribute() {
+		assertEquals("xmlns", EgovXMLConstants.XMLNS_ATTRIBUTE);
+	}
+
+	@Test
+	void testW3cXmlSchemaNsUri() {
+		assertEquals("http://www.w3.org/2001/XMLSchema", EgovXMLConstants.W3C_XML_SCHEMA_NS_URI);
+	}
+
+	@Test
+	void testW3cXmlSchemaInstanceNsUri() {
+		assertEquals("http://www.w3.org/2001/XMLSchema-instance", EgovXMLConstants.W3C_XML_SCHEMA_INSTANCE_NS_URI);
+	}
+
+	@Test
+	void testW3cXpathDatatypeNsUri() {
+		assertEquals("http://www.w3.org/2003/11/xpath-datatypes", EgovXMLConstants.W3C_XPATH_DATATYPE_NS_URI);
+	}
+
+	@Test
+	void testXmlDtdNsUri() {
+		assertEquals("http://www.w3.org/TR/REC-xml", EgovXMLConstants.XML_DTD_NS_URI);
+	}
+
+	@Test
+	void testRelaxngNsUri() {
+		assertEquals("http://relaxng.org/ns/structure/1.0", EgovXMLConstants.RELAXNG_NS_URI);
+	}
+
+	@Test
+	void testFeatureSecureProcessing() {
+		assertNotNull(EgovXMLConstants.FEATURE_SECURE_PROCESSING);
+		assertEquals("http://jakarta.xml.XMLConstants/feature/secure-processing", EgovXMLConstants.FEATURE_SECURE_PROCESSING);
+	}
+}


### PR DESCRIPTION
## 변경 사유

미테스트 순수 유틸 클래스 3종에 JUnit 5 단위 테스트를 추가하여 회귀 방지 커버리지를 확보한다.
외부 파일·DB·네트워크 의존 없이 결정적으로 검증 가능한 메서드만 선별하였다.

## 변경 내용

- `EgovXMLConstantsTest`: XML 네임스페이스 관련 상수(NULL_NS_URI, XML_NS_URI, W3C_XML_SCHEMA_NS_URI 등) 12건 검증
- `EgovResourceCloseHelperTest`: null 리소스, 정상 스트림, 복수 리소스, IOException 발생 시 무시 동작 5건 검증
- `EgovDoubleSubmitHelperTest`: getNewUUID() 형식(UUID 패턴, 대문자), 유일성, 상수값 7건 검증

## 테스트 방법

JUnit Platform Console Standalone으로 격리 컴파일·실행 확인: 24 tests found / 24 tests successful / 0 tests failed

## 체크리스트

- [x] 단일 주제만 다룸 (테스트 파일 3개 추가 외 변경 없음)
- [x] pom.xml 등 빌드 설정 변경 없음
- [x] 기존 동작에 영향 없음 (테스트 추가만)
- [x] 테스트 통과 확인 (24/24 green)
