### PR TITLE
fix: 이메일 로컬파트 하이픈·언더스코어 부당 거부 수정 (checkFormatMail 항상-false 분기)

### DIFF
--- a/src/main/java/egovframework/com/utl/fcc/service/EgovFormatCheckUtil.java
+++ b/src/main/java/egovframework/com/utl/fcc/service/EgovFormatCheckUtil.java
@@ -200,7 +200,7 @@ public class EgovFormatCheckUtil {
 			continue;
 		} else if(mail1.charAt(i) <= '9' && mail1.charAt(i) >= '0') {
 			continue;
-		} else if(mail1.charAt(i) == '-' && mail1.charAt(i) == '_') {
+		} else if(mail1.charAt(i) == '-' || mail1.charAt(i) == '_') {
 			continue;
 		} else {
 			return false;

--- a/src/test/java/egovframework/com/utl/fcc/service/EgovFormatCheckUtilTest.java
+++ b/src/test/java/egovframework/com/utl/fcc/service/EgovFormatCheckUtilTest.java
@@ -1,0 +1,48 @@
+package egovframework.com.utl.fcc.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+public class EgovFormatCheckUtilTest {
+
+	@Test
+	void testLocalPartWithHyphenIsValid() {
+		// 로컬파트에 하이픈(-)이 포함되어도 유효한 이메일로 인정되어야 한다.
+		assertTrue(EgovFormatCheckUtil.checkFormatMail("hong-gil", "example.com"), "하이픈 포함 로컬파트");
+	}
+
+	@Test
+	void testLocalPartWithUnderscoreIsValid() {
+		// 로컬파트에 언더스코어(_)가 포함되어도 유효한 이메일로 인정되어야 한다.
+		assertTrue(EgovFormatCheckUtil.checkFormatMail("hong_gil", "example.com"), "언더스코어 포함 로컬파트");
+	}
+
+	@Test
+	void testLocalPartAlphaNumericIsValid() {
+		// 영문 대소문자와 숫자로 구성된 로컬파트는 유효해야 한다.
+		assertTrue(EgovFormatCheckUtil.checkFormatMail("HongGil123", "example.com"), "영숫자 로컬파트");
+	}
+
+	@Test
+	void testLocalPartWithDisallowedCharIsInvalid() {
+		// 허용되지 않는 문자가 포함된 로컬파트는 거부되어야 한다.
+		assertFalse(EgovFormatCheckUtil.checkFormatMail("hong!gil", "example.com"), "느낌표 포함 로컬파트");
+		assertFalse(EgovFormatCheckUtil.checkFormatMail("hong gil", "example.com"), "공백 포함 로컬파트");
+	}
+
+	@Test
+	void testDomainMustContainExactlyOneDot() {
+		// 도메인은 점(.)을 정확히 1개 포함하는 xxx.xxx 형태여야 한다.
+		assertTrue(EgovFormatCheckUtil.checkFormatMail("honggil", "example.com"), "점 1개 도메인");
+		assertFalse(EgovFormatCheckUtil.checkFormatMail("honggil", "examplecom"), "점 없는 도메인");
+		assertFalse(EgovFormatCheckUtil.checkFormatMail("honggil", "mail.example.com"), "점 2개 도메인");
+	}
+
+	@Test
+	void testSingleArgDelegatesToTwoArg() {
+		// '@'로 분리되는 단일 인자 메서드도 동일 규칙을 따른다.
+		assertTrue(EgovFormatCheckUtil.checkFormatMail("hong-gil@example.com"), "하이픈 포함 전체 이메일");
+		assertFalse(EgovFormatCheckUtil.checkFormatMail("hong-gil@@example.com"), "'@' 2개");
+	}
+}


### PR DESCRIPTION
## 변경 이유

`EgovFormatCheckUtil.checkFormatMail`의 허용문자 검사가 `mail1.charAt(i) == '-' && mail1.charAt(i) == '_'`로 되어 있습니다. 한 문자가 동시에 `-`이면서 `_`일 수는 없으므로 이 분기는 항상 false로 평가됩니다.

## 변경 내용

해당 조건을 `||`로 교정합니다(1줄 수정). 인접한 영문·숫자 허용 분기와 동일한 의도이며, 하이픈 또는 언더스코어 중 하나에 해당하면 허용하도록 바로잡습니다.

## 테스트 방법

JUnit5 단위테스트 6건을 추가했습니다. surefire가 `skipTests=true`로 설정되어 `mvn test`로는 실행되지 않아 junit-platform-console standalone으로 직접 실행해 검증했습니다. 수정 전에는 하이픈·언더스코어 케이스 2건이 FAIL로 결함을 가드하며, 교정 후 6건 모두 통과합니다.

## 영향 범위

로컬파트에 하이픈·언더스코어가 포함된 정상 이메일(예: `hong-gil`, `hong_gil`)이 거부되던 문제가 해소됩니다. 그 외 검증 동작에는 영향이 없습니다.
