### PR TITLE
fix: 주소 연계 API 호출 시 confmKey 미인코딩 수정

### DIFF
--- a/src/main/java/egovframework/com/sym/adr/web/EgovAdressCntcController.java
+++ b/src/main/java/egovframework/com/sym/adr/web/EgovAdressCntcController.java
@@ -48,7 +48,8 @@ public class EgovAdressCntcController {
 		String confmKey = req.getParameter("confmKey");
 		String keyword = req.getParameter("keyword");
 		String apiUrl = "http://www.juso.go.kr/addrlink/addrLinkApi.do?currentPage=" + currentPage + "&countPerPage="
-			+ countPerPage + "&keyword=" + URLEncoder.encode(keyword, "UTF-8") + "&confmKey=" + confmKey;
+			+ countPerPage + "&keyword=" + URLEncoder.encode(keyword, "UTF-8") + "&confmKey="
+			+ URLEncoder.encode(confmKey, "UTF-8");
 		URL url = new URL(EgovWebUtil.filePathBlackList(apiUrl));
 		try (BufferedReader br = new BufferedReader(new InputStreamReader(url.openStream(), "UTF-8"));) {//2022.01 Resources should be closed
 			StringBuffer sb = new StringBuffer();


### PR DESCRIPTION
## 변경 이유

`EgovAdressCntcController.getAddrApi`가 juso.go.kr 주소 연계 API URL을 만들 때 `confmKey`(인증키)를 URL 인코딩 없이 그대로 연결합니다.

```java
... + "&keyword=" + URLEncoder.encode(keyword, "UTF-8") + "&confmKey=" + confmKey;
```

`confmKey`에 URL 예약문자가 포함되면 질의 문자열이 어긋날 수 있습니다. 같은 클래스의 자매 메서드 `getAddrApiTest`는 `confmKey`를 `URLEncoder.encode(confmKey, "UTF-8")`로 인코딩하고 있어 동작이 불일치합니다.

## 변경 내용

`getAddrApi`도 자매 메서드와 동일하게 `confmKey`를 UTF-8로 URL 인코딩합니다.

## 테스트 방법

해당 메서드는 외부 API를 직접 호출하는 구조라 단위 테스트로 분리하기 어렵습니다. 같은 클래스의 `getAddrApiTest`가 이미 동일하게 `confmKey`를 인코딩하고 있어, 이 변경은 두 메서드의 동작을 일치시키는 수정입니다.

## 영향 범위

`getAddrApi`의 URL 구성만 변경하며, `confmKey`가 예약문자를 포함하지 않으면 결과는 동일합니다.
