### PR TITLE
fix: EgovXMLDoc.getXMLToClass XXE 방지 옵션 적용

### DIFF
--- a/src/main/java/egovframework/com/utl/sim/service/EgovXMLDoc.java
+++ b/src/main/java/egovframework/com/utl/sim/service/EgovXMLDoc.java
@@ -68,7 +68,11 @@ public class EgovXMLDoc {
 			File xmlFile = new File(storePathString,FilenameUtils.getName(file));
 			if (xmlFile.exists() && xmlFile.isFile()) {
 				fis = new FileInputStream(xmlFile);
-				mailDoc = (SndngMailDocument) SndngMailDocument.Factory.parse(xmlFile);
+				// XXE 방지: DOCTYPE 선언 차단 및 외부 DTD 로딩 비활성화 (getXMLDocument/getXMLFile와 동일 수준)
+				XmlOptions xmlOptions = new XmlOptions();
+				xmlOptions.setDisallowDocTypeDeclaration(true);
+				xmlOptions.setLoadExternalDTD(false);
+				mailDoc = (SndngMailDocument) SndngMailDocument.Factory.parse(xmlFile, xmlOptions);
 
 			}
 		} finally {

--- a/src/test/java/egovframework/com/utl/sim/service/EgovXMLDocXxeTest.java
+++ b/src/test/java/egovframework/com/utl/sim/service/EgovXMLDocXxeTest.java
@@ -1,0 +1,45 @@
+package egovframework.com.utl.sim.service;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.apache.xmlbeans.XmlException;
+import org.apache.xmlbeans.XmlObject;
+import org.apache.xmlbeans.XmlOptions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * EgovXMLDoc.getXMLToClass 에 적용한 XXE 방지 옵션의 동작을 검증한다.
+ *
+ * <p>getXMLToClass 는 SndngMailDocument.Factory.parse 호출 시
+ * {@link XmlOptions#setDisallowDocTypeDeclaration(boolean)} 와
+ * {@link XmlOptions#setLoadExternalDTD(boolean)} 를 적용한다. XXE 공격은
+ * DOCTYPE 선언을 통한 외부 엔티티 참조에서 비롯되므로, DOCTYPE 선언 자체가
+ * 거부되는지를 동일한 XMLBeans 파서로 확인한다.</p>
+ */
+class EgovXMLDocXxeTest {
+
+	// 외부 접근 없이 DOCTYPE 차단 효과만 격리하기 위해 내부 엔티티만 사용한다.
+	private static final String DOCTYPE_PAYLOAD =
+		"<?xml version=\"1.0\"?>"
+		+ "<!DOCTYPE foo [<!ENTITY bar \"baz\">]>"
+		+ "<foo>&bar;</foo>";
+
+	@Test
+	@DisplayName("하드닝 옵션 적용 시 DOCTYPE 선언 XML은 XmlException으로 거부된다")
+	void hardenedOptionsRejectDoctype() {
+		XmlOptions xmlOptions = new XmlOptions();
+		xmlOptions.setDisallowDocTypeDeclaration(true);
+		xmlOptions.setLoadExternalDTD(false);
+
+		assertThrows(XmlException.class, () -> XmlObject.Factory.parse(DOCTYPE_PAYLOAD, xmlOptions));
+	}
+
+	@Test
+	@DisplayName("옵션 미적용 시 동일 DOCTYPE 입력이 파싱됨 - 차단 주체가 옵션임을 확인")
+	void defaultOptionsAllowDoctype() throws Exception {
+		XmlObject parsed = XmlObject.Factory.parse(DOCTYPE_PAYLOAD);
+		assertNotNull(parsed);
+	}
+}


### PR DESCRIPTION
## 개요

`EgovXMLDoc.getXMLToClass`가 XML 파일을 파싱할 때 외부 엔티티/DTD 차단 설정 없이 `SndngMailDocument.Factory.parse`를 호출하여 XXE(XML External Entity)에 노출됩니다. 같은 클래스의 `getXMLDocument`(DOM)와 `getXMLFile`(Transformer)은 이미 시큐어코딩으로 외부 엔티티를 차단하고 있어, 해당 메서드만 일관성이 누락된 상태입니다.

## 변경 내용

`XmlOptions`에 다음을 적용해 DOCTYPE 선언 기반 외부 엔티티 참조를 차단합니다.

- `setDisallowDocTypeDeclaration(true)` — DOCTYPE 선언 자체를 거부
- `setLoadExternalDTD(false)` — 외부 DTD 로딩 비활성화

## 검증

`EgovXMLDocXxeTest` 단위테스트를 추가했습니다.

- 하드닝 옵션 적용 시 DOCTYPE 선언 XML이 `XmlException`으로 거부됨
- 옵션 미적용 시 동일 입력이 파싱됨(차단 주체가 옵션임을 확인)

XMLBeans 5.3.0 기준으로 두 테스트 모두 통과합니다.
