### PR TITLE
롤 관리 검증 실패 시 롤 타입 목록 복원

### DIFF
--- a/src/main/java/egovframework/com/sec/rmt/web/EgovRoleManageController.java
+++ b/src/main/java/egovframework/com/sec/rmt/web/EgovRoleManageController.java
@@ -182,6 +182,7 @@ public class EgovRoleManageController {
                               ModelMap model) throws Exception {
 
     	if (bindingResult.hasErrors()) {
+			model.addAttribute("cmmCodeDetailList", getCmmCodeDetailList(new ComDefaultCodeVO(),"COM029"));
 			return "egovframework/com/sec/rmt/EgovRoleInsert";
 		} else {
     	    String roleTyp = roleManage.getRoleTyp();
@@ -218,6 +219,7 @@ public class EgovRoleManageController {
             ModelMap model) throws Exception {
 
     	if (bindingResult.hasErrors()) {
+			model.addAttribute("cmmCodeDetailList", getCmmCodeDetailList(new ComDefaultCodeVO(),"COM029"));
 			return "egovframework/com/sec/rmt/EgovRoleUpdate";
 		} else {
     	egovRoleManageService.updateRole(roleManage);


### PR DESCRIPTION
## 요약
- 롤 등록/수정 검증 실패 시 `COM029` 롤 타입 코드 목록을 다시 모델에 추가했습니다.
- 같은 JSP를 다시 렌더링해도 `roleTyp` 선택 목록이 비지 않도록 했습니다.

## 발생 가능한 문제
- 롤 등록/수정 화면 진입 시에는 `cmmCodeDetailList`가 모델에 추가됩니다.
- 하지만 `BindingResult` 오류 분기에서는 같은 JSP로 돌아가면서 목록을 다시 넣지 않아 `<form:options items="${cmmCodeDetailList}">`가 옵션 없이 렌더링될 수 있습니다.
- 이 상태에서 사용자가 값을 고쳐 다시 제출하면 `roleTyp`이 전송되지 않아 등록 시 `ROLE_TY`가 누락되거나 수정 시 기존 `ROLE_TY`가 손실될 수 있습니다.

## 검증
- `git diff --check`
- `/Users/minseok/.m2/wrapper/dists/apache-maven-3.6.3-bin/1iopthnavndlasol9gbrbg6bf2/apache-maven-3.6.3/bin/mvn -B verify --file pom.xml`
  - `BUILD SUCCESS`
  - 현재 POM 설정상 Surefire 테스트는 skip됩니다.
  - 기존 Javadoc 경고는 남아 있지만 빌드는 성공했습니다.