### PR TITLE
fix: EgovArticleServiceImpl 첨부파일 삭제 가드 조건 오류 수정 (|| → &&)

### DIFF
--- a/src/main/java/egovframework/com/cop/bbs/service/impl/EgovArticleServiceImpl.java
+++ b/src/main/java/egovframework/com/cop/bbs/service/impl/EgovArticleServiceImpl.java
@@ -159,7 +159,7 @@ public class EgovArticleServiceImpl extends EgovAbstractServiceImpl implements E
 
 		egovArticleDao.deleteArticle(board);
 
-		if (!"".equals(fvo.getAtchFileId()) || fvo.getAtchFileId() != null) {
+		if (fvo.getAtchFileId() != null && !"".equals(fvo.getAtchFileId())) {
 			fileService.deleteAllFileInf(fvo);
 		}
 

--- a/src/test/java/egovframework/com/cop/bbs/service/impl/EgovArticleServiceImplTest_deleteArticleGuard.java
+++ b/src/test/java/egovframework/com/cop/bbs/service/impl/EgovArticleServiceImplTest_deleteArticleGuard.java
@@ -1,0 +1,105 @@
+package egovframework.com.cop.bbs.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.lang.reflect.Proxy;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import egovframework.com.cmm.service.EgovFileMngService;
+import egovframework.com.cmm.service.FileVO;
+import egovframework.com.cop.bbs.service.Board;
+
+/**
+ * deleteArticle()의 첨부파일 삭제 가드 검증.
+ *
+ * <p>첨부파일 식별자(atchFileId)가 없는(null/빈문자열) 게시물을 삭제할 때는
+ * deleteAllFileInf()가 호출되지 않아야 한다. 기존 조건식이 OR(||)로 작성되어
+ * 항상 참이 되던 버그(가드 무력화)에 대한 회귀 방지 테스트.</p>
+ *
+ * <p>Spring 컨텍스트·DB 없이 경량 페이크(DAO 서브클래스, 서비스 동적 프록시)와
+ * ReflectionTestUtils 필드 주입으로 가드 분기만 결정적으로 검증한다.</p>
+ */
+public class EgovArticleServiceImplTest_deleteArticleGuard {
+
+	/** deleteAllFileInf 호출 횟수 및 인자를 기록하는 EgovFileMngService 페이크 생성. */
+	private EgovFileMngService recordingFileService(AtomicInteger calls, AtomicReference<FileVO> captured) {
+		return (EgovFileMngService) Proxy.newProxyInstance(
+				getClass().getClassLoader(),
+				new Class<?>[] { EgovFileMngService.class },
+				(proxy, method, args) -> {
+					if ("deleteAllFileInf".equals(method.getName())) {
+						calls.incrementAndGet();
+						captured.set((FileVO) args[0]);
+						return null;
+					}
+					Class<?> rt = method.getReturnType();
+					if (rt == int.class) {
+						return 0;
+					}
+					return null;
+				});
+	}
+
+	private EgovArticleServiceImpl newService(EgovFileMngService fileService) {
+		EgovArticleServiceImpl service = new EgovArticleServiceImpl();
+		// deleteArticle 경로에서 DAO는 update만 수행 → no-op 서브클래스로 DB 의존 제거
+		EgovArticleDAO dao = new EgovArticleDAO() {
+			@Override
+			public void deleteArticle(Board board) {
+				// no-op
+			}
+		};
+		ReflectionTestUtils.setField(service, "egovArticleDao", dao);
+		ReflectionTestUtils.setField(service, "fileService", fileService);
+		return service;
+	}
+
+	@Test
+	public void deleteArticle_atchFileIdNull_doesNotDeleteFiles() throws Exception {
+		AtomicInteger calls = new AtomicInteger();
+		AtomicReference<FileVO> captured = new AtomicReference<>();
+		EgovArticleServiceImpl service = newService(recordingFileService(calls, captured));
+
+		Board board = new Board();
+		board.setAtchFileId(null);
+
+		service.deleteArticle(board);
+
+		assertEquals(0, calls.get(), "첨부ID가 null이면 deleteAllFileInf를 호출하지 않아야 한다");
+		assertNull(captured.get());
+	}
+
+	@Test
+	public void deleteArticle_atchFileIdEmpty_doesNotDeleteFiles() throws Exception {
+		AtomicInteger calls = new AtomicInteger();
+		AtomicReference<FileVO> captured = new AtomicReference<>();
+		EgovArticleServiceImpl service = newService(recordingFileService(calls, captured));
+
+		Board board = new Board();
+		board.setAtchFileId("");
+
+		service.deleteArticle(board);
+
+		assertEquals(0, calls.get(), "첨부ID가 빈 문자열이면 deleteAllFileInf를 호출하지 않아야 한다");
+	}
+
+	@Test
+	public void deleteArticle_atchFileIdPresent_deletesFiles() throws Exception {
+		AtomicInteger calls = new AtomicInteger();
+		AtomicReference<FileVO> captured = new AtomicReference<>();
+		EgovArticleServiceImpl service = newService(recordingFileService(calls, captured));
+
+		Board board = new Board();
+		board.setAtchFileId("FILE_000000000000001");
+
+		service.deleteArticle(board);
+
+		assertEquals(1, calls.get(), "첨부ID가 있으면 deleteAllFileInf를 1회 호출해야 한다");
+		assertEquals("FILE_000000000000001", captured.get().getAtchFileId());
+	}
+}


### PR DESCRIPTION
## 문제

`EgovArticleServiceImpl.deleteArticle()`의 첨부파일 삭제 가드가 동어반복이라 항상 참으로 평가됩니다.

```java
if (!"".equals(fvo.getAtchFileId()) || fvo.getAtchFileId() != null) {
    fileService.deleteAllFileInf(fvo);
}
```

`atchFileId`가 `null`이면 첫 절 `!"".equals(null)`이 `true`, 빈 문자열이면 둘째 절 `"" != null`이 `true`가 되어, 두 조건을 동시에 만족하지 못하는 경우가 없습니다. 즉 가드가 무력화되어 첨부ID가 없는 게시물을 삭제할 때도 `deleteAllFileInf(fvo)`가 호출됩니다.

이 경우 `ATCH_FILE_ID`가 `null`/빈 값인 채로 파일정보 삭제 쿼리가 실행되어 불필요한 DML이 발생합니다(첨부 없는 게시물 삭제가 일반적인 경로입니다).

## 수정

조건을 `&&`로 교정하여 첨부ID가 실제로 존재할 때만 삭제하도록 합니다.

```java
if (fvo.getAtchFileId() != null && !"".equals(fvo.getAtchFileId())) {
    fileService.deleteAllFileInf(fvo);
}
```

| atchFileId | 변경 전 | 변경 후 |
|---|---|---|
| `null` | 삭제 호출(불필요) | 호출 안 함 |
| `""` | 삭제 호출(불필요) | 호출 안 함 |
| `"FILE_..."` | 삭제 호출 | 삭제 호출 |

첨부가 있는 게시물의 삭제 동작은 그대로 유지됩니다.

## 테스트

`EgovArticleServiceImplTest_deleteArticleGuard`를 추가했습니다. null/빈/존재 세 케이스에서 `deleteAllFileInf` 호출 여부를 검증합니다.

본 리포의 테스트는 라이브 DB를 전제로 surefire 설정상 기본 skip됩니다. 추가한 테스트는 Spring 컨텍스트·DB 없이 동작하도록 작성하여(경량 페이크 주입) 로컬에서 `skipTests=false`로 실행해 3/3 통과를 확인했습니다. 수정 전 코드(`||`)로 되돌리면 null·빈 케이스 2건이 실패합니다.

## 영향 범위

호출처는 `EgovArticleController`의 게시물 삭제(`deleteArticle.do` 등)이며, 첨부 있는 게시물의 동작 변화는 없습니다.