### PR TITLE
fix: OAuth 로그인 state(CSRF) 검증 추가

### DIFF
--- a/src/main/java/egovframework/com/ext/oauth/service/OAuthLogin.java
+++ b/src/main/java/egovframework/com/ext/oauth/service/OAuthLogin.java
@@ -49,12 +49,10 @@ public class OAuthLogin {
 	}
 
 	// 230825 카카오톡 scope 변경으로 인한 scope 처리 추가
-	public String getOAuthURL() {
-		if (oauthVO.getOrigin().equals("naver")) { // naver의 경우 state가 필수 조건에 포함
-			return this.oauthService.getAuthorizationUrl() + "&state=test&scope=" + oauthVO.getScope();
-		} else { // 필수, 추가 동의 항목 포함
-			return this.oauthService.getAuthorizationUrl() + "&scope=" + oauthVO.getScope();
-		}
+	// CSRF(로그인 CSRF) 방어를 위해 호출자가 생성·세션에 보관한 state를 모든 제공자 인가 URL에 부착한다.
+	public String getOAuthURL(String state) {
+		// scribejava가 state를 표준 방식으로 부착한다(naver는 state 필수, google·kakao도 동일 적용).
+		return this.oauthService.getAuthorizationUrl(state) + "&scope=" + oauthVO.getScope();
 	}
 
 	public OAuthUniversalUser getUserProfile(String code) throws Exception {

--- a/src/main/java/egovframework/com/ext/oauth/web/EgovSignupController.java
+++ b/src/main/java/egovframework/com/ext/oauth/web/EgovSignupController.java
@@ -18,6 +18,9 @@
  */
 package egovframework.com.ext.oauth.web;
 
+import java.security.SecureRandom;
+import java.util.Base64;
+
 import egovframework.com.cmm.util.EgovUserDetailsHelper;
 import egovframework.com.cmm.LoginVO;
 
@@ -39,6 +42,7 @@ import egovframework.com.ext.oauth.service.OAuthConfig;
 import egovframework.com.ext.oauth.service.OAuthLogin;
 import egovframework.com.ext.oauth.service.OAuthUniversalUser;
 import egovframework.com.ext.oauth.service.OAuthVO;
+import jakarta.servlet.http.HttpSession;
 
 /**
  * 소셜 계정으로 일반회원 가입을 처리하는 컨트롤러 클래스
@@ -64,6 +68,18 @@ public class EgovSignupController {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(EgovSignupController.class);
 
+	/** OAuth CSRF 방어용 state 값을 보관하는 세션 키 */
+	private static final String OAUTH_STATE_SESSION_KEY = "oauthState";
+
+	private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+
+	/** 예측 불가능한 OAuth state 값을 생성한다(URL-safe Base64). */
+	private static String generateState() {
+		byte[] bytes = new byte[32];
+		SECURE_RANDOM.nextBytes(bytes);
+		return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+	}
+
 	@Autowired
 	private OAuthVO naverAuthVO;
 
@@ -74,32 +90,42 @@ public class EgovSignupController {
 	private OAuthVO kakaoAuthVO;
 
 	@RequestMapping(value = "/uat/uia/oauthLoginUsr", method = RequestMethod.GET)
-	public String login(Model model) throws Exception {
+	public String login(Model model, HttpSession session) throws Exception {
 		LOGGER.debug("===>>> OAuth Login .....");
 
 		model.addAttribute("loginRequestVO", new LoginRequestVO());
 		model.addAttribute("defaultForm", new ComDefaultVO());
 
+		// 콜백에서 대조할 CSRF 방어용 state를 1회 생성해 세션에 보관하고 모든 제공자 인가 URL에 부착한다.
+		String state = generateState();
+		session.setAttribute(OAUTH_STATE_SESSION_KEY, state);
+
 		OAuthLogin naverLogin = new OAuthLogin(naverAuthVO);
-		LOGGER.debug("naverLogin.getOAuthURL() = "+naverLogin.getOAuthURL());
-		model.addAttribute("naver_url", naverLogin.getOAuthURL());
+		model.addAttribute("naver_url", naverLogin.getOAuthURL(state));
 
 		OAuthLogin googleLogin = new OAuthLogin(googleAuthVO);
-		LOGGER.debug("googleLogin.getOAuthURL() = "+googleLogin.getOAuthURL());
-		model.addAttribute("google_url", googleLogin.getOAuthURL());
+		model.addAttribute("google_url", googleLogin.getOAuthURL(state));
 
 		OAuthLogin kakaoLogin = new OAuthLogin(kakaoAuthVO);
-		LOGGER.debug("kakaoLogin.getOAuthURL() = "+kakaoLogin.getOAuthURL());
-		model.addAttribute("kakao_url", kakaoLogin.getOAuthURL());
+		model.addAttribute("kakao_url", kakaoLogin.getOAuthURL(state));
 
 		return "egovframework/com/uat/uia/EgovLoginUsrOauth";
 	}
 
 	@RequestMapping(value = "/auth/{oauthService}/callback", method = { RequestMethod.GET, RequestMethod.POST })
-	public String oauthLoginCallback(@PathVariable String oauthService, Model model, @RequestParam String code,
-			@RequestParam(required = false) String state) throws Exception {
+	public String oauthLoginCallback(@PathVariable String oauthService, Model model,
+			@RequestParam String code, @RequestParam(required = false) String state, HttpSession session) throws Exception {
 
 		LOGGER.debug("oauthLoginCallback: service={}", oauthService);
+
+		// CSRF(로그인 CSRF) 방어 - 콜백의 state를 세션에 보관한 값과 대조한다. 1회용이므로 검증 후 제거한다.
+		String sessionState = (String) session.getAttribute(OAUTH_STATE_SESSION_KEY);
+		session.removeAttribute(OAUTH_STATE_SESSION_KEY);
+		if (sessionState == null || !sessionState.equals(state)) {
+			LOGGER.warn("OAuth state가 일치하지 않아 콜백 요청을 차단합니다. service={}", oauthService);
+			model.addAttribute("message", "Invalid OAuth state.");
+			return "egovframework/com/uat/uia/EgovLoginUsrOauthResult";
+		}
 
 		OAuthVO oauthVO = null;
 		if (StringUtils.equals(OAuthConfig.GOOGLE_SERVICE_NAME, oauthService)) {

--- a/src/test/java/egovframework/com/ext/oauth/web/EgovSignupControllerStateTest.java
+++ b/src/test/java/egovframework/com/ext/oauth/web/EgovSignupControllerStateTest.java
@@ -1,0 +1,98 @@
+package egovframework.com.ext.oauth.web;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.ui.ExtendedModelMap;
+import org.springframework.ui.Model;
+
+import jakarta.servlet.http.HttpSession;
+
+/**
+ * {@link EgovSignupController} 의 OAuth state(CSRF) 검증을 확인한다.
+ *
+ * <p>이전 구현은 인가 URL의 state를 상수("test")로 두거나 아예 부착하지 않았고, 콜백에서
+ * state를 검증하지 않아 로그인 CSRF가 가능했다. 본 테스트는 콜백이 세션에 보관된 state와
+ * 일치하지 않으면 사용자 프로필 조회로 진행하지 않고 차단함을 검증한다. 차단 경로는 외부
+ * OAuth 서버 호출 이전에 동작하므로 네트워크 없이 결정적으로 검증된다.</p>
+ */
+class EgovSignupControllerStateTest {
+
+    private static final String RESULT_VIEW = "egovframework/com/uat/uia/EgovLoginUsrOauthResult";
+
+    /** getAttribute/setAttribute/removeAttribute만 Map으로 처리하는 HttpSession 페이크. */
+    private static HttpSession fakeSession(Map<String, Object> store) {
+        InvocationHandler handler = (proxy, method, args) -> {
+            switch (method.getName()) {
+                case "getAttribute":
+                    return store.get((String) args[0]);
+                case "setAttribute":
+                    store.put((String) args[0], args[1]);
+                    return null;
+                case "removeAttribute":
+                    store.remove((String) args[0]);
+                    return null;
+                default:
+                    Class<?> rt = method.getReturnType();
+                    if (rt.equals(boolean.class)) {
+                        return false;
+                    }
+                    return rt.isPrimitive() ? 0 : null;
+            }
+        };
+        return (HttpSession) Proxy.newProxyInstance(
+                HttpSession.class.getClassLoader(), new Class<?>[] { HttpSession.class }, handler);
+    }
+
+    @Test
+    @DisplayName("콜백 state가 세션 state와 다르면 차단한다")
+    void callbackWithMismatchedStateIsBlocked() throws Exception {
+        EgovSignupController controller = new EgovSignupController();
+        Model model = new ExtendedModelMap();
+        Map<String, Object> store = new HashMap<>();
+        store.put("oauthState", "expected-state");
+
+        // 외부 OAuth 호출(getUserProfile)에 도달하기 전에 차단되어야 한다.
+        String view = controller.oauthLoginCallback("naver", model, "any-code", "forged-state", fakeSession(store));
+
+        assertEquals(RESULT_VIEW, view);
+        assertEquals("Invalid OAuth state.", model.getAttribute("message"));
+    }
+
+    @Test
+    @DisplayName("콜백에 state가 없으면 차단한다")
+    void callbackWithoutStateIsBlocked() throws Exception {
+        EgovSignupController controller = new EgovSignupController();
+        Model model = new ExtendedModelMap();
+        Map<String, Object> store = new HashMap<>();
+        store.put("oauthState", "expected-state");
+
+        String view = controller.oauthLoginCallback("naver", model, "any-code", null, fakeSession(store));
+
+        assertEquals(RESULT_VIEW, view);
+        assertEquals("Invalid OAuth state.", model.getAttribute("message"));
+    }
+
+    @Test
+    @DisplayName("생성된 state는 예측 불가능하고 매번 다르다")
+    void generatedStateIsUnpredictable() throws Exception {
+        Method method = EgovSignupController.class.getDeclaredMethod("generateState");
+        method.setAccessible(true);
+
+        String first = (String) method.invoke(null);
+        String second = (String) method.invoke(null);
+
+        assertTrue(first != null && !first.isBlank());
+        assertNotEquals(first, second);
+        assertNotEquals("test", first);
+    }
+}


### PR DESCRIPTION
## 변경 이유

OAuth 로그인의 `state` 처리에 CSRF(로그인 CSRF) 취약점이 있습니다.

- `OAuthLogin.getOAuthURL()`: 네이버 인가 URL에 `state`를 상수 `"test"`로 하드코딩하고, 구글·카카오에는 `state`를 아예 부착하지 않습니다.
- `EgovSignupController.oauthLoginCallback()`: 콜백이 `code`만 받고 `state`를 수신·검증하지 않습니다.

`state`는 콜백에서 세션에 보관한 값과 대조해 로그인 CSRF를 막는 필수 파라미터입니다(RFC 6749 §10.12). 값이 고정·예측 가능하고 콜백 검증도 없으면 공격자가 유도한 콜백을 그대로 처리하게 됩니다.

## 변경 내용

- 로그인 진입(`/uat/uia/oauthLoginUsr`) 시 `SecureRandom`으로 예측 불가능한 `state`를 생성해 세션에 보관하고, 모든 제공자 인가 URL에 부착합니다(`scribejava`의 `getAuthorizationUrl(state)` 사용 — 네이버 필수 조건도 충족).
- 콜백에서 `state`를 수신해 세션값과 대조하고, 불일치/누락 시 사용자 프로필 조회 이전에 요청을 차단합니다. `state`는 1회용이므로 검증 후 세션에서 제거합니다.

## 테스트 방법

`EgovSignupControllerStateTest`(3건):
- 콜백 `state`가 세션값과 다르면 차단됨을 검증
- 콜백에 `state`가 없으면 차단됨을 검증
- 생성된 `state`가 매번 다르고 예측 불가능함을 검증

차단 경로는 외부 OAuth 서버 호출 이전에 동작하므로 네트워크 없이 검증됩니다.

## 영향 범위

OAuth 로그인 진입·콜백의 `state` 처리만 변경하며 정상 로그인 흐름은 동일합니다.
