### PR TITLE
익명 만족도 수정 시 비밀번호 검증 추가

### DIFF
--- a/src/main/java/egovframework/com/cop/stf/web/EgovBBSSatisfactionController.java
+++ b/src/main/java/egovframework/com/cop/stf/web/EgovBBSSatisfactionController.java
@@ -1,6 +1,7 @@
 package egovframework.com.cop.stf.web;
 
 import java.util.Map;
+import java.util.Objects;
 
 import org.egovframe.rte.fdl.property.EgovPropertyService;
 import org.egovframe.rte.ptl.mvc.tags.ui.pagination.PaginationInfo;
@@ -298,10 +299,7 @@ public class EgovBBSSatisfactionController {
 	//-------------------------------
 	// 패스워드 비교
 	//-------------------------------
-	String dbpassword = bbsSatisfactionService.getSatisfactionPassword(satisfactionVO);
-	String enpassword = EgovFileScrty.encryptPassword(satisfactionVO.getConfirmPassword(), satisfaction.getStsfdgNo());
-
-	if (!dbpassword.equals(enpassword)) {
+	if (!matchesSatisfactionPassword(satisfactionVO, satisfactionVO.getConfirmPassword())) {
 
 	    model.addAttribute("subMsg", egovMessageSource.getMessage("cop.password.not.same.msg"));
 
@@ -431,10 +429,7 @@ public class EgovBBSSatisfactionController {
 	//-------------------------------
 	// 패스워드 비교
 	//-------------------------------
-	String dbpassword = bbsSatisfactionService.getSatisfactionPassword(satisfactionVO);
-	String enpassword = EgovFileScrty.encryptPassword(satisfactionVO.getConfirmPassword(), satisfactionVO.getStsfdgNo());
-
-	if (!dbpassword.equals(enpassword)) {
+	if (!matchesSatisfactionPassword(satisfactionVO, satisfactionVO.getConfirmPassword())) {
 
 	    model.addAttribute("subMsg", egovMessageSource.getMessage("cop.password.not.same.msg"));
 
@@ -522,6 +517,11 @@ public class EgovBBSSatisfactionController {
 		    return "forward:/cop/bbs/anonymous/selectBoardArticle.do";
 		}
 
+		if (!matchesSatisfactionPassword(satisfaction, satisfaction.getStsfdgPassword())) {
+		    model.addAttribute("subMsg", egovMessageSource.getMessage("cop.password.not.same.msg"));
+		    return "forward:/cop/bbs/anonymous/selectBoardArticle.do";
+		}
+
 		satisfaction.setLastUpdusrId("ANONYMOUS");
 		satisfaction.setStsfdgPassword(EgovFileScrty.encryptPassword(satisfaction.getStsfdgPassword(), satisfaction.getStsfdgNo()));
 
@@ -534,4 +534,11 @@ public class EgovBBSSatisfactionController {
 
 		return "forward:/cop/bbs/anonymous/selectBoardArticle.do";
     }
+
+	private boolean matchesSatisfactionPassword(Satisfaction satisfaction, String rawPassword) throws Exception {
+		String dbpassword = bbsSatisfactionService.getSatisfactionPassword(satisfaction);
+		String enpassword = EgovFileScrty.encryptPassword(rawPassword, satisfaction.getStsfdgNo());
+
+		return Objects.equals(dbpassword, enpassword);
+	}
 }

--- a/src/test/java/egovframework/com/cop/stf/web/EgovBBSSatisfactionControllerTest.java
+++ b/src/test/java/egovframework/com/cop/stf/web/EgovBBSSatisfactionControllerTest.java
@@ -1,0 +1,126 @@
+package egovframework.com.cop.stf.web;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.ui.ModelMap;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.BindingResult;
+
+import egovframework.com.cmm.EgovMessageSource;
+import egovframework.com.cop.bbs.service.EgovBBSSatisfactionService;
+import egovframework.com.cop.bbs.service.Satisfaction;
+import egovframework.com.cop.bbs.service.SatisfactionVO;
+import egovframework.com.utl.sim.service.EgovFileScrty;
+
+class EgovBBSSatisfactionControllerTest {
+
+	private static final String PASSWORD_MESSAGE = "cop.password.not.same.msg";
+
+	@Test
+	void updateAnonymousSatisfactionRejectsInvalidPassword() throws Exception {
+		EgovBBSSatisfactionController controller = controllerWithStoredPassword("correct");
+		RecordingSatisfactionService service = (RecordingSatisfactionService) controller.bbsSatisfactionService;
+
+		Satisfaction satisfaction = satisfactionWithPassword("wrong");
+		BindingResult bindingResult = new BeanPropertyBindingResult(satisfaction, "satisfaction");
+		ModelMap model = new ModelMap();
+
+		String view = controller.updateAnonymousSatisfaction(new SatisfactionVO(), satisfaction, bindingResult, model);
+
+		assertEquals("forward:/cop/bbs/anonymous/selectBoardArticle.do", view);
+		assertEquals(PASSWORD_MESSAGE, model.get("subMsg"));
+		assertFalse(service.updateCalled);
+	}
+
+	@Test
+	void deleteAnonymousSatisfactionTreatsMissingPasswordAsMismatch() throws Exception {
+		EgovBBSSatisfactionController controller = controllerWithStoredPassword(null);
+		RecordingSatisfactionService service = (RecordingSatisfactionService) controller.bbsSatisfactionService;
+
+		SatisfactionVO satisfactionVO = new SatisfactionVO();
+		satisfactionVO.setStsfdgNo("SATISFACTION_1");
+		satisfactionVO.setConfirmPassword("any-password");
+		ModelMap model = new ModelMap();
+
+		String view = controller.deleteAnonymousSatisfaction(satisfactionVO, new Satisfaction(), model);
+
+		assertEquals("forward:/cop/bbs/anonymous/selectArticleDetail.do", view);
+		assertEquals(PASSWORD_MESSAGE, model.get("subMsg"));
+		assertFalse(service.deleteCalled);
+	}
+
+	private EgovBBSSatisfactionController controllerWithStoredPassword(String rawPassword) throws Exception {
+		EgovBBSSatisfactionController controller = new EgovBBSSatisfactionController();
+		controller.bbsSatisfactionService = new RecordingSatisfactionService(rawPassword);
+		controller.egovMessageSource = new TestMessageSource();
+		return controller;
+	}
+
+	private Satisfaction satisfactionWithPassword(String password) {
+		Satisfaction satisfaction = new Satisfaction();
+		satisfaction.setStsfdgNo("SATISFACTION_1");
+		satisfaction.setWrterNm("writer");
+		satisfaction.setStsfdgPassword(password);
+		satisfaction.setStsfdgCn("content");
+		satisfaction.setStsfdg(5);
+		return satisfaction;
+	}
+
+	private static final class TestMessageSource extends EgovMessageSource {
+		@Override
+		public String getMessage(String code) {
+			return code;
+		}
+	}
+
+	private static final class RecordingSatisfactionService implements EgovBBSSatisfactionService {
+
+		private final String storedPassword;
+		private boolean updateCalled;
+		private boolean deleteCalled;
+
+		private RecordingSatisfactionService(String rawPassword) throws Exception {
+			this.storedPassword = rawPassword == null ? null
+					: EgovFileScrty.encryptPassword(rawPassword, "SATISFACTION_1");
+		}
+
+		@Override
+		public boolean canUseSatisfaction(String bbsId) throws Exception {
+			return true;
+		}
+
+		@Override
+		public Map<String, Object> selectSatisfactionList(SatisfactionVO satisfactionVO) throws Exception {
+			return Collections.emptyMap();
+		}
+
+		@Override
+		public void insertSatisfaction(Satisfaction satisfaction) throws Exception {
+		}
+
+		@Override
+		public void deleteSatisfaction(SatisfactionVO satisfactionVO) throws Exception {
+			deleteCalled = true;
+		}
+
+		@Override
+		public Satisfaction selectSatisfaction(SatisfactionVO satisfactionVO) throws Exception {
+			return null;
+		}
+
+		@Override
+		public void updateSatisfaction(Satisfaction satisfaction) throws Exception {
+			updateCalled = true;
+		}
+
+		@Override
+		public String getSatisfactionPassword(Satisfaction satisfaction) throws Exception {
+			return storedPassword;
+		}
+	}
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

익명 만족도 수정 요청에서 저장된 비밀번호를 다시 검증하도록 수정했습니다.

기존 흐름에서는 수정 화면 진입 시 비밀번호를 확인하지만, 최종 수정 엔드포인트인 `/cop/stf/anonymous/updateSatisfaction.do`에서는 저장된 비밀번호와 요청 비밀번호를 비교하지 않았습니다. 이 상태에서는 `stsfdgNo`와 필수 입력값을 포함한 수정 POST가 직접 호출되면 원래 비밀번호를 알지 못해도 익명 만족도 내용, 평점, 작성자명, 비밀번호가 갱신될 수 있습니다.

이번 변경에서는 익명 수정 처리 전에 `getSatisfactionPassword`로 저장된 비밀번호를 조회하고, 요청 비밀번호를 같은 방식으로 암호화해 비교한 뒤 일치하지 않으면 기존 비밀번호 불일치 메시지로 되돌리도록 했습니다. 기존 익명 조회/삭제의 비밀번호 비교도 같은 헬퍼로 통일하여 대상 비밀번호가 조회되지 않는 경우 불일치로 처리합니다.

검증한 재현 조건:
- 익명 만족도 등록 후 표시되는 `stsfdgNo`를 가진 상태
- `/cop/stf/anonymous/updateSatisfaction.do`로 필수 입력값과 임의의 `stsfdgPassword`를 포함해 직접 POST
- 기존 `main` 기준 동일 테스트는 `subMsg`가 비밀번호 불일치 메시지로 설정되지 않아 실패
- 수정 후에는 비밀번호 불일치 시 update 서비스가 호출되지 않음

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

검증:
- `git diff --check`
- 수정된 컨트롤러와 테스트 클래스 `javac` 컴파일
- `EgovBBSSatisfactionControllerTestRunner` 실행
- 동일 테스트를 `main` 기준 컨트롤러에 적용했을 때 `updateAnonymousSatisfactionRejectsInvalidPassword` 실패 확인

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

컨트롤러 단위 검증으로 확인했습니다.
