### PR TITLE
fix: 빈 문자열 참조 비교(!= "")를 isEmpty()로 수정

### DIFF
--- a/src/main/java/egovframework/com/cop/com/web/EgovCopViewController.java
+++ b/src/main/java/egovframework/com/cop/com/web/EgovCopViewController.java
@@ -44,14 +44,14 @@ public class EgovCopViewController {
 		String height = (String) commandMap.get("height");
 		String typeFlag = (String) commandMap.get("typeFlag");
 
-		if (trgetId != null && trgetId != "") {
-			if (typeFlag != null && typeFlag != "") {
+		if (trgetId != null && !trgetId.isEmpty()) {
+			if (typeFlag != null && !typeFlag.isEmpty()) {
 				model.addAttribute("requestUrl", requestUrl + "?trgetId=" + trgetId + "&PopFlag=Y&typeFlag=" + typeFlag);
 			} else {
 				model.addAttribute("requestUrl", requestUrl + "?trgetId=" + trgetId + "&PopFlag=Y");
 			}
 		} else {
-			if (typeFlag != null && typeFlag != "") {
+			if (typeFlag != null && !typeFlag.isEmpty()) {
 				model.addAttribute("requestUrl", requestUrl + "?PopFlag=Y&typeFlag=" + typeFlag);
 			} else {
 				model.addAttribute("requestUrl", requestUrl + "?PopFlag=Y");

--- a/src/main/java/egovframework/com/cop/ems/service/impl/EgovSndngMailServiceImpl.java
+++ b/src/main/java/egovframework/com/cop/ems/service/impl/EgovSndngMailServiceImpl.java
@@ -60,7 +60,7 @@ public class EgovSndngMailServiceImpl extends EgovAbstractServiceImpl implements
 		try {
 			EmailAttachment attachment = new EmailAttachment();
 			// 첨부파일이 있을 때
-			if (atchmnFileNm != "" && atchmnFileNm != null && atchmnFilePath != "" && atchmnFilePath != null) {
+			if (atchmnFileNm != null && !atchmnFileNm.isEmpty() && atchmnFilePath != null && !atchmnFilePath.isEmpty()) {
 				// 첨부할 attachment 정보를 생성합니다
 				attachment.setPath(atchmnFilePath);
 				attachment.setDisposition(EmailAttachment.ATTACHMENT);

--- a/src/main/java/egovframework/com/sym/ccm/zip/web/EgovCcmZipManageController.java
+++ b/src/main/java/egovframework/com/sym/ccm/zip/web/EgovCcmZipManageController.java
@@ -118,7 +118,7 @@ public class EgovCcmZipManageController {
 
 		String sList = "";
 
-		if (searchVO.getSearchList() != null && searchVO.getSearchList() != "") {
+		if (searchVO.getSearchList() != null && !searchVO.getSearchList().isEmpty()) {
 			sList = searchVO.getSearchList().substring(0, 1);
 		}
 		model.addAttribute("searchList", sList);

--- a/src/main/java/egovframework/com/uss/olp/qtm/web/EgovQustnrTmplatManageController.java
+++ b/src/main/java/egovframework/com/uss/olp/qtm/web/EgovQustnrTmplatManageController.java
@@ -307,7 +307,7 @@ public class EgovQustnrTmplatManageController {
 				LOGGER.info("getOriginalFilename => {}", file.getOriginalFilename());
 
 				// 파일 수정여부 확인
-				if (file.getOriginalFilename() != "") {
+				if (file.getOriginalFilename() != null && !file.getOriginalFilename().isEmpty()) {
 					if (file.getName().equals("qestnrTmplatImage")) {
 						qustnrTmplatManageVO.setQestnrTmplatImagepathnm(file.getBytes());
 					}


### PR DESCRIPTION
## 개요

문자열을 `""` 리터럴과 `!=`/`==`로 비교하면 값이 아니라 **참조**를 비교합니다. 서블릿 요청 파라미터, VO getter, `MultipartFile.getOriginalFilename()` 등 런타임에 생성되는 문자열은 `""` 리터럴과 다른 인스턴스이므로, 빈 값 판별이 의도와 다르게 동작합니다(빈 문자열도 "비어있지 않음"으로 처리됨).

## 변경 내용

null 가드를 유지하면서 `isEmpty()`로 교체했습니다.

- `EgovCopViewController`: `trgetId`/`typeFlag` 빈 값 판별 (3곳)
- `EgovSndngMailServiceImpl`: 첨부파일명/경로 판별, null 검사를 앞으로 정렬해 NPE 방지
- `EgovCcmZipManageController`: `searchList`가 빈 값일 때 `substring(0, 1)` 호출로 `StringIndexOutOfBoundsException`이 발생할 수 있어 함께 방지
- `EgovQustnrTmplatManageController`: 업로드 파일명 null/빈 값 판별

## 검증

`mvn compile` 빌드 성공을 확인했습니다. 동작 변경 없이 빈 값 판별 정확성만 개선되며, `EgovCcmZipManageController`는 빈 값 입력 시 예외 가능성이 제거됩니다.
