### PR TITLE
fix: 백업 TAR 엔트리의 한글 파일명 깨짐(charset) 수정

### DIFF
--- a/src/main/java/egovframework/com/sym/sym/bak/service/BackupJob.java
+++ b/src/main/java/egovframework/com/sym/sym/bak/service/BackupJob.java
@@ -5,6 +5,7 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
@@ -174,7 +175,8 @@ public class BackupJob implements Job {
 			if (log.isDebugEnabled()) {
 				log.debug("charter set : {}", Charset.defaultCharset().name());
 			}
-			aosOutput = new ArchiveStreamFactory().createArchiveOutputStream(archiveFormat, fosOutput);
+			// 엔트리 이름(한글 파일명 포함)을 UTF-8로 기록하도록 인코딩을 지정한다.
+			aosOutput = new ArchiveStreamFactory(StandardCharsets.UTF_8.name()).createArchiveOutputStream(archiveFormat, fosOutput);
 
 			// Zip에서는 처리안해도 한글안깨져서 주석처리함.
 			// if (ArchiveStreamFactory.ZIP.equals(archiveFormat)) {
@@ -199,9 +201,8 @@ public class BackupJob implements Job {
 				try (FileInputStream finput = new FileInputStream(sfile);) {
 
 					if (ArchiveStreamFactory.TAR.equals(archiveFormat)) {
-						// 파일이름 한글처리 ~~~
-						entry = new TarArchiveEntry(sfile,
-								new String(sfile.getAbsolutePath().getBytes(Charset.defaultCharset().name()), "UTF-8"));
+						// 파일이름 한글처리 ~~~ (엔트리 이름 인코딩은 ArchiveStreamFactory에서 UTF-8로 지정)
+						entry = new TarArchiveEntry(sfile, sfile.getAbsolutePath());
 						((TarArchiveEntry) entry).setSize(sfile.length());
 					} else {
 						entry = new ZipArchiveEntry(sfile.getAbsolutePath());

--- a/src/test/java/egovframework/com/sym/sym/bak/service/BackupJobFileNameCharsetTest.java
+++ b/src/test/java/egovframework/com/sym/sym/bak/service/BackupJobFileNameCharsetTest.java
@@ -1,0 +1,60 @@
+package egovframework.com.sym.sym.bak.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.commons.compress.archivers.ArchiveOutputStream;
+import org.apache.commons.compress.archivers.ArchiveStreamFactory;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@code BackupJob}의 TAR 엔트리 이름 한글 처리(charset)를 검증한다.
+ *
+ * <p>이전 구현은 엔트리 이름을 {@code new String(path.getBytes(기본charset), "UTF-8")}로
+ * 만들었는데, 기본 charset이 UTF-8이 아닌 환경(예: 한국 Windows의 MS949)에서는 한글 경로가
+ * 깨졌다(mojibake). 본 테스트는 그 라운드트립이 실제로 이름을 손상시킴을 보이고, 수정 방식
+ * (ArchiveStreamFactory에 UTF-8 인코딩 지정 + 원본 경로 사용)이 한글 엔트리 이름을 보존함을
+ * 검증한다.</p>
+ */
+class BackupJobFileNameCharsetTest {
+
+    @Test
+    @DisplayName("기본 charset이 UTF-8이 아니면 기존 라운드트립이 한글 이름을 손상시킨다")
+    void legacyRoundTripCorruptsKoreanName() {
+        String name = "백업한글파일";
+
+        // 한국 Windows 기본 charset(MS949)을 가정한 기존 코드의 라운드트립.
+        String roundTripped = new String(name.getBytes(Charset.forName("MS949")), StandardCharsets.UTF_8);
+
+        assertNotEquals(name, roundTripped, "기본 charset이 UTF-8이 아니면 한글 이름이 손상되어야 한다(버그 재현)");
+    }
+
+    @Test
+    @DisplayName("UTF-8 인코딩과 원본 경로를 쓰면 한글 TAR 엔트리 이름이 보존된다")
+    void utf8TarPreservesKoreanEntryName() throws Exception {
+        String name = "백업/한글-파일.txt";
+
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        try (ArchiveOutputStream aos = new ArchiveStreamFactory(StandardCharsets.UTF_8.name())
+                .createArchiveOutputStream(ArchiveStreamFactory.TAR, bos)) {
+            TarArchiveEntry entry = new TarArchiveEntry(name);
+            entry.setSize(0);
+            aos.putArchiveEntry(entry);
+            aos.closeArchiveEntry();
+        }
+
+        try (TarArchiveInputStream tis = new TarArchiveInputStream(
+                new ByteArrayInputStream(bos.toByteArray()), StandardCharsets.UTF_8.name())) {
+            TarArchiveEntry read = tis.getNextTarEntry();
+            assertEquals(name, read.getName(), "UTF-8로 기록한 한글 엔트리 이름이 그대로 복원되어야 한다");
+        }
+    }
+}


### PR DESCRIPTION
## 변경 이유

`BackupJob`이 TAR 백업 엔트리 이름을 다음과 같이 만듭니다.

```java
new TarArchiveEntry(sfile,
    new String(sfile.getAbsolutePath().getBytes(Charset.defaultCharset().name()), "UTF-8"));
```

기본 charset으로 인코딩한 바이트를 UTF-8로 재해석하는 라운드트립이라, 기본 charset이 UTF-8이 아닌 환경(예: 한국 Windows의 MS949)에서는 한글이 포함된 경로가 깨집니다(mojibake). 주석의 의도("파일이름 한글처리")와 달리 오히려 한글 엔트리 이름을 손상시킵니다.

## 변경 내용

- `ArchiveStreamFactory`에 UTF-8 인코딩을 지정해 엔트리 이름을 UTF-8로 기록합니다.
- 손상을 유발하던 charset 라운드트립을 제거하고 원본 경로를 그대로 사용합니다.

## 테스트 방법

`BackupJobFileNameCharsetTest`:
- 기본 charset이 UTF-8이 아닐 때(MS949 가정) 기존 라운드트립이 한글 이름을 손상시킴을 확인(버그 재현)
- UTF-8 인코딩 + 원본 경로로 기록한 TAR의 한글 엔트리 이름이 그대로 복원됨을 확인

(압축 로직이 정적 기준 디렉터리에 의존해 단위 환경에서 직접 구동이 어려워, charset 동작을 결정적으로 검증하는 형태로 작성했습니다.)

## 영향 범위

백업 엔트리 이름 인코딩만 변경합니다. 엔트리 이름이 ASCII인 경우 결과는 동일합니다.
