### PR TITLE
fix: EgovWebUtil 보안 필터 인자 오류 수정 (LDAP 파이프 미제거, %00 NPE)

### DIFF
--- a/src/main/java/egovframework/com/cmm/EgovWebUtil.java
+++ b/src/main/java/egovframework/com/cmm/EgovWebUtil.java
@@ -45,7 +45,7 @@ public class EgovWebUtil {
 		String returnValue = value;
 		returnValue = clearXSSMinimum(returnValue);
 
-		returnValue = returnValue.replaceAll("%00", null);
+		returnValue = returnValue.replace("%00", "");
 
 		returnValue = returnValue.replaceAll("%", "&#37;");
 
@@ -183,7 +183,7 @@ public class EgovWebUtil {
 		/*특수문자 선택적 제거*/
 		returnValue = returnValue.replaceAll("\\*", "");
 		returnValue = returnValue.replaceAll("&", "");
-		returnValue = returnValue.replaceAll("|", "");
+		returnValue = returnValue.replace("|", "");
 		returnValue = returnValue.replaceAll("//", "");
 		//...
 		//개별로 필요한 항목들 추가 필요

--- a/src/test/java/egovframework/com/cmm/EgovWebUtilTest.java
+++ b/src/test/java/egovframework/com/cmm/EgovWebUtilTest.java
@@ -1,0 +1,57 @@
+package egovframework.com.cmm;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * EgovWebUtil 보안 필터 메서드 검증.
+ *
+ * <p>정규식/replacement 인자 오류로 필터가 의도대로 동작하지 않던 두 결함에 대한
+ * 회귀 방지 테스트. 순수 static 유틸이므로 Spring 컨텍스트·DB 없이 결정적으로 검증한다.</p>
+ *
+ * <ul>
+ *   <li>clearXSSMaximum: {@code replaceAll("%00", null)}의 null replacement → "%00" 입력 시 NPE.</li>
+ *   <li>removeLDAPInjectionRisk: {@code replaceAll("|", "")}의 빈 교대 정규식 → 리터럴 '|' 미제거.</li>
+ * </ul>
+ */
+public class EgovWebUtilTest {
+
+	@Test
+	public void clearXSSMaximum_removesNullByteSequence_withoutNpe() {
+		// 변경 전: replaceAll("%00", null)이 "%00" 매칭 시 NullPointerException
+		String result = EgovWebUtil.clearXSSMaximum("abc%00def");
+
+		assertEquals("abcdef", result, "%00 시퀀스는 제거되어야 한다");
+	}
+
+	@Test
+	public void clearXSSMaximum_noNullByte_unchangedForPlainText() {
+		String result = EgovWebUtil.clearXSSMaximum("abcdef");
+
+		assertEquals("abcdef", result);
+	}
+
+	@Test
+	public void removeLDAPInjectionRisk_removesPipe() {
+		// 변경 전: replaceAll("|", "")은 빈 교대 정규식이라 리터럴 '|'를 제거하지 못함
+		String result = EgovWebUtil.removeLDAPInjectionRisk("admin|x");
+
+		assertEquals("adminx", result, "LDAP OR 연산자 '|'는 제거되어야 한다");
+		assertFalse(result.contains("|"), "결과에 '|'가 남아 있으면 안 된다");
+	}
+
+	@Test
+	public void removeLDAPInjectionRisk_keepsNormalCharacters() {
+		String result = EgovWebUtil.removeLDAPInjectionRisk("hong gildong");
+
+		assertEquals("hong gildong", result);
+	}
+
+	@Test
+	public void removeLDAPInjectionRisk_nullOrBlankReturnsEmpty() {
+		assertEquals("", EgovWebUtil.removeLDAPInjectionRisk(null));
+		assertEquals("", EgovWebUtil.removeLDAPInjectionRisk("   "));
+	}
+}


### PR DESCRIPTION
`EgovWebUtil`의 보안 필터 메서드 두 곳에서 `replaceAll` 사용 오류로 필터가 의도대로 동작하지 않는 문제를 수정합니다.

## 1. clearXSSMaximum — `%00` 입력 시 NPE

```java
returnValue = returnValue.replaceAll("%00", null);
```

`replaceAll`의 replacement에 `null`이 전달되어, 입력에 `%00`이 매칭되면 `NullPointerException`("Cannot invoke String.length() because replacement is null")이 발생합니다. 이 메서드는 채팅 메시지(`ChatServerEndPoint`), 사용자명(`UsersServerEndPoint`), 다운로드 파일명(`EgovFileDownloadController`) 등 사용자 입력 경로에서 호출되어, `%00`이 포함된 입력으로 예외가 트리거될 수 있습니다.

## 2. removeLDAPInjectionRisk — 리터럴 `|` 미제거

```java
returnValue = returnValue.replaceAll("|", "");
```

정규식 `"|"`는 빈 교대(empty alternation)로 해석되어 리터럴 파이프 문자를 제거하지 못합니다. `|`는 LDAP 필터의 OR 연산자로 이 메서드가 차단해야 할 인젝션 문자인데 그대로 통과합니다. 이 메서드는 LDAP DAO들(`OrgManageLdapDAO`, `DeptManageLdapDAO`, `UserManageLdapDAO`)에서 `dn` 인자에 적용됩니다.

## 수정

두 곳 모두 정규식이 아니라 리터럴 문자열 치환이 목적이므로 `String.replace(CharSequence, CharSequence)`로 교정합니다. `replace`는 정규식을 사용하지 않아 메타문자 이스케이프가 불필요하고(이번 `|` 결함과 같은 오용을 구조적으로 차단), 불필요한 패턴 컴파일도 없습니다.

```java
returnValue = returnValue.replace("%00", "");
returnValue = returnValue.replace("|", "");
```

## 동작 비교

| 입력 | 메서드 | 변경 전 | 변경 후 |
|---|---|---|---|
| `"abc%00def"` | clearXSSMaximum | NPE | `"abcdef"` |
| `"admin\|x"` | removeLDAPInjectionRisk | `"admin\|x"` | `"adminx"` |

## 테스트

`EgovWebUtilTest`를 추가했습니다. `%00` 제거·정상문자 보존, 리터럴 파이프 제거·정상문자 보존·null/공백 처리 5개 케이스를 검증합니다.

본 리포의 테스트는 surefire 설정상 기본 skip되므로, 순수 static 메서드 특성을 살려 Spring 컨텍스트·DB 없이 동작하도록 작성하고 로컬에서 `skipTests=false`로 5/5 통과를 확인했습니다. 수정 전 코드로 되돌리면 LDAP 파이프 케이스 실패와 `%00` 케이스 NPE가 재현됩니다.