### PR TITLE
refactor: uss/utl/cmm 소규모 모듈 VO Lombok @Getter/@Setter 적용

### DIFF
--- a/src/main/java/egovframework/com/uss/cmt/service/CmtDefaultVO.java
+++ b/src/main/java/egovframework/com/uss/cmt/service/CmtDefaultVO.java
@@ -2,6 +2,9 @@ package egovframework.com.uss.cmt.service;
 
 import java.io.Serializable;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * 출퇴근관리 VO 클래스
  * @author 표준프레임워크센터 개발팀
@@ -18,6 +21,8 @@ import java.io.Serializable;
  *
  * </pre>
  */
+@Getter
+@Setter
 public class CmtDefaultVO implements Serializable {
 
 	private static final long serialVersionUID = -2782974258506027986L;
@@ -48,170 +53,5 @@ public class CmtDefaultVO implements Serializable {
 
     /** recordCountPerPage */
     private int recordCountPerPage = 10;
-
-
-	/**
-	 * searchCondition attribute 값을  리턴한다.
-	 * 
-	 * @return String
-	 */
-	public String getSearchCondition() {
-		return searchCondition;
-	}
-
-	/**
-	 * searchCondition attribute 값을 설정한다.
-	 * 
-	 * @param searchCondition String
-	 */
-	public void setSearchCondition(String searchCondition) {
-		this.searchCondition = searchCondition;
-	}
-
-	/**
-	 * searchKeyword attribute 값을  리턴한다.
-	 * 
-	 * @return String
-	 */
-	public String getSearchKeyword() {
-		return searchKeyword;
-	}
-
-	/**
-	 * searchKeyword attribute 값을 설정한다.
-	 * 
-	 * @param searchKeyword String
-	 */
-	public void setSearchKeyword(String searchKeyword) {
-		this.searchKeyword = searchKeyword;
-	}
-
-	/**
-	 * searchUseYn attribute 값을  리턴한다.
-	 * 
-	 * @return String
-	 */
-	public String getSearchUseYn() {
-		return searchUseYn;
-	}
-
-	/**
-	 * searchUseYn attribute 값을 설정한다.
-	 * 
-	 * @param searchUseYn String
-	 */
-	public void setSearchUseYn(String searchUseYn) {
-		this.searchUseYn = searchUseYn;
-	}
-
-	/**
-	 * pageIndex attribute 값을  리턴한다.
-	 * 
-	 * @return int
-	 */
-	public int getPageIndex() {
-		return pageIndex;
-	}
-
-	/**
-	 * pageIndex attribute 값을 설정한다.
-	 * 
-	 * @param pageIndex int
-	 */
-	public void setPageIndex(int pageIndex) {
-		this.pageIndex = pageIndex;
-	}
-
-	/**
-	 * pageUnit attribute 값을  리턴한다.
-	 * 
-	 * @return int
-	 */
-	public int getPageUnit() {
-		return pageUnit;
-	}
-
-	/**
-	 * pageUnit attribute 값을 설정한다.
-	 * 
-	 * @param pageUnit int
-	 */
-	public void setPageUnit(int pageUnit) {
-		this.pageUnit = pageUnit;
-	}
-
-	/**
-	 * pageSize attribute 값을  리턴한다.
-	 * 
-	 * @return int
-	 */
-	public int getPageSize() {
-		return pageSize;
-	}
-
-	/**
-	 * pageSize attribute 값을 설정한다.
-	 * 
-	 * @param pageSize int
-	 */
-	public void setPageSize(int pageSize) {
-		this.pageSize = pageSize;
-	}
-
-	/**
-	 * firstIndex attribute 값을  리턴한다.
-	 * 
-	 * @return int
-	 */
-	public int getFirstIndex() {
-		return firstIndex;
-	}
-
-	/**
-	 * firstIndex attribute 값을 설정한다.
-	 * 
-	 * @param firstIndex int
-	 */
-	public void setFirstIndex(int firstIndex) {
-		this.firstIndex = firstIndex;
-	}
-
-	/**
-	 * lastIndex attribute 값을  리턴한다.
-	 * 
-	 * @return int
-	 */
-	public int getLastIndex() {
-		return lastIndex;
-	}
-
-	/**
-	 * lastIndex attribute 값을 설정한다.
-	 * 
-	 * @param lastIndex int
-	 */
-	public void setLastIndex(int lastIndex) {
-		this.lastIndex = lastIndex;
-	}
-
-	/**
-	 * recordCountPerPage attribute 값을  리턴한다.
-	 * 
-	 * @return int
-	 */
-	public int getRecordCountPerPage() {
-		return recordCountPerPage;
-	}
-
-	/**
-	 * recordCountPerPage attribute 값을 설정한다.
-	 * 
-	 * @param recordCountPerPage int
-	 */
-	public void setRecordCountPerPage(int recordCountPerPage) {
-		this.recordCountPerPage = recordCountPerPage;
-	}
-
-
 
 }

--- a/src/main/java/egovframework/com/uss/cmt/service/CmtManageVO.java
+++ b/src/main/java/egovframework/com/uss/cmt/service/CmtManageVO.java
@@ -3,9 +3,12 @@ package egovframework.com.uss.cmt.service;
 import java.io.Serializable;
 import java.util.List;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * 출퇴근관리 VO 클래스
- * 
+ *
  * @author 표준프레임워크센터 개발팀
  * @since 2014.12.20
  * @version 1.0
@@ -21,6 +24,8 @@ import java.util.List;
  *
  *      </pre>
  */
+@Getter
+@Setter
 public class CmtManageVO implements Serializable {
 
 	/**
@@ -38,63 +43,14 @@ public class CmtManageVO implements Serializable {
 	/** 댓글 관리 목록 */
 	private List<CmtManageVO> cmtManageList;
 
-	/**
-	 * @return 댓글 관리 목록을 반환합니다.
-	 */
-	public List<CmtManageVO> getCmtManageList() {
-		return cmtManageList;
-	}
-
-	/**
-	 * @param cmtManageList 설정할 댓글 관리 목록
-	 */
-	public void setCmtManageList(List<CmtManageVO> cmtManageList) {
-		this.cmtManageList = cmtManageList;
-	}
-
 	/** 사용자 이름 문자열 */
 	private String userNmString;
-
-	/**
-	 * @return 사용자 이름 문자열을 반환합니다.
-	 */
-	public String getUserNmString() {
-		return userNmString;
-	}
-
-	/**
-	 * @param userNmString 설정할 사용자 이름 문자열
-	 */
-	public void setUserNmString(String userNmString) {
-		this.userNmString = userNmString;
-	}
 
 	/** 사용자 식별자 */
 	private String usid;
 
-	/**
-	 * @return 사용자 식별자를 반환합니다.
-	 */
-	public String getUsid() {
-		return usid;
-	}
-
-	/**
-	 * @param usid 설정할 사용자 식별자
-	 */
-	public void setUsid(String usid) {
-		this.usid = usid;
-	}
-
 	/** 작업 시작 상태 */
 	private String wrkStartStatus;
-
-	/**
-	 * @return 작업 시작 상태를 반환합니다.
-	 */
-	public String getWrkStartStatus() {
-		return wrkStartStatus;
-	}
 
 	/**
 	 * @param workStartStatus 설정할 작업 시작 상태
@@ -107,13 +63,6 @@ public class CmtManageVO implements Serializable {
 	private String wrkEndStatus;
 
 	/**
-	 * @return 작업 종료 상태를 반환합니다.
-	 */
-	public String getWrkEndStatus() {
-		return wrkEndStatus;
-	}
-
-	/**
 	 * @param workEndStatus 설정할 작업 종료 상태
 	 */
 	public void setWrkEndStatus(String workEndStatus) {
@@ -123,29 +72,8 @@ public class CmtManageVO implements Serializable {
 	/** 날짜 */
 	private String date;
 
-	/**
-	 * @return 날짜를 반환합니다.
-	 */
-	public String getDate() {
-		return date;
-	}
-
-	/**
-	 * @param date 설정할 날짜
-	 */
-	public void setDate(String date) {
-		this.date = date;
-	}
-
 	/** 작업 시간 */
 	private String wrkHours;
-
-	/**
-	 * @return 작업 시간을 반환합니다.
-	 */
-	public String getWrkHours() {
-		return wrkHours;
-	}
 
 	/**
 	 * @param workHours 설정할 작업 시간
@@ -157,137 +85,25 @@ public class CmtManageVO implements Serializable {
 	/** 작업 시간 ID */
 	private String wrktmId;
 
-	/**
-	 * @return 작업 시간 ID를 반환합니다.
-	 */
-	public String getWrktmId() {
-		return wrktmId;
-	}
-
-	/**
-	 * @param wrktmId 설정할 작업 시간 ID
-	 */
-	public void setWrktmId(String wrktmId) {
-		this.wrktmId = wrktmId;
-	}
-
 	/** 작업 시작 시간 */
 	private String wrkStartTime;
-
-	/**
-	 * @return 작업 시작 시간을 반환합니다.
-	 */
-	public String getWrkStartTime() {
-		return wrkStartTime;
-	}
-
-	/**
-	 * @param wrkStartTime 설정할 작업 시작 시간
-	 */
-	public void setWrkStartTime(String wrkStartTime) {
-		this.wrkStartTime = wrkStartTime;
-	}
 
 	/** 작업 종료 시간 */
 	private String wrkEndTime;
 
-	/**
-	 * @return 작업 종료 시간을 반환합니다.
-	 */
-	public String getWrkEndTime() {
-		return wrkEndTime;
-	}
-
-	/**
-	 * @param wrkEndTime 설정할 작업 종료 시간
-	 */
-	public void setWrkEndTime(String wrkEndTime) {
-		this.wrkEndTime = wrkEndTime;
-	}
-
 	/** 초과 작업 시간 */
 	private String ovtmwrkHours;
-
-	/**
-	 * @return 초과 작업 시간을 반환합니다.
-	 */
-	public String getOvtmwrkHours() {
-		return ovtmwrkHours;
-	}
-
-	/**
-	 * @param ovtmwrkHours 설정할 초과 작업 시간
-	 */
-	public void setOvtmwrkHours(String ovtmwrkHours) {
-		this.ovtmwrkHours = ovtmwrkHours;
-	}
 
 	/** 비고 */
 	private String rm;
 
-	/**
-	 * @return 비고를 반환합니다.
-	 */
-	public String getRm() {
-		return rm;
-	}
-
-	/**
-	 * @param rm 설정할 비고
-	 */
-	public void setRm(String rm) {
-		this.rm = rm;
-	}
-
 	/** 직원 ID */
 	private String emplyrId;
-
-	/**
-	 * @return 직원 ID를 반환합니다.
-	 */
-	public String getEmplyrId() {
-		return emplyrId;
-	}
-
-	/**
-	 * @param emplyrId 설정할 직원 ID
-	 */
-	public void setEmplyrId(String emplyrId) {
-		this.emplyrId = emplyrId;
-	}
 
 	/** 조직 ID */
 	private String orgnztId;
 
-	/**
-	 * @return 조직 ID를 반환합니다.
-	 */
-	public String getOrgnztId() {
-		return orgnztId;
-	}
-
-	/**
-	 * @param orgnztId 설정할 조직 ID
-	 */
-	public void setOrgnztId(String orgnztId) {
-		this.orgnztId = orgnztId;
-	}
-
 	/** 작업 날짜 */
 	private String wrktDt;
-
-	/**
-	 * @return 작업 날짜를 반환합니다.
-	 */
-	public String getWrktDt() {
-		return wrktDt;
-	}
-
-	/**
-	 * @param wrktDt 설정할 작업 날짜
-	 */
-	public void setWrktDt(String wrktDt) {
-		this.wrktDt = wrktDt;
-	}
 
 }

--- a/src/main/java/egovframework/com/uss/ion/rwd/service/RwardManageVO.java
+++ b/src/main/java/egovframework/com/uss/ion/rwd/service/RwardManageVO.java
@@ -3,6 +3,9 @@ package egovframework.com.uss.ion.rwd.service;
 import java.io.Serializable;
 import java.util.List;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * 개요
  * - 포상관리에 대한 Vo 클래스를 정의한다.
@@ -13,30 +16,19 @@ import java.util.List;
  * @version 1.0
  * @created 06-15-2010 오후 2:08:56
  */
-
+@Getter
+@Setter
 public class RwardManageVO extends RwardManage implements Serializable {
 
 	/**
 	 * serialVersionUID
 	 */
 	private static final long serialVersionUID = 1L;
+
 	/**
 	 * 포상자 목록
 	 */
 	List<RwardManageVO> rwardManageList;
-
-	/**
-	 * @return the rwardManageList
-	 */
-	public List<RwardManageVO> getRwardManageList() {
-		return rwardManageList;
-	}
-	/**
-	 * @param RwardManage the rwardManage to set
-	 */
-	public void setRwardManageList(List<RwardManageVO> rwardManageList) {
-		this.rwardManageList = rwardManageList;
-	}
 
 	/**
 	*  포상자명
@@ -93,139 +85,4 @@ public class RwardManageVO extends RwardManage implements Serializable {
 	*/
 	private String searchFromDateView;
 
-
-	/**
-	 * @return the searchToDateView
-	 */
-	public String getSearchToDateView() {
-		return searchToDateView;
-	}
-	/**
-	 * @param searchToDateView the searchToDateView to set
-	 */
-	public void setSearchToDateView(String searchToDateView) {
-		this.searchToDateView = searchToDateView;
-	}
-	/**
-	 * @return the searchFromDateView
-	 */
-	public String getSearchFromDateView() {
-		return searchFromDateView;
-	}
-	/**
-	 * @param searchFromDateView the searchFromDateView to set
-	 */
-	public void setSearchFromDateView(String searchFromDateView) {
-		this.searchFromDateView = searchFromDateView;
-	}
-
-
-	/**
-	 * @return the rwardManNm
-	 */
-	public String getRwardManNm() {
-		return rwardManNm;
-	}
-	/**
-	 * @param rwardManNm the rwardManNm to set
-	 */
-	public void setRwardManNm(String rwardManNm) {
-		this.rwardManNm = rwardManNm;
-	}
-	/**
-	 * @return the sanctnerNm
-	 */
-	public String getSanctnerNm() {
-		return sanctnerNm;
-	}
-	/**
-	 * @param sanctnerNm the sanctnerNm to set
-	 */
-	public void setSanctnerNm(String sanctnerNm) {
-		this.sanctnerNm = sanctnerNm;
-	}
-	/**
-	 * @return the rwardCdNm
-	 */
-	public String getRwardCdNm() {
-		return rwardCdNm;
-	}
-	/**
-	 * @param rwardCdNm the rwardCdNm to set
-	 */
-	public void setRwardCdNm(String rwardCdNm) {
-		this.rwardCdNm = rwardCdNm;
-	}
-	/**
-	 * @return the orgnztNm
-	 */
-	public String getOrgnztNm() {
-		return orgnztNm;
-	}
-	/**
-	 * @param orgnztNm the orgnztNm to set
-	 */
-	public void setOrgnztNm(String orgnztNm) {
-		this.orgnztNm = orgnztNm;
-	}
-	/**
-	 * @return the sanctnerOrgnztNm
-	 */
-	public String getSanctnerOrgnztNm() {
-		return sanctnerOrgnztNm;
-	}
-	/**
-	 * @param sanctnerOrgnztNm the sanctnerOrgnztNm to set
-	 */
-	public void setSanctnerOrgnztNm(String sanctnerOrgnztNm) {
-		this.sanctnerOrgnztNm = sanctnerOrgnztNm;
-	}
-	/**
-	 * @return the searchFromDate
-	 */
-	public String getSearchFromDate() {
-		return searchFromDate;
-	}
-	/**
-	 * @param searchFromDate the searchFromDate to set
-	 */
-	public void setSearchFromDate(String searchFromDate) {
-		this.searchFromDate = searchFromDate;
-	}
-	/**
-	 * @return the searchToDate
-	 */
-	public String getSearchToDate() {
-		return searchToDate;
-	}
-	/**
-	 * @param searchToDate the searchToDate to set
-	 */
-	public void setSearchToDate(String searchToDate) {
-		this.searchToDate = searchToDate;
-	}
-	/**
-	 * @return the searchNm
-	 */
-	public String getSearchNm() {
-		return searchNm;
-	}
-	/**
-	 * @param searchNm the searchNm to set
-	 */
-	public void setSearchNm(String searchNm) {
-		this.searchNm = searchNm;
-	}
-	/**
-	 * @return the searchConfmAt
-	 */
-	public String getSearchConfmAt() {
-		return searchConfmAt;
-	}
-	/**
-	 * @param searchConfmAt the searchConfmAt to set
-	 */
-	public void setSearchConfmAt(String searchConfmAt) {
-		this.searchConfmAt = searchConfmAt;
-	}
 }

--- a/src/main/java/egovframework/com/uss/ion/vct/service/VcatnManageVO.java
+++ b/src/main/java/egovframework/com/uss/ion/vct/service/VcatnManageVO.java
@@ -4,6 +4,8 @@ import java.util.List;
 
 import egovframework.com.cmm.ComDefaultVO;
 
+import lombok.Getter;
+import lombok.Setter;
 import org.egovframe.rte.ptl.reactive.validation.EgovNullCheck;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
@@ -19,116 +21,116 @@ import jakarta.validation.constraints.Size;
  * @version 1.0
  * @created 06-15-2010 오후 2:08:56
  */
-
+@Getter
+@Setter
 public class VcatnManageVO extends ComDefaultVO {
 
 	/**
 	 * serialVersionUID
 	 */
 	private static final long serialVersionUID = 1L;
-	
+
 	/**
-	*  신청자ID	      
-	*/ 
+	*  신청자ID
+	*/
 	private String applcntId;
 
 	/**
-	*  휴가구분	      
-	*/ 
+	*  휴가구분
+	*/
 	@EgovNullCheck
 	private String vcatnSe;
 
 	/**
 	*  시작일자
-	*/ 
+	*/
 	@EgovNullCheck
 	@Size(max = 8)
 	private String bgnde;
 
 	/**
-	*  종료일자	      
-	*/ 
+	*  종료일자
+	*/
 	@EgovNullCheck
 	@Size(max = 8)
 	private String endde;
-	
+
 	/**
-	*  신청일자	      
-	*/ 
+	*  신청일자
+	*/
 	private String reqstDe;
 
 	/**
-	*  휴가사유	      
-	*/ 
+	*  휴가사유
+	*/
 	@EgovNullCheck
 	@Size(max = 200)
 	private String vcatnResn;
-	
+
 	/**
-	*  발생연도	      
-	*/ 
+	*  발생연도
+	*/
 	private String occrrncYear;
 
 	/**
-	*  정오구분	      
-	*/ 
+	*  정오구분
+	*/
 	private String noonSe;
-	
+
 	/**
-	*  결재자ID	      
-	*/ 
+	*  결재자ID
+	*/
 	@NotBlank(message = "{comUssIonVct.vcatnManage.validate.sanctnerId.required}")
 	private String sanctnerId;
 
 	/**
-	*  승인여부	      
-	*/ 
+	*  승인여부
+	*/
 	private String confmAt;
 
 	/**
-	*  결재일시	      
-	*/ 
+	*  결재일시
+	*/
 	private String sanctnDt;
 
 	/**
-	*  반려사유	      
-	*/ 
+	*  반려사유
+	*/
 	private String returnResn;
 
 	/**
-	*  약식결재ID	      
-	*/ 
-	private String infrmlSanctnId;	
-	
-	
+	*  약식결재ID
+	*/
+	private String infrmlSanctnId;
+
 	/**
-	*  최초등록자ID	
-	*/ 
+	*  최초등록자ID
+	*/
 	private String frstRegisterId;
 
 	/**
-	*  최초등록시점	
-	*/ 
+	*  최초등록시점
+	*/
 	private String frstRegisterPnttm;
 
 	/**
-	*  최종수정자ID	
-	*/ 
+	*  최종수정자ID
+	*/
 	private String lastUpdusrId;
 
 	/**
-	*  최종수정시점	
-	*/ 
+	*  최종수정시점
+	*/
 	private String lastUpdusrPnttm;
 
 	/**
 	*  sanctnDtNm (승인권자 표시용)
-	*/ 
+	*/
 	private String sanctnDtNm;
-	
+
 	/**
-	*  orgnztNm	
-	*/ 
+	*  orgnztNm
+	*/
 	private String orgnztNm;
 
 	/**
@@ -216,7 +218,6 @@ public class VcatnManageVO extends ComDefaultVO {
 	*/
 	private String tempOrgnztNm;
 
-
 	/**
 	*  신청자ID
 	*/
@@ -237,525 +238,4 @@ public class VcatnManageVO extends ComDefaultVO {
 	*/
 	private String enddeKey;
 
-	/**
-	 * @return the sanctnDtNm
-	 */
-	public String getSanctnDtNm() {
-		return sanctnDtNm;
-	}
-
-	/**
-	 * @param sanctnDtNm the sanctnDtNm to set
-	 */
-	public void setSanctnDtNm(String sanctnDtNm) {
-		this.sanctnDtNm = sanctnDtNm;
-	}
-
-	/**
-	 * @return the orgnztNm
-	 */
-	public String getOrgnztNm() {
-		return orgnztNm;
-	}
-
-	/**
-	 * @param orgnztNm the orgnztNm to set
-	 */
-	public void setOrgnztNm(String orgnztNm) {
-		this.orgnztNm = orgnztNm;
-	}
-
-	/**
-	 * @return the applcntId
-	 */
-	public String getApplcntId() {
-		return applcntId;
-	}
-
-	/**
-	 * @param applcntId the applcntId to set
-	 */
-	public void setApplcntId(String applcntId) {
-		this.applcntId = applcntId;
-	}
-
-	/**
-	 * @return the vcatnSe
-	 */
-	public String getVcatnSe() {
-		return vcatnSe;
-	}
-
-	/**
-	 * @param vcatnSe the vcatnSe to set
-	 */
-	public void setVcatnSe(String vcatnSe) {
-		this.vcatnSe = vcatnSe;
-	}
-
-	/**
-	 * @return the bgnde
-	 */
-	public String getBgnde() {
-		return bgnde;
-	}
-
-	/**
-	 * @param bgnde the bgnde to set
-	 */
-	public void setBgnde(String bgnde) {
-		this.bgnde = bgnde;
-	}
-
-	/**
-	 * @return the endde
-	 */
-	public String getEndde() {
-		return endde;
-	}
-
-	/**
-	 * @param endde the endde to set
-	 */
-	public void setEndde(String endde) {
-		this.endde = endde;
-	}
-
-	/**
-	 * @return the reqstDe
-	 */
-	public String getReqstDe() {
-		return reqstDe;
-	}
-
-	/**
-	 * @param reqstDe the reqstDe to set
-	 */
-	public void setReqstDe(String reqstDe) {
-		this.reqstDe = reqstDe;
-	}
-
-	/**
-	 * @return the vcatnResn
-	 */
-	public String getVcatnResn() {
-		return vcatnResn;
-	}
-
-	/**
-	 * @param vcatnResn the vcatnResn to set
-	 */
-	public void setVcatnResn(String vcatnResn) {
-		this.vcatnResn = vcatnResn;
-	}
-
-	/**
-	 * @return the occrrncYear
-	 */
-	public String getOccrrncYear() {
-		return occrrncYear;
-	}
-
-	/**
-	 * @param occrrncYear the occrrncYear to set
-	 */
-	public void setOccrrncYear(String occrrncYear) {
-		this.occrrncYear = occrrncYear;
-	}
-
-	/**
-	 * @return the sanctnerId
-	 */
-	public String getSanctnerId() {
-		return sanctnerId;
-	}
-
-	/**
-	 * @param sanctnerId the sanctnerId to set
-	 */
-	public void setSanctnerId(String sanctnerId) {
-		this.sanctnerId = sanctnerId;
-	}
-
-	/**
-	 * @return the confmAt
-	 */
-	public String getConfmAt() {
-		return confmAt;
-	}
-
-	/**
-	 * @param confmAt the confmAt to set
-	 */
-	public void setConfmAt(String confmAt) {
-		this.confmAt = confmAt;
-	}
-
-	/**
-	 * @return the sanctnDt
-	 */
-	public String getSanctnDt() {
-		return sanctnDt;
-	}
-
-	/**
-	 * @param sanctnDt the sanctnDt to set
-	 */
-	public void setSanctnDt(String sanctnDt) {
-		this.sanctnDt = sanctnDt;
-	}
-
-	/**
-	 * @return the returnResn
-	 */
-	public String getReturnResn() {
-		return returnResn;
-	}
-
-	/**
-	 * @param returnResn the returnResn to set
-	 */
-	public void setReturnResn(String returnResn) {
-		this.returnResn = returnResn;
-	}
-
-	/**
-	 * @return the infrmlSanctnId
-	 */
-	public String getInfrmlSanctnId() {
-		return infrmlSanctnId;
-	}
-
-	/**
-	 * @param infrmlSanctnId the infrmlSanctnId to set
-	 */
-	public void setInfrmlSanctnId(String infrmlSanctnId) {
-		this.infrmlSanctnId = infrmlSanctnId;
-	}
-
-	/**
-	 * @return the frstRegisterId
-	 */
-	public String getFrstRegisterId() {
-		return frstRegisterId;
-	}
-
-	/**
-	 * @param frstRegisterId the frstRegisterId to set
-	 */
-	public void setFrstRegisterId(String frstRegisterId) {
-		this.frstRegisterId = frstRegisterId;
-	}
-
-	/**
-	 * @return the frstRegisterPnttm
-	 */
-	public String getFrstRegisterPnttm() {
-		return frstRegisterPnttm;
-	}
-
-	/**
-	 * @param frstRegisterPnttm the frstRegisterPnttm to set
-	 */
-	public void setFrstRegisterPnttm(String frstRegisterPnttm) {
-		this.frstRegisterPnttm = frstRegisterPnttm;
-	}
-
-	/**
-	 * @return the lastUpdusrId
-	 */
-	public String getLastUpdusrId() {
-		return lastUpdusrId;
-	}
-
-	/**
-	 * @param lastUpdusrId the lastUpdusrId to set
-	 */
-	public void setLastUpdusrId(String lastUpdusrId) {
-		this.lastUpdusrId = lastUpdusrId;
-	}
-
-	/**
-	 * @return the lastUpdusrPnttm
-	 */
-	public String getLastUpdusrPnttm() {
-		return lastUpdusrPnttm;
-	}
-
-	/**
-	 * @param lastUpdusrPnttm the lastUpdusrPnttm to set
-	 */
-	public void setLastUpdusrPnttm(String lastUpdusrPnttm) {
-		this.lastUpdusrPnttm = lastUpdusrPnttm;
-	}
-
-	/**
-	 * @return the noonSe
-	 */
-	public String getNoonSe() {
-		return noonSe;
-	}
-
-	/**
-	 * @param noonSe the noonSe to set
-	 */
-	public void setNoonSe(String noonSe) {
-		this.noonSe = noonSe;
-	}
-
-	/**
-	 * @return the tempUsNm
-	 */
-	public String getTempUsNm() {
-		return tempUsNm;
-	}
-	/**
-	 * @param tempUsNm the tempUsNm to set
-	 */
-	public void setTempUsNm(String tempUsNm) {
-		this.tempUsNm = tempUsNm;
-	}
-	/**
-	 * @return the tempOrgnztNm
-	 */
-	public String getTempOrgnztNm() {
-		return tempOrgnztNm;
-	}
-	/**
-	 * @param tempOrgnztNm the tempOrgnztNm to set
-	 */
-	public void setTempOrgnztNm(String tempOrgnztNm) {
-		this.tempOrgnztNm = tempOrgnztNm;
-	}
-	/**
-	 * @return the tempBgnde
-	 */
-	public String getTempBgnde() {
-		return tempBgnde;
-	}
-	/**
-	 * @param tempBgnde the tempBgnde to set
-	 */
-	public void setTempBgnde(String tempBgnde) {
-		this.tempBgnde = tempBgnde;
-	}
-	/**
-	 * @return the tempEndde
-	 */
-	public String getTempEndde() {
-		return tempEndde;
-	}
-	/**
-	 * @param tempEndde the tempEndde to set
-	 */
-	public void setTempEndde(String tempEndde) {
-		this.tempEndde = tempEndde;
-	}
-	/**
-	 * @return the vcatnManageList
-	 */
-	public List<VcatnManageVO> getVcatnManageList() {
-		return vcatnManageList;
-	}
-	/**
-	 * @param vcatnManageList the vcatnManageList to set
-	 */
-	public void setVcatnManageList(List<VcatnManageVO> vcatnManageList) {
-		this.vcatnManageList = vcatnManageList;
-	}
-	/**
-	 * @return the applcntNm
-	 */
-	public String getApplcntNm() {
-		return applcntNm;
-	}
-	/**
-	 * @param applcntNm the applcntNm to set
-	 */
-	public void setApplcntNm(String applcntNm) {
-		this.applcntNm = applcntNm;
-	}
-	/**
-	 * @return the sanctnerNm
-	 */
-	public String getSanctnerNm() {
-		return sanctnerNm;
-	}
-
-	/**
-	 * @param sanctnerNm the sanctnerNm to set
-	 */
-	public void setSanctnerNm(String sanctnerNm) {
-		this.sanctnerNm = sanctnerNm;
-	}
-
-	/**
-	 * @return the vcatnSeNm
-	 */
-	public String getVcatnSeNm() {
-		return vcatnSeNm;
-	}
-	/**
-	 * @param vcatnSeNm the vcatnSeNm to set
-	 */
-	public void setVcatnSeNm(String vcatnSeNm) {
-		this.vcatnSeNm = vcatnSeNm;
-	}
-	/**
-	 * @return the usid
-	 */
-	public String getUsid() {
-		return usid;
-	}
-	/**
-	 * @param usid the usid to set
-	 */
-	public void setUsid(String usid) {
-		this.usid = usid;
-	}
-
-	/**
-	 * @return the sanctnerOrgnztNm
-	 */
-	public String getSanctnerOrgnztNm() {
-		return sanctnerOrgnztNm;
-	}
-	/**
-	 * @param sanctnerOrgnztNm the sanctnerOrgnztNm to set
-	 */
-	public void setSanctnerOrgnztNm(String sanctnerOrgnztNm) {
-		this.sanctnerOrgnztNm = sanctnerOrgnztNm;
-	}
-	/**
-	 * @return the occrncYrycCo
-	 */
-	public double getOccrncYrycCo() {
-		return occrncYrycCo;
-	}
-	/**
-	 * @param occrncYrycCo the occrncYrycCo to set
-	 */
-	public void setOccrncYrycCo(double occrncYrycCo) {
-		this.occrncYrycCo = occrncYrycCo;
-	}
-	/**
-	 * @return the useYrycCo
-	 */
-	public double getUseYrycCo() {
-		return useYrycCo;
-	}
-	/**
-	 * @param useYrycCo the useYrycCo to set
-	 */
-	public void setUseYrycCo(double useYrycCo) {
-		this.useYrycCo = useYrycCo;
-	}
-	/**
-	 * @return the remndrYrycCo
-	 */
-	public double getRemndrYrycCo() {
-		return remndrYrycCo;
-	}
-	/**
-	 * @param remndrYrycCo the remndrYrycCo to set
-	 */
-	public void setRemndrYrycCo(double remndrYrycCo) {
-		this.remndrYrycCo = remndrYrycCo;
-	}
-	/**
-	 * @return the searchYear
-	 */
-	public String getSearchYear() {
-		return searchYear;
-	}
-	/**
-	 * @param searchYear the searchYear to set
-	 */
-	public void setSearchYear(String searchYear) {
-		this.searchYear = searchYear;
-	}
-	/**
-	 * @return the searchMonth
-	 */
-	public String getSearchMonth() {
-		return searchMonth;
-	}
-	/**
-	 * @param searchMonth the searchMonth to set
-	 */
-	public void setSearchMonth(String searchMonth) {
-		this.searchMonth = searchMonth;
-	}
-	/**
-	 * @return the searchNm
-	 */
-	public String getSearchNm() {
-		return searchNm;
-	}
-	/**
-	 * @param searchNm the searchNm to set
-	 */
-	public void setSearchNm(String searchNm) {
-		this.searchNm = searchNm;
-	}
-	/**
-	 * @return the searchConfmAt
-	 */
-	public String getSearchConfmAt() {
-		return searchConfmAt;
-	}
-	/**
-	 * @param searchConfmAt the searchConfmAt to set
-	 */
-	public void setSearchConfmAt(String searchConfmAt) {
-		this.searchConfmAt = searchConfmAt;
-	}
-	/**
-	 * @return the applcntIdKey
-	 */
-	public String getApplcntIdKey() {
-		return applcntIdKey;
-	}
-	/**
-	 * @param applcntIdKey the applcntIdKey to set
-	 */
-	public void setApplcntIdKey(String applcntIdKey) {
-		this.applcntIdKey = applcntIdKey;
-	}
-	/**
-	 * @return the vcatnSeKey
-	 */
-	public String getVcatnSeKey() {
-		return vcatnSeKey;
-	}
-	/**
-	 * @param vcatnSeKey the vcatnSeKey to set
-	 */
-	public void setVcatnSeKey(String vcatnSeKey) {
-		this.vcatnSeKey = vcatnSeKey;
-	}
-	/**
-	 * @return the bgndeKey
-	 */
-	public String getBgndeKey() {
-		return bgndeKey;
-	}
-	/**
-	 * @param bgndeKey the bgndeKey to set
-	 */
-	public void setBgndeKey(String bgndeKey) {
-		this.bgndeKey = bgndeKey;
-	}
-	/**
-	 * @return the enddeKey
-	 */
-	public String getEnddeKey() {
-		return enddeKey;
-	}
-	/**
-	 * @param enddeKey the enddeKey to set
-	 */
-	public void setEnddeKey(String enddeKey) {
-		this.enddeKey = enddeKey;
-	}
 }

--- a/src/main/java/egovframework/com/uss/mpe/service/IndvdlPgeVO.java
+++ b/src/main/java/egovframework/com/uss/mpe/service/IndvdlPgeVO.java
@@ -2,19 +2,24 @@ package egovframework.com.uss.mpe.service;
 
 import egovframework.com.cmm.ComDefaultVO;
 
+import lombok.Getter;
+import lombok.Setter;
 import org.egovframe.rte.ptl.reactive.validation.EgovNullCheck;
 import jakarta.validation.constraints.Size;
 
 /**
  * 개요 - 마이페이지에 대한 model 클래스를 정의한다.
- * 
+ *
  * 상세내용 - 마이페이지의 컨텐츠아이디, 컨텐츠 명, 컨텐츠 URL, 컨텐츠 사용 여부 항목을 관리한다.
- * 
+ *
  * @author 이창원
  * @version 1.0
  * @created 05-8-2009 오후 2:20:27
  */
+@Getter
+@Setter
 public class IndvdlPgeVO extends ComDefaultVO {
+
 	/**
 	 * serialVersionUID
 	 */
@@ -24,81 +29,39 @@ public class IndvdlPgeVO extends ComDefaultVO {
 	 * 컨텐츠 아이디
 	 */
 	private String cntntsId;
+
 	/**
 	 * 컨텐츠 명
 	 */
 	@EgovNullCheck
-	@Size(max=100)
+	@Size(max = 100)
 	private String cntntsNm;
+
 	/**
 	 * 컨텐츠 미리보기 URL
 	 */
 	@EgovNullCheck
-	@Size(max=1000)
+	@Size(max = 1000)
 	private String cntntsLinkUrl;
+
 	/**
 	 * 컨텐츠 URL
 	 */
 	@EgovNullCheck
-	@Size(max=255)
+	@Size(max = 255)
 	private String cntcUrl;
+
 	/**
 	 * 컨텐츠 설명
 	 */
 	@EgovNullCheck
-	@Size(max=250)
+	@Size(max = 250)
 	private String cntntsDc;
+
 	/**
 	 * 컨텐츠 사용 여부
 	 */
 	@EgovNullCheck
 	private String cntntsUseAt;
 
-	public String getCntntsId() {
-		return cntntsId;
-	}
-
-	public void setCntntsId(String cntntsId) {
-		this.cntntsId = cntntsId;
-	}
-
-	public String getCntntsNm() {
-		return cntntsNm;
-	}
-
-	public void setCntntsNm(String cntntsNm) {
-		this.cntntsNm = cntntsNm;
-	}
-
-	public String getCntntsLinkUrl() {
-		return cntntsLinkUrl;
-	}
-
-	public void setCntntsLinkUrl(String cntntsLinkUrl) {
-		this.cntntsLinkUrl = cntntsLinkUrl;
-	}
-
-	public String getCntcUrl() {
-		return cntcUrl;
-	}
-
-	public void setCntcUrl(String cntcUrl) {
-		this.cntcUrl = cntcUrl;
-	}
-
-	public String getCntntsDc() {
-		return cntntsDc;
-	}
-
-	public void setCntntsDc(String cntntsDc) {
-		this.cntntsDc = cntntsDc;
-	}
-
-	public String getCntntsUseAt() {
-		return cntntsUseAt;
-	}
-
-	public void setCntntsUseAt(String cntntsUseAt) {
-		this.cntntsUseAt = cntntsUseAt;
-	}
 }

--- a/src/main/java/egovframework/com/uss/olh/faq/service/FaqDefaultVO.java
+++ b/src/main/java/egovframework/com/uss/olh/faq/service/FaqDefaultVO.java
@@ -2,6 +2,8 @@ package egovframework.com.uss.olh.faq.service;
 
 import java.io.Serializable;
 
+import lombok.Getter;
+import lombok.Setter;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
 /**
@@ -21,6 +23,8 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
  *
  * </pre>
  */
+@Getter
+@Setter
 public class FaqDefaultVO implements Serializable {
 
 	private static final long serialVersionUID = -7135776861537710232L;
@@ -53,153 +57,9 @@ public class FaqDefaultVO implements Serializable {
 	private int recordCountPerPage = 10;
 
 	/**
-	 * searchCnd attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getSearchCnd() {
-		return searchCnd;
-	}
-
-	/**
-	 * searchCnd attribute 값을 설정한다.
-	 * @return searchCnd String
-	 */
-	public void setSearchCnd(String searchCnd) {
-		this.searchCnd = searchCnd;
-	}
-
-	/**
-	 * searchWrd attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getSearchWrd() {
-		return searchWrd;
-	}
-
-	/**
-	 * searchWrd attribute 값을 설정한다.
-	 * @return searchWrd String
-	 */
-	public void setSearchWrd(String searchWrd) {
-		this.searchWrd = searchWrd;
-	}
-
-	/**
-	 * searchUseYn attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getSearchUseYn() {
-		return searchUseYn;
-	}
-
-	/**
-	 * searchUseYn attribute 값을 설정한다.
-	 * @return searchUseYn String
-	 */
-	public void setSearchUseYn(String searchUseYn) {
-		this.searchUseYn = searchUseYn;
-	}
-
-	/**
-	 * pageIndex attribute 를 리턴한다.
-	 * @return the int
-	 */
-	public int getPageIndex() {
-		return pageIndex;
-	}
-
-	/**
-	 * pageIndex attribute 값을 설정한다.
-	 * @return pageIndex int
-	 */
-	public void setPageIndex(int pageIndex) {
-		this.pageIndex = pageIndex;
-	}
-
-	/**
-	 * pageUnit attribute 를 리턴한다.
-	 * @return the int
-	 */
-	public int getPageUnit() {
-		return pageUnit;
-	}
-
-	/**
-	 * pageUnit attribute 값을 설정한다.
-	 * @return pageUnit int
-	 */
-	public void setPageUnit(int pageUnit) {
-		this.pageUnit = pageUnit;
-	}
-
-	/**
-	 * pageSize attribute 를 리턴한다.
-	 * @return the int
-	 */
-	public int getPageSize() {
-		return pageSize;
-	}
-
-	/**
-	 * pageSize attribute 값을 설정한다.
-	 * @return pageSize int
-	 */
-	public void setPageSize(int pageSize) {
-		this.pageSize = pageSize;
-	}
-
-	/**
-	 * firstIndex attribute 를 리턴한다.
-	 * @return the int
-	 */
-	public int getFirstIndex() {
-		return firstIndex;
-	}
-
-	/**
-	 * firstIndex attribute 값을 설정한다.
-	 * @return firstIndex int
-	 */
-	public void setFirstIndex(int firstIndex) {
-		this.firstIndex = firstIndex;
-	}
-
-	/**
-	 * lastIndex attribute 를 리턴한다.
-	 * @return the int
-	 */
-	public int getLastIndex() {
-		return lastIndex;
-	}
-
-	/**
-	 * lastIndex attribute 값을 설정한다.
-	 * @return lastIndex int
-	 */
-	public void setLastIndex(int lastIndex) {
-		this.lastIndex = lastIndex;
-	}
-
-	/**
-	 * recordCountPerPage attribute 를 리턴한다.
-	 * @return the int
-	 */
-	public int getRecordCountPerPage() {
-		return recordCountPerPage;
-	}
-
-	/**
-	 * recordCountPerPage attribute 값을 설정한다.
-	 * @return recordCountPerPage int
-	 */
-	public void setRecordCountPerPage(int recordCountPerPage) {
-		this.recordCountPerPage = recordCountPerPage;
-	}
-	
-	/**
 	 * toString 메소드를 대치한다.
 	 */
-	public String toString(){
+	public String toString() {
 		return ToStringBuilder.reflectionToString(this);
 	}
 

--- a/src/main/java/egovframework/com/utl/pao/service/PrntngOutptVO.java
+++ b/src/main/java/egovframework/com/utl/pao/service/PrntngOutptVO.java
@@ -2,6 +2,9 @@ package egovframework.com.utl.pao.service;
 
 import java.io.Serializable;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  *
  * 관인이미지 모델 클래스
@@ -19,6 +22,8 @@ import java.io.Serializable;
  *
  * </pre>
  */
+@Getter
+@Setter
 public class PrntngOutptVO implements Serializable {
 
 	private static final long serialVersionUID = 941289557959718464L;
@@ -71,54 +76,5 @@ public class PrntngOutptVO implements Serializable {
 			this.imgInfo[i] = imgInfo[i];
 		}
 	}
-
-	/**
-	 * imgType attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getImgType() {
-		return imgType;
-	}
-
-	/**
-	 * imgType attribute 값을 설정한다.
-	 * @param imgType String
-	 */
-	public void setImgType(String imgType) {
-		this.imgType = imgType;
-	}
-
-	/**
-	 * orgCode attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getOrgCode() {
-		return orgCode;
-	}
-
-	/**
-	 * orgCode attribute 값을 설정한다.
-	 * @param orgCode String
-	 */
-	public void setOrgCode(String orgCode) {
-		this.orgCode = orgCode;
-	}
-
-	/**
-	 * erncslSe attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getErncslSe() {
-		return erncslSe;
-	}
-
-	/**
-	 * erncslSe attribute 값을 설정한다.
-	 * @param erncslSe String
-	 */
-	public void setErncslSe(String erncslSe) {
-		this.erncslSe = erncslSe;
-	}
-
 
 }

--- a/src/main/java/egovframework/com/utl/sys/trm/service/CntcVO.java
+++ b/src/main/java/egovframework/com/utl/sys/trm/service/CntcVO.java
@@ -4,6 +4,9 @@ import java.io.Serializable;
 
 import egovframework.com.cmm.ComDefaultVO;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * 연계정보에 대한 VO 클래스
  *
@@ -20,119 +23,45 @@ import egovframework.com.cmm.ComDefaultVO;
  *  2010.06.21   김진만     최초 생성
  * </pre>
  */
+@Getter
+@Setter
 public class CntcVO extends ComDefaultVO implements Serializable {
 
 	private static final long serialVersionUID = -4961144967939216693L;
+
 	/**
 	 * 연계ID
 	 */
 	private String cntcId;
+
 	/**
 	 * 연계명
 	 */
 	private String cntcNm;
+
 	/**
 	 * 제공기관명
 	 */
 	private String provdInsttNm;
+
 	/**
 	 * 제공시스템명
 	 */
 	private String provdSysNm;
+
 	/**
 	 * 제공서비스명
 	 */
 	private String provdSvcNm;
+
 	/**
 	 * 요청기관명
 	 */
 	private String requstInsttNm;
+
 	/**
 	 * 요청시스템명
 	 */
 	private String requstSysNm;
-	/**
-	 * @return the cntcId
-	 */
-	public String getCntcId() {
-		return cntcId;
-	}
-	/**
-	 * @return the cntcNm
-	 */
-	public String getCntcNm() {
-		return cntcNm;
-	}
-	/**
-	 * @return the provdInsttNm
-	 */
-	public String getProvdInsttNm() {
-		return provdInsttNm;
-	}
-	/**
-	 * @return the provdSysNm
-	 */
-	public String getProvdSysNm() {
-		return provdSysNm;
-	}
-	/**
-	 * @return the provdSvcNm
-	 */
-	public String getProvdSvcNm() {
-		return provdSvcNm;
-	}
-	/**
-	 * @return the requstInsttNm
-	 */
-	public String getRequstInsttNm() {
-		return requstInsttNm;
-	}
-	/**
-	 * @return the requstSysNm
-	 */
-	public String getRequstSysNm() {
-		return requstSysNm;
-	}
-	/**
-	 * @param cntcId the cntcId to set
-	 */
-	public void setCntcId(String cntcId) {
-		this.cntcId = cntcId;
-	}
-	/**
-	 * @param cntcNm the cntcNm to set
-	 */
-	public void setCntcNm(String cntcNm) {
-		this.cntcNm = cntcNm;
-	}
-	/**
-	 * @param provdInsttNm the provdInsttNm to set
-	 */
-	public void setProvdInsttNm(String provdInsttNm) {
-		this.provdInsttNm = provdInsttNm;
-	}
-	/**
-	 * @param provdSysNm the provdSysNm to set
-	 */
-	public void setProvdSysNm(String provdSysNm) {
-		this.provdSysNm = provdSysNm;
-	}
-	/**
-	 * @param provdSvcNm the provdSvcNm to set
-	 */
-	public void setProvdSvcNm(String provdSvcNm) {
-		this.provdSvcNm = provdSvcNm;
-	}
-	/**
-	 * @param requstInsttNm the requstInsttNm to set
-	 */
-	public void setRequstInsttNm(String requstInsttNm) {
-		this.requstInsttNm = requstInsttNm;
-	}
-	/**
-	 * @param requstSysNm the requstSysNm to set
-	 */
-	public void setRequstSysNm(String requstSysNm) {
-		this.requstSysNm = requstSysNm;
-	}
+
 }


### PR DESCRIPTION
## 개요

uss/utl/cmm 소규모 모듈 VO 8개를 Lombok `@Getter`/`@Setter`로 정리합니다. 순수 위임 접근자만 정리했으며 동작은 동일합니다.

## 변경 사항

- `CmtDefaultVO`, `CmtManageVO`, `RwardManageVO`, `VcatnManageVO`, `FaqDefaultVO`, `IndvdlPgeVO`, `CntcVO`, `PrntngOutptVO`
- 단순 위임 접근자 제거 후 `@Getter @Setter` 적용
- 커스텀 접근자는 보존: `CmtManageVO`의 파라미터명 불일치 setter(setWrkStartStatus 등), `PrntngOutptVO`의 방어적 배열 복사 접근자(getImgInfo/setImgInfo)

## 검증
- JDK 17 환경 `mvn -DskipTests compile` BUILD SUCCESS
- 기존 VO Lombok 적용 사례(#799~#834 등)와 동일 패턴
