### PR TITLE
chore: dependencyManagement 관리 대상 의존성 버전 선언 제거

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,27 +130,22 @@
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-core</artifactId>
-			<version>2.25.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-slf4j2-impl</artifactId>
-			<version>2.25.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>2.0.17</version>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>jcl-over-slf4j</artifactId>
-			<version>2.0.17</version>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>log4j-over-slf4j</artifactId>
-			<version>2.0.17</version>
 		</dependency>
 
 		<dependency>
@@ -267,7 +262,6 @@
 		<dependency>
 			<groupId>com.sun.mail</groupId>
 			<artifactId>jakarta.mail</artifactId>
-			<version>2.0.2</version>
 		</dependency>
 
 		<!-- LDAP SDK -->
@@ -383,7 +377,6 @@
 		<dependency>
 			<groupId>org.eclipse.parsson</groupId>
 			<artifactId>parsson</artifactId>
-			<version>1.1.7</version>
 		</dependency>
 
 		<!-- ajax json -->
@@ -406,7 +399,6 @@
 		<dependency>
 			<groupId>org.springframework.ldap</groupId>
 			<artifactId>spring-ldap-core</artifactId>
-			<version>2.4.4</version>
 			<exclusions>
 				<exclusion>
 					<groupId>org.springframework</groupId>
@@ -456,7 +448,6 @@
 		<dependency>
 			<groupId>org.apache.xmlbeans</groupId>
 			<artifactId>xmlbeans</artifactId>
-			<version>5.3.0</version>
 		</dependency>
 
 		<!-- CVE-2024-7254: mysql-connector-j에서 주입되는 protobuf-java 3.25.1 취약점
@@ -485,13 +476,11 @@
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
-			<version>5.12.1</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-params</artifactId>
-			<version>5.12.1</version>
 			<scope>test</scope>
 		</dependency>
 		<!-- HSQLDB(테스트용) -->
@@ -556,14 +545,12 @@
 		<dependency>
 			<groupId>commons-beanutils</groupId>
 			<artifactId>commons-beanutils</artifactId>
-			<version>1.11.0</version>
 		</dependency>
 
 		<!-- CVE-2025-48924: 취약점 보완용 업데이트 -->
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-lang3</artifactId>
-			<version>3.18.0</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [x] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

### 변경 내용
- 상위 POM에서 관리 중인 의존성의 중복 버전 선언 제거
- `Duplicating managed version` 관련 Maven 경고 해소

### 비고
- 기능 변경 없음
- 의존성 버전은 기존 dependencyManagement 설정을 그대로 사용

```
Description	Resource	Path	Location	Type
Duplicating managed version 1.1.7 for parsson	pom.xml	/egovframe-common-components	line 386	Maven pom Loading Problem
Duplicating managed version 1.1.7 for parsson [OverridingOfManagedDependency]	pom.xml	/egovframe-common-components	line 386	Language Servers
Duplicating managed version 1.11.0 for commons-beanutils	pom.xml	/egovframe-common-components	line 559	Maven pom Loading Problem
Duplicating managed version 1.11.0 for commons-beanutils [OverridingOfManagedDependency]	pom.xml	/egovframe-common-components	line 559	Language Servers
Duplicating managed version 2.0.17 for jcl-over-slf4j	pom.xml	/egovframe-common-components	line 148	Maven pom Loading Problem
Duplicating managed version 2.0.17 for jcl-over-slf4j [OverridingOfManagedDependency]	pom.xml	/egovframe-common-components	line 148	Language Servers
Duplicating managed version 2.0.17 for log4j-over-slf4j	pom.xml	/egovframe-common-components	line 153	Maven pom Loading Problem
Duplicating managed version 2.0.17 for log4j-over-slf4j [OverridingOfManagedDependency]	pom.xml	/egovframe-common-components	line 153	Language Servers
Duplicating managed version 2.0.17 for slf4j-api	pom.xml	/egovframe-common-components	line 143	Maven pom Loading Problem
Duplicating managed version 2.0.17 for slf4j-api [OverridingOfManagedDependency]	pom.xml	/egovframe-common-components	line 143	Language Servers
Duplicating managed version 2.0.2 for jakarta.mail	pom.xml	/egovframe-common-components	line 270	Maven pom Loading Problem
Duplicating managed version 2.0.2 for jakarta.mail [OverridingOfManagedDependency]	pom.xml	/egovframe-common-components	line 270	Language Servers
Duplicating managed version 2.25.3 for log4j-core	pom.xml	/egovframe-common-components	line 133	Maven pom Loading Problem
Duplicating managed version 2.25.3 for log4j-core [OverridingOfManagedDependency]	pom.xml	/egovframe-common-components	line 133	Language Servers
Duplicating managed version 2.25.3 for log4j-slf4j2-impl	pom.xml	/egovframe-common-components	line 138	Maven pom Loading Problem
Duplicating managed version 2.25.3 for log4j-slf4j2-impl [OverridingOfManagedDependency]	pom.xml	/egovframe-common-components	line 138	Language Servers
Duplicating managed version 2.4.4 for spring-ldap-core	pom.xml	/egovframe-common-components	line 409	Maven pom Loading Problem
Duplicating managed version 2.4.4 for spring-ldap-core [OverridingOfManagedDependency]	pom.xml	/egovframe-common-components	line 409	Language Servers
Duplicating managed version 3.18.0 for commons-lang3	pom.xml	/egovframe-common-components	line 566	Maven pom Loading Problem
Duplicating managed version 3.18.0 for commons-lang3 [OverridingOfManagedDependency]	pom.xml	/egovframe-common-components	line 566	Language Servers
Duplicating managed version 5.12.1 for junit-jupiter-engine	pom.xml	/egovframe-common-components	line 488	Maven pom Loading Problem
Duplicating managed version 5.12.1 for junit-jupiter-engine [OverridingOfManagedDependency]	pom.xml	/egovframe-common-components	line 488	Language Servers
Duplicating managed version 5.12.1 for junit-jupiter-params	pom.xml	/egovframe-common-components	line 494	Maven pom Loading Problem
Duplicating managed version 5.12.1 for junit-jupiter-params [OverridingOfManagedDependency]	pom.xml	/egovframe-common-components	line 494	Language Servers
Duplicating managed version 5.3.0 for xmlbeans	pom.xml	/egovframe-common-components	line 459	Maven pom Loading Problem
Duplicating managed version 5.3.0 for xmlbeans [OverridingOfManagedDependency]	pom.xml	/egovframe-common-components	line 459	Language Servers
```

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.
