### PR TITLE
fix: EgovNumberUtil.getRandomNum 정수 오버플로 및 무한 루프 수정

### DIFF
--- a/src/main/java/egovframework/com/utl/fcc/service/EgovNumberUtil.java
+++ b/src/main/java/egovframework/com/utl/fcc/service/EgovNumberUtil.java
@@ -36,14 +36,17 @@ public class EgovNumberUtil {
 	 * @see
 	 */
 	public static int getRandomNum(int startNum, int endNum) {
-		int randomNum = 0;
+		if (startNum > endNum) {
+			throw new IllegalArgumentException("startNum(" + startNum + ")은 endNum(" + endNum + ")보다 클 수 없습니다.");
+		}
 
-		do {
-			// 종료숫자내에서 랜덤 숫자를 발생시킨다.
-			randomNum = rnd.nextInt(endNum + 1);
-		} while (randomNum < startNum); // 랜덤 숫자가 시작숫자보다 작을경우 다시 랜덤숫자를 발생시킨다.
+		// (endNum - startNum + 1)이 int 범위를 넘을 수 있으므로 long으로 구간 크기를 계산한다.
+		// endNum이 Integer.MAX_VALUE일 때 endNum + 1 오버플로와, endNum < startNum일 때
+		// 발생하던 무한 루프를 함께 방지한다.
+		long range = (long) endNum - (long) startNum + 1L;
 
-		return randomNum;
+		// [startNum, endNum] 구간에서 균등하게 난수를 뽑는다.
+		return (int) (startNum + rnd.nextLong(range));
 	}
 
 	/**

--- a/src/main/java/egovframework/com/utl/fcc/service/EgovNumberUtil.java
+++ b/src/main/java/egovframework/com/utl/fcc/service/EgovNumberUtil.java
@@ -28,11 +28,19 @@ public class EgovNumberUtil {
 	private static SecureRandom rnd = new SecureRandom();
 
 	/**
-	 * 특정숫자 집합에서 랜덤 숫자를 구하는 기능 시작숫자와 종료숫자 사이에서 구한 랜덤 숫자를 반환한다
+	 * 특정숫자 집합에서 랜덤 숫자를 구하는 기능. 시작숫자(startNum)와 종료숫자(endNum) 사이에서
+	 * 균등하게 추출한 랜덤 숫자를 반환한다.
 	 *
-	 * @param startNum - 시작숫자
-	 * @param endNum - 종료숫자
-	 * @return 랜덤숫자
+	 * <p>반환값의 범위는 [startNum, endNum]으로 시작숫자와 종료숫자를 모두 포함한다(양 끝 포함).
+	 * startNum과 endNum이 같으면 항상 해당 값을 반환한다.</p>
+	 *
+	 * <p>음수 구간도 지원한다. 예를 들어 startNum이 -10, endNum이 -1이면 -10 이상 -1 이하의
+	 * 값을 반환하며, Integer.MIN_VALUE ~ Integer.MAX_VALUE 전 구간을 지원한다.</p>
+	 *
+	 * @param startNum - 시작숫자(반환 범위의 하한, 포함)
+	 * @param endNum - 종료숫자(반환 범위의 상한, 포함)
+	 * @return startNum 이상 endNum 이하의 랜덤숫자
+	 * @throws IllegalArgumentException startNum이 endNum보다 큰 경우
 	 * @see
 	 */
 	public static int getRandomNum(int startNum, int endNum) {

--- a/src/test/java/egovframework/com/utl/fcc/service/EgovNumberUtilTest.java
+++ b/src/test/java/egovframework/com/utl/fcc/service/EgovNumberUtilTest.java
@@ -1,0 +1,55 @@
+package egovframework.com.utl.fcc.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+
+public class EgovNumberUtilTest {
+
+	@Test
+	void testRandomInRange() {
+		// 반복 호출해도 항상 [startNum, endNum] 구간 안의 값을 반환해야 한다.
+		for (int i = 0; i < 1000; i++) {
+			int r = EgovNumberUtil.getRandomNum(10, 20);
+			assertTrue(r >= 10 && r <= 20, "구간 밖 값: " + r);
+		}
+	}
+
+	@Test
+	void testStartEqualsEnd() {
+		assertEquals(7, EgovNumberUtil.getRandomNum(7, 7), "단일 값 구간은 그 값을 반환해야 한다.");
+	}
+
+	@Test
+	void testNegativeRange() {
+		for (int i = 0; i < 1000; i++) {
+			int r = EgovNumberUtil.getRandomNum(-20, -10);
+			assertTrue(r >= -20 && r <= -10, "음수 구간 밖 값: " + r);
+		}
+	}
+
+	@Test
+	void testMaxValueDoesNotOverflow() {
+		// 기존 코드는 endNum + 1 오버플로로 IllegalArgumentException이 발생했다.
+		assertTimeoutPreemptively(Duration.ofSeconds(2), () -> {
+			int r = EgovNumberUtil.getRandomNum(0, Integer.MAX_VALUE);
+			assertTrue(r >= 0, "음수 반환: " + r);
+		});
+	}
+
+	@Test
+	void testFullIntRange() {
+		// MIN..MAX 전체 구간(구간 크기 2^32)에서도 예외 없이 동작해야 한다.
+		assertTimeoutPreemptively(Duration.ofSeconds(2),
+				() -> EgovNumberUtil.getRandomNum(Integer.MIN_VALUE, Integer.MAX_VALUE));
+	}
+
+	@Test
+	void testStartGreaterThanEndThrows() {
+		// 기존 코드는 endNum < startNum일 때 무한 루프에 빠졌다. 이제는 즉시 예외를 던진다.
+		assertTimeoutPreemptively(Duration.ofSeconds(2), () -> assertThrows(IllegalArgumentException.class,
+				() -> EgovNumberUtil.getRandomNum(20, 10)));
+	}
+}


### PR DESCRIPTION
## 문제

`EgovNumberUtil.getRandomNum(int startNum, int endNum)`에 두 가지 결함이 있습니다.

```java
do {
    randomNum = rnd.nextInt(endNum + 1);
} while (randomNum < startNum);
```

1. **정수 오버플로** — `endNum`이 `Integer.MAX_VALUE`이면 `endNum + 1`이 `Integer.MIN_VALUE`로 오버플로되어 `rnd.nextInt(음수)`가 `IllegalArgumentException`을 던집니다. `endNum == -1`인 경우에도 `nextInt(0)`으로 같은 예외가 발생합니다.
2. **무한 루프** — `endNum`이 `startNum`보다 작으면 `nextInt(endNum + 1)`의 결과가 항상 `startNum`보다 작아 `do-while` 루프가 종료되지 않습니다.

추가로 `startNum`이 음수일 때 기존 구현은 음수 구간을 반영하지 못하고 `[0, endNum]` 범위만 반환했습니다. Javadoc은 "시작숫자와 종료숫자 사이"의 난수를 반환한다고 명시합니다.

## 수정

```java
if (startNum > endNum) {
    throw new IllegalArgumentException(...);
}
long range = (long) endNum - (long) startNum + 1L;
return (int) (startNum + rnd.nextLong(range));
```

- 구간 크기를 `long`으로 계산해 `endNum + 1` 오버플로를 제거합니다.
- `rnd.nextLong(range)`로 `[startNum, endNum]` 구간에서 균등하게 난수를 뽑습니다. 구간 크기가 최대 2^32라 `long` 범위에 안전하게 들어갑니다.
- `startNum > endNum`이면 무한 루프 대신 즉시 `IllegalArgumentException`을 던집니다.
- 보안 난수(`SecureRandom`) 사용은 그대로 유지합니다.

## 검증

`EgovNumberUtilTest` 6건을 추가했습니다.

- 일반 구간 반복 호출이 항상 구간 안의 값 반환
- `startNum == endNum`이 그 값 반환
- 음수 구간 `[-20, -10]` 정상 반환
- `endNum == Integer.MAX_VALUE` 오버플로 없이 정상 동작
- 전체 int 구간 `[MIN, MAX]` 정상 동작
- `startNum > endNum` 시 `IllegalArgumentException`

이 저장소는 `pom.xml`의 surefire `skipTests=true` 설정으로 `mvn test`가 테스트를 실행하지 않아, `junit-platform-console-standalone`로 클래스패스를 직접 구성해 6건 모두 통과를 확인했습니다.

```
[         6 tests successful      ]
[         0 tests failed          ]
```