### PR TITLE
fix: EgovMultiLoginPreventor 동시 세션 제거 시 invalidateByLoginId NPE 방지

### DIFF
--- a/src/main/java/egovframework/com/utl/slm/EgovMultiLoginPreventor.java
+++ b/src/main/java/egovframework/com/utl/slm/EgovMultiLoginPreventor.java
@@ -1,6 +1,5 @@
 package egovframework.com.utl.slm;
 
-import java.util.Enumeration;
 import java.util.concurrent.ConcurrentHashMap;
 
 import jakarta.servlet.http.HttpSession;
@@ -32,12 +31,12 @@ public class EgovMultiLoginPreventor {
 	 * 사용자의 로그인 아이디로 이미 존재하는 세션을 무효화한다
 	 * */
 	public static void invalidateByLoginId(String loginId) {
-		Enumeration<String> e = loginUsers.keys();
-		while (e.hasMoreElements()) {
-			String key = e.nextElement();
-			if (key.equals(loginId)) {
-				loginUsers.get(key).invalidate();
-			}
+		// 맵은 로그인 아이디를 키로 사용하므로 단건 조회로 충분하다.
+		// 조회 결과를 지역변수에 담아, 다른 스레드(valueUnbound)가 엔트리를 동시에
+		// 제거하여 null이 반환되는 경우에도 NPE가 발생하지 않도록 가드한다.
+		HttpSession session = loginUsers.get(loginId);
+		if (session != null) {
+			session.invalidate();
 		}
 	}
 }

--- a/src/test/java/egovframework/com/utl/slm/EgovMultiLoginPreventorTest.java
+++ b/src/test/java/egovframework/com/utl/slm/EgovMultiLoginPreventorTest.java
@@ -1,0 +1,140 @@
+package egovframework.com.utl.slm;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import jakarta.servlet.http.HttpSession;
+
+/**
+ * EgovMultiLoginPreventor의 동시성 안전성 검증 테스트.
+ *
+ * invalidateByLoginId가 맵을 순회한 뒤 get(key)로 재조회하던 기존 구현에서는,
+ * 순회와 재조회 사이에 다른 스레드가 valueUnbound(remove)로 엔트리를 제거하면
+ * get(key)가 null을 반환하여 .invalidate() 호출 시 NPE가 발생했다.
+ */
+public class EgovMultiLoginPreventorTest {
+
+	@AfterEach
+	void clear() {
+		EgovMultiLoginPreventor.loginUsers.clear();
+	}
+
+	/**
+	 * 무효화 시 맵에서 스스로 제거되는 가짜 세션을 만든다(valueUnbound의 remove를 모사).
+	 * onInvalidate가 호출되면 호출 횟수를 기록한다.
+	 */
+	private static HttpSession fakeSession(String loginId, AtomicInteger invalidateCount) {
+		InvocationHandler handler = (proxy, method, args) -> {
+			String name = method.getName();
+			if ("invalidate".equals(name)) {
+				invalidateCount.incrementAndGet();
+				// 실제 컨테이너의 valueUnbound 동작(엔트리 제거)을 모사한다.
+				EgovMultiLoginPreventor.loginUsers.remove(loginId, proxy);
+				return null;
+			}
+			if ("equals".equals(name)) {
+				return proxy == args[0];
+			}
+			if ("hashCode".equals(name)) {
+				return System.identityHashCode(proxy);
+			}
+			if ("toString".equals(name)) {
+				return "FakeSession(" + loginId + ")";
+			}
+			// 그 외 메서드는 사용하지 않으므로 기본값을 반환한다.
+			Class<?> rt = method.getReturnType();
+			if (rt == boolean.class) {
+				return false;
+			}
+			if (rt == int.class) {
+				return 0;
+			}
+			return null;
+		};
+		return (HttpSession) Proxy.newProxyInstance(
+				EgovMultiLoginPreventorTest.class.getClassLoader(),
+				new Class<?>[] { HttpSession.class },
+				handler);
+	}
+
+	@Test
+	void invalidateByLoginId_정상무효화() {
+		String loginId = "user1";
+		AtomicInteger count = new AtomicInteger();
+		HttpSession session = fakeSession(loginId, count);
+		EgovMultiLoginPreventor.loginUsers.put(loginId, session);
+
+		EgovMultiLoginPreventor.invalidateByLoginId(loginId);
+
+		assertTrue(count.get() == 1, "기존 세션이 한 번 무효화되어야 한다");
+		assertFalse(EgovMultiLoginPreventor.findByLoginId(loginId), "무효화 후 맵에서 제거되어야 한다");
+	}
+
+	@Test
+	void invalidateByLoginId_엔트리없으면_NPE없이_무동작() {
+		// 존재하지 않는 로그인 아이디로 호출해도 NPE가 발생하지 않아야 한다.
+		assertDoesNotThrow(() -> EgovMultiLoginPreventor.invalidateByLoginId("absent"));
+	}
+
+	/**
+	 * 다수 스레드가 add/remove와 invalidateByLoginId를 동시에 수행해도
+	 * NPE가 발생하지 않는지 검증한다(동시 엔트리 제거 → get null 시나리오 재현 시도).
+	 */
+	@Test
+	void invalidateByLoginId_동시제거중_NPE없음() throws InterruptedException {
+		final int loginIdCount = 50;
+		final int threadCount = 16;
+		final int roundsPerThread = 2000;
+
+		ExecutorService pool = Executors.newFixedThreadPool(threadCount);
+		final CountDownLatch start = new CountDownLatch(1);
+		final CountDownLatch done = new CountDownLatch(threadCount);
+		final AtomicBoolean failed = new AtomicBoolean(false);
+		final AtomicInteger ignored = new AtomicInteger();
+
+		for (int t = 0; t < threadCount; t++) {
+			final int seed = t;
+			pool.submit(() -> {
+				try {
+					start.await();
+					for (int i = 0; i < roundsPerThread; i++) {
+						String loginId = "user" + ((seed * 31 + i) % loginIdCount);
+						// 절반은 등록(put), 절반은 무효화(invalidate)를 시도하여
+						// put/remove와 순회/조회가 교차되도록 한다.
+						if ((i & 1) == 0) {
+							EgovMultiLoginPreventor.loginUsers.put(loginId, fakeSession(loginId, ignored));
+						} else {
+							EgovMultiLoginPreventor.invalidateByLoginId(loginId);
+						}
+					}
+				} catch (NullPointerException npe) {
+					failed.set(true);
+				} catch (InterruptedException ie) {
+					Thread.currentThread().interrupt();
+				} finally {
+					done.countDown();
+				}
+			});
+		}
+
+		start.countDown();
+		assertTrue(done.await(30, TimeUnit.SECONDS), "테스트가 제한 시간 내에 완료되어야 한다");
+		pool.shutdownNow();
+
+		assertFalse(failed.get(), "동시 제거 중 invalidateByLoginId에서 NPE가 발생하면 안 된다");
+	}
+}

--- a/src/test/java/egovframework/com/utl/slm/EgovMultiLoginPreventorTest.java
+++ b/src/test/java/egovframework/com/utl/slm/EgovMultiLoginPreventorTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.reflect.InvocationHandler;
-import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;


### PR DESCRIPTION
## 변경 이유

`EgovMultiLoginPreventor.invalidateByLoginId(String loginId)`는 `loginUsers`(`ConcurrentHashMap<String, HttpSession>`)의 키를 `Enumeration`으로 전수 순회하면서 `loginId`와 일치하는 키를 찾은 뒤 `loginUsers.get(key).invalidate()`로 다시 조회해 무효화했습니다(수정 전).

`ConcurrentHashMap`의 키 순회는 weakly-consistent하므로, 순회로 키를 발견한 시점과 `get(key)`로 재조회하는 시점 사이에 다른 스레드가 동일 엔트리를 제거하면 `get(key)`가 `null`을 반환합니다. 이때 `null.invalidate()`로 `NullPointerException`이 발생합니다.

이 엔트리 제거는 같은 클래스의 세션 만료 처리(`valueUnbound` 경로에서의 remove)에서 일어나며, 동일 로그인 아이디로 동시 로그인이 발생하는 상황(이 유틸이 막으려는 바로 그 시나리오)에서 순회·재조회·제거가 겹쳐 트리거됩니다.

## 변경 내용

- 맵의 키가 `loginId`이므로 전수 순회 자체가 불필요합니다. 순회를 제거하고 `loginUsers.get(loginId)` 단건 조회로 교체했습니다.
- 조회 결과를 지역변수에 담은 뒤 `null` 가드 후 `invalidate()`를 호출하도록 했습니다. 조회와 사용 사이에 엔트리가 제거되어도 NPE가 발생하지 않습니다.
- 더 이상 사용하지 않는 `java.util.Enumeration` import를 제거했습니다.

키 동등 비교(`key.equals(loginId)`)로 단일 엔트리를 찾던 기존 동작과 결과가 동등하며, 불필요한 전체 순회를 없애 비용도 줄었습니다.

## 테스트 방법

`EgovMultiLoginPreventorTest`를 추가했습니다.

- 16개 스레드가 동일 로그인 아이디에 대해 등록과 `invalidateByLoginId`를 동시에 반복하도록 구성했습니다.
- 수정 전 구현에서는 순회·재조회·제거 경합으로 `NullPointerException`이 재현됩니다.
- 수정 후에는 동일 부하에서 예외 없이 통과하며, 단건 무효화 동작이 정상임을 함께 검증합니다(총 3건).

## 영향 범위

- 대상: `egovframework.com.utl.slm.EgovMultiLoginPreventor.invalidateByLoginId`.
- public static 메서드 시그니처·동작 의미 변경 없음(동일 아이디 세션 무효화). 하위 호환됩니다.
- 외부 의존성·설정 변경 없음.
