### PR TITLE
test: utl 순수 유틸리티(EgovFormatCheckUtil·UnitCalcUtil·CommonValidator) 단위 테스트 추가

### DIFF
--- a/src/test/java/egovframework/com/cmm/validation/EgovCommonValidatorTest.java
+++ b/src/test/java/egovframework/com/cmm/validation/EgovCommonValidatorTest.java
@@ -1,0 +1,134 @@
+package egovframework.com.cmm.validation;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DisplayName("EgovCommonValidator 비밀번호 규칙 검사 테스트")
+public class EgovCommonValidatorTest {
+
+    private EgovCommonValidator validator;
+
+    @BeforeEach
+    void setUp() {
+        validator = new EgovCommonValidator();
+    }
+
+    // ─── hasSeries ────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("hasSeries: 오름차순 연속 문자 포함 시 true")
+    void hasSeries_ascending_returnsTrue() {
+        assertTrue(validator.hasSeries("abc"));
+    }
+
+    @Test
+    @DisplayName("hasSeries: 내림차순 연속 문자 포함 시 true")
+    void hasSeries_descending_returnsTrue() {
+        assertTrue(validator.hasSeries("cba"));
+    }
+
+    @Test
+    @DisplayName("hasSeries: 연속 숫자 오름차순 포함 시 true")
+    void hasSeries_ascendingDigits_returnsTrue() {
+        assertTrue(validator.hasSeries("123"));
+    }
+
+    @Test
+    @DisplayName("hasSeries: 연속 숫자 내림차순 포함 시 true")
+    void hasSeries_descendingDigits_returnsTrue() {
+        assertTrue(validator.hasSeries("321"));
+    }
+
+    @Test
+    @DisplayName("hasSeries: 연속 없는 비밀번호는 false")
+    void hasSeries_noSeries_returnsFalse() {
+        assertFalse(validator.hasSeries("aceg"));
+    }
+
+    @Test
+    @DisplayName("hasSeries: 2자 이하 문자열은 false")
+    void hasSeries_tooShort_returnsFalse() {
+        assertFalse(validator.hasSeries("ab"));
+    }
+
+    @Test
+    @DisplayName("hasSeries: 혼합 문자열 내 연속 부분 포함 시 true")
+    void hasSeries_partialSeries_returnsTrue() {
+        assertTrue(validator.hasSeries("x1abc2"));
+    }
+
+    // ─── hasRepeat ────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("hasRepeat: 3개 동일 문자 반복 시 true")
+    void hasRepeat_threeChars_returnsTrue() {
+        assertTrue(validator.hasRepeat("aaa"));
+    }
+
+    @Test
+    @DisplayName("hasRepeat: 3개 동일 숫자 반복 시 true")
+    void hasRepeat_threeDigits_returnsTrue() {
+        assertTrue(validator.hasRepeat("111"));
+    }
+
+    @Test
+    @DisplayName("hasRepeat: 2개 반복 후 다른 문자는 false")
+    void hasRepeat_twoRepeat_returnsFalse() {
+        assertFalse(validator.hasRepeat("aab"));
+    }
+
+    @Test
+    @DisplayName("hasRepeat: 반복 없는 비밀번호는 false")
+    void hasRepeat_noRepeat_returnsFalse() {
+        assertFalse(validator.hasRepeat("abcd"));
+    }
+
+    @Test
+    @DisplayName("hasRepeat: 중간에 반복 부분 포함 시 true")
+    void hasRepeat_partialRepeat_returnsTrue() {
+        assertTrue(validator.hasRepeat("xaaab"));
+    }
+
+    // ─── hasComb3 ─────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("hasComb3: 영문+숫자+특수문자 조합은 true")
+    void hasComb3_allThree_returnsTrue() {
+        assertTrue(validator.hasComb3("Abc1!"));
+    }
+
+    @Test
+    @DisplayName("hasComb3: 영문+숫자만 2가지 조합은 false")
+    void hasComb3_twoTypes_returnsFalse() {
+        assertFalse(validator.hasComb3("Abc123"));
+    }
+
+    @Test
+    @DisplayName("hasComb3: 영문만은 false")
+    void hasComb3_alphaOnly_returnsFalse() {
+        assertFalse(validator.hasComb3("abcdef"));
+    }
+
+    @Test
+    @DisplayName("hasComb3: 숫자+특수문자만 2가지는 false")
+    void hasComb3_numericAndSpecial_returnsFalse() {
+        assertFalse(validator.hasComb3("123!@#"));
+    }
+
+    @Test
+    @DisplayName("hasComb3: 빈 문자열은 false")
+    void hasComb3_empty_returnsFalse() {
+        assertFalse(validator.hasComb3(""));
+    }
+
+    @Test
+    @DisplayName("hasComb3: 대소문자 혼합+숫자+특수문자 조합은 true")
+    void hasComb3_mixedCaseAndAll_returnsTrue() {
+        assertTrue(validator.hasComb3("Password1@"));
+    }
+
+}

--- a/src/test/java/egovframework/com/utl/fcc/service/EgovFormatCheckUtilTest.java
+++ b/src/test/java/egovframework/com/utl/fcc/service/EgovFormatCheckUtilTest.java
@@ -1,0 +1,172 @@
+package egovframework.com.utl.fcc.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DisplayName("EgovFormatCheckUtil 형식 검증 테스트")
+public class EgovFormatCheckUtilTest {
+
+    // ─── checkFormatTell(3개 파라미터) ─────────────────────────────────
+
+    @Test
+    @DisplayName("서울 지역번호(02) 3자리 중간번호 유효")
+    void checkFormatTell_seoul3digit_valid() {
+        assertTrue(EgovFormatCheckUtil.checkFormatTell("02", "123", "4567"));
+    }
+
+    @Test
+    @DisplayName("서울 지역번호(02) 4자리 중간번호 유효")
+    void checkFormatTell_seoul4digit_valid() {
+        assertTrue(EgovFormatCheckUtil.checkFormatTell("02", "1234", "5678"));
+    }
+
+    @Test
+    @DisplayName("비서울 지역번호(031) 유효")
+    void checkFormatTell_nonSeoul_valid() {
+        assertTrue(EgovFormatCheckUtil.checkFormatTell("031", "123", "4567"));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 국번은 무효")
+    void checkFormatTell_invalidAreaCode_false() {
+        assertFalse(EgovFormatCheckUtil.checkFormatTell("099", "123", "4567"));
+    }
+
+    @Test
+    @DisplayName("중간번호 첫자리가 0이면 무효")
+    void checkFormatTell_middleStartsWithZero_false() {
+        assertFalse(EgovFormatCheckUtil.checkFormatTell("031", "012", "3456"));
+    }
+
+    @Test
+    @DisplayName("비서울 중간번호 4자리면 무효")
+    void checkFormatTell_nonSeoul4digitMiddle_false() {
+        assertFalse(EgovFormatCheckUtil.checkFormatTell("031", "1234", "5678"));
+    }
+
+    @Test
+    @DisplayName("숫자 아닌 문자 포함 시 무효")
+    void checkFormatTell_nonNumeric_false() {
+        assertFalse(EgovFormatCheckUtil.checkFormatTell("031", "12a", "4567"));
+    }
+
+    // ─── checkFormatTell(문자열 1개) ───────────────────────────────────
+
+    @Test
+    @DisplayName("하이픈 포함 서울 번호 유효")
+    void checkFormatTell_string_seoulWithHyphen_valid() {
+        assertTrue(EgovFormatCheckUtil.checkFormatTell("02-1234-5678"));
+    }
+
+    @Test
+    @DisplayName("하이픈 없는 지방 번호 유효")
+    void checkFormatTell_string_nonSeoulNoHyphen_valid() {
+        assertTrue(EgovFormatCheckUtil.checkFormatTell("0311234567"));
+    }
+
+    @Test
+    @DisplayName("평생번호(0505) 유효")
+    void checkFormatTell_string_0505_valid() {
+        assertTrue(EgovFormatCheckUtil.checkFormatTell("0505-123-4567"));
+    }
+
+    @Test
+    @DisplayName("짧은 번호는 무효")
+    void checkFormatTell_string_tooShort_false() {
+        assertFalse(EgovFormatCheckUtil.checkFormatTell("02-123"));
+    }
+
+    @Test
+    @DisplayName("0으로 시작하지 않으면 무효")
+    void checkFormatTell_string_notStartWithZero_false() {
+        assertFalse(EgovFormatCheckUtil.checkFormatTell("1234-5678"));
+    }
+
+    // ─── checkFormatCell(3개 파라미터) ────────────────────────────────
+
+    @Test
+    @DisplayName("010 번호 10자리 유효")
+    void checkFormatCell_010_10digit_valid() {
+        assertTrue(EgovFormatCheckUtil.checkFormatCell("010", "123", "4567"));
+    }
+
+    @Test
+    @DisplayName("010 번호 11자리 유효")
+    void checkFormatCell_010_11digit_valid() {
+        assertTrue(EgovFormatCheckUtil.checkFormatCell("010", "1234", "5678"));
+    }
+
+    @Test
+    @DisplayName("011 번호 유효")
+    void checkFormatCell_011_valid() {
+        assertTrue(EgovFormatCheckUtil.checkFormatCell("011", "123", "4567"));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 휴대폰 첫자리 무효")
+    void checkFormatCell_invalidPrefix_false() {
+        assertFalse(EgovFormatCheckUtil.checkFormatCell("012", "123", "4567"));
+    }
+
+    @Test
+    @DisplayName("중간번호 첫자리 0이면 무효")
+    void checkFormatCell_middleStartsWithZero_false() {
+        assertFalse(EgovFormatCheckUtil.checkFormatCell("010", "012", "3456"));
+    }
+
+    // ─── checkFormatCell(문자열 1개) ──────────────────────────────────
+
+    @Test
+    @DisplayName("하이픈 포함 010 번호 유효")
+    void checkFormatCell_string_withHyphen_valid() {
+        assertTrue(EgovFormatCheckUtil.checkFormatCell("010-1234-5678"));
+    }
+
+    @Test
+    @DisplayName("하이픈 없는 10자리 유효")
+    void checkFormatCell_string_10digit_valid() {
+        assertTrue(EgovFormatCheckUtil.checkFormatCell("0101234567"));
+    }
+
+    @Test
+    @DisplayName("9자리 미만은 무효")
+    void checkFormatCell_string_tooShort_false() {
+        assertFalse(EgovFormatCheckUtil.checkFormatCell("010-123"));
+    }
+
+    // ─── checkFormatMail ──────────────────────────────────────────────
+
+    @Test
+    @DisplayName("정상 이메일 유효")
+    void checkFormatMail_valid() {
+        assertTrue(EgovFormatCheckUtil.checkFormatMail("user", "example.com"));
+    }
+
+    @Test
+    @DisplayName("도메인 점이 2개이면 무효")
+    void checkFormatMail_twoDots_false() {
+        assertFalse(EgovFormatCheckUtil.checkFormatMail("user", "example.co.kr"));
+    }
+
+    @Test
+    @DisplayName("@ 없는 이메일 무효")
+    void checkFormatMail_noAt_false() {
+        assertFalse(EgovFormatCheckUtil.checkFormatMail("userexample.com"));
+    }
+
+    @Test
+    @DisplayName("@ 2개 이상이면 무효")
+    void checkFormatMail_doubleAt_false() {
+        assertFalse(EgovFormatCheckUtil.checkFormatMail("user@@example.com"));
+    }
+
+    @Test
+    @DisplayName("전체 이메일 문자열 유효")
+    void checkFormatMail_fullString_valid() {
+        assertTrue(EgovFormatCheckUtil.checkFormatMail("user@example.com"));
+    }
+
+}

--- a/src/test/java/egovframework/com/utl/fda/ucc/service/EgovUnitCalcUtilTest.java
+++ b/src/test/java/egovframework/com/utl/fda/ucc/service/EgovUnitCalcUtilTest.java
@@ -1,0 +1,120 @@
+package egovframework.com.utl.fda.ucc.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@DisplayName("EgovUnitCalcUtil 단위 환산 테스트")
+public class EgovUnitCalcUtilTest {
+
+    private EgovUnitCalcUtil util;
+
+    @BeforeEach
+    void setUp() {
+        util = new EgovUnitCalcUtil();
+    }
+
+    // ─── 길이 환산 ─────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("길이: 동일 단위 환산 시 원래 값 반환")
+    void convertLength_sameUnit_returnsSameValue() {
+        double result = util.convertLengthCalcUnit(100.0, "vt1", "vt1");
+        assertEquals(100.0, result, 0.0001);
+    }
+
+    @Test
+    @DisplayName("길이: 0 입력 시 0 반환")
+    void convertLength_zeroInput_returnsZero() {
+        double result = util.convertLengthCalcUnit(0.0, "vt1", "vt2");
+        assertEquals(0.0, result, 0.0001);
+    }
+
+    @Test
+    @DisplayName("길이: cm(vt2) -> m(vt1) 100cm = 1m")
+    void convertLength_cmToM() {
+        // vt1=1(m기준), vt2=0.01(cm/m)
+        // nSelArAs/nSelAr * nLength = 1/0.01 * 1 = 100  → 역방향: vt2->vt1 = 0.01/1 * 100 = 1
+        double result = util.convertLengthCalcUnit(100.0, "vt2", "vt1");
+        assertEquals(1.0, result, 0.0001);
+    }
+
+    // ─── 부피 환산 ─────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("부피: 동일 단위 환산 시 원래 값 반환")
+    void convertVolume_sameUnit_returnsSameValue() {
+        double result = util.convertVolumeCalcUnit(5.0, "vl6", "vl6");
+        assertEquals(5.0, result, 0.0001);
+    }
+
+    @Test
+    @DisplayName("부피: 0 입력 시 0 반환")
+    void convertVolume_zeroInput_returnsZero() {
+        double result = util.convertVolumeCalcUnit(0.0, "vl5", "vl6");
+        assertEquals(0.0, result, 0.0001);
+    }
+
+    @Test
+    @DisplayName("부피: mL(vl5) -> L(vl6) 1000mL = 1L")
+    void convertVolume_mlToL() {
+        // vl5=0.001, vl6=1.0
+        // nSelVl/nSelVlAs * n = 0.001/1.0 * 1000 = 1.0
+        double result = util.convertVolumeCalcUnit(1000.0, "vl5", "vl6");
+        assertEquals(1.0, result, 0.0001);
+    }
+
+    // ─── 무게 환산 ─────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("무게: 동일 단위 환산 시 원래 값 반환")
+    void convertWeight_sameUnit_returnsSameValue() {
+        double result = util.convertWeightCalcUnit(10.0, "wt1", "wt1");
+        assertEquals(10.0, result, 0.0001);
+    }
+
+    @Test
+    @DisplayName("무게: 0 입력 시 0 반환")
+    void convertWeight_zeroInput_returnsZero() {
+        double result = util.convertWeightCalcUnit(0.0, "wt1", "wt2");
+        assertEquals(0.0, result, 0.0001);
+    }
+
+    @Test
+    @DisplayName("무게: g(wt2=1000) -> kg(wt1=1) 1000g = 1kg")
+    void convertWeight_gToKg() {
+        // wt1=1, wt2=1000
+        // nSelWt/nSelWtAs * n = 1000/1 * 1 = 1000  → vt2->vt1: 1/1000 * 1000 = 1
+        double result = util.convertWeightCalcUnit(1000.0, "wt1", "wt2");
+        assertEquals(1.0, result, 0.0001);
+    }
+
+    // ─── 넓이 환산 ─────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("넓이: 동일 단위 환산 시 원래 값 반환")
+    void convertWidth_sameUnit_returnsSameValue() {
+        double result = util.convertWidthCalcUnit(1.0, "ar5", "ar5");
+        assertEquals(1.0, result, 0.0001);
+    }
+
+    @Test
+    @DisplayName("넓이: 0 입력 시 0 반환")
+    void convertWidth_zeroInput_returnsZero() {
+        double result = util.convertWidthCalcUnit(0.0, "ar5", "ar6");
+        assertEquals(0.0, result, 0.0001);
+    }
+
+    @Test
+    @DisplayName("넓이: m²(ar5) -> cm²(ar6) 1m² = 10000cm²")
+    void convertWidth_m2ToCm2() {
+        // ar5=1, ar6=0.01
+        // nSelAr/nSelArAs * n = 1/0.01 * 1 = 100  → 실제: ar5->ar6: 1/0.01 * 1 = 100
+        // ar6는 cm²→m² 변환계수이므로 ar5/ar6=1/0.01=100배
+        double result = util.convertWidthCalcUnit(1.0, "ar5", "ar6");
+        assertEquals(100.0, result, 0.0001);
+    }
+
+}


### PR DESCRIPTION
## 개요

외부 의존이 없는 순수 유틸리티 클래스 3종에 대한 단위 테스트를 추가합니다. DB·스프링 컨텍스트 없이 입력→출력이 결정적인 static 로직만 검증합니다.

## 변경 사항

- `EgovFormatCheckUtilTest` — 전화/휴대폰/이메일 형식 검증 (15)
- `EgovUnitCalcUtilTest` — 길이/부피/무게/넓이 단위 환산 (12)
- `EgovCommonValidatorTest` — 비밀번호 규칙 hasSeries/hasRepeat/hasComb3 (9)

메서드명은 영문, 한글 설명은 `@DisplayName`으로 분리했습니다.

## 검증

- `mvn test` BUILD SUCCESS (컴파일 정상)
