### PR TITLE
방명록 수정 및 삭제 시 작성자 검증 추가

### DIFF
--- a/src/main/java/egovframework/com/cop/bbs/web/EgovArticleController.java
+++ b/src/main/java/egovframework/com/cop/bbs/web/EgovArticleController.java
@@ -870,13 +870,16 @@ public class EgovArticleController {
 	 * @throws Exception
 	 */
 	@RequestMapping("/cop/bbs/deleteGuestArticle.do")
-	public String deleteGuestList(@ModelAttribute("searchVO") BoardVO boardVO, @Valid @ModelAttribute("articleVO") Board board,
-			ModelMap model) throws Exception {
+	public String deleteGuestList(HttpServletRequest request, @ModelAttribute("searchVO") BoardVO boardVO,
+			@Valid @ModelAttribute("articleVO") Board board, ModelMap model) throws Exception {
 		@SuppressWarnings("unused")
 		LoginVO user = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();
 		Boolean isAuthenticated = EgovUserDetailsHelper.isAuthenticated();
 
 		if (isAuthenticated) {
+			BoardVO vo = egovArticleService.selectArticleDetail(boardVO);
+			EgovXssChecker.checkerUserXss(request, vo.getFrstRegisterId());
+
 			egovArticleService.deleteArticle(boardVO);
 		}
 
@@ -893,7 +896,7 @@ public class EgovArticleController {
 	 * @throws Exception
 	 */
 	@RequestMapping("/cop/bbs/updateGuestArticleView.do")
-	public String updateGuestArticleView(@ModelAttribute("searchVO") BoardVO boardVO,
+	public String updateGuestArticleView(HttpServletRequest request, @ModelAttribute("searchVO") BoardVO boardVO,
 			@ModelAttribute("boardMasterVO") BoardMasterVO brdMstrVO, ModelMap model) throws Exception {
 
 		LoginVO user = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();
@@ -907,6 +910,7 @@ public class EgovArticleController {
 		model.addAttribute("sessionUniqId", (user == null || user.getUniqId() == null) ? "" : user.getUniqId());
 
 		BoardVO vo = egovArticleService.selectArticleDetail(boardVO);
+		EgovXssChecker.checkerUserXss(request, vo.getFrstRegisterId());
 
 		boardVO.setBbsId(boardVO.getBbsId());
 		boardVO.setBbsNm(boardVO.getBbsNm());
@@ -947,8 +951,8 @@ public class EgovArticleController {
 	 * @throws Exception
 	 */
 	@RequestMapping("/cop/bbs/updateGuestArticle.do")
-	public String updateGuestArticle(@ModelAttribute("searchVO") BoardVO boardVO, @Valid @ModelAttribute Board board,
-			BindingResult bindingResult, ModelMap model) throws Exception {
+	public String updateGuestArticle(HttpServletRequest request, @ModelAttribute("searchVO") BoardVO boardVO,
+			@Valid @ModelAttribute Board board, BindingResult bindingResult, ModelMap model) throws Exception {
 
 		// BBST02, BBST04
 		LoginVO user = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();
@@ -957,6 +961,9 @@ public class EgovArticleController {
 		if (!isAuthenticated) { // KISA 보안취약점 조치 (2018-12-10, 이정은)
 			return "redirect:/uat/uia/egovLoginUsr.do";
 		}
+
+		BoardVO article = egovArticleService.selectArticleDetail(boardVO);
+		EgovXssChecker.checkerUserXss(request, article.getFrstRegisterId());
 
 		if (bindingResult.hasErrors()) {
 


### PR DESCRIPTION
## 요약
- 방명록 수정화면, 수정, 삭제 요청에서 저장된 작성자와 현재 로그인 사용자를 검증하도록 했습니다.
- 일반 게시글 수정/삭제에서 이미 사용하는 `EgovXssChecker` 기반 작성자 검증을 방명록에도 적용했습니다.

## 문제 상황
- 화면에서는 방명록 항목의 `result.frstRegisterId`가 `sessionUniqId`와 같을 때만 수정/삭제 버튼을 보여줍니다.
- 하지만 서버의 `/cop/bbs/updateGuestArticleView.do`, `/cop/bbs/updateGuestArticle.do`, `/cop/bbs/deleteGuestArticle.do`는 기존 코드 기준으로 로그인 여부만 확인했습니다.
- 실제 `updateArticle`/`deleteArticle` SQL은 `BBS_ID`와 `NTT_ID`만 조건으로 사용하므로, 직접 요청에서는 화면의 작성자 제한을 우회할 수 있습니다.

## 수정 내용
- 수정화면 조회 전에 `selectArticleDetail`로 기존 방명록 작성자를 조회하고 `EgovXssChecker`로 검증합니다.
- 수정/삭제 처리 전에 동일하게 저장된 `frstRegisterId`를 검증합니다.
- 작성자가 아닌 사용자는 기존 공통 예외인 `EgovXssException` 경로로 차단됩니다.

## 검증
- `git diff --check`
- JSP의 작성자 UI 제한 조건 확인: `EgovGuestArticleList.jsp`의 `result.frstRegisterId == sessionUniqId`
- SQL 쓰기 조건 확인: `EgovArticle_SQL_mysql.xml`의 `updateArticle`/`deleteArticle`은 `BBS_ID`와 `NTT_ID` 기준
- `/Users/minseok/.m2/wrapper/dists/apache-maven-3.6.3-bin/1iopthnavndlasol9gbrbg6bf2/apache-maven-3.6.3/bin/mvn -B verify --file pom.xml`
  - `BUILD SUCCESS`
  - 현재 POM 설정상 Surefire 테스트는 skipped로 처리됩니다.
  - 기존 Javadoc 경고는 남아 있지만 빌드는 성공했습니다.
