### PR TITLE
fix: EgovDateUtil.isLeapYear 윤년 판정 반전 수정

### DIFF
--- a/src/main/java/egovframework/com/utl/fcc/service/EgovDateUtil.java
+++ b/src/main/java/egovframework/com/utl/fcc/service/EgovDateUtil.java
@@ -407,19 +407,18 @@ public class EgovDateUtil {
 	 * </p>
 	 *
 	 * <pre>
-	 * DateUtil.isLeapYear(2004) = false
-	 * DateUtil.isLeapYear(2005) = true
-	 * DateUtil.isLeapYear(2006) = true
+	 * DateUtil.isLeapYear(2004) = true
+	 * DateUtil.isLeapYear(2005) = false
+	 * DateUtil.isLeapYear(2006) = false
+	 * DateUtil.isLeapYear(1900) = false
+	 * DateUtil.isLeapYear(2000) = true
 	 * </pre>
 	 *
 	 * @param year 연도
 	 * @return 윤년 여부
 	 */
 	public static boolean isLeapYear(int year) {
-		if (year % 4 == 0 && year % 100 != 0 || year % 400 == 0) {
-			return false;
-		}
-		return true;
+		return year % 4 == 0 && year % 100 != 0 || year % 400 == 0;
 	}
 
 	/**

--- a/src/test/java/egovframework/com/utl/fcc/service/EgovDateUtilLeapYearTest.java
+++ b/src/test/java/egovframework/com/utl/fcc/service/EgovDateUtilLeapYearTest.java
@@ -1,0 +1,27 @@
+package egovframework.com.utl.fcc.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+public class EgovDateUtilLeapYearTest {
+
+	@Test
+	void testLeapYears() {
+		// 4의 배수이면서 100의 배수가 아닌 해, 또는 400의 배수인 해는 윤년이다.
+		assertTrue(EgovDateUtil.isLeapYear(2024), "2024는 윤년");
+		assertTrue(EgovDateUtil.isLeapYear(2000), "2000은 400의 배수이므로 윤년");
+		assertTrue(EgovDateUtil.isLeapYear(2400), "2400은 400의 배수이므로 윤년");
+		assertTrue(EgovDateUtil.isLeapYear(1600), "1600은 400의 배수이므로 윤년");
+	}
+
+	@Test
+	void testCommonYears() {
+		// 위 조건을 만족하지 않는 해는 평년이다.
+		assertFalse(EgovDateUtil.isLeapYear(2023), "2023은 평년");
+		assertFalse(EgovDateUtil.isLeapYear(2025), "2025는 평년");
+		assertFalse(EgovDateUtil.isLeapYear(2100), "2100은 100의 배수이나 400의 배수가 아니므로 평년");
+		assertFalse(EgovDateUtil.isLeapYear(1900), "1900은 100의 배수이나 400의 배수가 아니므로 평년");
+		assertFalse(EgovDateUtil.isLeapYear(2200), "2200은 100의 배수이나 400의 배수가 아니므로 평년");
+	}
+}


### PR DESCRIPTION
## 문제

`EgovDateUtil.isLeapYear(int)`가 윤년과 평년을 반대로 반환합니다. `isLeapYear(2024)`가 `false`를 돌려줍니다. Javadoc 예시도 `2004=false`처럼 반대로 적혀 있어 문서까지 잘못된 동작을 그대로 기술하고 있습니다.

## 원인

윤년 판정 조건식 자체는 정확합니다. 다만 if 블록 안에서 `true`/`false` 반환이 서로 뒤바뀌어 있어 결과만 반전됐습니다. 같은 파일의 `leapYear()`는 동일한 조건으로 `"29"`/`"28"`을 정상 반환하므로, 잘못된 쪽은 `isLeapYear` 하나입니다.

## 수정

조건식을 그대로 반환하도록 정리해 `leapYear()`와 같은 표현을 따르게 했습니다. 반대로 적혀 있던 Javadoc 예시를 정정하고, 자주 헷갈리는 세기 경계 케이스(1900=false, 2000=true)를 예시에 추가했습니다.

## 테스트

`EgovDateUtilLeapYearTest`를 추가했습니다. 윤년(2024/2000/2400/1600)과 평년(2023/2025/2100/1900/2200)을 검증합니다. 수정 전 코드로 돌리면 모든 케이스가 반대값으로 실패하고, 수정 후 전부 통과합니다.

이 레포는 surefire가 `skipTests`로 설정돼 있어 빌드 시 테스트가 실행되지 않습니다. 그래서 JUnit 콘솔 런처로 직접 실행해 통과를 확인했습니다.
