### PR TITLE
Fix: 로그인 정책 등록 및 수정 오류 수정

### DIFF
--- a/src/main/java/egovframework/com/uat/uap/service/impl/EgovLoginPolicyServiceImpl.java
+++ b/src/main/java/egovframework/com/uat/uap/service/impl/EgovLoginPolicyServiceImpl.java
@@ -24,11 +24,13 @@ package egovframework.com.uat.uap.service.impl;
 import java.util.List;
 
 import org.egovframe.rte.fdl.cmmn.EgovAbstractServiceImpl;
+import org.egovframe.rte.fdl.cmmn.exception.EgovBizException;
 import org.springframework.stereotype.Service;
 
 import egovframework.com.uat.uap.service.EgovLoginPolicyService;
 import egovframework.com.uat.uap.service.LoginPolicy;
 import egovframework.com.uat.uap.service.LoginPolicyVO;
+import egovframework.com.utl.fcc.service.EgovStringUtil;
 import jakarta.annotation.Resource;
 
 @Service("egovLoginPolicyService")
@@ -83,6 +85,21 @@ public class EgovLoginPolicyServiceImpl extends EgovAbstractServiceImpl implemen
 	@Override
 	public void updateLoginPolicy(LoginPolicy loginPolicy) throws Exception {
 		loginPolicyDAO.updateLoginPolicy(loginPolicy);
+
+		LoginPolicyVO loginPolicyVO = new LoginPolicyVO();
+		loginPolicyVO.setEmplyrId(loginPolicy.getEmplyrId());
+
+		LoginPolicyVO updatedLoginPolicy = loginPolicyDAO.selectLoginPolicy(loginPolicyVO);
+		boolean ipInfoUpdated = updatedLoginPolicy != null
+				&& EgovStringUtil.isNullToString(loginPolicy.getIpInfo())
+						.equals(EgovStringUtil.isNullToString(updatedLoginPolicy.getIpInfo()));
+		boolean lmttAtUpdated = updatedLoginPolicy != null
+				&& EgovStringUtil.isNullToString(loginPolicy.getLmttAt())
+						.equals(EgovStringUtil.isNullToString(updatedLoginPolicy.getLmttAt()));
+
+		if (!ipInfoUpdated || !lmttAtUpdated) {
+			throw new EgovBizException("Login policy update was not persisted.");
+		}
 	}
 
 	/**

--- a/src/main/java/egovframework/com/uat/uap/web/EgovLoginPolicyController.java
+++ b/src/main/java/egovframework/com/uat/uap/web/EgovLoginPolicyController.java
@@ -28,6 +28,7 @@ import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import egovframework.com.cmm.EgovMessageSource;
 import egovframework.com.cmm.LoginVO;
@@ -139,7 +140,8 @@ public class EgovLoginPolicyController {
 	@RequestMapping("/uat/uap/addLoginPolicy.do")
 	public String insertLoginPolicy(@Valid @ModelAttribute("loginPolicy") LoginPolicy loginPolicy,
 			                         BindingResult bindingResult,
-                                     ModelMap model) throws Exception {
+                                     ModelMap model,
+                                     RedirectAttributes redirectAttributes) throws Exception {
 
     	if (bindingResult.hasErrors()) {
     		model.addAttribute("loginPolicyVO", loginPolicy);
@@ -152,10 +154,10 @@ public class EgovLoginPolicyController {
 			egovLoginPolicyService.insertLoginPolicy(loginPolicy);
 			model.addAttribute("message", egovMessageSource.getMessage("success.common.update"));
 
-			model.addAttribute("emplyrId", loginPolicy.getEmplyrId());
-			model.addAttribute("searchCondition", loginPolicy.getSearchCondition());
-			model.addAttribute("searchKeyword", loginPolicy.getSearchKeyword());
-			model.addAttribute("pageIndex", loginPolicy.getPageIndex());
+			redirectAttributes.addAttribute("emplyrId", loginPolicy.getEmplyrId());
+			redirectAttributes.addAttribute("searchCondition", loginPolicy.getSearchCondition());
+			redirectAttributes.addAttribute("searchKeyword", loginPolicy.getSearchKeyword());
+			redirectAttributes.addAttribute("pageIndex", loginPolicy.getPageIndex());
 
 			return "redirect:/uat/uap/getLoginPolicy.do";
 		}

--- a/src/main/java/egovframework/com/uat/uap/web/EgovLoginPolicyController.java
+++ b/src/main/java/egovframework/com/uat/uap/web/EgovLoginPolicyController.java
@@ -21,6 +21,7 @@
 
 package egovframework.com.uat.uap.web;
 
+import org.egovframe.rte.fdl.cmmn.exception.EgovBizException;
 import org.egovframe.rte.ptl.mvc.tags.ui.pagination.PaginationInfo;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
@@ -171,7 +172,8 @@ public class EgovLoginPolicyController {
 	@RequestMapping("/uat/uap/updtLoginPolicy.do")
 	public String updateLoginPolicy(@Valid @ModelAttribute("loginPolicy") LoginPolicy loginPolicy,
 			                         BindingResult bindingResult,
-                                     ModelMap model) throws Exception {
+                                     ModelMap model,
+                                     RedirectAttributes redirectAttributes) throws Exception {
 
     	if (bindingResult.hasErrors()) {
     		model.addAttribute("loginPolicyVO", loginPolicy);
@@ -180,12 +182,18 @@ public class EgovLoginPolicyController {
 			LoginVO user = (LoginVO)EgovUserDetailsHelper.getAuthenticatedUser();
 			loginPolicy.setUserId(user == null ? "" : EgovStringUtil.isNullToString(user.getId()));
 
-			egovLoginPolicyService.updateLoginPolicy(loginPolicy);
-			model.addAttribute("message", egovMessageSource.getMessage("success.common.update"));
+			try {
+				egovLoginPolicyService.updateLoginPolicy(loginPolicy);
+			} catch (EgovBizException e) {
+				model.addAttribute("loginPolicyVO", loginPolicy);
+				model.addAttribute("loginPolicy", loginPolicy);
+				model.addAttribute("message", egovMessageSource.getMessage("fail.common.update"));
+				return "egovframework/com/uat/uap/EgovLoginPolicyUpdt";
+			}
 
-			model.addAttribute("searchCondition", loginPolicy.getSearchCondition());
-			model.addAttribute("searchKeyword", loginPolicy.getSearchKeyword());
-			model.addAttribute("pageIndex", loginPolicy.getPageIndex());
+			redirectAttributes.addAttribute("searchCondition", loginPolicy.getSearchCondition());
+			redirectAttributes.addAttribute("searchKeyword", loginPolicy.getSearchKeyword());
+			redirectAttributes.addAttribute("pageIndex", loginPolicy.getPageIndex());
 
 			return "redirect:/uat/uap/selectLoginPolicyList.do";
 		}

--- a/src/main/webapp/WEB-INF/jsp/egovframework/com/uat/uap/EgovLoginPolicyUpdt.jsp
+++ b/src/main/webapp/WEB-INF/jsp/egovframework/com/uat/uap/EgovLoginPolicyUpdt.jsp
@@ -121,7 +121,7 @@ function ipValidate() {
 <body>
 
 <noscript class="noScriptTitle"><spring:message code="common.noScriptTitle.msg" /></noscript><!-- 자바스크립트를 지원하지 않는 브라우저에서는 일부 기능을 사용하실 수 없습니다. -->
-<form:form modelAttribute="loginPolicy" method="post" action="${pageContext.request.contextPath}/uat/uap/updtLoginPolicy.do' />">
+<form:form modelAttribute="loginPolicy" method="post" action="${pageContext.request.contextPath}/uat/uap/updtLoginPolicy.do">
 <div class="wTableFrm">
 	<!-- 타이틀 -->
 	<h2><spring:message code="comUatUap.loginPolicyUpdt.pageTop.title"/></h2><!-- 로그인정책 수정 -->
@@ -135,7 +135,8 @@ function ipValidate() {
 		<tr>
 			<th><spring:message code="comUatUap.loginPolicyUpdt.emplyrId"/> </th><!-- 사용자ID -->
 			<td class="left">
-			    <input name="emplyrId" id="emplyrId" title="<spring:message code="comUatUap.loginPolicyUpdt.emplyrId"/>" type="text" value="<c:out value='${loginPolicy.emplyrId}'/>" readonly="readonly" style="width:180px" />
+			    <input id="emplyrId" title="<spring:message code="comUatUap.loginPolicyUpdt.emplyrId"/>" type="text" value="<c:out value='${loginPolicy.emplyrId}'/>" readonly="readonly" style="width:180px" />
+			    <input name="emplyrId" value="<c:out value='${loginPolicy.emplyrId}'/>" type="hidden">
 			    <input name="emplyrIdEncrypt" id="emplyrIdEncrypt" value="${egovc:encrypt(loginPolicy.emplyrId)}" type="hidden">
 			</td>
 		</tr>

--- a/src/main/webapp/WEB-INF/jsp/egovframework/com/uat/uap/EgovLoginPolicyUpdt.jsp
+++ b/src/main/webapp/WEB-INF/jsp/egovframework/com/uat/uap/EgovLoginPolicyUpdt.jsp
@@ -135,7 +135,7 @@ function ipValidate() {
 		<tr>
 			<th><spring:message code="comUatUap.loginPolicyUpdt.emplyrId"/> </th><!-- 사용자ID -->
 			<td class="left">
-			    <input name="emplyrId" id="emplyrId" title="<spring:message code="comUatUap.loginPolicyUpdt.emplyrId"/>" type="text" <c:if test="${registerFlag == 'UPDATE'}">disabled</c:if> value="<c:out value='${loginPolicy.emplyrId}'/>" disabled="disabled" style="width:180px" />
+			    <input name="emplyrId" id="emplyrId" title="<spring:message code="comUatUap.loginPolicyUpdt.emplyrId"/>" type="text" value="<c:out value='${loginPolicy.emplyrId}'/>" readonly="readonly" style="width:180px" />
 			    <input name="emplyrIdEncrypt" id="emplyrIdEncrypt" value="${egovc:encrypt(loginPolicy.emplyrId)}" type="hidden">
 			</td>
 		</tr>

--- a/src/test/java/egovframework/com/uat/uap/service/impl/EgovLoginPolicyServiceImplTest.java
+++ b/src/test/java/egovframework/com/uat/uap/service/impl/EgovLoginPolicyServiceImplTest.java
@@ -1,0 +1,76 @@
+package egovframework.com.uat.uap.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.egovframe.rte.fdl.cmmn.exception.EgovBizException;
+import org.junit.jupiter.api.Test;
+
+import egovframework.com.uat.uap.service.LoginPolicy;
+import egovframework.com.uat.uap.service.LoginPolicyVO;
+
+class EgovLoginPolicyServiceImplTest {
+
+	@Test
+	void updateLoginPolicyCompletesWhenPersistedValuesMatch() {
+		EgovLoginPolicyServiceImpl service = new EgovLoginPolicyServiceImpl();
+		StubLoginPolicyDAO loginPolicyDAO = new StubLoginPolicyDAO();
+		service.loginPolicyDAO = loginPolicyDAO;
+
+		LoginPolicy loginPolicy = loginPolicy("TEST1", "192.168.0.10", "Y");
+		loginPolicyDAO.selectedLoginPolicy = loginPolicyVO("TEST1", "192.168.0.10", "Y");
+
+		assertDoesNotThrow(() -> service.updateLoginPolicy(loginPolicy));
+		assertSame(loginPolicy, loginPolicyDAO.updatedLoginPolicy);
+		assertEquals("TEST1", loginPolicyDAO.selectedLoginPolicyRequest.getEmplyrId());
+	}
+
+	@Test
+	void updateLoginPolicyThrowsWhenPersistedValuesDoNotMatch() {
+		EgovLoginPolicyServiceImpl service = new EgovLoginPolicyServiceImpl();
+		StubLoginPolicyDAO loginPolicyDAO = new StubLoginPolicyDAO();
+		service.loginPolicyDAO = loginPolicyDAO;
+
+		LoginPolicy loginPolicy = loginPolicy("TEST1", "192.168.0.10", "Y");
+		loginPolicyDAO.selectedLoginPolicy = loginPolicyVO("TEST1", "10.0.0.1", "N");
+
+		assertThrows(EgovBizException.class, () -> service.updateLoginPolicy(loginPolicy));
+		assertSame(loginPolicy, loginPolicyDAO.updatedLoginPolicy);
+	}
+
+	private static LoginPolicy loginPolicy(String emplyrId, String ipInfo, String lmttAt) {
+		LoginPolicy loginPolicy = new LoginPolicy();
+		loginPolicy.setEmplyrId(emplyrId);
+		loginPolicy.setIpInfo(ipInfo);
+		loginPolicy.setLmttAt(lmttAt);
+		return loginPolicy;
+	}
+
+	private static LoginPolicyVO loginPolicyVO(String emplyrId, String ipInfo, String lmttAt) {
+		LoginPolicyVO loginPolicyVO = new LoginPolicyVO();
+		loginPolicyVO.setEmplyrId(emplyrId);
+		loginPolicyVO.setIpInfo(ipInfo);
+		loginPolicyVO.setLmttAt(lmttAt);
+		return loginPolicyVO;
+	}
+
+	private static class StubLoginPolicyDAO extends LoginPolicyDAO {
+
+		private LoginPolicy updatedLoginPolicy;
+		private LoginPolicyVO selectedLoginPolicy;
+		private LoginPolicyVO selectedLoginPolicyRequest;
+
+		@Override
+		public void updateLoginPolicy(LoginPolicy loginPolicy) {
+			updatedLoginPolicy = loginPolicy;
+		}
+
+		@Override
+		public LoginPolicyVO selectLoginPolicy(LoginPolicyVO loginPolicyVO) {
+			selectedLoginPolicyRequest = loginPolicyVO;
+			return selectedLoginPolicy;
+		}
+	}
+}

--- a/src/test/java/egovframework/com/uat/uap/web/EgovLoginPolicyControllerTest.java
+++ b/src/test/java/egovframework/com/uat/uap/web/EgovLoginPolicyControllerTest.java
@@ -59,6 +59,29 @@ class EgovLoginPolicyControllerTest {
 		assertEquals("2", String.valueOf(redirectAttributes.get("pageIndex")));
 	}
 
+	@Test
+	void updateLoginPolicyKeepsSubmittedEmplyrId() throws Exception {
+		EgovLoginPolicyController controller = new EgovLoginPolicyController();
+		StubLoginPolicyService loginPolicyService = new StubLoginPolicyService();
+		controller.egovLoginPolicyService = loginPolicyService;
+		controller.egovMessageSource = new StubMessageSource();
+		EgovUserDetailsHelper userDetailsHelper = new EgovUserDetailsHelper();
+		previousUserDetailsService = userDetailsHelper.getEgovUserDetailsService();
+		userDetailsHelper.setEgovUserDetailsService(new StubUserDetailsService());
+
+		LoginPolicy loginPolicy = new LoginPolicy();
+		loginPolicy.setEmplyrId("TEST1");
+		loginPolicy.setIpInfo("192.168.0.10");
+		loginPolicy.setLmttAt("Y");
+
+		String viewName = controller.updateLoginPolicy(loginPolicy,
+				new BeanPropertyBindingResult(loginPolicy, "loginPolicy"), new ModelMap());
+
+		assertEquals("redirect:/uat/uap/selectLoginPolicyList.do", viewName);
+		assertSame(loginPolicy, loginPolicyService.updatedLoginPolicy);
+		assertEquals("TEST1", loginPolicyService.updatedLoginPolicy.getEmplyrId());
+	}
+
 	private static class StubMessageSource extends EgovMessageSource {
 		@Override
 		public String getMessage(String code) {
@@ -69,6 +92,7 @@ class EgovLoginPolicyControllerTest {
 	private static class StubLoginPolicyService implements EgovLoginPolicyService {
 
 		private LoginPolicy insertedLoginPolicy;
+		private LoginPolicy updatedLoginPolicy;
 
 		@Override
 		public List<LoginPolicyVO> selectLoginPolicyList(LoginPolicyVO loginPolicyVO) {
@@ -92,7 +116,7 @@ class EgovLoginPolicyControllerTest {
 
 		@Override
 		public void updateLoginPolicy(LoginPolicy loginPolicy) {
-			// Not used by this test.
+			updatedLoginPolicy = loginPolicy;
 		}
 
 		@Override

--- a/src/test/java/egovframework/com/uat/uap/web/EgovLoginPolicyControllerTest.java
+++ b/src/test/java/egovframework/com/uat/uap/web/EgovLoginPolicyControllerTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import java.util.Collections;
 import java.util.List;
 
+import org.egovframe.rte.fdl.cmmn.exception.EgovBizException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.ui.ModelMap;
@@ -75,11 +76,38 @@ class EgovLoginPolicyControllerTest {
 		loginPolicy.setLmttAt("Y");
 
 		String viewName = controller.updateLoginPolicy(loginPolicy,
-				new BeanPropertyBindingResult(loginPolicy, "loginPolicy"), new ModelMap());
+				new BeanPropertyBindingResult(loginPolicy, "loginPolicy"), new ModelMap(),
+				new RedirectAttributesModelMap());
 
 		assertEquals("redirect:/uat/uap/selectLoginPolicyList.do", viewName);
 		assertSame(loginPolicy, loginPolicyService.updatedLoginPolicy);
 		assertEquals("TEST1", loginPolicyService.updatedLoginPolicy.getEmplyrId());
+	}
+
+	@Test
+	void updateLoginPolicyReturnsUpdateViewWhenServiceReportsFailure() throws Exception {
+		EgovLoginPolicyController controller = new EgovLoginPolicyController();
+		StubLoginPolicyService loginPolicyService = new StubLoginPolicyService();
+		controller.egovLoginPolicyService = loginPolicyService;
+		controller.egovMessageSource = new StubMessageSource();
+		EgovUserDetailsHelper userDetailsHelper = new EgovUserDetailsHelper();
+		previousUserDetailsService = userDetailsHelper.getEgovUserDetailsService();
+		userDetailsHelper.setEgovUserDetailsService(new StubUserDetailsService());
+
+		LoginPolicy loginPolicy = new LoginPolicy();
+		loginPolicy.setEmplyrId("TEST1");
+		loginPolicy.setIpInfo("192.168.0.10");
+		loginPolicy.setLmttAt("Y");
+		loginPolicyService.updateException = new EgovBizException("Login policy update was not persisted.");
+
+		ModelMap model = new ModelMap();
+		String viewName = controller.updateLoginPolicy(loginPolicy,
+				new BeanPropertyBindingResult(loginPolicy, "loginPolicy"), model,
+				new RedirectAttributesModelMap());
+
+		assertEquals("egovframework/com/uat/uap/EgovLoginPolicyUpdt", viewName);
+		assertSame(loginPolicy, loginPolicyService.updatedLoginPolicy);
+		assertEquals("fail.common.update", model.get("message"));
 	}
 
 	private static class StubMessageSource extends EgovMessageSource {
@@ -93,6 +121,7 @@ class EgovLoginPolicyControllerTest {
 
 		private LoginPolicy insertedLoginPolicy;
 		private LoginPolicy updatedLoginPolicy;
+		private Exception updateException;
 
 		@Override
 		public List<LoginPolicyVO> selectLoginPolicyList(LoginPolicyVO loginPolicyVO) {
@@ -115,8 +144,11 @@ class EgovLoginPolicyControllerTest {
 		}
 
 		@Override
-		public void updateLoginPolicy(LoginPolicy loginPolicy) {
+		public void updateLoginPolicy(LoginPolicy loginPolicy) throws Exception {
 			updatedLoginPolicy = loginPolicy;
+			if (updateException != null) {
+				throw updateException;
+			}
 		}
 
 		@Override

--- a/src/test/java/egovframework/com/uat/uap/web/EgovLoginPolicyControllerTest.java
+++ b/src/test/java/egovframework/com/uat/uap/web/EgovLoginPolicyControllerTest.java
@@ -1,0 +1,121 @@
+package egovframework.com.uat.uap.web;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.ui.ModelMap;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.web.servlet.mvc.support.RedirectAttributesModelMap;
+
+import egovframework.com.cmm.EgovMessageSource;
+import egovframework.com.cmm.service.EgovUserDetailsService;
+import egovframework.com.cmm.util.EgovUserDetailsHelper;
+import egovframework.com.uat.uap.service.EgovLoginPolicyService;
+import egovframework.com.uat.uap.service.LoginPolicy;
+import egovframework.com.uat.uap.service.LoginPolicyVO;
+
+class EgovLoginPolicyControllerTest {
+
+	private EgovUserDetailsService previousUserDetailsService;
+
+	@AfterEach
+	void tearDown() {
+		new EgovUserDetailsHelper().setEgovUserDetailsService(previousUserDetailsService);
+	}
+
+	@Test
+	void insertLoginPolicyAddsEmplyrIdToRedirect() throws Exception {
+		EgovLoginPolicyController controller = new EgovLoginPolicyController();
+		StubLoginPolicyService loginPolicyService = new StubLoginPolicyService();
+		controller.egovLoginPolicyService = loginPolicyService;
+		controller.egovMessageSource = new StubMessageSource();
+		EgovUserDetailsHelper userDetailsHelper = new EgovUserDetailsHelper();
+		previousUserDetailsService = userDetailsHelper.getEgovUserDetailsService();
+		userDetailsHelper.setEgovUserDetailsService(new StubUserDetailsService());
+
+		LoginPolicy loginPolicy = new LoginPolicy();
+		loginPolicy.setEmplyrId("TEST1");
+		loginPolicy.setIpInfo("127.0.0.1");
+		loginPolicy.setLmttAt("Y");
+		loginPolicy.setSearchCondition("1");
+		loginPolicy.setSearchKeyword("tester");
+		loginPolicy.setPageIndex(2);
+
+		RedirectAttributesModelMap redirectAttributes = new RedirectAttributesModelMap();
+
+		String viewName = controller.insertLoginPolicy(loginPolicy,
+				new BeanPropertyBindingResult(loginPolicy, "loginPolicy"), new ModelMap(), redirectAttributes);
+
+		assertEquals("redirect:/uat/uap/getLoginPolicy.do", viewName);
+		assertSame(loginPolicy, loginPolicyService.insertedLoginPolicy);
+		assertEquals("TEST1", redirectAttributes.get("emplyrId"));
+		assertEquals("1", redirectAttributes.get("searchCondition"));
+		assertEquals("tester", redirectAttributes.get("searchKeyword"));
+		assertEquals("2", String.valueOf(redirectAttributes.get("pageIndex")));
+	}
+
+	private static class StubMessageSource extends EgovMessageSource {
+		@Override
+		public String getMessage(String code) {
+			return code;
+		}
+	}
+
+	private static class StubLoginPolicyService implements EgovLoginPolicyService {
+
+		private LoginPolicy insertedLoginPolicy;
+
+		@Override
+		public List<LoginPolicyVO> selectLoginPolicyList(LoginPolicyVO loginPolicyVO) {
+			return Collections.emptyList();
+		}
+
+		@Override
+		public int selectLoginPolicyListTotCnt(LoginPolicyVO loginPolicyVO) {
+			return 0;
+		}
+
+		@Override
+		public LoginPolicyVO selectLoginPolicy(LoginPolicyVO loginPolicyVO) {
+			return null;
+		}
+
+		@Override
+		public void insertLoginPolicy(LoginPolicy loginPolicy) {
+			insertedLoginPolicy = loginPolicy;
+		}
+
+		@Override
+		public void updateLoginPolicy(LoginPolicy loginPolicy) {
+			// Not used by this test.
+		}
+
+		@Override
+		public void deleteLoginPolicy(LoginPolicy loginPolicy) {
+			// Not used by this test.
+		}
+	}
+
+	private static class StubUserDetailsService implements EgovUserDetailsService {
+
+		@Override
+		public Object getAuthenticatedUser() {
+			return null;
+		}
+
+		@Override
+		public List<String> getAuthorities() {
+			return Collections.emptyList();
+		}
+
+		@Override
+		public Boolean isAuthenticated() {
+			return Boolean.FALSE;
+		}
+	}
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification
- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

**로그인 정책 관리 등록 및 수정 오류 수정**

1. 로그인 정책 최초 등록 후 상세 화면 이동 시 `emplyrId` 파라미터 누락으로 Tomcat 400 오류가 발생하는 문제 수정
   - 등록 완료 후 상세 조회 화면으로 redirect 시 `RedirectAttributes`를 사용하여 `emplyrId`, 검색조건, 검색어, 페이지 번호 전달
   - 이슈 재현 방법 : 로그인 정책 관리 → 계정 선택 → IP 정보 및 IP 제한여부 변경 → 저장 → 400 에러

2. 로그인 정책 수정 화면에서 IP 정보와 제한여부 수정값이 실제 반영되지 않을 수 있는 문제 수정
   - 수정 JSP의 form action URL 오타 수정
   - 사용자 ID 표시용 input과 실제 전송용 `emplyrId` hidden input 분리
   - 수정 대상 사용자 ID가 안정적으로 전달되도록 변경
   - `updateLoginPolicy()` 서비스 계층에서 수정 후 동일 사용자 ID로 재조회
   - `ipInfo`, `lmttAt` 값의 실제 저장 여부 검증 추가
   - 저장값이 요청값과 일치하지 않을 경우 `EgovBizException` 발생
   - 컨트롤러에서 수정 실패 메시지와 함께 수정 화면으로 이동 처리

3. 관련 회귀 검증 테스트 추가 및 수정
   - 등록 후 redirect 파라미터 전달 검증
   - 수정 요청 시 `emplyrId` 유지 검증
   - 서비스 계층의 수정값 저장 여부 검증
   - 저장값 불일치 시 수정 실패 처리 검증

## JUnit 테스트 JUnit tests
- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser
- [X] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

