### PR TITLE
fix: 웹메신저 connectedAllUsers 순회를 synchronized로 감싸 ConcurrentModificationException 방지

### DIFF
--- a/src/main/java/egovframework/com/ext/msg/server/UsersServerEndPoint.java
+++ b/src/main/java/egovframework/com/ext/msg/server/UsersServerEndPoint.java
@@ -21,8 +21,10 @@ package egovframework.com.ext.msg.server;
 import java.io.IOException;
 import java.io.StringReader;
 import java.security.SecureRandom;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import org.slf4j.Logger;
@@ -107,11 +109,10 @@ public class UsersServerEndPoint {
 				if (username != null && !isExisted(username)) {
 					userSession.getUserProperties().put("username", username);
 
-					synchronized (connectedAllUsers) {
-						for (Session session : connectedAllUsers) { // NOPMD - CloseResource
-							session.getBasicRemote().sendText(buildJsonUserData(getUsers()));
-						}
-					}
+					// 사용자 목록 payload는 한 번만 생성하고, 공유 락은 세션 스냅샷에만 보유한다.
+					// 실제 sendText(네트워크 I/O)는 락 밖에서 수행해 전송 지연이 다른 작업을 막지 않도록 한다.
+					String userListPayload = buildJsonUserData(getUsers());
+					broadcast(userListPayload);
 				} else {
 					if (LOGGER.isDebugEnabled()) {
 						LOGGER.debug("username을 다시 입력하게하는 로직 넣기.");
@@ -176,13 +177,29 @@ public class UsersServerEndPoint {
 		connectedAllUsers.remove(userSession);
 
 		if (disconnectedUser != null) {
-			Json.createObjectBuilder().add("disconnectedUser", disconnectedUser).build().toString();
+			// payload는 한 번만 생성하고, 공유 락은 세션 스냅샷에만 보유한다(전송은 락 밖).
+			String payload = Json.createObjectBuilder().add("disconnectedUser", disconnectedUser).build().toString();
+			broadcast(payload);
+		}
+	}
 
-			synchronized (connectedAllUsers) {
-				for (Session session : connectedAllUsers) {// NOPMD - CloseResource
-					session.getBasicRemote().sendText(
-							Json.createObjectBuilder().add("disconnectedUser", disconnectedUser).build().toString());
-				}
+	/**
+	 * 접속 중인 모든 사용자에게 동일한 메시지를 전송한다.
+	 * 공유 컬렉션 락은 세션 목록 스냅샷에만 보유하고, 네트워크 I/O(sendText)는 락 밖에서 수행한다.
+	 * 특정 세션 전송 실패가 나머지 전송을 막지 않도록 세션별로 예외를 처리한다.
+	 *
+	 * @param payload 전송할 메시지(JSON 문자열)
+	 */
+	private void broadcast(String payload) {
+		List<Session> snapshot;
+		synchronized (connectedAllUsers) {
+			snapshot = new ArrayList<>(connectedAllUsers);
+		}
+		for (Session session : snapshot) {
+			try {
+				session.getBasicRemote().sendText(payload);
+			} catch (IOException e) {
+				LOGGER.warn("UsersServerEndPoint broadcast 전송 실패: {}", e.getMessage());
 			}
 		}
 	}

--- a/src/main/java/egovframework/com/ext/msg/server/UsersServerEndPoint.java
+++ b/src/main/java/egovframework/com/ext/msg/server/UsersServerEndPoint.java
@@ -107,8 +107,10 @@ public class UsersServerEndPoint {
 				if (username != null && !isExisted(username)) {
 					userSession.getUserProperties().put("username", username);
 
-					for (Session session : connectedAllUsers) { // NOPMD - CloseResource
-						session.getBasicRemote().sendText(buildJsonUserData(getUsers()));
+					synchronized (connectedAllUsers) {
+						for (Session session : connectedAllUsers) { // NOPMD - CloseResource
+							session.getBasicRemote().sendText(buildJsonUserData(getUsers()));
+						}
 					}
 				} else {
 					if (LOGGER.isDebugEnabled()) {
@@ -131,10 +133,12 @@ public class UsersServerEndPoint {
 
 				if (connectingUser != null && !username.equals(connectingUser)) {
 					// 사용자들 중 선택한 유저와 연결
-					for (Session session : connectedAllUsers) {// NOPMD - CloseResource
-						if (connectingUser.equals(session.getUserProperties().get("username"))) {
-							// 선택한 사용자면 chatroomMember로 추가.
-							chatroomMembers.add(session);
+					synchronized (connectedAllUsers) {
+						for (Session session : connectedAllUsers) {// NOPMD - CloseResource
+							if (connectingUser.equals(session.getUserProperties().get("username"))) {
+								// 선택한 사용자면 chatroomMember로 추가.
+								chatroomMembers.add(session);
+							}
 						}
 					}
 
@@ -174,9 +178,11 @@ public class UsersServerEndPoint {
 		if (disconnectedUser != null) {
 			Json.createObjectBuilder().add("disconnectedUser", disconnectedUser).build().toString();
 
-			for (Session session : connectedAllUsers) {// NOPMD - CloseResource
-				session.getBasicRemote().sendText(
-						Json.createObjectBuilder().add("disconnectedUser", disconnectedUser).build().toString());
+			synchronized (connectedAllUsers) {
+				for (Session session : connectedAllUsers) {// NOPMD - CloseResource
+					session.getBasicRemote().sendText(
+							Json.createObjectBuilder().add("disconnectedUser", disconnectedUser).build().toString());
+				}
 			}
 		}
 	}
@@ -189,9 +195,11 @@ public class UsersServerEndPoint {
 	private Set<String> getUsers() {
 		HashSet<String> returnSet = new HashSet<String>();
 
-		for (Session session : connectedAllUsers) { // NOPMD - CloseResource
-			if (session.getUserProperties().get("username") != null) {
-				returnSet.add(session.getUserProperties().get("username").toString());
+		synchronized (connectedAllUsers) {
+			for (Session session : connectedAllUsers) { // NOPMD - CloseResource
+				if (session.getUserProperties().get("username") != null) {
+					returnSet.add(session.getUserProperties().get("username").toString());
+				}
 			}
 		}
 		return returnSet;
@@ -221,9 +229,11 @@ public class UsersServerEndPoint {
 	 */
 	private boolean isExisted(String username) {
 		// 이미 username을 가진 session이 있는지 검사.
-		for (Session existedUser : connectedAllUsers) {// NOPMD - CloseResource
-			if (username.equals(existedUser.getUserProperties().get("username"))) {
-				return true;
+		synchronized (connectedAllUsers) {
+			for (Session existedUser : connectedAllUsers) {// NOPMD - CloseResource
+				if (username.equals(existedUser.getUserProperties().get("username"))) {
+					return true;
+				}
 			}
 		}
 		return false;

--- a/src/test/java/egovframework/com/ext/msg/server/UsersServerEndPointConcurrencyTest.java
+++ b/src/test/java/egovframework/com/ext/msg/server/UsersServerEndPointConcurrencyTest.java
@@ -1,0 +1,291 @@
+/*
+ * Copyright The eGovFrame Open Community (http://open.egovframe.go.kr)).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package egovframework.com.ext.msg.server;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.net.URI;
+import java.security.Principal;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import jakarta.websocket.CloseReason;
+import jakarta.websocket.Extension;
+import jakarta.websocket.MessageHandler;
+import jakarta.websocket.RemoteEndpoint;
+import jakarta.websocket.Session;
+import jakarta.websocket.WebSocketContainer;
+
+/**
+ * {@link UsersServerEndPoint}의 connectedAllUsers(synchronizedSet) 순회 동기화 검증.
+ *
+ * <p>
+ * synchronizedSet은 개별 연산만 동기화하고 순회는 사용자가 set에 직접 synchronized 해야 한다.
+ * 순회 중 다른 스레드가 add/remove로 set을 변이하면 HashSet의 fail-fast 이터레이터가
+ * ConcurrentModificationException을 던진다. 수정 전 코드(맨몸 순회)에서는 이 테스트가
+ * 예외를 잡아내고, 순회를 synchronized 블록으로 감싼 수정 후에는 무예외로 통과한다.
+ * </p>
+ *
+ * <p>
+ * 실제 WebSocket 연결 없이 {@link Session} 인터페이스를 인라인 구현한 fake로 구동한다.
+ * reader는 리플렉션으로 private getUsers()를 반복 호출(순수 순회, I/O 0)하고,
+ * mutator는 static connectedAllUsers 필드에 fake Session을 add/remove 한다.
+ * </p>
+ */
+class UsersServerEndPointConcurrencyTest {
+
+	private static final int THREADS = 16;
+	private static final int ROUNDS = 300;
+
+	/**
+	 * static connectedAllUsers 필드를 리플렉션으로 얻는다.
+	 */
+	@SuppressWarnings("unchecked")
+	private static Set<Session> connectedAllUsers() throws Exception {
+		Field field = UsersServerEndPoint.class.getDeclaredField("connectedAllUsers");
+		field.setAccessible(true);
+		return (Set<Session>) field.get(null);
+	}
+
+	@AfterEach
+	void clearConnectedUsers() throws Exception {
+		connectedAllUsers().clear();
+	}
+
+	@Test
+	void getUsers_undersimultaneous_addRemove_doesNotThrow() throws Exception {
+		final Set<Session> users = connectedAllUsers();
+
+		// 순회 시작 시점에 비어있지 않도록 baseline 세션을 채워둔다.
+		for (int i = 0; i < 8; i++) {
+			users.add(new FakeSession("baseline-" + i));
+		}
+
+		final Method getUsers = UsersServerEndPoint.class.getDeclaredMethod("getUsers");
+		getUsers.setAccessible(true);
+
+		final UsersServerEndPoint endpoint = new UsersServerEndPoint();
+		final AtomicReference<Throwable> failure = new AtomicReference<>();
+		final CountDownLatch ready = new CountDownLatch(THREADS);
+		final CountDownLatch start = new CountDownLatch(1);
+		final CountDownLatch done = new CountDownLatch(THREADS);
+
+		for (int t = 0; t < THREADS; t++) {
+			final boolean reader = (t % 2 == 0);
+			final int id = t;
+			new Thread(() -> {
+				ready.countDown();
+				try {
+					start.await();
+					for (int r = 0; r < ROUNDS; r++) {
+						if (reader) {
+							// 순수 순회 경로: private getUsers() 반복 호출
+							getUsers.invoke(endpoint);
+						} else {
+							// 구조 변경: add 후 remove 반복
+							Session s = new FakeSession("mutator-" + id + "-" + r);
+							users.add(s);
+							users.remove(s);
+						}
+					}
+				} catch (Throwable e) {
+					// 리플렉션 호출 예외는 원인으로 펼쳐 기록한다.
+					failure.compareAndSet(null, e.getCause() != null ? e.getCause() : e);
+				} finally {
+					done.countDown();
+				}
+			}).start();
+		}
+
+		ready.await();
+		start.countDown();
+		done.await();
+
+		assertNull(failure.get(), "순회 중 구조 변경으로 예외가 발생하면 안 된다: " + failure.get());
+	}
+
+	/**
+	 * {@link Session} 인터페이스의 인라인 fake 구현.
+	 *
+	 * <p>
+	 * getUserProperties()만 사전 채운 Map을 반환하고, 나머지 추상 메서드는 모두
+	 * 기본값(null/0/false)을 반환한다. 망/실제 WebSocket 연결은 필요하지 않다.
+	 * </p>
+	 */
+	private static final class FakeSession implements Session {
+
+		private final Map<String, Object> userProperties = new HashMap<>();
+
+		FakeSession(String username) {
+			userProperties.put("username", username);
+		}
+
+		@Override
+		public Map<String, Object> getUserProperties() {
+			return userProperties;
+		}
+
+		@Override
+		public WebSocketContainer getContainer() {
+			return null;
+		}
+
+		@Override
+		public void addMessageHandler(MessageHandler handler) {
+			// no-op
+		}
+
+		@Override
+		public <T> void addMessageHandler(Class<T> clazz, MessageHandler.Whole<T> handler) {
+			// no-op
+		}
+
+		@Override
+		public <T> void addMessageHandler(Class<T> clazz, MessageHandler.Partial<T> handler) {
+			// no-op
+		}
+
+		@Override
+		public Set<MessageHandler> getMessageHandlers() {
+			return null;
+		}
+
+		@Override
+		public void removeMessageHandler(MessageHandler handler) {
+			// no-op
+		}
+
+		@Override
+		public String getProtocolVersion() {
+			return null;
+		}
+
+		@Override
+		public String getNegotiatedSubprotocol() {
+			return null;
+		}
+
+		@Override
+		public List<Extension> getNegotiatedExtensions() {
+			return null;
+		}
+
+		@Override
+		public boolean isSecure() {
+			return false;
+		}
+
+		@Override
+		public boolean isOpen() {
+			return false;
+		}
+
+		@Override
+		public long getMaxIdleTimeout() {
+			return 0;
+		}
+
+		@Override
+		public void setMaxIdleTimeout(long milliseconds) {
+			// no-op
+		}
+
+		@Override
+		public void setMaxBinaryMessageBufferSize(int length) {
+			// no-op
+		}
+
+		@Override
+		public int getMaxBinaryMessageBufferSize() {
+			return 0;
+		}
+
+		@Override
+		public void setMaxTextMessageBufferSize(int length) {
+			// no-op
+		}
+
+		@Override
+		public int getMaxTextMessageBufferSize() {
+			return 0;
+		}
+
+		@Override
+		public RemoteEndpoint.Async getAsyncRemote() {
+			return null;
+		}
+
+		@Override
+		public RemoteEndpoint.Basic getBasicRemote() {
+			return null;
+		}
+
+		@Override
+		public String getId() {
+			return null;
+		}
+
+		@Override
+		public void close() throws IOException {
+			// no-op
+		}
+
+		@Override
+		public void close(CloseReason closeReason) throws IOException {
+			// no-op
+		}
+
+		@Override
+		public URI getRequestURI() {
+			return null;
+		}
+
+		@Override
+		public Map<String, List<String>> getRequestParameterMap() {
+			return null;
+		}
+
+		@Override
+		public String getQueryString() {
+			return null;
+		}
+
+		@Override
+		public Map<String, String> getPathParameters() {
+			return null;
+		}
+
+		@Override
+		public Principal getUserPrincipal() {
+			return null;
+		}
+
+		@Override
+		public Set<Session> getOpenSessions() {
+			return null;
+		}
+	}
+}

--- a/src/test/java/egovframework/com/ext/msg/server/UsersServerEndPointConcurrencyTest.java
+++ b/src/test/java/egovframework/com/ext/msg/server/UsersServerEndPointConcurrencyTest.java
@@ -15,13 +15,19 @@
  */
 package egovframework.com.ext.msg.server;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
+import java.io.OutputStream;
+import java.io.Writer;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.net.URI;
+import java.nio.ByteBuffer;
 import java.security.Principal;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -33,6 +39,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import jakarta.websocket.CloseReason;
+import jakarta.websocket.EncodeException;
 import jakarta.websocket.Extension;
 import jakarta.websocket.MessageHandler;
 import jakarta.websocket.RemoteEndpoint;
@@ -127,6 +134,27 @@ class UsersServerEndPointConcurrencyTest {
 		assertNull(failure.get(), "순회 중 구조 변경으로 예외가 발생하면 안 된다: " + failure.get());
 	}
 
+	@Test
+	void broadcast_모든세션에전달하고_실패세션이있어도나머지는전달된다() throws Exception {
+		final Set<Session> users = connectedAllUsers();
+		FakeSession s1 = new FakeSession("u1");
+		FakeSession bad = new FakeSession("bad", true); // sendText에서 IOException
+		FakeSession s2 = new FakeSession("u2");
+		users.add(s1);
+		users.add(bad);
+		users.add(s2);
+
+		Method broadcast = UsersServerEndPoint.class.getDeclaredMethod("broadcast", String.class);
+		broadcast.setAccessible(true);
+		broadcast.invoke(new UsersServerEndPoint(), "hello");
+
+		// 실패 세션이 있어도 정상 세션은 모두 수신한다(전송 실패가 나머지를 막지 않음)
+		assertEquals(List.of("hello"), ((RecordingBasicRemote) s1.getBasicRemote()).sentText());
+		assertEquals(List.of("hello"), ((RecordingBasicRemote) s2.getBasicRemote()).sentText());
+		assertTrue(((RecordingBasicRemote) bad.getBasicRemote()).sendAttempted(),
+			"실패 세션도 전송이 시도되어야 한다");
+	}
+
 	/**
 	 * {@link Session} 인터페이스의 인라인 fake 구현.
 	 *
@@ -138,14 +166,25 @@ class UsersServerEndPointConcurrencyTest {
 	private static final class FakeSession implements Session {
 
 		private final Map<String, Object> userProperties = new HashMap<>();
+		private final RecordingBasicRemote basicRemote;
 
 		FakeSession(String username) {
+			this(username, false);
+		}
+
+		FakeSession(String username, boolean failOnSend) {
 			userProperties.put("username", username);
+			this.basicRemote = new RecordingBasicRemote(failOnSend);
 		}
 
 		@Override
 		public Map<String, Object> getUserProperties() {
 			return userProperties;
+		}
+
+		@Override
+		public RemoteEndpoint.Basic getBasicRemote() {
+			return basicRemote;
 		}
 
 		@Override
@@ -239,11 +278,6 @@ class UsersServerEndPointConcurrencyTest {
 		}
 
 		@Override
-		public RemoteEndpoint.Basic getBasicRemote() {
-			return null;
-		}
-
-		@Override
 		public String getId() {
 			return null;
 		}
@@ -286,6 +320,93 @@ class UsersServerEndPointConcurrencyTest {
 		@Override
 		public Set<Session> getOpenSessions() {
 			return null;
+		}
+	}
+
+	/**
+	 * {@link RemoteEndpoint.Basic}의 인라인 fake. sendText(String) 호출만 기록하며,
+	 * failOnSend가 true면 IOException을 던져 전송 실패 세션을 시뮬레이션한다.
+	 */
+	private static final class RecordingBasicRemote implements RemoteEndpoint.Basic {
+
+		private final boolean failOnSend;
+		private final List<String> sent = new ArrayList<>();
+		private boolean sendAttempted;
+
+		RecordingBasicRemote(boolean failOnSend) {
+			this.failOnSend = failOnSend;
+		}
+
+		List<String> sentText() {
+			return sent;
+		}
+
+		boolean sendAttempted() {
+			return sendAttempted;
+		}
+
+		@Override
+		public void sendText(String text) throws IOException {
+			sendAttempted = true;
+			if (failOnSend) {
+				throw new IOException("simulated send failure");
+			}
+			sent.add(text);
+		}
+
+		@Override
+		public void sendText(String partialMessage, boolean isLast) throws IOException {
+			sendText(partialMessage);
+		}
+
+		@Override
+		public void sendBinary(ByteBuffer data) throws IOException {
+			// no-op
+		}
+
+		@Override
+		public void sendBinary(ByteBuffer partialByte, boolean isLast) throws IOException {
+			// no-op
+		}
+
+		@Override
+		public void sendObject(Object data) throws IOException, EncodeException {
+			// no-op
+		}
+
+		@Override
+		public OutputStream getSendStream() throws IOException {
+			return null;
+		}
+
+		@Override
+		public Writer getSendWriter() throws IOException {
+			return null;
+		}
+
+		@Override
+		public void setBatchingAllowed(boolean allowed) throws IOException {
+			// no-op
+		}
+
+		@Override
+		public boolean getBatchingAllowed() {
+			return false;
+		}
+
+		@Override
+		public void flushBatch() throws IOException {
+			// no-op
+		}
+
+		@Override
+		public void sendPing(ByteBuffer applicationData) throws IOException {
+			// no-op
+		}
+
+		@Override
+		public void sendPong(ByteBuffer applicationData) throws IOException {
+			// no-op
 		}
 	}
 }


### PR DESCRIPTION
## 변경 이유

WebSocket 메신저의 `UsersServerEndPoint`는 접속 사용자 목록 `connectedAllUsers`(`Collections.synchronizedSet`)를 여러 곳에서 동기화 없이 순회합니다. 다중 접속 환경에서 `@OnOpen`의 add와 `@OnClose`의 remove가 다른 스레드에서 일어나면, 순회 중인 스레드에서 `ConcurrentModificationException`이 발생합니다.

`Collections.synchronizedSet`은 add/remove 같은 개별 연산만 동기화하고, 순회는 호출자가 직접 해당 set에 `synchronized` 블록을 잡아야 합니다(Javadoc 명시). 기존 코드의 5개 순회 루프에는 그 동기화가 빠져 있습니다.

## 변경 내용

5개 순회를 각각 `synchronized(connectedAllUsers)` 블록으로 감쌌습니다. add/remove가 쓰는 것과 같은 모니터를 잡으므로 순회와 변이가 상호배제되어 예외가 사라집니다. 통지와 탐색 로직 자체는 그대로입니다.

사용자에게 메시지를 보내는 일부 순회는 `sendText`(블로킹 I/O)를 락 보유 중 호출하므로, 느린 클라이언트가 있으면 락 구간이 길어질 수 있습니다. 이번 변경은 Javadoc이 권하는 정석 동기화로 정확성과 기존 동작 보존을 우선했습니다. 락 구간을 줄이는 스냅샷 방식은 순회와 add/remove의 원자성, 전송 타이밍을 바꾸는 별개 설계라 후속으로 분리하는 편이 낫다고 봅니다.

## 테스트 방법

신규 동시성 테스트를 추가했습니다. `jakarta.websocket.Session`을 인메모리 fake로 구현해 실제 WebSocket 연결 없이, 한 그룹은 사용자 목록을 순회(`getUsers`)하고 다른 그룹은 동시에 세션을 add/remove 하도록 16스레드로 돌립니다. 수정 전 코드로 실행하면 순회 중 `ConcurrentModificationException`으로 실패하고, 수정 후 통과합니다.

이 레포는 surefire가 `skipTests`로 설정돼 빌드 시 테스트가 실행되지 않아, JUnit 콘솔 런처로 직접 실행해 통과를 검증했습니다.

## 영향 범위

`UsersServerEndPoint`의 순회 구간에 한정됩니다. 메시지 통지 대상과 순서, add/remove 동작은 동일하며, 동기화 모니터만 추가됩니다.
