### PR TITLE
[security] parsson 1.1.7 → 1.1.8 패치 업그레이드

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -383,7 +383,7 @@
 		<dependency>
 			<groupId>org.eclipse.parsson</groupId>
 			<artifactId>parsson</artifactId>
-			<version>1.1.7</version>
+			<version>1.1.8</version>
 		</dependency>
 
 		<!-- ajax json -->


### PR DESCRIPTION
Eclipse Parsson 의존성을 1.1.7에서 1.1.8 패치 버전으로 올립니다. JSON 처리 관련 안정성/보안 패치 반영이며 API 변경은 없습니다.

기존 5.0.x 대상 PR #794를 main 대상으로 재제출한 것이며, #794는 닫습니다.