### PR TITLE
뉴스 등록 검증 실패 시 첨부파일 저장 방지

### DIFF
--- a/src/main/java/egovframework/com/uss/ion/nws/web/EgovNewsController.java
+++ b/src/main/java/egovframework/com/uss/ion/nws/web/EgovNewsController.java
@@ -143,6 +143,11 @@ public class EgovNewsController {
 	@RequestMapping("/uss/ion/nws/insertNews.do")
 	public String insertNews(final MultipartHttpServletRequest multiRequest, @Valid @ModelAttribute("newsVO") NewsVO newsVO, BindingResult bindingResult, ModelMap model) throws Exception {
 
+		if(bindingResult.hasErrors()){
+			model.addAttribute("newsVO", newsVO);
+			return "egovframework/com/uss/ion/nws/EgovNewsRegist";
+		}
+
 		// 첨부파일 관련 첨부파일ID 생성
 		List<FileVO> fvoList = null;
 		String atchFileId = "";
@@ -157,11 +162,6 @@ public class EgovNewsController {
 
 		// 리턴받은 첨부파일ID를 셋팅한다..
 		newsVO.setAtchFileId(atchFileId); // 첨부파일 ID
-
-		if(bindingResult.hasErrors()){
-			model.addAttribute("newsVO", newsVO);
-			return "egovframework/com/uss/ion/nws/EgovNewsRegist";
-		}
 
 		// 로그인VO에서 사용자 정보 가져오기
 		LoginVO loginVO = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();

--- a/src/test/java/egovframework/com/uss/ion/nws/web/EgovNewsControllerTest.java
+++ b/src/test/java/egovframework/com/uss/ion/nws/web/EgovNewsControllerTest.java
@@ -1,0 +1,64 @@
+package egovframework.com.uss.ion.nws.web;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.lang.reflect.Proxy;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.ui.ModelMap;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.multipart.MultipartHttpServletRequest;
+
+import egovframework.com.uss.ion.nws.service.NewsVO;
+
+class EgovNewsControllerTest {
+
+	private static final String REGIST_VIEW = "egovframework/com/uss/ion/nws/EgovNewsRegist";
+
+	@Test
+	void insertNewsReturnsRegistViewBeforeReadingFilesWhenValidationFails() throws Exception {
+		EgovNewsController controller = new EgovNewsController();
+		NewsVO newsVO = new NewsVO();
+		BindingResult bindingResult = new BeanPropertyBindingResult(newsVO, "newsVO");
+		bindingResult.rejectValue("newsSj", "required");
+
+		MultipartHttpServletRequest request = multipartRequestFailingOnFileAccess();
+
+		ModelMap model = new ModelMap();
+		String view = controller.insertNews(request, newsVO, bindingResult, model);
+
+		assertEquals(REGIST_VIEW, view);
+		assertEquals(newsVO, model.get("newsVO"));
+		assertNull(newsVO.getAtchFileId());
+	}
+
+	private MultipartHttpServletRequest multipartRequestFailingOnFileAccess() {
+		return (MultipartHttpServletRequest) Proxy.newProxyInstance(MultipartHttpServletRequest.class.getClassLoader(),
+				new Class<?>[] { MultipartHttpServletRequest.class }, (proxy, method, args) -> {
+					if (method.getDeclaringClass() == Object.class) {
+						return handleObjectMethod(proxy, method.getName(), args);
+					}
+
+					if ("getFiles".equals(method.getName())) {
+						throw new AssertionError("Validation errors must be handled before reading multipart files.");
+					}
+
+					throw new UnsupportedOperationException(method.toString());
+				});
+	}
+
+	private Object handleObjectMethod(Object proxy, String methodName, Object[] args) {
+		if ("toString".equals(methodName)) {
+			return "multipartRequest";
+		}
+		if ("hashCode".equals(methodName)) {
+			return System.identityHashCode(proxy);
+		}
+		if ("equals".equals(methodName)) {
+			return proxy == args[0];
+		}
+		throw new UnsupportedOperationException(methodName);
+	}
+}


### PR DESCRIPTION
## 변경 내용

- 뉴스 등록 처리에서 입력값 검증 오류를 먼저 확인하도록 순서를 조정했습니다.
- 검증 오류가 있으면 첨부파일 목록을 읽거나 저장하지 않고 등록 화면으로 반환합니다.
- 검증 실패 시 multipart 파일 접근이 발생하지 않는 회귀 테스트를 추가했습니다.

## 원인 및 영향

기존 `insertNews` 흐름은 `bindingResult.hasErrors()`를 확인하기 전에 `fileUtil.parseFileInf()`와 `fileMngService.insertFileInfs()`를 실행했습니다.

이 상태에서 뉴스 제목 또는 내용 누락처럼 `NewsVO`의 `@EgovNullCheck` 검증이 실패하고 첨부파일이 함께 제출되면, 뉴스 본문은 등록되지 않지만 첨부파일은 파일 시스템에 저장되고 `COMTNFILE` 계열 레코드가 생성될 수 있습니다.

이 수정은 서버 오류를 고치는 변경이라기보다, 검증 실패 시 발생할 수 있는 첨부파일 저장 부작용과 고아 첨부파일 가능성을 방지하는 정합성 개선입니다.

## 검증

- `git diff --check`
- `mvn -B test-compile`
- 컴파일된 `EgovNewsControllerTest` 테스트 메서드 직접 실행
  - 결과: `EgovNewsControllerTest passed`
- `mvn -B verify`
  - 저장소 POM 설정에 따라 surefire 테스트는 스킵되고, 컴파일/testCompile/WAR/Javadoc jar 생성은 성공했습니다.
