### PR TITLE
 EgovPrivacyLogAspect keySet() → entrySet() 전환으로 중복 탐색 제거

### DIFF
--- a/src/main/java/egovframework/com/sym/log/plg/service/EgovPrivacyLogAspect.java
+++ b/src/main/java/egovframework/com/sym/log/plg/service/EgovPrivacyLogAspect.java
@@ -119,10 +119,11 @@ public class EgovPrivacyLogAspect {
 			return list;
 		}
 
-		for (String key : target.keySet()) {
+		for (Map.Entry<String, String> entry : target.entrySet()) {
+			String key = entry.getKey();
 			// 조회된 데이터가 없으면 생략
 			if (data.containsKey(key) && data.get(key) != null && !data.get(key).toString().trim().equals("")) {
-				list.add(target.get(key));
+				list.add(entry.getValue());
 				LOGGER.debug("Service ('{}') : inquired data = {}", serviceName, key);
 			}
 		}
@@ -137,12 +138,13 @@ public class EgovPrivacyLogAspect {
 			return list;
 		}
 
-		for (String key : target.keySet()) {
+		for (Map.Entry<String, String> entry : target.entrySet()) {
+			String key = entry.getKey();
 			try {
 				Method method = data.getClass().getMethod("get" + key.substring(0, 1).toUpperCase() + key.substring(1));
 				Object returned = method.invoke(data);
 				if (returned != null && !returned.toString().trim().equals("")) {
-					list.add(target.get(key));
+					list.add(entry.getValue());
 				}
 			} catch (NoSuchMethodException ignore) {
 				LOGGER.error("[" + ignore.getClass() + "] Try/Catch... : " + ignore.getMessage());

--- a/src/test/java/egovframework/com/sym/log/plg/service/EgovPrivacyLogAspectTest.java
+++ b/src/test/java/egovframework/com/sym/log/plg/service/EgovPrivacyLogAspectTest.java
@@ -1,0 +1,275 @@
+package egovframework.com.sym.log.plg.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * EgovPrivacyLogAspect 단위 테스트
+ *
+ * @author Chung10kr
+ * @since 2026.06.20
+ * @version 1.0
+ * @see
+ *
+ *      <pre>
+ *  == 개정이력(Modification Information) ==
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2026.06.20  Chung10kr   2025년 컨트리뷰션 keySet → entrySet 전환 테스트 작성 (@Nested 구조)
+ *
+ *      </pre>
+ */
+class EgovPrivacyLogAspectTest {
+
+    /** 테스트 대상(SUT) */
+    private EgovPrivacyLogAspect sut;
+
+    /** 테스트용 target 맵: 필드키 → 레이블 */
+    private Map<String, String> target;
+
+    @BeforeEach
+    void setUp() {
+        sut = new EgovPrivacyLogAspect();
+
+        // target: 개인정보 항목 키 → 항목명 매핑 (LinkedHashMap으로 순서 보장)
+        target = new LinkedHashMap<>();
+        target.put("name", "이름");
+        target.put("email", "이메일");
+        target.put("phone", "전화번호");
+
+        sut.setTarget(target);
+    }
+
+    // ─────────────────────────────────────────────
+    // 테스트용 VO (모든 중첩 클래스에서 공유)
+    // ─────────────────────────────────────────────
+
+    static class SampleVO {
+        private final String name;
+        private final String email;
+        private final String phone;
+
+        SampleVO(String name, String email, String phone) {
+            this.name  = name;
+            this.email = email;
+            this.phone = phone;
+        }
+
+        public String getName()  { return name; }
+        public String getEmail() { return email; }
+        public String getPhone() { return phone; }
+    }
+
+    // ─────────────────────────────────────────────
+    // getItemValues(Map<?, ?> data, String serviceName)
+    // ─────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("getItemValues(Map) - Map 형태의 데이터에서 target 설정에 해당하는 개인정보 항목명 목록을 반환한다")
+    class GetItemValuesWithMap {
+
+        @Test
+        @DisplayName("정상_입력_모든_키_존재")
+        void 정상_입력_모든_키_존재() {
+            // given
+            Map<String, Object> data = new HashMap<>();
+            data.put("name",  "홍길동");
+            data.put("email", "hong@example.com");
+            data.put("phone", "010-1234-5678");
+
+            // when
+            List<String> result = sut.getItemValues(data, "TestService.method");
+
+            // then
+            assertNotNull(result);
+            assertEquals(3, result.size());
+            assertTrue(result.contains("이름"));
+            assertTrue(result.contains("이메일"));
+            assertTrue(result.contains("전화번호"));
+        }
+
+        @Test
+        @DisplayName("일부_키만_존재")
+        void 일부_키만_존재() {
+            // given
+            Map<String, Object> data = new HashMap<>();
+            data.put("name", "홍길동");
+            // email, phone 없음
+
+            // when
+            List<String> result = sut.getItemValues(data, "TestService.method");
+
+            // then
+            assertEquals(1, result.size());
+            assertEquals("이름", result.get(0));
+        }
+
+        @Test
+        @DisplayName("공백_값은_제외")
+        void 공백_값은_제외() {
+            // given
+            Map<String, Object> data = new HashMap<>();
+            data.put("name",  "  ");              // 공백만
+            data.put("email", "hong@example.com");
+            data.put("phone", "");                // 빈 문자열
+
+            // when
+            List<String> result = sut.getItemValues(data, "TestService.method");
+
+            // then
+            assertEquals(1, result.size());
+            assertEquals("이메일", result.get(0));
+        }
+
+        @Test
+        @DisplayName("null_값은_제외")
+        void null_값은_제외() {
+            // given
+            Map<String, Object> data = new HashMap<>();
+            data.put("name",  null);
+            data.put("email", "hong@example.com");
+
+            // when
+            List<String> result = sut.getItemValues(data, "TestService.method");
+
+            // then
+            assertEquals(1, result.size());
+            assertEquals("이메일", result.get(0));
+        }
+
+        @Test
+        @DisplayName("data가_null이면_빈_리스트_반환")
+        void data가_null이면_빈_리스트_반환() {
+            // when
+            List<String> result = sut.getItemValues((Map<?, ?>) null, "TestService.method");
+
+            // then
+            assertNotNull(result);
+            assertEquals(0, result.size());
+        }
+
+        @Test
+        @DisplayName("빈_맵이면_빈_리스트_반환")
+        void 빈_맵이면_빈_리스트_반환() {
+            // given
+            Map<String, Object> data = new HashMap<>();
+
+            // when
+            List<String> result = sut.getItemValues(data, "TestService.method");
+
+            // then
+            assertNotNull(result);
+            assertEquals(0, result.size());
+        }
+
+        @Test
+        @DisplayName("target에_없는_키는_무시")
+        void target에_없는_키는_무시() {
+            // given
+            Map<String, Object> data = new HashMap<>();
+            data.put("address", "서울시");
+            data.put("age",     "30");
+
+            // when
+            List<String> result = sut.getItemValues(data, "TestService.method");
+
+            // then
+            assertEquals(0, result.size());
+        }
+    }
+
+    // ─────────────────────────────────────────────
+    // getItemValues(Object data, String serviceName)
+    // ─────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("getItemValues(Object) - VO 객체의 getter를 리플렉션으로 호출하여 target 설정에 해당하는 개인정보 항목명 목록을 반환한다")
+    class GetItemValuesWithVO {
+
+        @Test
+        @DisplayName("정상_입력")
+        void 정상_입력() {
+            // given
+            SampleVO vo = new SampleVO("홍길동", "hong@example.com", "010-1234-5678");
+
+            // when
+            List<String> result = sut.getItemValues((Object) vo, "TestService.method");
+
+            // then
+            assertNotNull(result);
+            assertEquals(3, result.size());
+            assertTrue(result.contains("이름"));
+            assertTrue(result.contains("이메일"));
+            assertTrue(result.contains("전화번호"));
+        }
+
+        @Test
+        @DisplayName("null_필드는_제외")
+        void null_필드는_제외() {
+            // given
+            SampleVO vo = new SampleVO(null, "hong@example.com", null);
+
+            // when
+            List<String> result = sut.getItemValues((Object) vo, "TestService.method");
+
+            // then
+            assertEquals(1, result.size());
+            assertEquals("이메일", result.get(0));
+        }
+
+        @Test
+        @DisplayName("공백_필드는_제외")
+        void 공백_필드는_제외() {
+            // given
+            SampleVO vo = new SampleVO("홍길동", "  ", "");
+
+            // when
+            List<String> result = sut.getItemValues((Object) vo, "TestService.method");
+
+            // then
+            assertEquals(1, result.size());
+            assertEquals("이름", result.get(0));
+        }
+
+        @Test
+        @DisplayName("data가_null이면_빈_리스트_반환")
+        void data가_null이면_빈_리스트_반환() {
+            // when
+            List<String> result = sut.getItemValues((Object) null, "TestService.method");
+
+            // then
+            assertNotNull(result);
+            assertEquals(0, result.size());
+        }
+
+        @Test
+        @DisplayName("getter_없는_필드는_건너뜀")
+        void getter_없는_필드는_건너뜀() {
+            // given: name getter만 있고 email, phone getter가 없는 익명 객체
+            Object noGetterObj = new Object() {
+                @SuppressWarnings("unused")
+                public String getName() { return "홍길동"; }
+            };
+
+            // when
+            List<String> result = sut.getItemValues(noGetterObj, "TestService.method");
+
+            // then
+            assertEquals(1, result.size());
+            assertEquals("이름", result.get(0));
+        }
+    }
+
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [ ] 버그수정 Bug fixes
- [x] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source
EgovPrivacyLogAspect.java의 두 메서드에서 Map 순회 방식을 개선했습니다.
- getItemValues(Map) / getItemValues(Object) — 두 곳 동일 패턴
```java
// Before: keySet()으로 키만 꺼낸 뒤, 값이 필요할 때마다 target.get(key) 재호출
for (String key : target.keySet()) {
    list.add(target.get(key));  // Map을 두 번 탐색
}

// After: entrySet()으로 키·값을 한 번에 꺼냄
for (Map.Entry<String, String> entry : target.entrySet()) {
    String key = entry.getKey();
    list.add(entry.getValue());  // 재탐색 없음
}
```
- getItemValues() 두 메서드에서 keySet() 순회 후 target.get(key) 재호출하는 패턴을 entrySet()으로 전환하여 중복 탐색 제거
- 기존에 테스트가 없던 클래스에 @Nested 구조 단위 테스트 12개 신규 추가
 
## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [x] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.


- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

<img width="352" height="373" alt="스크린샷 2026-06-20 오후 10 35 04" src="https://github.com/user-attachments/assets/223b42d2-8ccf-4dd6-ba93-35ad022b2e5f" />