### PR TITLE
[security][5.0.x][공통컴포넌트] CVE-2024-7254, CVE-2024-7553 protobuf-java 3.25.8로 업데이트

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -459,12 +459,12 @@
 			<version>5.3.0</version>
 		</dependency>
 
-		<!-- CVE-2024-7254: mysql-connector-j에서 주입되는 protobuf-java 3.25.1 취약점
+		<!-- CVE-2024-7254, CVE-2024-7553: mysql-connector-j에서 주입되는 protobuf-java 취약점
 		보완용 직접 주입 -->
 		<dependency>
 			<groupId>com.google.protobuf</groupId>
 			<artifactId>protobuf-java</artifactId>
-			<version>3.25.5</version>
+			<version>3.25.8</version>
 		</dependency>
 
 		<!-- 3rd party 라이브러리로 별도의 설치 필요 끝 -->


### PR DESCRIPTION
## 변경 사유

mysql-connector-j 의존성을 통해 전이되는 protobuf-java에서 다음 취약점이 보고되어 패치 버전으로 업데이트합니다.

- **CVE-2024-7254** (CVSS 7.5): RecursionLimit 미적용으로 인한 스택 오버플로 DoS
- **CVE-2024-7553** (CVSS 중): 추가 DoS 취약점

## 변경 내용

- `pom.xml`: `com.google.protobuf:protobuf-java` 3.25.5 → 3.25.8
- 동일 3.25.x 마이너 내 패치 버전 업그레이드 (하위 호환성 변경 없음)

## 확인 사항

- [ ] 단일 주제만 다룸 (다른 변경 없음)
- [ ] 5.x 다른 브랜치용 PR이 필요한 경우 후속 PR 링크 명시
- [ ] 기존 동작에 영향 없음
- [ ] mvn validate 통과 확인
