### PR TITLE
fix: 번호 검증 유틸의 null 입력 시 NPE 방지

### DIFF
--- a/src/main/java/egovframework/com/utl/fcc/service/EgovNumberCheckUtil.java
+++ b/src/main/java/egovframework/com/utl/fcc/service/EgovNumberCheckUtil.java
@@ -91,7 +91,7 @@ public class EgovNumberCheckUtil {
 	 */
 	public static boolean checkJuminNumber(String jumin) {
 
-		if (jumin.length() != 13) {
+		if (jumin == null || jumin.length() != 13) {
 			return false;
 		}
 
@@ -152,7 +152,7 @@ public class EgovNumberCheckUtil {
 	 */
 	public static boolean checkBubinNumber(String bubin) {
 
-		if (bubin.length() != 13) {
+		if (bubin == null || bubin.length() != 13) {
 			return false;
 		}
 
@@ -209,7 +209,7 @@ public class EgovNumberCheckUtil {
 	 */
 	public static boolean checkCompNumber(String comp) {
 
-		if (comp.length() != 10) {
+		if (comp == null || comp.length() != 10) {
 			return false;
 		}
 		return checkCompNumber(comp.substring(0, 3), comp.substring(3, 5), comp.substring(5, 10));
@@ -297,7 +297,7 @@ public class EgovNumberCheckUtil {
 	 */
 	public static boolean checkForeignNumber(String foreign) {
 
-		if (foreign.length() != 13) {
+		if (foreign == null || foreign.length() != 13) {
 			return false;
 		}
 		return checkForeignNumber(foreign.substring(0, 6), foreign.substring(6, 13));

--- a/src/test/java/egovframework/com/utl/fcc/service/EgovNumberCheckUtilTest.java
+++ b/src/test/java/egovframework/com/utl/fcc/service/EgovNumberCheckUtilTest.java
@@ -19,4 +19,13 @@ public class EgovNumberCheckUtilTest {
         assertFalse(EgovNumberCheckUtil.checkForeignNumber("031015", "9223456"), "잘못된 성별 코드");
         assertFalse(EgovNumberCheckUtil.checkForeignNumber("881212", "5134560"), "체크섬 검증 실패");
     }
+
+	@Test
+	void testNullReturnsFalseWithoutException() {
+        // 단일 인자 검증 메서드는 null 입력 시 NPE가 아니라 false(무효)를 반환해야 한다.
+        assertFalse(EgovNumberCheckUtil.checkJuminNumber(null), "주민번호 null");
+        assertFalse(EgovNumberCheckUtil.checkBubinNumber(null), "법인번호 null");
+        assertFalse(EgovNumberCheckUtil.checkCompNumber(null), "사업자번호 null");
+        assertFalse(EgovNumberCheckUtil.checkForeignNumber((String) null), "외국인등록번호 null");
+    }
 }


### PR DESCRIPTION
## 개요

`EgovNumberCheckUtil`의 단일 인자 검증 메서드들이 `null` 입력 시 `NullPointerException`을 던지는 문제를 수정합니다.

## 문제

다음 메서드들은 입력 문자열의 길이를 먼저 검사하지만 null 검사가 없어, null이 전달되면 `length()` 호출에서 NPE가 발생합니다.

| 메서드 | 위치 |
| --- | --- |
| `checkJuminNumber(String)` | `jumin.length()` |
| `checkBubinNumber(String)` | `bubin.length()` |
| `checkCompNumber(String)` | `comp.length()` |
| `checkForeignNumber(String)` | `foreign.length()` |

```java
public static boolean checkJuminNumber(String jumin) {
    if (jumin.length() != 13) {   // jumin == null 이면 NPE
        return false;
    }
    ...
}
```

공개 검증 유틸리티는 일반적으로 null을 "유효하지 않은 값"으로 보고 `false`를 반환하는 것이 자연스러운 계약이며, 폼 입력 등 호출 측에서 null이 전달될 수 있습니다.

## 변경

각 메서드의 길이 검사 조건에 `x == null ||`을 병합하여, null이면 NPE 없이 `false`를 반환하도록 했습니다. **null이 아닌 입력에 대한 동작은 변경되지 않습니다.**

```java
if (jumin == null || jumin.length() != 13) {
    return false;
}
```

2개 인자 버전(`checkJuminNumber(String, String)` 등)은 내부에서 문자열 결합을 먼저 수행하며 Java의 문자열 결합이 null-safe 하므로 NPE가 발생하지 않아 변경 대상이 아닙니다.

## 검증

- `EgovNumberCheckUtilTest`에 null 입력 시 `false`를 반환하는지(예외가 발생하지 않는지) 확인하는 테스트를 추가했습니다.
- 기존 테스트 포함 통과(`Tests run: 3, Failures: 0, Errors: 0`).