### PR TITLE
[feat] 개인정보 마스킹 유틸(EgovPiiMaskUtil) 추가

### DIFF
--- a/src/main/java/egovframework/com/utl/fcc/service/EgovPiiMaskUtil.java
+++ b/src/main/java/egovframework/com/utl/fcc/service/EgovPiiMaskUtil.java
@@ -1,0 +1,304 @@
+package egovframework.com.utl.fcc.service;
+
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
+
+/**
+ * @Class Name  : EgovPiiMaskUtil.java
+ * @Description : 개인정보 마스킹 처리 관련 유틸리티
+ * @Modification Information
+ *
+ *     수정일         수정자                   수정내용
+ *     -------          --------        ---------------------------
+ *   2025.06.05     공통컴포넌트개발팀          최초 생성
+ *
+ * @author 공통컴포넌트 개발팀
+ * @since 2025. 06. 05
+ * @version 1.0
+ * @see
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2025.06.05  공통컴포넌트개발팀  최초 생성
+ *
+ * </pre>
+ */
+public class EgovPiiMaskUtil {
+
+    private EgovPiiMaskUtil() {
+        throw new IllegalStateException("유틸리티 클래스입니다.");
+    }
+
+    /** 주민등록번호 패턴: 생년월일 6자리 - 성별포함 7자리 */
+    private static final Pattern JUMIN_PATTERN =
+        Pattern.compile("(\\d{6})[-](\\d{7})");
+
+    /** 휴대폰 번호 패턴 (010/011/016/017/018/019 계열, 하이픈 있음) */
+    private static final Pattern PHONE_HYPHEN_PATTERN =
+        Pattern.compile("(0\\d{1,2})[-](\\d{3,4})[-](\\d{4})");
+
+    /** 휴대폰 번호 패턴 (하이픈 없음, 10~11자리 숫자) */
+    private static final Pattern PHONE_PLAIN_PATTERN =
+        Pattern.compile("(?<![\\d])(0\\d{9,10})(?![\\d])");
+
+    /** 이메일 패턴 */
+    private static final Pattern EMAIL_PATTERN =
+        Pattern.compile("([A-Za-z0-9._%+\\-]{2,})(@[A-Za-z0-9.\\-]+\\.[A-Za-z]{2,})");
+
+    /** 신용카드 패턴: 4자리-4자리-4자리-4자리 (하이픈 또는 공백 구분) */
+    private static final Pattern CARD_PATTERN =
+        Pattern.compile("(\\d{4})[-\\s](\\d{4})[-\\s](\\d{4})[-\\s](\\d{4})");
+
+    /** 사업자등록번호 패턴: 3자리-2자리-5자리 */
+    private static final Pattern BIZ_REG_PATTERN =
+        Pattern.compile("(\\d{3})[-](\\d{2})[-](\\d{5})");
+
+    /** 사설 IP 패턴: 10.x.x.x / 172.16~31.x.x / 192.168.x.x */
+    private static final Pattern PRIVATE_IP_PATTERN =
+        Pattern.compile(
+            "(?<![\\d.])" +
+            "(" +
+                "10\\.\\d{1,3}\\.\\d{1,3}" +
+                "|172\\.(1[6-9]|2\\d|3[01])\\.\\d{1,3}" +
+                "|192\\.168\\.\\d{1,3}" +
+            ")" +
+            "\\.(\\d{1,3})" +
+            "(?![\\d.])"
+        );
+
+    /**
+     * 주민등록번호를 마스킹한다.
+     * <p>뒤 7자리를 {@code *}로 대체한다. 예) {@code 901010-1234567} → {@code 901010-1******}</p>
+     *
+     * @param juminNo 주민등록번호 문자열 (null 허용)
+     * @return 마스킹된 주민등록번호. null 또는 빈 문자열이면 원본 반환
+     */
+    public static String maskJuminNo(String juminNo) {
+        if (juminNo == null || juminNo.isEmpty()) {
+            return juminNo;
+        }
+        Matcher m = JUMIN_PATTERN.matcher(juminNo);
+        if (!m.find()) {
+            return juminNo;
+        }
+        String front = m.group(1);
+        String back = m.group(2);
+        String masked = front + "-" + back.charAt(0) + "******";
+        return juminNo.substring(0, m.start()) + masked + juminNo.substring(m.end());
+    }
+
+    /**
+     * 전화번호(휴대폰/일반)를 마스킹한다.
+     * <p>가운데 구간을 {@code ****}로 대체한다. 예) {@code 010-1234-5678} → {@code 010-****-5678}</p>
+     *
+     * @param phoneNo 전화번호 문자열 (null 허용)
+     * @return 마스킹된 전화번호. null 또는 빈 문자열이면 원본 반환
+     */
+    public static String maskPhoneNo(String phoneNo) {
+        if (phoneNo == null || phoneNo.isEmpty()) {
+            return phoneNo;
+        }
+        Matcher m = PHONE_HYPHEN_PATTERN.matcher(phoneNo);
+        if (m.find()) {
+            String masked = m.group(1) + "-" + m.group(2).replaceAll("\\d", "*") + "-" + m.group(3);
+            return phoneNo.substring(0, m.start()) + masked + phoneNo.substring(m.end());
+        }
+        Matcher mp = PHONE_PLAIN_PATTERN.matcher(phoneNo);
+        if (mp.find()) {
+            String num = mp.group(1);
+            // 11자리: 3-4-4, 10자리: 3-3-4
+            String masked;
+            if (num.length() == 11) {
+                masked = num.substring(0, 3) + "****" + num.substring(7);
+            } else {
+                masked = num.substring(0, 3) + "***" + num.substring(6);
+            }
+            return phoneNo.substring(0, mp.start()) + masked + phoneNo.substring(mp.end());
+        }
+        return phoneNo;
+    }
+
+    /**
+     * 이메일 주소를 마스킹한다.
+     * <p>로컬 파트 앞 2자리를 제외한 나머지를 {@code *}로 대체한다. 예) {@code abcde@domain.com} → {@code ab***@domain.com}</p>
+     *
+     * @param email 이메일 주소 문자열 (null 허용)
+     * @return 마스킹된 이메일 주소. null 또는 빈 문자열이면 원본 반환
+     */
+    public static String maskEmail(String email) {
+        if (email == null || email.isEmpty()) {
+            return email;
+        }
+        Matcher m = EMAIL_PATTERN.matcher(email);
+        if (!m.find()) {
+            return email;
+        }
+        String local = m.group(1);
+        String domain = m.group(2);
+        int visibleLen = Math.min(2, local.length());
+        String masked = local.substring(0, visibleLen)
+            + "*".repeat(local.length() - visibleLen)
+            + domain;
+        return email.substring(0, m.start()) + masked + email.substring(m.end());
+    }
+
+    /**
+     * 신용카드 번호를 마스킹한다.
+     * <p>가운데 8자리를 {@code *}로 대체한다. 예) {@code 1234-5678-9012-3456} → {@code 1234-****-****-3456}</p>
+     *
+     * @param cardNo 신용카드 번호 문자열 (null 허용)
+     * @return 마스킹된 카드 번호. null 또는 빈 문자열이면 원본 반환
+     */
+    public static String maskCardNo(String cardNo) {
+        if (cardNo == null || cardNo.isEmpty()) {
+            return cardNo;
+        }
+        Matcher m = CARD_PATTERN.matcher(cardNo);
+        if (!m.find()) {
+            return cardNo;
+        }
+        char sep = m.group(0).charAt(4);
+        String masked = m.group(1) + sep + "****" + sep + "****" + sep + m.group(4);
+        return cardNo.substring(0, m.start()) + masked + cardNo.substring(m.end());
+    }
+
+    /**
+     * 사업자등록번호를 마스킹한다.
+     * <p>마지막 5자리를 {@code *}로 대체한다. 예) {@code 123-45-67890} → {@code 123-45-*****}</p>
+     *
+     * @param bizRegNo 사업자등록번호 문자열 (null 허용)
+     * @return 마스킹된 사업자등록번호. null 또는 빈 문자열이면 원본 반환
+     */
+    public static String maskBizRegNo(String bizRegNo) {
+        if (bizRegNo == null || bizRegNo.isEmpty()) {
+            return bizRegNo;
+        }
+        Matcher m = BIZ_REG_PATTERN.matcher(bizRegNo);
+        if (!m.find()) {
+            return bizRegNo;
+        }
+        String masked = m.group(1) + "-" + m.group(2) + "-*****";
+        return bizRegNo.substring(0, m.start()) + masked + bizRegNo.substring(m.end());
+    }
+
+    /**
+     * 사설 IP 주소의 마지막 옥텟을 마스킹한다.
+     * <p>10.x.x.x, 172.16~31.x.x, 192.168.x.x 대역에 한해 마지막 옥텟을 {@code ***}로 대체한다.</p>
+     * <p>예) {@code 192.168.1.100} → {@code 192.168.1.***}</p>
+     *
+     * @param ipAddress IP 주소 문자열 (null 허용)
+     * @return 마스킹된 IP 주소. null 또는 빈 문자열, 또는 공인 IP이면 원본 반환
+     */
+    public static String maskPrivateIp(String ipAddress) {
+        if (ipAddress == null || ipAddress.isEmpty()) {
+            return ipAddress;
+        }
+        Matcher m = PRIVATE_IP_PATTERN.matcher(ipAddress);
+        if (!m.find()) {
+            return ipAddress;
+        }
+        String masked = m.group(1) + ".***";
+        return ipAddress.substring(0, m.start()) + masked + ipAddress.substring(m.end());
+    }
+
+    /**
+     * 임의 텍스트에서 주민등록번호·전화번호·이메일·신용카드·사업자등록번호·사설IP를 탐지하여 일괄 마스킹한다.
+     * <p>외부 전송 전 인바운드 필터 등 텍스트 전처리 용도로 사용한다.</p>
+     * <p>오탐을 줄이기 위해 명확한 패턴만 처리하며, 불명확한 패턴은 건너뛴다.</p>
+     *
+     * @param text 마스킹 대상 텍스트 (null 허용)
+     * @return 개인정보가 마스킹된 텍스트. null이면 null 반환
+     */
+    public static String maskAll(String text) {
+        if (text == null) {
+            return null;
+        }
+        String result = text;
+        result = maskAllJuminNo(result);
+        result = maskAllPhoneNo(result);
+        result = maskAllEmail(result);
+        result = maskAllCardNo(result);
+        result = maskAllBizRegNo(result);
+        result = maskAllPrivateIp(result);
+        return result;
+    }
+
+    /* ============================================================
+     *  내부 일괄 처리 헬퍼 — 텍스트 전체에서 반복 치환
+     * ============================================================ */
+
+    private static String maskAllJuminNo(String text) {
+        Matcher m = JUMIN_PATTERN.matcher(text);
+        StringBuffer sb = new StringBuffer();
+        while (m.find()) {
+            String replacement = m.group(1) + "-" + m.group(2).charAt(0) + "******";
+            m.appendReplacement(sb, Matcher.quoteReplacement(replacement));
+        }
+        m.appendTail(sb);
+        return sb.toString();
+    }
+
+    private static String maskAllPhoneNo(String text) {
+        Matcher m = PHONE_HYPHEN_PATTERN.matcher(text);
+        StringBuffer sb = new StringBuffer();
+        while (m.find()) {
+            String replacement = m.group(1) + "-" + m.group(2).replaceAll("\\d", "*") + "-" + m.group(3);
+            m.appendReplacement(sb, Matcher.quoteReplacement(replacement));
+        }
+        m.appendTail(sb);
+        return sb.toString();
+    }
+
+    private static String maskAllEmail(String text) {
+        Matcher m = EMAIL_PATTERN.matcher(text);
+        StringBuffer sb = new StringBuffer();
+        while (m.find()) {
+            String local = m.group(1);
+            String domain = m.group(2);
+            int visibleLen = Math.min(2, local.length());
+            String replacement = local.substring(0, visibleLen)
+                + "*".repeat(local.length() - visibleLen)
+                + domain;
+            m.appendReplacement(sb, Matcher.quoteReplacement(replacement));
+        }
+        m.appendTail(sb);
+        return sb.toString();
+    }
+
+    private static String maskAllCardNo(String text) {
+        Matcher m = CARD_PATTERN.matcher(text);
+        StringBuffer sb = new StringBuffer();
+        while (m.find()) {
+            char sep = m.group(0).charAt(4);
+            String replacement = m.group(1) + sep + "****" + sep + "****" + sep + m.group(4);
+            m.appendReplacement(sb, Matcher.quoteReplacement(replacement));
+        }
+        m.appendTail(sb);
+        return sb.toString();
+    }
+
+    private static String maskAllBizRegNo(String text) {
+        Matcher m = BIZ_REG_PATTERN.matcher(text);
+        StringBuffer sb = new StringBuffer();
+        while (m.find()) {
+            String replacement = m.group(1) + "-" + m.group(2) + "-*****";
+            m.appendReplacement(sb, Matcher.quoteReplacement(replacement));
+        }
+        m.appendTail(sb);
+        return sb.toString();
+    }
+
+    private static String maskAllPrivateIp(String text) {
+        Matcher m = PRIVATE_IP_PATTERN.matcher(text);
+        StringBuffer sb = new StringBuffer();
+        while (m.find()) {
+            String replacement = m.group(1) + ".***";
+            m.appendReplacement(sb, Matcher.quoteReplacement(replacement));
+        }
+        m.appendTail(sb);
+        return sb.toString();
+    }
+}

--- a/src/main/java/egovframework/com/utl/fcc/service/EgovPiiMaskUtil.java
+++ b/src/main/java/egovframework/com/utl/fcc/service/EgovPiiMaskUtil.java
@@ -108,17 +108,23 @@ public class EgovPiiMaskUtil {
         }
         Matcher mp = PHONE_PLAIN_PATTERN.matcher(phoneNo);
         if (mp.find()) {
-            String num = mp.group(1);
-            // 11자리: 3-4-4, 10자리: 3-3-4
-            String masked;
-            if (num.length() == 11) {
-                masked = num.substring(0, 3) + "****" + num.substring(7);
-            } else {
-                masked = num.substring(0, 3) + "***" + num.substring(6);
-            }
+            String masked = maskPlainPhoneDigits(mp.group(1));
             return phoneNo.substring(0, mp.start()) + masked + phoneNo.substring(mp.end());
         }
         return phoneNo;
+    }
+
+    /**
+     * 하이픈 없는 10~11자리 휴대폰 번호 숫자열을 마스킹한다.
+     * <p>단일 마스킹({@link #maskPhoneNo})과 일괄 마스킹({@code maskAllPhoneNo})이
+     * 동일한 규칙을 사용하도록 공통 로직으로 분리한다. 11자리는 {@code 3-****-뒤4자리},
+     * 10자리는 {@code 3-***-뒤4자리} 형태로 가린다.</p>
+     */
+    private static String maskPlainPhoneDigits(String num) {
+        if (num.length() == 11) {
+            return num.substring(0, 3) + "****" + num.substring(7);
+        }
+        return num.substring(0, 3) + "***" + num.substring(6);
     }
 
     /**
@@ -242,6 +248,7 @@ public class EgovPiiMaskUtil {
     }
 
     private static String maskAllPhoneNo(String text) {
+        // 1) 하이픈 포함 번호 치환
         Matcher m = PHONE_HYPHEN_PATTERN.matcher(text);
         StringBuffer sb = new StringBuffer();
         while (m.find()) {
@@ -249,7 +256,16 @@ public class EgovPiiMaskUtil {
             m.appendReplacement(sb, Matcher.quoteReplacement(replacement));
         }
         m.appendTail(sb);
-        return sb.toString();
+
+        // 2) 하이픈 없는 번호 치환 — 단일 마스킹(maskPhoneNo)과 동일 규칙 적용.
+        //    1)에서 가려진 결과는 하이픈/별표를 포함하므로 연속 10~11자리 패턴에 매칭되지 않는다.
+        Matcher mp = PHONE_PLAIN_PATTERN.matcher(sb.toString());
+        StringBuffer sb2 = new StringBuffer();
+        while (mp.find()) {
+            mp.appendReplacement(sb2, Matcher.quoteReplacement(maskPlainPhoneDigits(mp.group(1))));
+        }
+        mp.appendTail(sb2);
+        return sb2.toString();
     }
 
     private static String maskAllEmail(String text) {

--- a/src/test/java/egovframework/com/utl/fcc/service/EgovPiiMaskUtilTest.java
+++ b/src/test/java/egovframework/com/utl/fcc/service/EgovPiiMaskUtilTest.java
@@ -2,6 +2,7 @@ package egovframework.com.utl.fcc.service;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -14,22 +15,26 @@ public class EgovPiiMaskUtilTest {
     // -----------------------------------------------------------------------
 
     @Test
-    void 주민번호_정상_마스킹() {
+    @DisplayName("주민번호 정상 마스킹")
+    void maskJuminNo_masksNormalValue() {
         assertEquals("901010-1******", EgovPiiMaskUtil.maskJuminNo("901010-1234567"));
     }
 
     @Test
-    void 주민번호_null_원본반환() {
+    @DisplayName("주민번호 null 원본반환")
+    void maskJuminNo_nullReturnsOriginal() {
         assertNull(EgovPiiMaskUtil.maskJuminNo(null));
     }
 
     @Test
-    void 주민번호_빈문자_원본반환() {
+    @DisplayName("주민번호 빈문자 원본반환")
+    void maskJuminNo_emptyReturnsOriginal() {
         assertEquals("", EgovPiiMaskUtil.maskJuminNo(""));
     }
 
     @Test
-    void 주민번호_미매칭_원본반환() {
+    @DisplayName("주민번호 미매칭 원본반환")
+    void maskJuminNo_noMatchReturnsOriginal() {
         assertEquals("ABC", EgovPiiMaskUtil.maskJuminNo("ABC"));
     }
 
@@ -38,32 +43,38 @@ public class EgovPiiMaskUtilTest {
     // -----------------------------------------------------------------------
 
     @Test
-    void 휴대폰_하이픈_가운데마스킹() {
+    @DisplayName("휴대폰 하이픈 가운데마스킹")
+    void maskPhoneNo_hyphenMasksMiddle() {
         assertEquals("010-****-5678", EgovPiiMaskUtil.maskPhoneNo("010-1234-5678"));
     }
 
     @Test
-    void 휴대폰_하이픈_3자리가운데() {
+    @DisplayName("휴대폰 하이픈 3자리가운데")
+    void maskPhoneNo_hyphenThreeDigitMiddle() {
         assertEquals("010-***-5678", EgovPiiMaskUtil.maskPhoneNo("010-123-5678"));
     }
 
     @Test
-    void 전화번호_null_원본반환() {
+    @DisplayName("전화번호 null 원본반환")
+    void maskPhoneNo_nullReturnsOriginal() {
         assertNull(EgovPiiMaskUtil.maskPhoneNo(null));
     }
 
     @Test
-    void 전화번호_빈문자_원본반환() {
+    @DisplayName("전화번호 빈문자 원본반환")
+    void maskPhoneNo_emptyReturnsOriginal() {
         assertEquals("", EgovPiiMaskUtil.maskPhoneNo(""));
     }
 
     @Test
-    void 전화번호_미매칭_원본반환() {
+    @DisplayName("전화번호 미매칭 원본반환")
+    void maskPhoneNo_noMatchReturnsOriginal() {
         assertEquals("없는번호", EgovPiiMaskUtil.maskPhoneNo("없는번호"));
     }
 
     @Test
-    void 전화번호_하이픈없이_11자리_마스킹() {
+    @DisplayName("전화번호 하이픈없이 11자리 마스킹")
+    void maskPhoneNo_plain11Digits() {
         // 하이픈 없이 11자리: 010****5678 형태로 가운데 마스킹
         assertEquals("010****5678", EgovPiiMaskUtil.maskPhoneNo("01012345678"));
         assertEquals("010****5678", EgovPiiMaskUtil.maskPhoneNo("01001235678"));
@@ -74,32 +85,38 @@ public class EgovPiiMaskUtilTest {
     // -----------------------------------------------------------------------
 
     @Test
-    void 이메일_정상_마스킹() {
+    @DisplayName("이메일 정상 마스킹")
+    void maskEmail_masksNormalValue() {
         assertEquals("ab***@domain.com", EgovPiiMaskUtil.maskEmail("abcde@domain.com"));
     }
 
     @Test
-    void 이메일_로컬파트_2자이하() {
+    @DisplayName("이메일 로컬파트 2자이하")
+    void maskEmail_localPartTwoCharsOrLess() {
         assertEquals("a@x.com", EgovPiiMaskUtil.maskEmail("a@x.com"));
     }
 
     @Test
-    void 이메일_로컬파트_2자() {
+    @DisplayName("이메일 로컬파트 2자")
+    void maskEmail_localPartTwoChars() {
         assertEquals("ab@test.com", EgovPiiMaskUtil.maskEmail("ab@test.com"));
     }
 
     @Test
-    void 이메일_null_원본반환() {
+    @DisplayName("이메일 null 원본반환")
+    void maskEmail_nullReturnsOriginal() {
         assertNull(EgovPiiMaskUtil.maskEmail(null));
     }
 
     @Test
-    void 이메일_빈문자_원본반환() {
+    @DisplayName("이메일 빈문자 원본반환")
+    void maskEmail_emptyReturnsOriginal() {
         assertEquals("", EgovPiiMaskUtil.maskEmail(""));
     }
 
     @Test
-    void 이메일_미매칭_원본반환() {
+    @DisplayName("이메일 미매칭 원본반환")
+    void maskEmail_noMatchReturnsOriginal() {
         assertEquals("notanemail", EgovPiiMaskUtil.maskEmail("notanemail"));
     }
 
@@ -108,27 +125,32 @@ public class EgovPiiMaskUtilTest {
     // -----------------------------------------------------------------------
 
     @Test
-    void 카드번호_하이픈구분_마스킹() {
+    @DisplayName("카드번호 하이픈구분 마스킹")
+    void maskCardNo_hyphenSeparated() {
         assertEquals("1234-****-****-3456", EgovPiiMaskUtil.maskCardNo("1234-5678-9012-3456"));
     }
 
     @Test
-    void 카드번호_공백구분_마스킹() {
+    @DisplayName("카드번호 공백구분 마스킹")
+    void maskCardNo_spaceSeparated() {
         assertEquals("1234 **** **** 3456", EgovPiiMaskUtil.maskCardNo("1234 5678 9012 3456"));
     }
 
     @Test
-    void 카드번호_null_원본반환() {
+    @DisplayName("카드번호 null 원본반환")
+    void maskCardNo_nullReturnsOriginal() {
         assertNull(EgovPiiMaskUtil.maskCardNo(null));
     }
 
     @Test
-    void 카드번호_빈문자_원본반환() {
+    @DisplayName("카드번호 빈문자 원본반환")
+    void maskCardNo_emptyReturnsOriginal() {
         assertEquals("", EgovPiiMaskUtil.maskCardNo(""));
     }
 
     @Test
-    void 카드번호_미매칭_원본반환() {
+    @DisplayName("카드번호 미매칭 원본반환")
+    void maskCardNo_noMatchReturnsOriginal() {
         assertEquals("1234-5678", EgovPiiMaskUtil.maskCardNo("1234-5678"));
     }
 
@@ -137,22 +159,26 @@ public class EgovPiiMaskUtilTest {
     // -----------------------------------------------------------------------
 
     @Test
-    void 사업자번호_정상_마스킹() {
+    @DisplayName("사업자번호 정상 마스킹")
+    void maskBizRegNo_masksNormalValue() {
         assertEquals("123-45-*****", EgovPiiMaskUtil.maskBizRegNo("123-45-67890"));
     }
 
     @Test
-    void 사업자번호_null_원본반환() {
+    @DisplayName("사업자번호 null 원본반환")
+    void maskBizRegNo_nullReturnsOriginal() {
         assertNull(EgovPiiMaskUtil.maskBizRegNo(null));
     }
 
     @Test
-    void 사업자번호_빈문자_원본반환() {
+    @DisplayName("사업자번호 빈문자 원본반환")
+    void maskBizRegNo_emptyReturnsOriginal() {
         assertEquals("", EgovPiiMaskUtil.maskBizRegNo(""));
     }
 
     @Test
-    void 사업자번호_미매칭_원본반환() {
+    @DisplayName("사업자번호 미매칭 원본반환")
+    void maskBizRegNo_noMatchReturnsOriginal() {
         assertEquals("1234567", EgovPiiMaskUtil.maskBizRegNo("1234567"));
     }
 
@@ -161,27 +187,32 @@ public class EgovPiiMaskUtilTest {
     // -----------------------------------------------------------------------
 
     @Test
-    void 사설IP_192168_마스킹() {
+    @DisplayName("사설IP 192168 마스킹")
+    void maskPrivateIp_192_168() {
         assertEquals("192.168.1.***", EgovPiiMaskUtil.maskPrivateIp("192.168.1.100"));
     }
 
     @Test
-    void 사설IP_10대역_마스킹() {
+    @DisplayName("사설IP 10대역 마스킹")
+    void maskPrivateIp_10Range() {
         assertEquals("10.0.0.***", EgovPiiMaskUtil.maskPrivateIp("10.0.0.1"));
     }
 
     @Test
-    void 사설IP_172대역_마스킹() {
+    @DisplayName("사설IP 172대역 마스킹")
+    void maskPrivateIp_172Range() {
         assertEquals("172.16.0.***", EgovPiiMaskUtil.maskPrivateIp("172.16.0.254"));
     }
 
     @Test
-    void 공인IP_미마스킹() {
+    @DisplayName("공인IP 미마스킹")
+    void maskPrivateIp_publicIpNotMasked() {
         assertEquals("8.8.8.8", EgovPiiMaskUtil.maskPrivateIp("8.8.8.8"));
     }
 
     @Test
-    void 사설IP_null_원본반환() {
+    @DisplayName("사설IP null 원본반환")
+    void maskPrivateIp_nullReturnsOriginal() {
         assertNull(EgovPiiMaskUtil.maskPrivateIp(null));
     }
 
@@ -190,7 +221,8 @@ public class EgovPiiMaskUtilTest {
     // -----------------------------------------------------------------------
 
     @Test
-    void maskAll_혼합텍스트_전체마스킹() {
+    @DisplayName("maskAll 혼합텍스트 전체마스킹")
+    void maskAll_mixedTextMasksAll() {
         String input = "사용자 홍길동(901010-1234567), 연락처: 010-1234-5678, "
             + "이메일: hong@example.com, 카드: 1234-5678-9012-3456, "
             + "사업자: 123-45-67890, IP: 192.168.0.10";
@@ -206,12 +238,23 @@ public class EgovPiiMaskUtilTest {
     }
 
     @Test
-    void maskAll_null_null반환() {
+    @DisplayName("maskAll 하이픈 없는 전화번호도 마스킹")
+    void maskAll_masksPlainPhoneNumbers() {
+        String input = "연락처 01012345678 / 보조 0212345678 끝";
+        String result = EgovPiiMaskUtil.maskAll(input);
+        assertTrue(result.contains("010****5678"), "하이픈 없는 11자리 휴대폰 마스킹");
+        assertTrue(result.contains("021***5678"), "하이픈 없는 10자리 번호 마스킹");
+    }
+
+    @Test
+    @DisplayName("maskAll null null반환")
+    void maskAll_nullReturnsNull() {
         assertNull(EgovPiiMaskUtil.maskAll(null));
     }
 
     @Test
-    void maskAll_개인정보없음_원본유지() {
+    @DisplayName("maskAll 개인정보없음 원본유지")
+    void maskAll_noPiiKeepsOriginal() {
         String text = "일반 텍스트입니다. 개인정보 없음.";
         assertEquals(text, EgovPiiMaskUtil.maskAll(text));
     }

--- a/src/test/java/egovframework/com/utl/fcc/service/EgovPiiMaskUtilTest.java
+++ b/src/test/java/egovframework/com/utl/fcc/service/EgovPiiMaskUtilTest.java
@@ -1,0 +1,218 @@
+package egovframework.com.utl.fcc.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * EgovPiiMaskUtil 단위 테스트
+ */
+public class EgovPiiMaskUtilTest {
+
+    // -----------------------------------------------------------------------
+    // maskJuminNo
+    // -----------------------------------------------------------------------
+
+    @Test
+    void 주민번호_정상_마스킹() {
+        assertEquals("901010-1******", EgovPiiMaskUtil.maskJuminNo("901010-1234567"));
+    }
+
+    @Test
+    void 주민번호_null_원본반환() {
+        assertNull(EgovPiiMaskUtil.maskJuminNo(null));
+    }
+
+    @Test
+    void 주민번호_빈문자_원본반환() {
+        assertEquals("", EgovPiiMaskUtil.maskJuminNo(""));
+    }
+
+    @Test
+    void 주민번호_미매칭_원본반환() {
+        assertEquals("ABC", EgovPiiMaskUtil.maskJuminNo("ABC"));
+    }
+
+    // -----------------------------------------------------------------------
+    // maskPhoneNo
+    // -----------------------------------------------------------------------
+
+    @Test
+    void 휴대폰_하이픈_가운데마스킹() {
+        assertEquals("010-****-5678", EgovPiiMaskUtil.maskPhoneNo("010-1234-5678"));
+    }
+
+    @Test
+    void 휴대폰_하이픈_3자리가운데() {
+        assertEquals("010-***-5678", EgovPiiMaskUtil.maskPhoneNo("010-123-5678"));
+    }
+
+    @Test
+    void 전화번호_null_원본반환() {
+        assertNull(EgovPiiMaskUtil.maskPhoneNo(null));
+    }
+
+    @Test
+    void 전화번호_빈문자_원본반환() {
+        assertEquals("", EgovPiiMaskUtil.maskPhoneNo(""));
+    }
+
+    @Test
+    void 전화번호_미매칭_원본반환() {
+        assertEquals("없는번호", EgovPiiMaskUtil.maskPhoneNo("없는번호"));
+    }
+
+    @Test
+    void 전화번호_하이픈없이_11자리_마스킹() {
+        // 하이픈 없이 11자리: 010****5678 형태로 가운데 마스킹
+        assertEquals("010****5678", EgovPiiMaskUtil.maskPhoneNo("01012345678"));
+        assertEquals("010****5678", EgovPiiMaskUtil.maskPhoneNo("01001235678"));
+    }
+
+    // -----------------------------------------------------------------------
+    // maskEmail
+    // -----------------------------------------------------------------------
+
+    @Test
+    void 이메일_정상_마스킹() {
+        assertEquals("ab***@domain.com", EgovPiiMaskUtil.maskEmail("abcde@domain.com"));
+    }
+
+    @Test
+    void 이메일_로컬파트_2자이하() {
+        assertEquals("a@x.com", EgovPiiMaskUtil.maskEmail("a@x.com"));
+    }
+
+    @Test
+    void 이메일_로컬파트_2자() {
+        assertEquals("ab@test.com", EgovPiiMaskUtil.maskEmail("ab@test.com"));
+    }
+
+    @Test
+    void 이메일_null_원본반환() {
+        assertNull(EgovPiiMaskUtil.maskEmail(null));
+    }
+
+    @Test
+    void 이메일_빈문자_원본반환() {
+        assertEquals("", EgovPiiMaskUtil.maskEmail(""));
+    }
+
+    @Test
+    void 이메일_미매칭_원본반환() {
+        assertEquals("notanemail", EgovPiiMaskUtil.maskEmail("notanemail"));
+    }
+
+    // -----------------------------------------------------------------------
+    // maskCardNo
+    // -----------------------------------------------------------------------
+
+    @Test
+    void 카드번호_하이픈구분_마스킹() {
+        assertEquals("1234-****-****-3456", EgovPiiMaskUtil.maskCardNo("1234-5678-9012-3456"));
+    }
+
+    @Test
+    void 카드번호_공백구분_마스킹() {
+        assertEquals("1234 **** **** 3456", EgovPiiMaskUtil.maskCardNo("1234 5678 9012 3456"));
+    }
+
+    @Test
+    void 카드번호_null_원본반환() {
+        assertNull(EgovPiiMaskUtil.maskCardNo(null));
+    }
+
+    @Test
+    void 카드번호_빈문자_원본반환() {
+        assertEquals("", EgovPiiMaskUtil.maskCardNo(""));
+    }
+
+    @Test
+    void 카드번호_미매칭_원본반환() {
+        assertEquals("1234-5678", EgovPiiMaskUtil.maskCardNo("1234-5678"));
+    }
+
+    // -----------------------------------------------------------------------
+    // maskBizRegNo
+    // -----------------------------------------------------------------------
+
+    @Test
+    void 사업자번호_정상_마스킹() {
+        assertEquals("123-45-*****", EgovPiiMaskUtil.maskBizRegNo("123-45-67890"));
+    }
+
+    @Test
+    void 사업자번호_null_원본반환() {
+        assertNull(EgovPiiMaskUtil.maskBizRegNo(null));
+    }
+
+    @Test
+    void 사업자번호_빈문자_원본반환() {
+        assertEquals("", EgovPiiMaskUtil.maskBizRegNo(""));
+    }
+
+    @Test
+    void 사업자번호_미매칭_원본반환() {
+        assertEquals("1234567", EgovPiiMaskUtil.maskBizRegNo("1234567"));
+    }
+
+    // -----------------------------------------------------------------------
+    // maskPrivateIp
+    // -----------------------------------------------------------------------
+
+    @Test
+    void 사설IP_192168_마스킹() {
+        assertEquals("192.168.1.***", EgovPiiMaskUtil.maskPrivateIp("192.168.1.100"));
+    }
+
+    @Test
+    void 사설IP_10대역_마스킹() {
+        assertEquals("10.0.0.***", EgovPiiMaskUtil.maskPrivateIp("10.0.0.1"));
+    }
+
+    @Test
+    void 사설IP_172대역_마스킹() {
+        assertEquals("172.16.0.***", EgovPiiMaskUtil.maskPrivateIp("172.16.0.254"));
+    }
+
+    @Test
+    void 공인IP_미마스킹() {
+        assertEquals("8.8.8.8", EgovPiiMaskUtil.maskPrivateIp("8.8.8.8"));
+    }
+
+    @Test
+    void 사설IP_null_원본반환() {
+        assertNull(EgovPiiMaskUtil.maskPrivateIp(null));
+    }
+
+    // -----------------------------------------------------------------------
+    // maskAll — 혼합 텍스트
+    // -----------------------------------------------------------------------
+
+    @Test
+    void maskAll_혼합텍스트_전체마스킹() {
+        String input = "사용자 홍길동(901010-1234567), 연락처: 010-1234-5678, "
+            + "이메일: hong@example.com, 카드: 1234-5678-9012-3456, "
+            + "사업자: 123-45-67890, IP: 192.168.0.10";
+
+        String result = EgovPiiMaskUtil.maskAll(input);
+
+        assertTrue(result.contains("901010-1******"), "주민번호 마스킹");
+        assertTrue(result.contains("010-****-5678"), "전화번호 마스킹");
+        assertTrue(result.contains("ho**@example.com"), "이메일 마스킹");
+        assertTrue(result.contains("1234-****-****-3456"), "카드번호 마스킹");
+        assertTrue(result.contains("123-45-*****"), "사업자번호 마스킹");
+        assertTrue(result.contains("192.168.0.***"), "사설IP 마스킹");
+    }
+
+    @Test
+    void maskAll_null_null반환() {
+        assertNull(EgovPiiMaskUtil.maskAll(null));
+    }
+
+    @Test
+    void maskAll_개인정보없음_원본유지() {
+        String text = "일반 텍스트입니다. 개인정보 없음.";
+        assertEquals(text, EgovPiiMaskUtil.maskAll(text));
+    }
+}


### PR DESCRIPTION
## 변경 사유

공공 서비스에서 로그 출력이나 외부 API 전송 전에 개인정보를 사전 마스킹해야 하는 경우가 많으나, 프레임워크 차원의 공통 유틸이 없어 프로젝트마다 정규식을 중복 구현하는 상황이다. 자주 쓰이는 개인정보 패턴에 대한 **범용 패턴 마스킹 유틸**을 공통컴포넌트에 추가한다.

> 본 유틸은 특정 기관 가이드라인(행안부·KISA 등)의 법적·기술적 마스킹 기준을 준수하도록 검증·인증된 구현이 아니라, 일반적으로 통용되는 패턴 기반 마스킹 유틸이다. 표의 마스킹 범위(예: 주민등록번호 뒤 6자리, 휴대폰 가운데 자리)는 관행적으로 널리 쓰이는 기본값이며, 더 엄격한 법적 요건이 있는 프로젝트는 호출 측에서 별도 조정이 필요하다.

## 변경 내용

`egovframework.com.utl.fcc.service.EgovPiiMaskUtil` 신규 추가.

- 외부 의존성 없음 (`java.util.regex` 표준 라이브러리만 사용)
- 모든 메서드는 `static`, null·빈 문자열·미매칭 입력에 대해 안전하게 원본 반환
- 정규식은 클래스 상수로 분리

지원 메서드:

| 메서드 | 마스킹 대상 | 예시 |
|---|---|---|
| `maskJuminNo` | 주민등록번호 | `901010-1234567` → `901010-1******` |
| `maskPhoneNo` | 휴대폰·전화(하이픈 유무 무관) | `010-1234-5678` → `010-****-5678` |
| `maskEmail` | 이메일 로컬파트 | `abcde@domain.com` → `ab***@domain.com` |
| `maskCardNo` | 신용카드 가운데 8자리 | `1234-5678-9012-3456` → `1234-****-****-3456` |
| `maskBizRegNo` | 사업자등록번호 | `123-45-67890` → `123-45-*****` |
| `maskPrivateIp` | 사설 IP 마지막 옥텟 | `192.168.1.100` → `192.168.1.***` |
| `maskAll` | 텍스트 내 위 항목 일괄 탐지·마스킹 | — |

## 테스트

`EgovPiiMaskUtilTest` 단위 테스트 34케이스 추가, 전량 통과 확인 (JDK 17). 하이픈 없는 휴대폰 번호 일괄 마스킹 회귀 테스트 포함.

Spring/DB 의존 없이 standalone 컴파일·실행 가능.

## 영향 범위

신규 파일 추가만이며 기존 코드 변경 없음.

- [x] 단일 주제만 다룸 (다른 변경 없음)
- [x] 기존 동작에 영향 없음
- [x] 테스트 통과 확인
