### PR TITLE
Fix: 로그인정책 대상자 ID 검증 추가

### DIFF
--- a/src/main/java/egovframework/com/uat/uap/web/EgovLoginPolicyController.java
+++ b/src/main/java/egovframework/com/uat/uap/web/EgovLoginPolicyController.java
@@ -21,6 +21,7 @@
 
 package egovframework.com.uat.uap.web;
 
+import org.egovframe.rte.fdl.crypto.EgovEnvCryptoService;
 import org.egovframe.rte.ptl.mvc.tags.ui.pagination.PaginationInfo;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
@@ -28,6 +29,7 @@ import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import egovframework.com.cmm.EgovMessageSource;
 import egovframework.com.cmm.LoginVO;
@@ -48,6 +50,9 @@ public class EgovLoginPolicyController {
 
 	@Resource(name="egovLoginPolicyService")
 	EgovLoginPolicyService egovLoginPolicyService;
+
+	@Resource(name = "egovEnvCryptoService")
+	EgovEnvCryptoService cryptoService;
 
 	/**
 	 * 로그인정책 목록 조회화면으로 이동한다.
@@ -139,12 +144,20 @@ public class EgovLoginPolicyController {
 	@RequestMapping("/uat/uap/addLoginPolicy.do")
 	public String insertLoginPolicy(@Valid @ModelAttribute("loginPolicy") LoginPolicy loginPolicy,
 			                         BindingResult bindingResult,
-                                     ModelMap model) throws Exception {
+                                     ModelMap model,
+                                     RedirectAttributes redirectAttributes) throws Exception {
 
     	if (bindingResult.hasErrors()) {
     		model.addAttribute("loginPolicyVO", loginPolicy);
 			return "egovframework/com/uat/uap/EgovLoginPolicyRegist";
 		} else {
+			if (!hasMatchingEncryptedEmplyrId(loginPolicy)) {
+				redirectAttributes.addFlashAttribute("message", egovMessageSource.getMessage("fail.common.insert"));
+				redirectAttributes.addAttribute("searchCondition", loginPolicy.getSearchCondition());
+				redirectAttributes.addAttribute("searchKeyword", loginPolicy.getSearchKeyword());
+				redirectAttributes.addAttribute("pageIndex", loginPolicy.getPageIndex());
+				return "redirect:/uat/uap/selectLoginPolicyList.do";
+			}
 
 			LoginVO user = (LoginVO)EgovUserDetailsHelper.getAuthenticatedUser();
 			loginPolicy.setUserId(user == null ? "" : EgovStringUtil.isNullToString(user.getId()));
@@ -169,12 +182,21 @@ public class EgovLoginPolicyController {
 	@RequestMapping("/uat/uap/updtLoginPolicy.do")
 	public String updateLoginPolicy(@Valid @ModelAttribute("loginPolicy") LoginPolicy loginPolicy,
 			                         BindingResult bindingResult,
-                                     ModelMap model) throws Exception {
+                                     ModelMap model,
+                                     RedirectAttributes redirectAttributes) throws Exception {
 
     	if (bindingResult.hasErrors()) {
     		model.addAttribute("loginPolicyVO", loginPolicy);
 			return "egovframework/com/uat/uap/EgovLoginPolicyUpdt";
 		} else {
+			if (!hasMatchingEncryptedEmplyrId(loginPolicy)) {
+				redirectAttributes.addFlashAttribute("message", egovMessageSource.getMessage("fail.common.update"));
+				redirectAttributes.addAttribute("searchCondition", loginPolicy.getSearchCondition());
+				redirectAttributes.addAttribute("searchKeyword", loginPolicy.getSearchKeyword());
+				redirectAttributes.addAttribute("pageIndex", loginPolicy.getPageIndex());
+				return "redirect:/uat/uap/selectLoginPolicyList.do";
+			}
+
 			LoginVO user = (LoginVO)EgovUserDetailsHelper.getAuthenticatedUser();
 			loginPolicy.setUserId(user == null ? "" : EgovStringUtil.isNullToString(user.getId()));
 
@@ -196,7 +218,16 @@ public class EgovLoginPolicyController {
 	 */
 	@RequestMapping("/uat/uap/removeLoginPolicy.do")
 	public String deleteLoginPolicy(@ModelAttribute("loginPolicy") LoginPolicy loginPolicy,
-                                     ModelMap model) throws Exception {
+                                     ModelMap model,
+                                     RedirectAttributes redirectAttributes) throws Exception {
+
+		if (!hasMatchingEncryptedEmplyrId(loginPolicy)) {
+			redirectAttributes.addFlashAttribute("message", egovMessageSource.getMessage("fail.common.delete"));
+			redirectAttributes.addAttribute("searchCondition", loginPolicy.getSearchCondition());
+			redirectAttributes.addAttribute("searchKeyword", loginPolicy.getSearchKeyword());
+			redirectAttributes.addAttribute("pageIndex", loginPolicy.getPageIndex());
+			return "redirect:/uat/uap/selectLoginPolicyList.do";
+		}
 
 		egovLoginPolicyService.deleteLoginPolicy(loginPolicy);
 
@@ -209,4 +240,19 @@ public class EgovLoginPolicyController {
 		return "redirect:/uat/uap/selectLoginPolicyList.do";
 	}
 
+	private boolean hasMatchingEncryptedEmplyrId(LoginPolicy loginPolicy) {
+		String emplyrId = EgovStringUtil.isNullToString(loginPolicy.getEmplyrId());
+		String emplyrIdEncrypt = EgovStringUtil.isNullToString(loginPolicy.getEmplyrIdEncrypt());
+
+		if ("".equals(emplyrId) || "".equals(emplyrIdEncrypt) || cryptoService == null) {
+			return false;
+		}
+
+		try {
+			String decryptedEmplyrId = cryptoService.decrypt(emplyrIdEncrypt);
+			return emplyrId.equals(EgovStringUtil.isNullToString(decryptedEmplyrId));
+		} catch (RuntimeException e) {
+			return false;
+		}
+	}
 }

--- a/src/test/java/egovframework/com/uat/uap/web/EgovLoginPolicyControllerTest.java
+++ b/src/test/java/egovframework/com/uat/uap/web/EgovLoginPolicyControllerTest.java
@@ -1,0 +1,278 @@
+package egovframework.com.uat.uap.web;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import java.lang.reflect.Proxy;
+import java.util.Collections;
+import java.util.List;
+
+import org.egovframe.rte.fdl.crypto.EgovEnvCryptoService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.ui.ModelMap;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.web.servlet.mvc.support.RedirectAttributesModelMap;
+
+import egovframework.com.cmm.EgovMessageSource;
+import egovframework.com.cmm.service.EgovUserDetailsService;
+import egovframework.com.cmm.util.EgovUserDetailsHelper;
+import egovframework.com.uat.uap.service.EgovLoginPolicyService;
+import egovframework.com.uat.uap.service.LoginPolicy;
+import egovframework.com.uat.uap.service.LoginPolicyVO;
+
+class EgovLoginPolicyControllerTest {
+
+	private EgovUserDetailsService previousUserDetailsService;
+
+	@AfterEach
+	void tearDown() {
+		new EgovUserDetailsHelper().setEgovUserDetailsService(previousUserDetailsService);
+	}
+
+	@Test
+	void insertLoginPolicyAddsEmplyrIdToModel() throws Exception {
+		EgovLoginPolicyController controller = new EgovLoginPolicyController();
+		StubLoginPolicyService loginPolicyService = new StubLoginPolicyService();
+		controller.egovLoginPolicyService = loginPolicyService;
+		controller.egovMessageSource = new StubMessageSource();
+		controller.cryptoService = cryptoService();
+		EgovUserDetailsHelper userDetailsHelper = new EgovUserDetailsHelper();
+		previousUserDetailsService = userDetailsHelper.getEgovUserDetailsService();
+		userDetailsHelper.setEgovUserDetailsService(new StubUserDetailsService());
+
+		LoginPolicy loginPolicy = new LoginPolicy();
+		loginPolicy.setEmplyrId("TEST1");
+		loginPolicy.setEmplyrIdEncrypt(encryptEmplyrId("TEST1"));
+		loginPolicy.setIpInfo("127.0.0.1");
+		loginPolicy.setLmttAt("Y");
+		loginPolicy.setSearchCondition("1");
+		loginPolicy.setSearchKeyword("tester");
+		loginPolicy.setPageIndex(2);
+
+		ModelMap model = new ModelMap();
+
+		String viewName = controller.insertLoginPolicy(loginPolicy,
+				new BeanPropertyBindingResult(loginPolicy, "loginPolicy"), model,
+				new RedirectAttributesModelMap());
+
+		assertEquals("redirect:/uat/uap/getLoginPolicy.do", viewName);
+		assertSame(loginPolicy, loginPolicyService.insertedLoginPolicy);
+		assertEquals("TEST1", model.get("emplyrId"));
+		assertEquals("1", model.get("searchCondition"));
+		assertEquals("tester", model.get("searchKeyword"));
+		assertEquals("2", String.valueOf(model.get("pageIndex")));
+	}
+
+	@Test
+	void insertLoginPolicyRedirectsToListWhenEncryptedEmplyrIdDoesNotMatch() throws Exception {
+		EgovLoginPolicyController controller = new EgovLoginPolicyController();
+		StubLoginPolicyService loginPolicyService = new StubLoginPolicyService();
+		controller.egovLoginPolicyService = loginPolicyService;
+		controller.egovMessageSource = new StubMessageSource();
+		controller.cryptoService = cryptoService();
+		EgovUserDetailsHelper userDetailsHelper = new EgovUserDetailsHelper();
+		previousUserDetailsService = userDetailsHelper.getEgovUserDetailsService();
+		userDetailsHelper.setEgovUserDetailsService(new StubUserDetailsService());
+
+		LoginPolicy loginPolicy = new LoginPolicy();
+		loginPolicy.setEmplyrId("TEST1");
+		loginPolicy.setEmplyrIdEncrypt(encryptEmplyrId("TEST2"));
+		loginPolicy.setIpInfo("127.0.0.1");
+		loginPolicy.setLmttAt("Y");
+
+		RedirectAttributesModelMap redirectAttributes = new RedirectAttributesModelMap();
+		String viewName = controller.insertLoginPolicy(loginPolicy,
+				new BeanPropertyBindingResult(loginPolicy, "loginPolicy"), new ModelMap(), redirectAttributes);
+
+		assertEquals("redirect:/uat/uap/selectLoginPolicyList.do", viewName);
+		assertNull(loginPolicyService.insertedLoginPolicy);
+		assertEquals("fail.common.insert", redirectAttributes.getFlashAttributes().get("message"));
+	}
+
+	@Test
+	void updateLoginPolicyAcceptsMatchingEncryptedEmplyrId() throws Exception {
+		EgovLoginPolicyController controller = new EgovLoginPolicyController();
+		StubLoginPolicyService loginPolicyService = new StubLoginPolicyService();
+		controller.egovLoginPolicyService = loginPolicyService;
+		controller.egovMessageSource = new StubMessageSource();
+		controller.cryptoService = cryptoService();
+		EgovUserDetailsHelper userDetailsHelper = new EgovUserDetailsHelper();
+		previousUserDetailsService = userDetailsHelper.getEgovUserDetailsService();
+		userDetailsHelper.setEgovUserDetailsService(new StubUserDetailsService());
+
+		LoginPolicy loginPolicy = new LoginPolicy();
+		loginPolicy.setEmplyrId("TEST1");
+		loginPolicy.setEmplyrIdEncrypt(encryptEmplyrId("TEST1"));
+		loginPolicy.setIpInfo("192.168.0.10");
+		loginPolicy.setLmttAt("Y");
+
+		String viewName = controller.updateLoginPolicy(loginPolicy,
+				new BeanPropertyBindingResult(loginPolicy, "loginPolicy"), new ModelMap(),
+				new RedirectAttributesModelMap());
+
+		assertEquals("redirect:/uat/uap/selectLoginPolicyList.do", viewName);
+		assertSame(loginPolicy, loginPolicyService.updatedLoginPolicy);
+		assertEquals("TEST1", loginPolicyService.updatedLoginPolicy.getEmplyrId());
+	}
+
+	@Test
+	void updateLoginPolicyRedirectsToListWhenEncryptedEmplyrIdDoesNotMatch() throws Exception {
+		EgovLoginPolicyController controller = new EgovLoginPolicyController();
+		StubLoginPolicyService loginPolicyService = new StubLoginPolicyService();
+		controller.egovLoginPolicyService = loginPolicyService;
+		controller.egovMessageSource = new StubMessageSource();
+		controller.cryptoService = cryptoService();
+		EgovUserDetailsHelper userDetailsHelper = new EgovUserDetailsHelper();
+		previousUserDetailsService = userDetailsHelper.getEgovUserDetailsService();
+		userDetailsHelper.setEgovUserDetailsService(new StubUserDetailsService());
+
+		LoginPolicy loginPolicy = new LoginPolicy();
+		loginPolicy.setEmplyrId("TEST1");
+		loginPolicy.setEmplyrIdEncrypt(encryptEmplyrId("TEST2"));
+		loginPolicy.setIpInfo("192.168.0.10");
+		loginPolicy.setLmttAt("Y");
+
+		RedirectAttributesModelMap redirectAttributes = new RedirectAttributesModelMap();
+		String viewName = controller.updateLoginPolicy(loginPolicy,
+				new BeanPropertyBindingResult(loginPolicy, "loginPolicy"), new ModelMap(),
+				redirectAttributes);
+
+		assertEquals("redirect:/uat/uap/selectLoginPolicyList.do", viewName);
+		assertNull(loginPolicyService.updatedLoginPolicy);
+		assertEquals("fail.common.update", redirectAttributes.getFlashAttributes().get("message"));
+	}
+
+	@Test
+	void deleteLoginPolicyAcceptsMatchingEncryptedEmplyrId() throws Exception {
+		EgovLoginPolicyController controller = new EgovLoginPolicyController();
+		StubLoginPolicyService loginPolicyService = new StubLoginPolicyService();
+		controller.egovLoginPolicyService = loginPolicyService;
+		controller.egovMessageSource = new StubMessageSource();
+		controller.cryptoService = cryptoService();
+
+		LoginPolicy loginPolicy = new LoginPolicy();
+		loginPolicy.setEmplyrId("TEST1");
+		loginPolicy.setEmplyrIdEncrypt(encryptEmplyrId("TEST1"));
+
+		ModelMap model = new ModelMap();
+		String viewName = controller.deleteLoginPolicy(loginPolicy, model, new RedirectAttributesModelMap());
+
+		assertEquals("redirect:/uat/uap/selectLoginPolicyList.do", viewName);
+		assertSame(loginPolicy, loginPolicyService.deletedLoginPolicy);
+		assertEquals("success.common.delete", model.get("message"));
+	}
+
+	@Test
+	void deleteLoginPolicyRedirectsToListWhenEncryptedEmplyrIdDoesNotMatch() throws Exception {
+		EgovLoginPolicyController controller = new EgovLoginPolicyController();
+		StubLoginPolicyService loginPolicyService = new StubLoginPolicyService();
+		controller.egovLoginPolicyService = loginPolicyService;
+		controller.egovMessageSource = new StubMessageSource();
+		controller.cryptoService = cryptoService();
+
+		LoginPolicy loginPolicy = new LoginPolicy();
+		loginPolicy.setEmplyrId("TEST1");
+		loginPolicy.setEmplyrIdEncrypt(encryptEmplyrId("TEST2"));
+
+		RedirectAttributesModelMap redirectAttributes = new RedirectAttributesModelMap();
+		String viewName = controller.deleteLoginPolicy(loginPolicy, new ModelMap(), redirectAttributes);
+
+		assertEquals("redirect:/uat/uap/selectLoginPolicyList.do", viewName);
+		assertNull(loginPolicyService.deletedLoginPolicy);
+		assertEquals("fail.common.delete", redirectAttributes.getFlashAttributes().get("message"));
+	}
+
+	private static EgovEnvCryptoService cryptoService() {
+		return (EgovEnvCryptoService) Proxy.newProxyInstance(EgovEnvCryptoService.class.getClassLoader(),
+				new Class<?>[] {EgovEnvCryptoService.class}, (proxy, method, args) -> {
+					if ("decrypt".equals(method.getName())) {
+						return decryptEmplyrId((String) args[0]);
+					}
+					if ("encrypt".equals(method.getName())) {
+						return encryptEmplyrId((String) args[0]);
+					}
+					if (Boolean.TYPE.equals(method.getReturnType())) {
+						return Boolean.FALSE;
+					}
+					if (Integer.TYPE.equals(method.getReturnType())) {
+						return 0;
+					}
+					return null;
+				});
+	}
+
+	private static String encryptEmplyrId(String emplyrId) {
+		return "encrypted:" + emplyrId;
+	}
+
+	private static String decryptEmplyrId(String emplyrIdEncrypt) {
+		if (emplyrIdEncrypt != null && emplyrIdEncrypt.startsWith("encrypted:")) {
+			return emplyrIdEncrypt.substring("encrypted:".length());
+		}
+		throw new IllegalArgumentException("Invalid encrypted ID.");
+	}
+
+	private static class StubMessageSource extends EgovMessageSource {
+		@Override
+		public String getMessage(String code) {
+			return code;
+		}
+	}
+
+	private static class StubLoginPolicyService implements EgovLoginPolicyService {
+
+		private LoginPolicy insertedLoginPolicy;
+		private LoginPolicy updatedLoginPolicy;
+		private LoginPolicy deletedLoginPolicy;
+
+		@Override
+		public List<LoginPolicyVO> selectLoginPolicyList(LoginPolicyVO loginPolicyVO) {
+			return Collections.emptyList();
+		}
+
+		@Override
+		public int selectLoginPolicyListTotCnt(LoginPolicyVO loginPolicyVO) {
+			return 0;
+		}
+
+		@Override
+		public LoginPolicyVO selectLoginPolicy(LoginPolicyVO loginPolicyVO) {
+			return null;
+		}
+
+		@Override
+		public void insertLoginPolicy(LoginPolicy loginPolicy) {
+			insertedLoginPolicy = loginPolicy;
+		}
+
+		@Override
+		public void updateLoginPolicy(LoginPolicy loginPolicy) throws Exception {
+			updatedLoginPolicy = loginPolicy;
+		}
+
+		@Override
+		public void deleteLoginPolicy(LoginPolicy loginPolicy) {
+			deletedLoginPolicy = loginPolicy;
+		}
+	}
+
+	private static class StubUserDetailsService implements EgovUserDetailsService {
+
+		@Override
+		public Object getAuthenticatedUser() {
+			return null;
+		}
+
+		@Override
+		public List<String> getAuthorities() {
+			return Collections.emptyList();
+		}
+
+		@Override
+		public Boolean isAuthenticated() {
+			return Boolean.FALSE;
+		}
+	}
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification
- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source
로그인 정책 등록, 수정, 삭제 요청에서 제출된 `emplyrId`와 `emplyrIdEncrypt` 복호화 값이 일치하는지 검증하도록 수정했습니다.

대상자 ID 검증에 실패하면 로그인 정책 변경 서비스가 호출되지 않고 목록 화면으로 리다이렉트됩니다. 이를 통해 hidden 필드의 `emplyrId`를 변조하여 다른 대상자의 로그인 정책을 등록, 수정, 삭제할 수 있는 위험을 방지합니다.

컨트롤러 단위 테스트에 정상 토큰과 불일치 토큰 케이스를 추가했습니다.

## JUnit 테스트 JUnit tests
- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser
- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video.