### PR TITLE
댓글 수정 및 삭제 시 작성자 검증 추가

### DIFF
--- a/src/main/java/egovframework/com/cop/cmt/web/EgovArticleCommentController.java
+++ b/src/main/java/egovframework/com/cop/cmt/web/EgovArticleCommentController.java
@@ -15,11 +15,13 @@ import org.springframework.web.bind.annotation.RequestParam;
 import egovframework.com.cmm.EgovMessageSource;
 import egovframework.com.cmm.LoginVO;
 import egovframework.com.cmm.util.EgovUserDetailsHelper;
+import egovframework.com.cmm.util.EgovXssChecker;
 import egovframework.com.cop.cmt.service.Comment;
 import egovframework.com.cop.cmt.service.CommentVO;
 import egovframework.com.cop.cmt.service.EgovArticleCommentService;
 import egovframework.com.utl.fcc.service.EgovStringUtil;
 import jakarta.annotation.Resource;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 
 /**
@@ -175,13 +177,14 @@ public class EgovArticleCommentController {
      * @throws Exception
      */
     @RequestMapping("/cop/cmt/deleteArticleComment.do")
-    public String deleteArticleComment(@ModelAttribute("searchVO") CommentVO commentVO, @ModelAttribute("comment") Comment comment,
+    public String deleteArticleComment(HttpServletRequest request, @ModelAttribute("searchVO") CommentVO commentVO, @ModelAttribute("comment") Comment comment,
     		ModelMap model, @RequestParam HashMap<String, String> map) throws Exception {
 		@SuppressWarnings("unused")
 		LoginVO user = (LoginVO)EgovUserDetailsHelper.getAuthenticatedUser();
 		Boolean isAuthenticated = EgovUserDetailsHelper.isAuthenticated();
 
 		if (isAuthenticated) {
+		    checkCommentOwner(request, commentVO.getCommentNo());
 		    egovArticleCommentService.deleteArticleComment(commentVO);
 		}
 
@@ -263,7 +266,7 @@ public class EgovArticleCommentController {
      * @throws Exception
      */
     @RequestMapping("/cop/cmt/updateArticleComment.do")
-    public String updateArticleComment(@ModelAttribute("searchVO") CommentVO commentVO, @Valid @ModelAttribute("comment") Comment comment,
+    public String updateArticleComment(HttpServletRequest request, @ModelAttribute("searchVO") CommentVO commentVO, @Valid @ModelAttribute("comment") Comment comment,
 	    BindingResult bindingResult, ModelMap model) throws Exception {
 
 		LoginVO user = (LoginVO)EgovUserDetailsHelper.getAuthenticatedUser();
@@ -276,6 +279,7 @@ public class EgovArticleCommentController {
 		}
 
 		if (isAuthenticated) {
+		    checkCommentOwner(request, comment.getCommentNo());
 		    comment.setLastUpdusrId(user == null ? "" : EgovStringUtil.isNullToString(user.getUniqId()));
 
 		    egovArticleCommentService.updateArticleComment(comment);
@@ -285,6 +289,14 @@ public class EgovArticleCommentController {
 		}
 
 		return "forward:/cop/bbs/selectArticleDetail.do";
+    }
+
+    private void checkCommentOwner(HttpServletRequest request, String commentNo) throws Exception {
+		CommentVO ownerVO = new CommentVO();
+		ownerVO.setCommentNo(commentNo);
+
+		CommentVO data = egovArticleCommentService.selectArticleCommentDetail(ownerVO);
+		EgovXssChecker.checkerUserXss(request, data == null ? null : data.getWrterId());
     }
 
 

--- a/src/test/java/egovframework/com/cop/cmt/web/EgovArticleCommentControllerTest.java
+++ b/src/test/java/egovframework/com/cop/cmt/web/EgovArticleCommentControllerTest.java
@@ -1,0 +1,142 @@
+package egovframework.com.cop.cmt.web;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.egovframe.rte.fdl.cmmn.exception.FdlException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.ui.ModelMap;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.BindingResult;
+
+import egovframework.com.cmm.LoginVO;
+import egovframework.com.cmm.exception.EgovXssException;
+import egovframework.com.cmm.service.EgovUserDetailsService;
+import egovframework.com.cmm.util.EgovUserDetailsHelper;
+import egovframework.com.cop.cmt.service.Comment;
+import egovframework.com.cop.cmt.service.CommentVO;
+import egovframework.com.cop.cmt.service.EgovArticleCommentService;
+
+class EgovArticleCommentControllerTest {
+
+	private static final String LOGIN_USER_ID = "LOGIN_USER";
+	private static final String COMMENT_OWNER_ID = "COMMENT_OWNER";
+
+	@AfterEach
+	void tearDown() {
+		new EgovUserDetailsHelper().setEgovUserDetailsService(new TestUserDetailsService(null, false));
+	}
+
+	@Test
+	void updateArticleCommentRejectsNonOwner() {
+		EgovArticleCommentController controller = controllerWithCommentOwner(COMMENT_OWNER_ID);
+		RecordingArticleCommentService service = (RecordingArticleCommentService) controller.egovArticleCommentService;
+		Comment comment = new Comment();
+		comment.setCommentNo("COMMENT_1");
+		comment.setCommentCn("updated");
+		BindingResult bindingResult = new BeanPropertyBindingResult(comment, "comment");
+
+		assertThrows(EgovXssException.class,
+				() -> controller.updateArticleComment(null, new CommentVO(), comment, bindingResult, new ModelMap()));
+		assertFalse(service.updateCalled);
+	}
+
+	@Test
+	void deleteArticleCommentRejectsNonOwner() {
+		EgovArticleCommentController controller = controllerWithCommentOwner(COMMENT_OWNER_ID);
+		RecordingArticleCommentService service = (RecordingArticleCommentService) controller.egovArticleCommentService;
+		CommentVO commentVO = new CommentVO();
+		commentVO.setCommentNo("COMMENT_1");
+
+		assertThrows(EgovXssException.class,
+				() -> controller.deleteArticleComment(null, commentVO, new Comment(), new ModelMap(), new HashMap<>()));
+		assertFalse(service.deleteCalled);
+	}
+
+	private EgovArticleCommentController controllerWithCommentOwner(String commentOwnerId) {
+		LoginVO loginVO = new LoginVO();
+		loginVO.setId("login-user");
+		loginVO.setUniqId(LOGIN_USER_ID);
+
+		new EgovUserDetailsHelper().setEgovUserDetailsService(new TestUserDetailsService(loginVO, true));
+
+		EgovArticleCommentController controller = new EgovArticleCommentController();
+		controller.egovArticleCommentService = new RecordingArticleCommentService(commentOwnerId);
+		return controller;
+	}
+
+	private static final class TestUserDetailsService implements EgovUserDetailsService {
+
+		private final LoginVO loginVO;
+		private final boolean authenticated;
+
+		private TestUserDetailsService(LoginVO loginVO, boolean authenticated) {
+			this.loginVO = loginVO;
+			this.authenticated = authenticated;
+		}
+
+		@Override
+		public Object getAuthenticatedUser() {
+			return loginVO;
+		}
+
+		@Override
+		public List<String> getAuthorities() {
+			return Collections.emptyList();
+		}
+
+		@Override
+		public Boolean isAuthenticated() {
+			return authenticated;
+		}
+	}
+
+	private static final class RecordingArticleCommentService implements EgovArticleCommentService {
+
+		private final String commentOwnerId;
+		private boolean updateCalled;
+		private boolean deleteCalled;
+
+		private RecordingArticleCommentService(String commentOwnerId) {
+			this.commentOwnerId = commentOwnerId;
+		}
+
+		@Override
+		public boolean canUseComment(String bbsId) throws Exception {
+			return true;
+		}
+
+		@Override
+		public Map<String, Object> selectArticleCommentList(CommentVO commentVO) {
+			return Collections.emptyMap();
+		}
+
+		@Override
+		public void insertArticleComment(Comment comment) throws FdlException {
+		}
+
+		@Override
+		public void deleteArticleComment(CommentVO commentVO) {
+			deleteCalled = true;
+		}
+
+		@Override
+		public CommentVO selectArticleCommentDetail(CommentVO commentVO) {
+			CommentVO result = new CommentVO();
+			result.setCommentNo(commentVO.getCommentNo());
+			result.setWrterId(commentOwnerId);
+			return result;
+		}
+
+		@Override
+		public void updateArticleComment(Comment comment) {
+			updateCalled = true;
+		}
+	}
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

댓글 수정/삭제 요청에서 댓글 작성자와 현재 로그인 사용자가 같은지 서버에서 검증하도록 수정했습니다.

기존 JSP는 `result.wrterId == sessionUniqId` 조건으로 본인 댓글에만 수정/삭제 버튼을 보여주지만, 실제 엔드포인트인 `/cop/cmt/updateArticleComment.do`, `/cop/cmt/deleteArticleComment.do`는 로그인 여부만 확인했습니다. 이 상태에서는 로그인 사용자가 다른 사용자의 `commentNo`를 포함해 직접 요청하면 해당 댓글을 수정하거나 삭제할 수 있습니다.

이번 변경에서는 수정/삭제 처리 전에 기존 댓글을 조회하고, 저장된 `wrterId`를 `EgovXssChecker.checkerUserXss`로 확인하도록 했습니다. 게시글/Q&A 수정·삭제에서 사용하는 사용자 소유권 검증 방식과 같은 흐름입니다.

검증한 재현 조건:
- 댓글 작성자 `COMMENT_OWNER`와 로그인 사용자 `LOGIN_USER`가 다른 상태
- `/cop/cmt/updateArticleComment.do` 또는 `/cop/cmt/deleteArticleComment.do`를 `commentNo`와 함께 직접 호출
- 기존 `main` 기준 컨트롤러는 비작성자 조건에서도 update/delete 서비스가 호출됨
- 수정 후에는 같은 조건에서 `EgovXssException`이 발생하고 update/delete 서비스가 호출되지 않음

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

검증:
- `git diff --check`
- 수정된 컨트롤러와 테스트 클래스 `javac` 컴파일
- `EgovArticleCommentControllerTestRunner` 실행
- 동일 조건을 `main` 기준 원본 컨트롤러에 적용했을 때 비작성자 update/delete 서비스 호출 확인

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

컨트롤러 단위 검증으로 확인했습니다.
