### PR TITLE
fix: Captcha 토큰 생성을 SecureRandom으로 변경

### DIFF
--- a/src/main/java/egovframework/com/ext/captcha/EgovCaptchaController.java
+++ b/src/main/java/egovframework/com/ext/captcha/EgovCaptchaController.java
@@ -6,7 +6,7 @@ import java.awt.Font;
 import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
-import java.util.Random;
+import java.security.SecureRandom;
 
 import javax.imageio.ImageIO;
 
@@ -144,7 +144,8 @@ public class EgovCaptchaController {
 	private String generateRandomText(int length) {
 		String chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
 		StringBuilder sb = new StringBuilder();
-		Random random = new Random();
+		// CAPTCHA 토큰은 예측 불가능해야 하므로 SecureRandom 사용 (CWE-330)
+		SecureRandom random = new SecureRandom();
 		for (int i = 0; i < length; i++) {
 			sb.append(chars.charAt(random.nextInt(chars.length())));
 		}


### PR DESCRIPTION
## 개요

`EgovCaptchaController.generateRandomText`가 `java.util.Random`으로 CAPTCHA 인증 문자열을 생성합니다. `java.util.Random`은 시드가 예측 가능하여 생성되는 토큰을 추정할 수 있고(CWE-330), 이는 봇 차단이라는 CAPTCHA 본래 목적을 약화시킵니다.

## 변경 내용

CAPTCHA 토큰 생성을 예측 불가능한 `java.security.SecureRandom`으로 교체했습니다.

- `import java.util.Random` → `java.security.SecureRandom`
- `generateRandomText`의 난수 생성기를 `SecureRandom`으로 변경

이미지 노이즈(선 두께·좌표)에 사용되는 `Math.random()`은 보안과 무관한 시각 요소이므로 변경하지 않았습니다.

## 검증

`mvn compile` 빌드 성공을 확인했습니다. 토큰 길이·문자 집합 등 기존 동작은 동일하며 난수원만 안전하게 교체됩니다.
