### PR TITLE
스크랩 조회·수정·삭제 시 작성자 검증 추가

### DIFF
--- a/src/main/java/egovframework/com/cop/scp/web/EgovArticleScrapController.java
+++ b/src/main/java/egovframework/com/cop/scp/web/EgovArticleScrapController.java
@@ -14,6 +14,7 @@ import egovframework.com.cmm.EgovMessageSource;
 import egovframework.com.cmm.LoginVO;
 import egovframework.com.cmm.annotation.IncludedInfo;
 import egovframework.com.cmm.util.EgovUserDetailsHelper;
+import egovframework.com.cmm.util.EgovXssChecker;
 import egovframework.com.cop.bbs.service.BoardVO;
 import egovframework.com.cop.bbs.service.EgovArticleService;
 import egovframework.com.cop.scp.service.EgovArticleScrapService;
@@ -21,6 +22,7 @@ import egovframework.com.cop.scp.service.Scrap;
 import egovframework.com.cop.scp.service.ScrapVO;
 import egovframework.com.utl.fcc.service.EgovStringUtil;
 import jakarta.annotation.Resource;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 
 /**
@@ -112,7 +114,8 @@ public class EgovArticleScrapController {
      * @throws Exception
      */
     @RequestMapping("/cop/scp/selectArticleScrapDetail.do")
-    public String selectArticleScrapDetail(@ModelAttribute("searchVO") ScrapVO scrapVO, ModelMap model) throws Exception {
+    public String selectArticleScrapDetail(HttpServletRequest request, @ModelAttribute("searchVO") ScrapVO scrapVO,
+            ModelMap model) throws Exception {
 		LoginVO user = (LoginVO)EgovUserDetailsHelper.getAuthenticatedUser();
    	 	// KISA 보안취약점 조치 (2018-12-10, 신용호)
         Boolean isAuthenticated = EgovUserDetailsHelper.isAuthenticated();
@@ -122,6 +125,7 @@ public class EgovArticleScrapController {
         }
 
 		ScrapVO scrap = egovArticleScrapService.selectArticleScrapDetail(scrapVO);
+		EgovXssChecker.checkerUserXss(request, scrap == null ? null : scrap.getFrstRegisterId());
 
 		model.addAttribute("sessionUniqId", user == null ? "" : EgovStringUtil.isNullToString(user.getUniqId()));
 		model.addAttribute("result", scrap);
@@ -216,12 +220,16 @@ public class EgovArticleScrapController {
      * @throws Exception
      */
     @RequestMapping("/cop/scp/deleteArticleScrap.do")
-    public String deleteArticleScrap(@ModelAttribute("searchVO") ScrapVO scrapVO, @ModelAttribute("Scrap") Scrap scrap, ModelMap model) throws Exception {
+    public String deleteArticleScrap(HttpServletRequest request, @ModelAttribute("searchVO") ScrapVO scrapVO,
+            @ModelAttribute("Scrap") Scrap scrap, ModelMap model) throws Exception {
 	@SuppressWarnings("unused")
 		LoginVO user = (LoginVO)EgovUserDetailsHelper.getAuthenticatedUser();
 		Boolean isAuthenticated = EgovUserDetailsHelper.isAuthenticated();
 
 		if (isAuthenticated) {
+			ScrapVO data = egovArticleScrapService.selectArticleScrapDetail(scrapVO);
+			EgovXssChecker.checkerUserXss(request, data == null ? null : data.getFrstRegisterId());
+
 		    egovArticleScrapService.deleteArticleScrap(scrapVO);
 		}
 
@@ -237,8 +245,16 @@ public class EgovArticleScrapController {
      * @throws Exception
      */
     @RequestMapping("/cop/scp/updateArticleScrapView.do")
-    public String updateArticleScrapView(@ModelAttribute("searchVO") ScrapVO scrapVO, @ModelAttribute("scrap") Scrap scrap, ModelMap model) throws Exception {
+    public String updateArticleScrapView(HttpServletRequest request, @ModelAttribute("searchVO") ScrapVO scrapVO,
+            @ModelAttribute("scrap") Scrap scrap, ModelMap model) throws Exception {
+		Boolean isAuthenticated = EgovUserDetailsHelper.isAuthenticated();
+
+		if (!isAuthenticated) {
+			return "redirect:/uat/uia/egovLoginUsr.do";
+		}
+
 		Scrap vo = egovArticleScrapService.selectArticleScrapDetail(scrapVO);
+		EgovXssChecker.checkerUserXss(request, vo == null ? null : vo.getFrstRegisterId());
 
 		model.addAttribute("articleScrapVO", vo);
 
@@ -266,11 +282,18 @@ public class EgovArticleScrapController {
      * @throws Exception
      */
     @RequestMapping("/cop/scp/updateArticleScrap.do")
-    public String updateArticleScrap(@ModelAttribute("searchVO") ScrapVO scrapVO, @Valid @ModelAttribute("Scrap") Scrap scrap,
-	    BindingResult bindingResult, ModelMap model) throws Exception {
+    public String updateArticleScrap(HttpServletRequest request, @ModelAttribute("searchVO") ScrapVO scrapVO,
+            @Valid @ModelAttribute("Scrap") Scrap scrap, BindingResult bindingResult, ModelMap model) throws Exception {
 
 		LoginVO user = (LoginVO)EgovUserDetailsHelper.getAuthenticatedUser();
 		Boolean isAuthenticated = EgovUserDetailsHelper.isAuthenticated();
+
+		if (!isAuthenticated) {
+			return "redirect:/uat/uia/egovLoginUsr.do";
+		}
+
+		ScrapVO data = egovArticleScrapService.selectArticleScrapDetail(scrapVO);
+		EgovXssChecker.checkerUserXss(request, data == null ? null : data.getFrstRegisterId());
 
 		if (bindingResult.hasErrors()) {
 
@@ -281,11 +304,9 @@ public class EgovArticleScrapController {
 		    return "egovframework/com/cop/scp/EgovArticleScrapUpdt";
 		}
 
-		if (isAuthenticated) {
-		    scrap.setLastUpdusrId(user == null ? "" : EgovStringUtil.isNullToString(user.getUniqId()));
+		scrap.setLastUpdusrId(user == null ? "" : EgovStringUtil.isNullToString(user.getUniqId()));
 
-		    egovArticleScrapService.updateArticleScrap(scrap);
-		}
+		egovArticleScrapService.updateArticleScrap(scrap);
 
 		return "forward:/cop/scp/selectArticleScrapList.do";
     }


### PR DESCRIPTION
## 요약
- 스크랩 상세 조회, 수정화면, 수정, 삭제 요청에서 저장된 작성자와 현재 로그인 사용자를 검증하도록 했습니다.
- 스크랩은 개인 보관 데이터이므로 목록뿐 아니라 직접 접근 가능한 상세/쓰기 엔드포인트에서도 동일한 소유자 검증이 필요합니다.

## 문제 상황
- 스크랩 목록 조회 SQL은 `FRST_REGISTER_ID = 로그인 사용자 uniqId` 조건으로 제한됩니다.
- 하지만 상세 조회, 수정, 삭제 경로는 기존 코드 기준으로 `scrapId`만 받아 처리합니다.
- mapper의 `selectArticleScrapDetail`, `updateArticleScrap`, `deleteArticleScrap`도 `SCRAP_ID`만 조건으로 사용하므로, 직접 요청에서는 다른 사용자의 스크랩 ID를 지정할 수 있습니다.

## 수정 내용
- `/cop/scp/selectArticleScrapDetail.do`에서 조회된 `frstRegisterId`를 `EgovXssChecker`로 검증합니다.
- `/cop/scp/updateArticleScrapView.do`, `/cop/scp/updateArticleScrap.do`, `/cop/scp/deleteArticleScrap.do`에서도 쓰기 전에 동일 검증을 수행합니다.
- 수정 저장은 인증 확인 후 작성자 검증을 통과한 경우에만 `updateArticleScrap`을 호출하도록 흐름을 정리했습니다.

## 검증
- `git diff --check`
- 목록 SQL의 사용자 제한 확인: `EgovArticleScrap_SQL_mysql.xml`의 `FRST_REGISTER_ID = #{uniqId}`
- 상세/수정/삭제 SQL의 기존 조건 확인: `selectArticleScrapDetail`/`updateArticleScrap`/`deleteArticleScrap`은 `SCRAP_ID` 기준
- `/Users/minseok/.m2/wrapper/dists/apache-maven-3.6.3-bin/1iopthnavndlasol9gbrbg6bf2/apache-maven-3.6.3/bin/mvn -B verify --file pom.xml`
  - `BUILD SUCCESS`
  - 현재 POM 설정상 Surefire 테스트는 skipped로 처리됩니다.
  - 기존 Javadoc 경고는 남아 있지만 빌드는 성공했습니다.
