### PR TITLE
fix: CAPTCHA 요청값 검증 및 보안 난수 적용

### DIFF
--- a/src/main/java/egovframework/com/ext/captcha/EgovCaptchaController.java
+++ b/src/main/java/egovframework/com/ext/captcha/EgovCaptchaController.java
@@ -6,7 +6,7 @@ import java.awt.Font;
 import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
-import java.util.Random;
+import java.security.SecureRandom;
 
 import javax.imageio.ImageIO;
 
@@ -44,6 +44,17 @@ import jakarta.servlet.http.HttpSession;
  */
 @Controller
 public class EgovCaptchaController {
+
+	private static final int DEFAULT_CAPTCHA_LENGTH = 5;
+	private static final int MIN_CAPTCHA_LENGTH = 4;
+	private static final int MAX_CAPTCHA_LENGTH = 10;
+	private static final int MIN_IMAGE_WIDTH = 50;
+	private static final int MAX_IMAGE_WIDTH = 500;
+	private static final int MIN_IMAGE_HEIGHT = 30;
+	private static final int MAX_IMAGE_HEIGHT = 200;
+	private static final int MAX_PAGE_NAME_LENGTH = 50;
+	private static final String CAPTCHA_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+	private static final SecureRandom SECURE_RANDOM = new SecureRandom();
 
 	protected final Log logger = LogFactory.getLog(getClass());
 
@@ -97,10 +108,17 @@ public class EgovCaptchaController {
 	public void generate(HttpServletRequest request, HttpServletResponse response,
 			@RequestParam(value = "width", defaultValue = "150") int width,
 			@RequestParam(value = "height", defaultValue = "50") int height,
-			@RequestParam(value = "lenght", defaultValue = "5") int length,
+			@RequestParam(value = "length", required = false) Integer length,
+			@RequestParam(value = "lenght", required = false) Integer legacyLength,
 			@RequestParam(value = "pgNm", defaultValue = "capt") String pgNm) {
+		int captchaLength = resolveCaptchaLength(length, legacyLength);
+		if (!isValidRequest(width, height, captchaLength, pgNm)) {
+			response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+			return;
+		}
+
 		try {
-			String captchaTxt = generateRandomText(length);
+			String captchaTxt = generateRandomText(captchaLength);
 			request.getSession().setAttribute("captcha" + pgNm, captchaTxt);
 
 			BufferedImage bufferedImage = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
@@ -116,13 +134,13 @@ public class EgovCaptchaController {
 			//랜덤줄긋기
 			g2d.setColor(Color.white);
 			for(int i =0; i <8; i++) {//i= 선 갯수 x1,y1 시작점, x2,y2 끝점
-				float thickness = 1.0f + (float)(Math.random() * 3.0f); // 두께 조절
+				float thickness = 1.0f + SECURE_RANDOM.nextFloat() * 3.0f; // 두께 조절
 			    g2d.setStroke(new BasicStroke(thickness));
 
-				int x1 = (int)(Math.random()*width);
-				int y1 = (int)(Math.random()*height);
-				int x2 = (int)(Math.random()*width);
-				int y2 = (int)(Math.random()*height);
+				int x1 = SECURE_RANDOM.nextInt(width);
+				int y1 = SECURE_RANDOM.nextInt(height);
+				int x2 = SECURE_RANDOM.nextInt(width);
+				int y2 = SECURE_RANDOM.nextInt(height);
 				g2d.drawLine(x1,y1,x2,y2);
 			}
 			g2d.setStroke(new BasicStroke(1.0f));
@@ -135,6 +153,23 @@ public class EgovCaptchaController {
 		}
 	}
 
+	private int resolveCaptchaLength(Integer length, Integer legacyLength) {
+		if (length != null) {
+			return length;
+		}
+		if (legacyLength != null) {
+			return legacyLength;
+		}
+		return DEFAULT_CAPTCHA_LENGTH;
+	}
+
+	private boolean isValidRequest(int width, int height, int length, String pgNm) {
+		return width >= MIN_IMAGE_WIDTH && width <= MAX_IMAGE_WIDTH
+				&& height >= MIN_IMAGE_HEIGHT && height <= MAX_IMAGE_HEIGHT
+				&& length >= MIN_CAPTCHA_LENGTH && length <= MAX_CAPTCHA_LENGTH
+				&& pgNm != null && !pgNm.isBlank() && pgNm.length() <= MAX_PAGE_NAME_LENGTH;
+	}
+
 	/**
 	 * 임의의 문자열을 인자로 받은 길이 만큼 생성
 	 * 
@@ -142,11 +177,9 @@ public class EgovCaptchaController {
 	 * @return length 인자의 길이만큼 생성된 임의의 문자열
 	 */
 	private String generateRandomText(int length) {
-		String chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
 		StringBuilder sb = new StringBuilder();
-		Random random = new Random();
 		for (int i = 0; i < length; i++) {
-			sb.append(chars.charAt(random.nextInt(chars.length())));
+			sb.append(CAPTCHA_CHARS.charAt(SECURE_RANDOM.nextInt(CAPTCHA_CHARS.length())));
 		}
 		return sb.toString();
 	}

--- a/src/test/java/egovframework/com/ext/captcha/EgovCaptchaControllerTest.java
+++ b/src/test/java/egovframework/com/ext/captcha/EgovCaptchaControllerTest.java
@@ -1,0 +1,203 @@
+package egovframework.com.ext.captcha;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.lang.reflect.Proxy;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.WriteListener;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+
+class EgovCaptchaControllerTest {
+
+	private static final byte[] PNG_SIGNATURE = {
+			(byte) 0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a
+	};
+
+	private final EgovCaptchaController controller = new EgovCaptchaController();
+
+	@Test
+	void generateCreatesPngAndStoresDefaultLengthCaptcha() {
+		RequestStub request = new RequestStub();
+		ResponseStub response = new ResponseStub();
+
+		controller.generate(request.proxy(), response.proxy(), 150, 50, null, null, "test");
+
+		assertEquals(200, response.status);
+		assertEquals("image/png", response.contentType);
+		assertPng(response.content.toByteArray());
+		assertCaptcha(request, "test", 5);
+	}
+
+	@Test
+	void generateUsesLengthBeforeLegacyLenght() {
+		RequestStub request = new RequestStub();
+		ResponseStub response = new ResponseStub();
+
+		controller.generate(request.proxy(), response.proxy(), 150, 50, 6, 9, "modern");
+
+		assertEquals(200, response.status);
+		assertCaptcha(request, "modern", 6);
+	}
+
+	@Test
+	void generateSupportsLegacyLenghtParameter() {
+		RequestStub request = new RequestStub();
+		ResponseStub response = new ResponseStub();
+
+		controller.generate(request.proxy(), response.proxy(), 150, 50, null, 7, "legacy");
+
+		assertEquals(200, response.status);
+		assertCaptcha(request, "legacy", 7);
+	}
+
+	@ParameterizedTest
+	@MethodSource("invalidRequests")
+	void generateRejectsInvalidRequestBeforeCreatingSession(
+			int width, int height, Integer length, String pgNm) {
+		RequestStub request = new RequestStub();
+		ResponseStub response = new ResponseStub();
+
+		controller.generate(request.proxy(), response.proxy(), width, height, length, null, pgNm);
+
+		assertEquals(400, response.status);
+		assertEquals(0, response.content.size());
+		assertNull(request.session);
+	}
+
+	private static Stream<Arguments> invalidRequests() {
+		return Stream.of(
+				Arguments.of(49, 50, 5, "test"),
+				Arguments.of(501, 50, 5, "test"),
+				Arguments.of(150, 29, 5, "test"),
+				Arguments.of(150, 201, 5, "test"),
+				Arguments.of(150, 50, 3, "test"),
+				Arguments.of(150, 50, 11, "test"),
+				Arguments.of(150, 50, 5, ""),
+				Arguments.of(150, 50, 5, "a".repeat(51)));
+	}
+
+	private void assertPng(byte[] content) {
+		assertTrue(content.length > PNG_SIGNATURE.length);
+		byte[] signature = new byte[PNG_SIGNATURE.length];
+		System.arraycopy(content, 0, signature, 0, PNG_SIGNATURE.length);
+		assertArrayEquals(PNG_SIGNATURE, signature);
+	}
+
+	private void assertCaptcha(RequestStub request, String pgNm, int expectedLength) {
+		assertNotNull(request.session);
+		String captcha = (String) request.sessionAttributes.get("captcha" + pgNm);
+		assertNotNull(captcha);
+		assertEquals(expectedLength, captcha.length());
+		assertTrue(captcha.matches("[A-Za-z0-9]+"));
+	}
+
+	private static Object defaultValue(Class<?> returnType) {
+		if (!returnType.isPrimitive()) {
+			return null;
+		}
+		if (returnType == boolean.class) {
+			return false;
+		}
+		if (returnType == char.class) {
+			return '\0';
+		}
+		return 0;
+	}
+
+	private static class RequestStub {
+
+		private final Map<String, Object> sessionAttributes = new HashMap<>();
+		private HttpSession session;
+
+		private HttpServletRequest proxy() {
+			return (HttpServletRequest) Proxy.newProxyInstance(
+					HttpServletRequest.class.getClassLoader(),
+					new Class<?>[] { HttpServletRequest.class },
+					(proxy, method, args) -> {
+						if ("getSession".equals(method.getName())) {
+							boolean create = args == null || args.length == 0 || Boolean.TRUE.equals(args[0]);
+							if (session == null && create) {
+								session = sessionProxy();
+							}
+							return session;
+						}
+						return defaultValue(method.getReturnType());
+					});
+		}
+
+		private HttpSession sessionProxy() {
+			return (HttpSession) Proxy.newProxyInstance(
+					HttpSession.class.getClassLoader(),
+					new Class<?>[] { HttpSession.class },
+					(proxy, method, args) -> {
+						if ("setAttribute".equals(method.getName())) {
+							sessionAttributes.put((String) args[0], args[1]);
+							return null;
+						}
+						if ("getAttribute".equals(method.getName())) {
+							return sessionAttributes.get(args[0]);
+						}
+						return defaultValue(method.getReturnType());
+					});
+		}
+	}
+
+	private static class ResponseStub {
+
+		private int status = HttpServletResponse.SC_OK;
+		private String contentType;
+		private final ByteArrayOutputStream content = new ByteArrayOutputStream();
+		private final ServletOutputStream outputStream = new ServletOutputStream() {
+			@Override
+			public void write(int value) {
+				content.write(value);
+			}
+
+			@Override
+			public boolean isReady() {
+				return true;
+			}
+
+			@Override
+			public void setWriteListener(WriteListener writeListener) {
+				// Synchronous test output stream.
+			}
+		};
+
+		private HttpServletResponse proxy() {
+			return (HttpServletResponse) Proxy.newProxyInstance(
+					HttpServletResponse.class.getClassLoader(),
+					new Class<?>[] { HttpServletResponse.class },
+					(proxy, method, args) -> {
+						if ("setStatus".equals(method.getName())) {
+							status = (Integer) args[0];
+							return null;
+						}
+						if ("setContentType".equals(method.getName())) {
+							contentType = (String) args[0];
+							return null;
+						}
+						if ("getOutputStream".equals(method.getName())) {
+							return outputStream;
+						}
+						return defaultValue(method.getReturnType());
+					});
+		}
+	}
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

CAPTCHA 이미지 생성 요청값에 제한이 없어 비정상적으로 큰 이미지 생성 요청 시 서버 메모리가 과도하게 사용될 수 있는 문제를 수정했습니다.

- CAPTCHA 이미지 너비를 50~500px로 제한
- CAPTCHA 이미지 높이를 30~200px로 제한
- CAPTCHA 문자열 길이를 4~10자로 제한
- 프로그램 구분값(`pgNm`)을 최대 50자로 제한
- 유효하지 않은 요청은 이미지와 세션을 생성하기 전에 HTTP 400 응답 처리
- `Random` 및 `Math.random()`을 `SecureRandom`으로 변경
- 올바른 `length` 파라미터를 지원하고 기존 `lenght` 파라미터와의 호환성 유지
- CAPTCHA 생성 및 요청값 검증을 위한 JUnit 테스트 추가

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [x] JUnit 테스트 JUnit tests
- [x] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [X] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

CAPTCHA는 화면 디자인 변경이 없는 백엔드 보안 개선으로, 수정 전후 소스 diff와 테스트 결과를 첨부합니다.
- 수정 전: 요청값 제한 없이 이미지 생성, `Random` 및 `Math.random()` 사용
- 수정 후: 요청값 범위 검증, 비정상 요청 HTTP 400 처리, `SecureRandom` 적용
- 
<img width="804" height="352" alt="image" src="https://github.com/user-attachments/assets/9d294cb3-30e2-4db7-8599-6b2efcd9b767" />

