### PR TITLE
fix: 서버자원모니터링 sendEmail이 항상 null인 필드 참조로 발생하는 NPE 수정

### DIFF
--- a/src/main/java/egovframework/com/utl/sys/srm/service/EgovServerResrceMntrngScheduling.java
+++ b/src/main/java/egovframework/com/utl/sys/srm/service/EgovServerResrceMntrngScheduling.java
@@ -198,10 +198,8 @@ public class EgovServerResrceMntrngScheduling extends EgovAbstractServiceImpl {
 
 	/**
 	 * 이메일을 전송한다.
-	 * @param serverResrceMntrngVO - 서버자원모니터링 Vo
+	 * @param serverResrceMntrng - 서버자원모니터링 정보
 	 * @return
-	 *
-	 * @param serverResrceMntrngVO
 	 */
 	public void sendEmail(ServerResrceMntrng serverResrceMntrng) {
 		String subject = "";
@@ -224,26 +222,26 @@ public class EgovServerResrceMntrngScheduling extends EgovAbstractServiceImpl {
 		if (StringUtils.isNotEmpty(text)) {
 			text = EgovStringUtil.replace(text, "{모니터링종류}", "서버자원서비스모니터링");
 			errorContents = "서버명 : ";
-			errorContents += serverResrceMntrngVO.getServerNm();
+			errorContents += serverResrceMntrng.getServerNm();
 			errorContents += "\n";
 			errorContents += "서버IP : ";
-			errorContents += serverResrceMntrngVO.getServerEqpmnIp();
+			errorContents += serverResrceMntrng.getServerEqpmnIp();
 			errorContents += "\n";
 			errorContents += "CPU사용률 : ";
-			errorContents += serverResrceMntrngVO.getCpuUseRt();
+			errorContents += serverResrceMntrng.getCpuUseRt();
 			errorContents += "\n";
 			errorContents += "메모리사용률 : ";
-			errorContents += serverResrceMntrngVO.getMoryUseRt();
+			errorContents += serverResrceMntrng.getMoryUseRt();
 			errorContents += "\n";
 			errorContents += "서비스상태 : 비정상";
 			errorContents += "\n";
 			errorContents += "내용 : ";
-			errorContents += serverResrceMntrngVO.getLogInfo();
+			errorContents += serverResrceMntrng.getLogInfo();
 			errorContents += "\n";
 			errorContents += "생성일시 : ";
-			errorContents += EgovDateUtil.convertDate(serverResrceMntrngVO.getCreatDt(), "", "", "");
+			errorContents += EgovDateUtil.convertDate(serverResrceMntrng.getCreatDt(), "", "", "");
 			errorContents += "\n";
-			errorContents += serverResrceMntrngVO.getServerNm() + " 의 서버자원 서비스 상태가 비정상입니다. \n로그를 확인해주세요.";
+			errorContents += serverResrceMntrng.getServerNm() + " 의 서버자원 서비스 상태가 비정상입니다. \n로그를 확인해주세요.";
 			text = EgovStringUtil.replace(text, "{에러내용}", errorContents);
 			msg.setText(text);
 		}

--- a/src/test/java/egovframework/com/utl/sys/srm/service/EgovServerResrceMntrngSchedulingTest.java
+++ b/src/test/java/egovframework/com/utl/sys/srm/service/EgovServerResrceMntrngSchedulingTest.java
@@ -1,0 +1,124 @@
+package egovframework.com.utl.sys.srm.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mail.MailMessage;
+import org.springframework.mail.MailSender;
+import org.springframework.mail.SimpleMailMessage;
+
+/**
+ * EgovServerResrceMntrngScheduling.sendEmail 단위 테스트.
+ *
+ * <p>Spring/DB/메일서버 없이 동작한다. MailSender 를 발송 메시지를 캡처하는
+ * 페이크로 주입하여, 전달한 ServerResrceMntrng 의 값이 메일 본문에 반영되는지 검증한다.</p>
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *  수정일      	         수정자              수정내용
+ *  ----------   ---------   ---------------------------
+ *  2026.06.18   z3rotig4r           sendEmail NPE 회귀 방지 테스트 추가
+ *
+ * </pre>
+ */
+class EgovServerResrceMntrngSchedulingTest {
+
+	/** 발송 요청된 메시지를 캡처하는 페이크 MailSender. */
+	private static class CapturingMailSender implements MailSender {
+		private final List<SimpleMailMessage> sent = new ArrayList<>();
+
+		@Override
+		public void send(SimpleMailMessage simpleMessage) {
+			sent.add(simpleMessage);
+		}
+
+		@Override
+		public void send(SimpleMailMessage... simpleMessages) {
+			for (SimpleMailMessage m : simpleMessages) {
+				sent.add(m);
+			}
+		}
+	}
+
+	private EgovServerResrceMntrngScheduling scheduling;
+	private CapturingMailSender mailSender;
+
+	@BeforeEach
+	void setUp() throws Exception {
+		scheduling = new EgovServerResrceMntrngScheduling();
+		mailSender = new CapturingMailSender();
+
+		// context-mail.xml 의 mntrngMessage 빈과 동일한 템플릿
+		SimpleMailMessage template = new SimpleMailMessage();
+		template.setFrom("SYSTEM < orgpig@naver.com >");
+		template.setSubject("{모니터링종류} 상태통보.");
+		template.setText("* {모니터링종류}  상태통보.\r{에러내용}");
+
+		setField("mntrngMessage", template);
+		setField("mntrngMailSender", mailSender);
+	}
+
+	private void setField(String name, Object value) throws Exception {
+		Field field = EgovServerResrceMntrngScheduling.class.getDeclaredField(name);
+		field.setAccessible(true);
+		field.set(scheduling, value);
+	}
+
+	private ServerResrceMntrng buildTarget() {
+		ServerResrceMntrng target = new ServerResrceMntrng();
+		target.setServerNm("WAS-01");
+		target.setServerEqpmnIp("192.168.0.10");
+		target.setCpuUseRt("95");
+		target.setMoryUseRt("92");
+		target.setLogInfo("적정수치를 초과하였습니다.");
+		target.setCreatDt("20260618120000");
+		target.setMngrEamilAddr("admin@example.com");
+		return target;
+	}
+
+	/**
+	 * 수정 후: 파라미터로 전달한 모니터링 정보가 메일 본문/수신자에 반영되어야 한다.
+	 * (수정 전에는 항상 null 인 인스턴스 필드를 읽어 NPE 가 발생했다.)
+	 */
+	@Test
+	void sendEmail_파라미터값이_메일본문에_반영된다() {
+		scheduling.sendEmail(buildTarget());
+
+		assertEquals(1, mailSender.sent.size(), "메일이 1건 발송되어야 한다");
+		SimpleMailMessage msg = mailSender.sent.get(0);
+
+		assertNotNull(msg.getTo());
+		assertEquals("admin@example.com", msg.getTo()[0]);
+		assertEquals("서버자원서비스모니터링 상태통보.", msg.getSubject());
+
+		String text = msg.getText();
+		assertNotNull(text);
+		assertTrue(text.contains("WAS-01"), "서버명이 본문에 포함되어야 한다");
+		assertTrue(text.contains("192.168.0.10"), "서버IP가 본문에 포함되어야 한다");
+		assertTrue(text.contains("95"), "CPU사용률이 본문에 포함되어야 한다");
+		assertTrue(text.contains("92"), "메모리사용률이 본문에 포함되어야 한다");
+		assertTrue(text.contains("적정수치를 초과하였습니다."), "로그정보가 본문에 포함되어야 한다");
+		assertTrue(text.contains("서버자원 서비스 상태가 비정상입니다."), "비정상 안내문이 포함되어야 한다");
+	}
+
+	/**
+	 * 페이크 MailSender 가 MailMessage 가 아닌 SimpleMailMessage 시그니처로 호출됨을 보증한다.
+	 * (회귀 시 send 미호출/예외를 조기에 드러낸다.)
+	 */
+	@Test
+	void sendEmail_send가_정확히_한번_호출된다() {
+		scheduling.sendEmail(buildTarget());
+
+		assertEquals(1, mailSender.sent.size());
+		MailMessage msg = mailSender.sent.get(0);
+		assertNotNull(msg);
+	}
+}


### PR DESCRIPTION
## 변경 이유

`EgovServerResrceMntrngScheduling.sendEmail(ServerResrceMntrng serverResrceMntrng)`이 CPU/메모리 임계 초과 알림 메일 본문을 구성할 때, 파라미터 `serverResrceMntrng`가 아니라 인스턴스 필드 `serverResrceMntrngVO`(`EgovServerResrceMntrngScheduling.java:71`, `private ServerResrceMntrngVO serverResrceMntrngVO = null;`)를 읽습니다.

이 필드는 클래스 어디에서도 대입되지 않아 항상 `null`이므로, 메일 발송 분기에 진입하는 순간 `serverResrceMntrngVO.getServerNm()` 호출에서 `NullPointerException`이 발생합니다(수정 전 기준 본문 `EgovServerResrceMntrngScheduling.java:227` 부근). 결과적으로 서버 자원 이상이 감지되어 관리자에게 경보 메일을 보내야 하는 시점에 오히려 알림이 실패합니다.

형제 클래스 `EgovNtwrkSvcMntrngScheduling.sendEmail(target)`은 동일한 구조의 메일 본문 구성에서 파라미터 `target`을 그대로 사용합니다(`EgovNtwrkSvcMntrngScheduling.java:171`, `errorContents += target.getSysNm();`). 즉 정상 구현은 파라미터를 참조하며, 본 클래스만 필드를 참조하는 불일치가 결함의 근거입니다.

## 변경 내용

- 메일 본문 구성 코드에서 항상 `null`인 필드 참조 `serverResrceMntrngVO.*`를 파라미터 참조 `serverResrceMntrng.*`로 교정했습니다.
- `sendEmail`의 javadoc `@param`을 실제 파라미터명(`serverResrceMntrng`)에 맞추고 중복 `@param` 항목을 정리했습니다.

동작상 변경되는 것은 메일 본문이 실제 전달된 모니터링 정보를 반영한다는 점뿐이며, 시그니처와 호출부는 그대로입니다.

## 테스트 방법

`EgovServerResrceMntrngSchedulingTest`를 추가했습니다.

- 발송 메시지를 가로채는 페이크 `MailSender`를 주입하고 `sendEmail`을 호출합니다.
- 수정 전 코드에서는 본문 구성 시 `NullPointerException`이 발생함을 재현하고, 수정 후에는 예외 없이 발송되는 것을 확인합니다.
- 발송된 메일 본문에 전달한 `ServerResrceMntrng`의 서버명·IP·CPU/메모리 사용률 등이 반영되는지 검증합니다(2건).

## 영향 범위

- 대상: `egovframework.com.utl.sys.srm.service.EgovServerResrceMntrngScheduling.sendEmail`.
- public 메서드 시그니처·호출 규약 변경 없음. 기존 스케줄링 호출 경로와 하위 호환됩니다.
- 외부 의존성·설정 변경 없음.
