### PR TITLE
공통상세코드 등록 실패 시 코드ID 목록 복원

### DIFF
--- a/src/main/java/egovframework/com/sym/ccm/cde/web/EgovCcmCmmnDetailCodeManageController.java
+++ b/src/main/java/egovframework/com/sym/ccm/cde/web/EgovCcmCmmnDetailCodeManageController.java
@@ -157,27 +157,28 @@ public class EgovCcmCmmnDetailCodeManageController {
 			@ModelAttribute("cmmnCodeVO") CmmnCodeVO cmmnCodeVO,
 			@ModelAttribute("cmmnDetailCodeVO") CmmnDetailCodeVO cmmnDetailCodeVO, ModelMap model) throws Exception {
 
+		addCodeSelectLists(cmmnCodeVO.getClCode(), model);
+
+		return "egovframework/com/sym/ccm/cde/EgovCcmCmmnDetailCodeRegist";
+	}
+
+	private void addCodeSelectLists(String clCode, ModelMap model) throws Exception {
 		CmmnClCodeVO searchClCodeVO = new CmmnClCodeVO();
 		searchClCodeVO.setFirstIndex(0);
 		List<CmmnClCodeVO> clCodeList = cmmnClCodeManageService.selectCmmnClCodeList(searchClCodeVO);
 		model.addAttribute("clCodeList", clCodeList);
 
-		CmmnCodeVO clCode = new CmmnCodeVO();
-		clCode.setClCode(cmmnCodeVO.getClCode());
-
-		if (!"".equals(cmmnCodeVO.getClCode())) {
+		if (!"".equals(clCode)) {
 
 			CmmnCodeVO searchCodeVO = new CmmnCodeVO();
 			searchCodeVO.setRecordCountPerPage(999999);
 			searchCodeVO.setFirstIndex(0);
 			searchCodeVO.setSearchCondition("clCode");
-			searchCodeVO.setSearchKeyword(cmmnCodeVO.getClCode());
+			searchCodeVO.setSearchKeyword(clCode);
 
 			List<CmmnCodeVO> codeList = cmmnCodeManageService.selectCmmnCodeList(searchCodeVO);
 			model.addAttribute("codeList", codeList);
 		}
-
-		return "egovframework/com/sym/ccm/cde/EgovCcmCmmnDetailCodeRegist";
 	}
 
 	/**
@@ -196,13 +197,9 @@ public class EgovCcmCmmnDetailCodeManageController {
 
 		LoginVO user = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();
 
-		CmmnClCodeVO searchClCodeVO = new CmmnClCodeVO();
-		searchClCodeVO.setFirstIndex(0);
-
 		if (bindingResult.hasErrors()) {
 
-			List<CmmnClCodeVO> clCodeList = cmmnClCodeManageService.selectCmmnClCodeList(searchClCodeVO);
-			model.addAttribute("clCodeList", clCodeList);
+			addCodeSelectLists(cmmnDetailCodeVO.getClCode(), model);
 
 			return "egovframework/com/sym/ccm/cde/EgovCcmCmmnDetailCodeRegist";
 		}
@@ -213,8 +210,7 @@ public class EgovCcmCmmnDetailCodeManageController {
 			if (vo != null) {
 				model.addAttribute("message", egovMessageSource.getMessage("comSymCcmCde.validate.codeCheck"));
 
-				List<CmmnClCodeVO> clCodeList = cmmnClCodeManageService.selectCmmnClCodeList(searchClCodeVO);
-				model.addAttribute("clCodeList", clCodeList);
+				addCodeSelectLists(cmmnDetailCodeVO.getClCode(), model);
 
 				return "egovframework/com/sym/ccm/cde/EgovCcmCmmnDetailCodeRegist";
 			}


### PR DESCRIPTION
## 변경 내용

공통상세코드 등록 화면에서 사용하는 분류코드 목록과 코드ID 목록 로딩을 `addCodeSelectLists`로 묶고, 등록 화면 최초 진입뿐 아니라 등록 실패로 같은 화면을 다시 표시하는 경로에서도 동일하게 사용하도록 수정했습니다.

## 문제 상황

공통상세코드 등록 JSP는 분류코드 select에 `clCodeList`, 코드ID select에 `codeList`를 사용합니다.

기존 컨트롤러는 등록 화면 최초 진입 시에는 선택한 분류코드 기준으로 `codeList`를 모델에 담았지만, 등록 요청 후 중복 상세코드가 확인되어 등록 화면으로 돌아가는 경로에서는 `clCodeList`만 다시 담고 `codeList`는 담지 않았습니다.

이 경우 화면이 500 오류로 실패하는 것은 아니지만, 코드ID select가 기본 선택 항목만 남은 상태로 렌더링될 수 있습니다. 사용자가 상세코드 값만 수정해서 다시 등록하려고 해도 코드ID 선택지가 없어 재입력 흐름이 깨질 수 있습니다.

## 발생 가능한 흐름

1. 공통상세코드 등록 화면에서 분류코드를 선택합니다.
2. 선택한 분류코드 기준으로 코드ID 목록이 조회됩니다.
3. 코드ID를 선택하고 이미 존재하는 상세코드 값을 입력한 뒤 등록합니다.
4. 서버에서 `(codeId, code)` 기준 중복 상세코드를 확인합니다.
5. 중복이면 등록 화면으로 돌아가면서 메시지를 표시합니다.
6. 기존에는 이 반환 경로에서 `codeList`가 다시 설정되지 않아 코드ID 목록이 비어 있을 수 있었습니다.

## 검증

- `git diff --check`
- `mvn -B verify --file pom.xml`

로컬 검증 환경:

- Apache Maven 3.6.3
- Java 17.0.14

참고: 현재 POM 설정에 따라 Surefire 단계에서 테스트는 skipped로 처리됩니다.
