### PR TITLE
fix: convertDate(4-arg) 명시적 포맷 인자가 무시되어 잘못된 결과 반환하는 문제 수정

### DIFF
--- a/src/main/java/egovframework/com/utl/fcc/service/EgovDateUtil.java
+++ b/src/main/java/egovframework/com/utl/fcc/service/EgovDateUtil.java
@@ -287,9 +287,13 @@ public class EgovDateUtil {
 		}
 		if (EgovStringUtil.isNullToString(fromDateFormat).isEmpty()) {
 			fromFormat = "yyyyMMddHHmmss"; // default값
+		} else {
+			fromFormat = fromDateFormat;
 		}
 		if (EgovStringUtil.isNullToString(toDateFormat).isEmpty()) {
 			toFormat = "yyyy-MM-dd HH:mm:ss"; // default값
+		} else {
+			toFormat = toDateFormat;
 		}
 
 		try {

--- a/src/test/java/egovframework/com/utl/fcc/service/EgovDateUtilConvertDateTest.java
+++ b/src/test/java/egovframework/com/utl/fcc/service/EgovDateUtilConvertDateTest.java
@@ -1,0 +1,45 @@
+package egovframework.com.utl.fcc.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * EgovDateUtil.convertDate(String, String, String, String) 포맷 인자 처리 검증.
+ *
+ * <p>변경 전: fromDateFormat/toDateFormat이 비어 있을 때만 기본 포맷을 대입하고,
+ * 값이 채워진 경우(else)에 사용자 지정 포맷을 대입하는 분기가 누락되어 있었다.
+ * 그 결과 호출자가 명시적 포맷을 넘기면 내부 포맷 변수가 빈 문자열로 남아
+ * {@code new SimpleDateFormat("")}로 파싱·포매팅되어 결과가 비거나 의도와 달랐다.
+ * 순수 static 유틸이므로 Spring 컨텍스트·DB 없이 결정적으로 검증한다.</p>
+ */
+public class EgovDateUtilConvertDateTest {
+
+	@Test
+	public void usesExplicitFromAndToFormats() {
+		// 변경 전: 두 포맷이 빈 문자열로 남아 SimpleDateFormat("")로 처리 → ""
+		String result = EgovDateUtil.convertDate("20240115", "yyyyMMdd", "yyyy-MM-dd", "");
+
+		assertEquals("2024-01-15", result, "명시한 from/to 포맷이 적용되어야 한다");
+	}
+
+	@Test
+	public void convertsBetweenDifferentExplicitFormats() {
+		String result = EgovDateUtil.convertDate("2024/01/15", "yyyy/MM/dd", "yyyyMMdd", "");
+
+		assertEquals("20240115", result);
+	}
+
+	@Test
+	public void emptyFormatsStillFallBackToDefaults() {
+		// 회귀 가드: 빈 포맷은 종전대로 기본 포맷(yyyyMMddHHmmss → yyyy-MM-dd HH:mm:ss) 사용
+		String result = EgovDateUtil.convertDate("20240115093000", "", "", "");
+
+		assertEquals("2024-01-15 09:30:00", result);
+	}
+
+	@Test
+	public void emptySourceReturnsEmpty() {
+		assertEquals("", EgovDateUtil.convertDate("", "yyyyMMdd", "yyyy-MM-dd", ""));
+	}
+}


### PR DESCRIPTION
## 문제

`EgovDateUtil.convertDate(String strSource, String fromDateFormat, String toDateFormat, String strTimeZone)`에서 포맷 인자를 처리하는 분기가 한쪽만 구현돼 있습니다.

```java
if (EgovStringUtil.isNullToString(fromDateFormat).isEmpty()) {
    fromFormat = "yyyyMMddHHmmss"; // 빈 값일 때만 기본 포맷 대입
}
// else가 없어 호출자가 넘긴 포맷을 대입하는 경로가 빠짐
```

포맷 인자가 비어 있을 때 기본값을 대입하지만, 값이 채워진 경우 사용자 포맷을 `fromFormat`/`toFormat`에 대입하는 `else` 분기가 없습니다. 그 결과 호출자가 명시적 포맷을 넘기면 두 변수가 빈 문자열로 남아 `new SimpleDateFormat("")`로 파싱·포매팅되어, 변환 결과가 비거나 의도와 다른 값이 됩니다.

메서드 시그니처와 Javadoc(`@param fromDateFormat 기존의 날짜 형태`)은 명시적 포맷 전달을 정상 사용으로 규정하므로, 문서화된 공개 API가 깨져 있는 상태입니다. (현재 저장소 내 호출부 5곳은 모두 `("","","")`로 호출해 기본값 경로만 타므로 영향받지 않습니다.)

## 수정

비어 있지 않은 포맷 인자를 대입하는 `else` 분기를 추가합니다. 기존 빈-포맷 기본값 동작은 그대로 유지됩니다.

## 검증

순수 static 유틸이라 Spring 컨텍스트·DB 없이 검증했습니다. `EgovDateUtilConvertDateTest` 4건(명시 포맷 적용, 서로 다른 포맷 간 변환, 빈 포맷→기본값 회귀 가드, 빈 소스→"").

- 수정 전: 명시 포맷 케이스 2건 실패 / 기본값 가드 2건 통과
- 수정 후: 4건 전부 통과

(`pom.xml`의 surefire `skipTests=true` 하드코딩으로 `mvn test`가 실행되지 않아, junit-platform-console-standalone로 클래스패스를 직접 구성해 구동했습니다.)
