### PR TITLE
Fix: 공통 컴포넌트 검증 및 파일 처리 안정성 개선

### DIFF
--- a/src/main/java/egovframework/com/cmm/service/impl/EgovFileMngServiceImpl.java
+++ b/src/main/java/egovframework/com/cmm/service/impl/EgovFileMngServiceImpl.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.lang3.StringUtils;
 import org.egovframe.rte.fdl.cmmn.EgovAbstractServiceImpl;
 import org.springframework.stereotype.Service;
 
@@ -69,7 +70,7 @@ public class EgovFileMngServiceImpl extends EgovAbstractServiceImpl implements E
 		if (fvoList.size() != 0) {
 			atchFileId = fileMngDAO.insertFileInfs(fvoList);
 		}
-		if (atchFileId == "") {
+		if (StringUtils.isEmpty(atchFileId)) {
 			atchFileId = null;
 		}
 		return atchFileId;

--- a/src/main/java/egovframework/com/cmm/web/EgovComUtlController.java
+++ b/src/main/java/egovframework/com/cmm/web/EgovComUtlController.java
@@ -43,6 +43,7 @@ public class EgovComUtlController {
     //@Resource(name = "egovUserManageService")
     //private EgovUserManageService egovUserManageService;
 	private static final Logger LOGGER = LoggerFactory.getLogger(EgovComUtlController.class);
+	private static final String ERROR_VIEW = "egovframework/com/cmm/error/egovError";
 
 	/** 암호화서비스 */
 	private static EgovEnvCryptoService cryptoService;
@@ -69,8 +70,13 @@ public class EgovComUtlController {
 
 		String link = "";
 		// 화이트 리스트가 비었는지 확인
-		if (egovWhitelist == null || egovWhitelist.isEmpty() || egovWhitelist.size() <= linkIndex) {
-			link="egovframework/com/cmm/egovError";
+		if (egovWhitelist == null || egovWhitelist.isEmpty()) {
+			link=ERROR_VIEW;
+			return link;
+		}
+
+		if (linkIndex == null || linkIndex < 0 || egovWhitelist.size() <= linkIndex) {
+			link=ERROR_VIEW;
 			return link;
 		}
 

--- a/src/main/java/egovframework/com/uss/umt/web/EgovEmplyrManageController.java
+++ b/src/main/java/egovframework/com/uss/umt/web/EgovEmplyrManageController.java
@@ -61,6 +61,8 @@ import jakarta.annotation.Resource;
 @Controller
 public class EgovEmplyrManageController {
 
+	private static final String ERROR_VIEW = "egovframework/com/cmm/error/egovError";
+
 	/** emplyrManageService */
 	@Resource(name = "emplyrManageService")
 	private EgovEmplyrManageService emplyrManageService;
@@ -549,20 +551,21 @@ public class EgovEmplyrManageController {
 	 * @throws Exception
 	 */
 	@RequestMapping(value = "/uss/umt/EgovRlnmCnfirm.do", method = RequestMethod.POST)
-	public String rlnmCnfirm(Model model, @RequestParam Map<String, Object> commandMap) throws Exception {
+	public String rlnmCnfirm(Model model, @RequestParam Map<String, Object> commandMap,
+			@RequestParam(value = "nextUrl", required = true) Integer linkIndex) throws Exception {
 
 		model.addAttribute("ihidnum", commandMap.get("ihidnum")); // 주민번호
 		model.addAttribute("realname", commandMap.get("realname")); // 사용자이름
 		model.addAttribute("sbscrbTy", commandMap.get("sbscrbTy")); // 사용자유형
 		model.addAttribute("nextUrlName", commandMap.get("nextUrlName")); // 다음단계버튼명(이동할 URL에 따른)
-		Integer linkIndex = Integer.parseInt((String) commandMap.get("nextUrl"));
-		model.addAttribute("nextUrl", linkIndex); // 다음단계로 이동할 URL
-
-		// 화이트 리스트 처리
 		String link = "";
-		// 화이트 리스트가 비었는지 확인
-		if (nextUrlWhitelist == null || nextUrlWhitelist.isEmpty() || nextUrlWhitelist.size() <= linkIndex) {
-			link = "egovframework/com/cmm/egovError";
+		if (nextUrlWhitelist == null || nextUrlWhitelist.isEmpty()) {
+			link = ERROR_VIEW;
+			return link;
+		}
+
+		if (linkIndex == null || linkIndex < 0 || nextUrlWhitelist.size() <= linkIndex) {
+			link = ERROR_VIEW;
 			return link;
 		}
 

--- a/src/main/java/egovframework/com/utl/fcc/service/EgovFileUploadUtil.java
+++ b/src/main/java/egovframework/com/utl/fcc/service/EgovFileUploadUtil.java
@@ -143,17 +143,22 @@ public class EgovFileUploadUtil extends EgovFormBasedFileUtil {
 						throw new SecurityException("Unacceptable file extension."); // 허용되지 않는 확장자 처리
 					}
 
+					long fileSize = mFile.getSize();
+					if (!checkFileMaxSize(mFile, maxFileSize)) {
+						throw new SecurityException("File size exceeds maximum allowed size.");
+					}
+
 					vo.setFileName(tmp);
 					vo.setContentType(mFile.getContentType());
 					vo.setServerSubPath(getTodayString());
 					vo.setPhysicalName(getPhysicalFileName() + "." + ext);
-					vo.setSize(mFile.getSize());
+					vo.setSize(fileSize);
 
 					if (tmp.lastIndexOf(".") >= 0) {
 						vo.setPhysicalName(vo.getPhysicalName()); // 2012.11 KISA 보안조치
 					}
 
-					if (mFile.getSize() > 0) {
+					if (fileSize > 0) {
 						InputStream is = null;
 
 						try {

--- a/src/main/java/egovframework/com/utl/sim/service/EgovXMLDoc.java
+++ b/src/main/java/egovframework/com/utl/sim/service/EgovXMLDoc.java
@@ -255,6 +255,7 @@ public class EgovXMLDoc {
 			transformer.setOutputProperty(OutputKeys.METHOD, "xml");
 			transformer.setOutputProperty(OutputKeys.INDENT, "yes");
 			transformer.transform(source, result);
+			retVal = true;
 		}
 
 		return retVal;

--- a/src/test/java/egovframework/com/cmm/web/EgovComUtlControllerTest.java
+++ b/src/test/java/egovframework/com/cmm/web/EgovComUtlControllerTest.java
@@ -1,0 +1,32 @@
+package egovframework.com.cmm.web;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class EgovComUtlControllerTest {
+
+	private static final String ERROR_VIEW = "egovframework/com/cmm/error/egovError";
+
+	private EgovComUtlController controller;
+
+	@BeforeEach
+	void setUp() {
+		controller = new EgovComUtlController();
+		controller.egovWhitelist = Arrays.asList("/egovframework/com/main_bottom");
+	}
+
+	@Test
+	void moveToPageRejectsNegativeLinkIndex() {
+		assertEquals(ERROR_VIEW, controller.moveToPage(-1));
+	}
+
+	@Test
+	void moveToPageRejectsOutOfRangeLinkIndex() {
+		assertEquals(ERROR_VIEW, controller.moveToPage(1));
+	}
+
+}

--- a/src/test/java/egovframework/com/uss/umt/web/EgovEmplyrManageControllerTest.java
+++ b/src/test/java/egovframework/com/uss/umt/web/EgovEmplyrManageControllerTest.java
@@ -1,0 +1,44 @@
+package egovframework.com.uss.umt.web;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.ui.ExtendedModelMap;
+import org.springframework.ui.Model;
+
+class EgovEmplyrManageControllerTest {
+
+	private static final String ERROR_VIEW = "egovframework/com/cmm/error/egovError";
+
+	private EgovEmplyrManageController controller;
+
+	@BeforeEach
+	void setUp() {
+		controller = new EgovEmplyrManageController();
+		controller.nextUrlWhitelist = Arrays.asList("/uss/umt/EgovMberSbscrbView.do");
+	}
+
+	@Test
+	void rlnmCnfirmRejectsNegativeNextUrlIndex() throws Exception {
+		assertEquals(ERROR_VIEW, controller.rlnmCnfirm(model(), commandMap(), -1));
+	}
+
+	@Test
+	void rlnmCnfirmRejectsOutOfRangeNextUrlIndex() throws Exception {
+		assertEquals(ERROR_VIEW, controller.rlnmCnfirm(model(), commandMap(), 1));
+	}
+
+	private Model model() {
+		return new ExtendedModelMap();
+	}
+
+	private Map<String, Object> commandMap() {
+		return new HashMap<>();
+	}
+
+}

--- a/src/test/java/egovframework/com/utl/fcc/service/EgovFileUploadUtilTest.java
+++ b/src/test/java/egovframework/com/utl/fcc/service/EgovFileUploadUtilTest.java
@@ -1,0 +1,130 @@
+package egovframework.com.utl.fcc.service;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Proxy;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.multipart.MultipartHttpServletRequest;
+
+class EgovFileUploadUtilTest {
+
+	@TempDir
+	Path uploadDir;
+
+	@Test
+	void uploadFilesExtRejectsFilesExceedingMaxFileSizeBeforeSaving() throws Exception {
+		MultipartHttpServletRequest request = multipartRequest(multipartFile("file", "too-big.png", "image/png", new byte[] {1, 2, 3}));
+
+		SecurityException exception = assertThrows(SecurityException.class,
+			() -> EgovFileUploadUtil.uploadFilesExt(request, uploadDir.toString(), 2L, ".png"));
+
+		assertEquals("File size exceeds maximum allowed size.", exception.getMessage());
+		assertEquals(0, countRegularFiles(uploadDir));
+	}
+
+	@Test
+	void uploadFilesExtStoresFilesAtMaxFileSize() throws Exception {
+		byte[] content = new byte[] {1, 2};
+		MultipartHttpServletRequest request = multipartRequest(multipartFile("file", "image.png", "image/png", content));
+
+		List<EgovFormBasedFileVo> files = EgovFileUploadUtil.uploadFilesExt(request, uploadDir.toString(), 2L, ".png");
+
+		assertEquals(1, files.size());
+		EgovFormBasedFileVo file = files.get(0);
+		assertEquals(2L, file.getSize());
+
+		Path storedFile = uploadDir.resolve(file.getServerSubPath()).resolve(file.getPhysicalName() + "_upfile");
+		assertTrue(Files.isRegularFile(storedFile));
+		assertArrayEquals(content, Files.readAllBytes(storedFile));
+	}
+
+	private MultipartHttpServletRequest multipartRequest(MultipartFile file) {
+		return (MultipartHttpServletRequest)Proxy.newProxyInstance(
+			MultipartHttpServletRequest.class.getClassLoader(),
+			new Class<?>[] {MultipartHttpServletRequest.class},
+			(proxy, method, args) -> {
+				if ("getFileNames".equals(method.getName())) {
+					return Collections.singleton(file.getName()).iterator();
+				}
+				if ("getFile".equals(method.getName())) {
+					return file.getName().equals(args[0]) ? file : null;
+				}
+				if ("toString".equals(method.getName())) {
+					return "MultipartHttpServletRequest proxy for " + file.getOriginalFilename();
+				}
+				if ("hashCode".equals(method.getName())) {
+					return System.identityHashCode(proxy);
+				}
+				if ("equals".equals(method.getName())) {
+					return proxy == args[0];
+				}
+				throw new UnsupportedOperationException(method.getName());
+			});
+	}
+
+	private MultipartFile multipartFile(String name, String originalFilename, String contentType, byte[] content) {
+		return new MultipartFile() {
+			@Override
+			public String getName() {
+				return name;
+			}
+
+			@Override
+			public String getOriginalFilename() {
+				return originalFilename;
+			}
+
+			@Override
+			public String getContentType() {
+				return contentType;
+			}
+
+			@Override
+			public boolean isEmpty() {
+				return content.length == 0;
+			}
+
+			@Override
+			public long getSize() {
+				return content.length;
+			}
+
+			@Override
+			public byte[] getBytes() {
+				return content.clone();
+			}
+
+			@Override
+			public InputStream getInputStream() {
+				return new ByteArrayInputStream(content);
+			}
+
+			@Override
+			public void transferTo(File dest) throws IOException {
+				Files.write(dest.toPath(), content);
+			}
+		};
+	}
+
+	private long countRegularFiles(Path path) throws Exception {
+		try (Stream<Path> files = Files.walk(path)) {
+			return files.filter(Files::isRegularFile).count();
+		}
+	}
+
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [X] 버그수정 Bug fixes
- [X] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source
`egovframework.com` 공통 컴포넌트의 입력값 검증 및 파일 처리 안정성 개선

- `egovframework.com.utl.fcc.service.EgovFileUploadUtil`
  - `uploadFilesExt`에서 파일 저장 전에 `maxFileSize` 제한값을 검증하도록 수정
  - 제한 크기를 초과한 파일은 저장하지 않고 `SecurityException`을 발생시키도록 수정
  - 파일 크기를 중복 조회하지 않도록 업로드 파일 크기 값을 재사용

- `egovframework.com.cmm.service.impl.EgovFileMngServiceImpl`
  - 첨부파일 등록 결과의 `atchFileId`가 빈 문자열인 경우 `null`로 처리하도록 수정
  - 문자열 참조 비교 대신 `StringUtils.isEmpty`를 사용하여 빈 값 판단 안정성 개선

- `egovframework.com.cmm.web.EgovComUtlController`, `egovframework.com.uss.umt.web.EgovEmplyrManageController`
  - `/EgovPageLink.do` 호출 시 `linkIndex`가 음수이거나 화이트리스트 범위를 벗어난 경우 공통 오류 화면으로 이동하도록 수정
  - 화이트리스트가 비어 있거나 존재하지 않는 경우도 동일하게 오류 화면으로 처리

- `egovframework.com.utl.sim.service.EgovXMLDoc`
  - XML 문서 저장 처리가 정상 완료된 경우 반환값이 `true`가 되도록 수정

- 테스트 코드
  - 파일 업로드 크기 제한 초과 시 저장되지 않는지 검증하는 JUnit 테스트 추가
  - 최대 허용 크기와 동일한 파일은 정상 저장되는지 검증하는 JUnit 테스트 추가
  - 공통 페이지 및 회원가입 화면 이동의 잘못된 화이트리스트 인덱스 처리 테스트 추가

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [x] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.
