### PR TITLE
refactor: uss/umt 사용자관리 보조 VO Lombok @Getter/@Setter 적용

### DIFF
--- a/src/main/java/egovframework/com/uss/umt/service/DeptManageVO.java
+++ b/src/main/java/egovframework/com/uss/umt/service/DeptManageVO.java
@@ -1,50 +1,16 @@
 package egovframework.com.uss.umt.service;
 
 import egovframework.com.cmm.ComDefaultVO;
+import lombok.Getter;
+import lombok.Setter;
 
+@Getter
+@Setter
 public class DeptManageVO extends ComDefaultVO {
 
 	private static final long serialVersionUID = 1L;
 	private String orgnztId;
 	private String orgnztNm;
 	private String orgnztDc;
-	
-	/**
-	 * @return the orgnztId
-	 */
-	public String getOrgnztId() {
-		return orgnztId;
-	}
-	/**
-	 * @param orgnztId the orgnztId to set
-	 */
-	public void setOrgnztId(String orgnztId) {
-		this.orgnztId = orgnztId;
-	}
-	/**
-	 * @return the orgnztNm
-	 */
-	public String getOrgnztNm() {
-		return orgnztNm;
-	}
-	/**
-	 * @param orgnztNm the orgnztNm to set
-	 */
-	public void setOrgnztNm(String orgnztNm) {
-		this.orgnztNm = orgnztNm;
-	}
-	/**
-	 * @return the orgnztDc
-	 */
-	public String getOrgnztDc() {
-		return orgnztDc;
-	}
-	/**
-	 * @param orgnztDc the orgnztDc to set
-	 */
-	public void setOrgnztDc(String orgnztDc) {
-		this.orgnztDc = orgnztDc;
-	}
-	
-	
+
 }

--- a/src/main/java/egovframework/com/uss/umt/service/EmplyrManageInsertVO.java
+++ b/src/main/java/egovframework/com/uss/umt/service/EmplyrManageInsertVO.java
@@ -2,16 +2,20 @@ package egovframework.com.uss.umt.service;
 
 import org.egovframe.rte.ptl.reactive.validation.EgovNullCheck;
 import org.egovframe.rte.ptl.reactive.validation.EgovPwdCheck;
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * 일반회원 등록용 VO 클래스
  * EmplyrManageVO를 상속받아 비밀번호 검증 필드를 추가
- * 
+ *
  * @author 공통서비스
  * @since 2025.12.16
  * @version 1.0
  * @see EmplyrManageVO
  */
+@Getter
+@Setter
 public class EmplyrManageInsertVO extends EmplyrManageVO {
 
 	private static final long serialVersionUID = 1L;
@@ -23,19 +27,4 @@ public class EmplyrManageInsertVO extends EmplyrManageVO {
 	@EgovPwdCheck
 	private String password2;
 
-	/**
-	 * password2 attribute 값을 리턴한다.
-	 * @return String
-	 */
-	public String getPassword2() {
-		return password2;
-	}
-
-	/**
-	 * password2 attribute 값을 설정한다.
-	 * @param password2 String
-	 */
-	public void setPassword2(String password2) {
-		this.password2 = password2;
-	}
 }

--- a/src/main/java/egovframework/com/uss/umt/service/EmplyrPasswordManageVO.java
+++ b/src/main/java/egovframework/com/uss/umt/service/EmplyrPasswordManageVO.java
@@ -1,9 +1,12 @@
 package egovframework.com.uss.umt.service;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * 일반회원 비밀번호 관리 VO 클래스
  * PasswordManageVO를 상속받아 일반회원 관련 필드를 추가
- * 
+ *
  * @author 공통서비스 개발팀 조재영
  * @since 2009.04.10
  * @version 1.0
@@ -20,6 +23,8 @@ package egovframework.com.uss.umt.service;
  *
  * </pre>
  */
+@Getter
+@Setter
 public class EmplyrPasswordManageVO extends PasswordManageVO {
 
 	private static final long serialVersionUID = 1L;
@@ -28,26 +33,10 @@ public class EmplyrPasswordManageVO extends PasswordManageVO {
 	 * 일반회원 ID
 	 */
 	private String emplyrId;
-	
+
 	/**
 	 * 일반회원 PW
 	 */
 	private String emplyrPassword;
-
-	public String getEmplyrId() {
-		return emplyrId;
-	}
-
-	public void setEmplyrId(String emplyrId) {
-		this.emplyrId = emplyrId;
-	}
-
-	public String getEmplyrPassword() {
-		return emplyrPassword;
-	}
-
-	public void setEmplyrPassword(String emplyrPassword) {
-		this.emplyrPassword = emplyrPassword;
-	}
 
 }

--- a/src/main/java/egovframework/com/uss/umt/service/EntrprsManageInsertVO.java
+++ b/src/main/java/egovframework/com/uss/umt/service/EntrprsManageInsertVO.java
@@ -2,16 +2,20 @@ package egovframework.com.uss.umt.service;
 
 import org.egovframe.rte.ptl.reactive.validation.EgovNullCheck;
 import org.egovframe.rte.ptl.reactive.validation.EgovPwdCheck;
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * 기업회원 등록용 VO 클래스
  * EntrprsManageVO를 상속받아 비밀번호 검증 필드를 추가
- * 
+ *
  * @author 공통서비스
  * @since 2025.12.16
  * @version 1.0
  * @see EntrprsManageVO
  */
+@Getter
+@Setter
 public class EntrprsManageInsertVO extends EntrprsManageVO {
 
 	private static final long serialVersionUID = 1L;
@@ -23,19 +27,4 @@ public class EntrprsManageInsertVO extends EntrprsManageVO {
 	@EgovPwdCheck
 	private String password2;
 
-	/**
-	 * password2 attribute 값을 리턴한다.
-	 * @return String
-	 */
-	public String getPassword2() {
-		return password2;
-	}
-
-	/**
-	 * password2 attribute 값을 설정한다.
-	 * @param password2 String
-	 */
-	public void setPassword2(String password2) {
-		this.password2 = password2;
-	}
 }

--- a/src/main/java/egovframework/com/uss/umt/service/EntrprsPasswordManageVO.java
+++ b/src/main/java/egovframework/com/uss/umt/service/EntrprsPasswordManageVO.java
@@ -1,31 +1,22 @@
 package egovframework.com.uss.umt.service;
 
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
 public class EntrprsPasswordManageVO extends PasswordManageVO {
+
+	private static final long serialVersionUID = 1L;
 
 	/**
 	 * 기업 회원 ID
 	 */
 	private String entrprsmberId;
-	
+
 	/**
 	 * 기업 회원 PW
 	 */
 	private String entrprsMberPassword;
-
-	public String getEntrprsMberPassword() {
-		return entrprsMberPassword;
-	}
-
-	public void setEntrprsMberPassword(String entrprsMberPassword) {
-		this.entrprsMberPassword = entrprsMberPassword;
-	}
-
-	public String getEntrprsmberId() {
-		return entrprsmberId;
-	}
-
-	public void setEntrprsmberId(String entrprsmberId) {
-		this.entrprsmberId = entrprsmberId;
-	}
 
 }

--- a/src/main/java/egovframework/com/uss/umt/service/MberManageInsertVO.java
+++ b/src/main/java/egovframework/com/uss/umt/service/MberManageInsertVO.java
@@ -2,16 +2,20 @@ package egovframework.com.uss.umt.service;
 
 import org.egovframe.rte.ptl.reactive.validation.EgovNullCheck;
 import org.egovframe.rte.ptl.reactive.validation.EgovPwdCheck;
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * 일반회원 등록용 VO 클래스
  * MberManageVO를 상속받아 비밀번호 검증 필드를 추가
- * 
+ *
  * @author 공통서비스
  * @since 2025.12.16
  * @version 1.0
  * @see MberManageVO
  */
+@Getter
+@Setter
 public class MberManageInsertVO extends MberManageVO {
 
 	private static final long serialVersionUID = 1L;
@@ -23,19 +27,4 @@ public class MberManageInsertVO extends MberManageVO {
 	@EgovPwdCheck
 	private String password2;
 
-	/**
-	 * password2 attribute 값을 리턴한다.
-	 * @return String
-	 */
-	public String getPassword2() {
-		return password2;
-	}
-
-	/**
-	 * password2 attribute 값을 설정한다.
-	 * @param password2 String
-	 */
-	public void setPassword2(String password2) {
-		this.password2 = password2;
-	}
 }

--- a/src/main/java/egovframework/com/uss/umt/service/MberPasswordManageVO.java
+++ b/src/main/java/egovframework/com/uss/umt/service/MberPasswordManageVO.java
@@ -1,14 +1,19 @@
 package egovframework.com.uss.umt.service;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * 일반회원 비밀번호 관리 VO 클래스
  * PasswordManageVO를 상속받아 일반회원 관련 필드를 추가
- * 
+ *
  * @author 공통서비스
  * @since 2025.12.16
  * @version 1.0
  * @see PasswordManageVO
  */
+@Getter
+@Setter
 public class MberPasswordManageVO extends PasswordManageVO {
 
 	private static final long serialVersionUID = 1L;
@@ -17,26 +22,10 @@ public class MberPasswordManageVO extends PasswordManageVO {
 	 * 일반회원 ID
 	 */
 	private String mberId;
-	
+
 	/**
 	 * 일반회원 PW
 	 */
 	private String mberPassword;
-
-	public String getMberId() {
-		return mberId;
-	}
-
-	public void setMberId(String mberId) {
-		this.mberId = mberId;
-	}
-
-	public String getMberPassword() {
-		return mberPassword;
-	}
-
-	public void setMberPassword(String mberPassword) {
-		this.mberPassword = mberPassword;
-	}
 
 }

--- a/src/main/java/egovframework/com/uss/umt/service/PasswordManageVO.java
+++ b/src/main/java/egovframework/com/uss/umt/service/PasswordManageVO.java
@@ -2,72 +2,37 @@ package egovframework.com.uss.umt.service;
 
 import org.egovframe.rte.ptl.reactive.validation.EgovNullCheck;
 import org.egovframe.rte.ptl.reactive.validation.EgovPwdCheck;
+import lombok.Getter;
+import lombok.Setter;
 
+@Getter
+@Setter
 public class PasswordManageVO {
-	
+
 	private static final long serialVersionUID = -4255594107023139972L;
-	
+
 	/** 이전비밀번호 - 비밀번호 변경시 사용*/
 	@EgovNullCheck
-    private String oldPassword = "";
-	
+	private String oldPassword = "";
+
 	/** 새 비밀번호 - 비밀번호 변경시 사용*/
 	@EgovNullCheck
 	@EgovPwdCheck
-    private String password = "";
+	private String password = "";
 
 	/** 새 비밀번호 확인- 비밀번호 변경시 사용*/
 	@EgovNullCheck
 	@EgovPwdCheck
-    private String password2 = "";
+	private String password2 = "";
 
-    /**
+	/**
 	 * 사용자고유아이디
 	 */
 	private String uniqId = "";
+
 	/**
 	 * 사용자 유형
 	 */
 	private String userTy = "";
-	
-	public String getUserTy() {
-		return userTy;
-	}
-
-	public void setUserTy(String userTy) {
-		this.userTy = userTy;
-	}
-
-	public String getUniqId() {
-		return uniqId;
-	}
-
-	public void setUniqId(String uniqId) {
-		this.uniqId = uniqId;
-	}
-
-	public String getOldPassword() {
-		return oldPassword;
-	}
-
-	public void setOldPassword(String oldPassword) {
-		this.oldPassword = oldPassword;
-	}
-
-	public String getPassword() {
-		return password;
-	}
-
-	public void setPassword(String password) {
-		this.password = password;
-	}
-
-	public String getPassword2() {
-		return password2;
-	}
-
-	public void setPassword2(String password2) {
-		this.password2 = password2;
-	}
 
 }

--- a/src/main/java/egovframework/com/uss/umt/service/StplatVO.java
+++ b/src/main/java/egovframework/com/uss/umt/service/StplatVO.java
@@ -1,6 +1,8 @@
 package egovframework.com.uss.umt.service;
 
 import java.io.Serializable;
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * 가입약관VO클래스로서가입약관확인시 비지니스로직 처리용 항목을 구성한다.
@@ -18,65 +20,19 @@ import java.io.Serializable;
  *
  * </pre>
  */
+@Getter
+@Setter
 public class StplatVO implements Serializable {
 
 	private static final long serialVersionUID = 3744005602026645L;
 
 	/** 약관아이디*/
-    private String useStplatId;
+	private String useStplatId;
 
-    /** 사용약관안내*/
-    private String useStplatCn;
+	/** 사용약관안내*/
+	private String useStplatCn;
 
-    /** 정보동의안내*/
-    private String infoProvdAgeCn;
-
-    /**
-	 * useStplatId attribute 값을  리턴한다.
-	 * @return String
-	 */
-	public String getUseStplatId() {
-		return useStplatId;
-	}
-
-	/**
-	 * useStplatId attribute 값을 설정한다.
-	 * @param useStplatId String
-	 */
-	public void setUseStplatId(String useStplatId) {
-		this.useStplatId = useStplatId;
-	}
-
-	/**
-	 * useStplatCn attribute 값을  리턴한다.
-	 * @return String
-	 */
-	public String getUseStplatCn() {
-		return useStplatCn;
-	}
-
-	/**
-	 * useStplatCn attribute 값을 설정한다.
-	 * @param useStplatCn String
-	 */
-	public void setUseStplatCn(String useStplatCn) {
-		this.useStplatCn = useStplatCn;
-	}
-
-	/**
-	 * infoProvdAgeCn attribute 값을  리턴한다.
-	 * @return String
-	 */
-	public String getInfoProvdAgeCn() {
-		return infoProvdAgeCn;
-	}
-
-	/**
-	 * infoProvdAgeCn attribute 값을 설정한다.
-	 * @param infoProvdAgeCn String
-	 */
-	public void setInfoProvdAgeCn(String infoProvdAgeCn) {
-		this.infoProvdAgeCn = infoProvdAgeCn;
-	}
+	/** 정보동의안내*/
+	private String infoProvdAgeCn;
 
 }

--- a/src/main/java/egovframework/com/uss/umt/service/UserDefaultVO.java
+++ b/src/main/java/egovframework/com/uss/umt/service/UserDefaultVO.java
@@ -1,6 +1,8 @@
 package egovframework.com.uss.umt.service;
 
 import java.io.Serializable;
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * 사용자정보 VO클래스로서일반회원, 기업회원, 업무사용자의  비지니스로직 처리시 기타조건성 항을 구성한다.
@@ -18,200 +20,40 @@ import java.io.Serializable;
  *
  * </pre>
  */
+@Getter
+@Setter
 public class UserDefaultVO implements Serializable {
 
 	private static final long serialVersionUID = 4829684178121022508L;
 
 	/** 검색조건-회원상태     (0, A, D, P)*/
-    private String sbscrbSttus = "0";
+	private String sbscrbSttus = "0";
 
 	/** 검색조건 */
-    private String searchCondition = "";
+	private String searchCondition = "";
 
-    /** 검색Keyword */
-    private String searchKeyword = "";
+	/** 검색Keyword */
+	private String searchKeyword = "";
 
-    /** 검색사용여부 */
-    private String searchUseYn = "";
+	/** 검색사용여부 */
+	private String searchUseYn = "";
 
-    /** 현재페이지 */
-    private int pageIndex = 1;
+	/** 현재페이지 */
+	private int pageIndex = 1;
 
-    /** 페이지개수 */
-    private int pageUnit = 10;
+	/** 페이지개수 */
+	private int pageUnit = 10;
 
-    /** 페이지사이즈 */
-    private int pageSize = 10;
+	/** 페이지사이즈 */
+	private int pageSize = 10;
 
-    /** firstIndex */
-    private int firstIndex = 1;
+	/** firstIndex */
+	private int firstIndex = 1;
 
-    /** lastIndex */
-    private int lastIndex = 1;
+	/** lastIndex */
+	private int lastIndex = 1;
 
-    /** recordCountPerPage */
-    private int recordCountPerPage = 10;
-
-	/**
-	 * sbscrbSttus attribute 값을  리턴한다.
-	 * @return String
-	 */
-	public String getSbscrbSttus() {
-		return sbscrbSttus;
-	}
-
-	/**
-	 * sbscrbSttus attribute 값을 설정한다.
-	 * @param sbscrbSttus String
-	 */
-	public void setSbscrbSttus(String sbscrbSttus) {
-		this.sbscrbSttus = sbscrbSttus;
-	}
-
-	/**
-	 * searchCondition attribute 값을  리턴한다.
-	 * @return String
-	 */
-	public String getSearchCondition() {
-		return searchCondition;
-	}
-
-	/**
-	 * searchCondition attribute 값을 설정한다.
-	 * @param searchCondition String
-	 */
-	public void setSearchCondition(String searchCondition) {
-		this.searchCondition = searchCondition;
-	}
-
-	/**
-	 * searchKeyword attribute 값을  리턴한다.
-	 * @return String
-	 */
-	public String getSearchKeyword() {
-		return searchKeyword;
-	}
-
-	/**
-	 * searchKeyword attribute 값을 설정한다.
-	 * @param searchKeyword String
-	 */
-	public void setSearchKeyword(String searchKeyword) {
-		this.searchKeyword = searchKeyword;
-	}
-
-	/**
-	 * searchUseYn attribute 값을  리턴한다.
-	 * @return String
-	 */
-	public String getSearchUseYn() {
-		return searchUseYn;
-	}
-
-	/**
-	 * searchUseYn attribute 값을 설정한다.
-	 * @param searchUseYn String
-	 */
-	public void setSearchUseYn(String searchUseYn) {
-		this.searchUseYn = searchUseYn;
-	}
-
-	/**
-	 * pageIndex attribute 값을  리턴한다.
-	 * @return int
-	 */
-	public int getPageIndex() {
-		return pageIndex;
-	}
-
-	/**
-	 * pageIndex attribute 값을 설정한다.
-	 * @param pageIndex int
-	 */
-	public void setPageIndex(int pageIndex) {
-		this.pageIndex = pageIndex;
-	}
-
-	/**
-	 * pageUnit attribute 값을  리턴한다.
-	 * @return int
-	 */
-	public int getPageUnit() {
-		return pageUnit;
-	}
-
-	/**
-	 * pageUnit attribute 값을 설정한다.
-	 * @param pageUnit int
-	 */
-	public void setPageUnit(int pageUnit) {
-		this.pageUnit = pageUnit;
-	}
-
-	/**
-	 * pageSize attribute 값을  리턴한다.
-	 * @return int
-	 */
-	public int getPageSize() {
-		return pageSize;
-	}
-
-	/**
-	 * pageSize attribute 값을 설정한다.
-	 * @param pageSize int
-	 */
-	public void setPageSize(int pageSize) {
-		this.pageSize = pageSize;
-	}
-
-	/**
-	 * firstIndex attribute 값을  리턴한다.
-	 * @return int
-	 */
-	public int getFirstIndex() {
-		return firstIndex;
-	}
-
-	/**
-	 * firstIndex attribute 값을 설정한다.
-	 * @param firstIndex int
-	 */
-	public void setFirstIndex(int firstIndex) {
-		this.firstIndex = firstIndex;
-	}
-
-	/**
-	 * lastIndex attribute 값을  리턴한다.
-	 * @return int
-	 */
-	public int getLastIndex() {
-		return lastIndex;
-	}
-
-	/**
-	 * lastIndex attribute 값을 설정한다.
-	 * @param lastIndex int
-	 */
-	public void setLastIndex(int lastIndex) {
-		this.lastIndex = lastIndex;
-	}
-
-	/**
-	 * recordCountPerPage attribute 값을  리턴한다.
-	 * @return int
-	 */
-	public int getRecordCountPerPage() {
-		return recordCountPerPage;
-	}
-
-	/**
-	 * recordCountPerPage attribute 값을 설정한다.
-	 * @param recordCountPerPage int
-	 */
-	public void setRecordCountPerPage(int recordCountPerPage) {
-		this.recordCountPerPage = recordCountPerPage;
-	}
-
-
+	/** recordCountPerPage */
+	private int recordCountPerPage = 10;
 
 }


### PR DESCRIPTION
## 개요

uss/umt(사용자관리) 모듈의 보조 VO 10개를 Lombok `@Getter`/`@Setter`로 정리합니다. 순수 위임 접근자만 정리했으며 동작은 동일합니다.

## 변경 사항

- `DeptManageVO`, `EmplyrManageInsertVO`, `EmplyrPasswordManageVO`, `EntrprsManageInsertVO`, `EntrprsPasswordManageVO`, `MberManageInsertVO`, `MberPasswordManageVO`, `PasswordManageVO`, `StplatVO`, `UserDefaultVO`
- 단순 위임 접근자 제거 후 `@Getter @Setter` 적용. 필드의 검증 어노테이션(`@EgovNullCheck`·`@EgovPwdCheck` 등)은 그대로 유지.

## 검증
- JDK 17 환경 `mvn -DskipTests compile` BUILD SUCCESS
- 기존 VO Lombok 적용 사례(#799~#834 등)와 동일 패턴
