### PR TITLE
명함 수정 및 삭제 시 작성자 검증 추가

### DIFF
--- a/src/main/java/egovframework/com/cop/ncm/web/EgovNcrdManageController.java
+++ b/src/main/java/egovframework/com/cop/ncm/web/EgovNcrdManageController.java
@@ -15,12 +15,14 @@ import org.springframework.web.bind.support.SessionStatus;
 import egovframework.com.cmm.LoginVO;
 import egovframework.com.cmm.annotation.IncludedInfo;
 import egovframework.com.cmm.util.EgovUserDetailsHelper;
+import egovframework.com.cmm.util.EgovXssChecker;
 import egovframework.com.cop.ncm.service.EgovNcrdManageService;
 import egovframework.com.cop.ncm.service.NameCard;
 import egovframework.com.cop.ncm.service.NameCardUser;
 import egovframework.com.cop.ncm.service.NameCardVO;
 import egovframework.com.utl.fcc.service.EgovStringUtil;
 import jakarta.annotation.Resource;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 
 /**
@@ -112,7 +114,7 @@ public class EgovNcrdManageController {
      */
 
     @RequestMapping("/cop/ncm/deleteNcrdInf.do")
-    public String deleteNcrdItem(@ModelAttribute("searchVO") NameCardVO ncrdVO, SessionStatus status,
+    public String deleteNcrdItem(HttpServletRequest request, @ModelAttribute("searchVO") NameCardVO ncrdVO, SessionStatus status,
 	    ModelMap model) throws Exception {
 
 	LoginVO user = (LoginVO)EgovUserDetailsHelper.getAuthenticatedUser();
@@ -121,6 +123,9 @@ public class EgovNcrdManageController {
     if(!isAuthenticated) {
         return "redirect:/uat/uia/egovLoginUsr.do";
     }
+
+	NameCardVO vo = ncrdService.selectNcrdItem(ncrdVO);
+	EgovXssChecker.checkerUserXss(request, vo == null ? null : vo.getFrstRegisterId());
 
 	ncrdVO.setEmplyrId(user == null ? "" : EgovStringUtil.isNullToString(user.getUniqId()));
 
@@ -190,7 +195,8 @@ public class EgovNcrdManageController {
      * @throws Exception
      */
     @RequestMapping("/cop/ncm/selectNcrdInf.do")
-    public String selectNcrdItem(@ModelAttribute("searchVO") NameCardVO ncrdVO, SessionStatus status, ModelMap model) throws Exception {
+    public String selectNcrdItem(HttpServletRequest request, @ModelAttribute("searchVO") NameCardVO ncrdVO, SessionStatus status,
+            ModelMap model) throws Exception {
 
 		LoginVO user = (LoginVO)EgovUserDetailsHelper.getAuthenticatedUser();
 		Boolean isAuthenticated = EgovUserDetailsHelper.isAuthenticated();
@@ -202,6 +208,7 @@ public class EgovNcrdManageController {
 		ncrdVO.setFrstRegisterId(user == null ? "" : EgovStringUtil.isNullToString(user.getUniqId()));
 
 		NameCardVO vo = ncrdService.selectNcrdItem(ncrdVO);
+		EgovXssChecker.checkerUserXss(request, vo == null ? null : vo.getFrstRegisterId());
 
 		model.addAttribute("ncrdVO", vo);
 
@@ -219,7 +226,7 @@ public class EgovNcrdManageController {
      * @throws Exception
      */
     @RequestMapping("/cop/ncm/updateNcrdInf.do")
-    public String updateNcrdItem(@ModelAttribute("searchVO") NameCardVO ncrdVO, @RequestParam("ncrdNm") String ncrdNm,
+    public String updateNcrdItem(HttpServletRequest request, @ModelAttribute("searchVO") NameCardVO ncrdVO, @RequestParam("ncrdNm") String ncrdNm,
 	    @Valid @ModelAttribute("nameCard") NameCard nameCard, BindingResult bindingResult, SessionStatus status, ModelMap model) throws Exception {
 		LoginVO user = (LoginVO)EgovUserDetailsHelper.getAuthenticatedUser();
 		Boolean isAuthenticated = EgovUserDetailsHelper.isAuthenticated();
@@ -227,6 +234,9 @@ public class EgovNcrdManageController {
 	    if(!isAuthenticated) {
 	        return "redirect:/uat/uia/egovLoginUsr.do";
 	    }
+
+		NameCardVO owner = ncrdService.selectNcrdItem(ncrdVO);
+		EgovXssChecker.checkerUserXss(request, owner == null ? null : owner.getFrstRegisterId());
 
 		if (bindingResult.hasErrors()) {
 		    ncrdVO.setFrstRegisterId(user == null ? "" : EgovStringUtil.isNullToString(user.getUniqId()));
@@ -340,15 +350,17 @@ public class EgovNcrdManageController {
     @RequestMapping("/cop/ncm/updateNcrdUseInf.do")
     public String updateNcrdUseInf(@ModelAttribute("ncrdUser") NameCardUser ncrdUser, @ModelAttribute("ncrdVO") NameCardVO ncrdVO,
 	    SessionStatus status, ModelMap model) throws Exception {
-		@SuppressWarnings("unused")
 		LoginVO user = (LoginVO)EgovUserDetailsHelper.getAuthenticatedUser();
 		Boolean isAuthenticated = EgovUserDetailsHelper.isAuthenticated();
 
-		ncrdUser.setUseAt("N");
-
-		if (isAuthenticated) {
-		    ncrdService.updateNcrdUseInf(ncrdUser);
+		if(!isAuthenticated) {
+			return "redirect:/uat/uia/egovLoginUsr.do";
 		}
+
+		ncrdUser.setUseAt("N");
+		ncrdUser.setEmplyrId(user == null ? "" : EgovStringUtil.isNullToString(user.getUniqId()));
+
+		ncrdService.updateNcrdUseInf(ncrdUser);
 
 		return "forward:/cop/ncm/selectMyNcrdUseInf.do";
     }


### PR DESCRIPTION
## 요약
- 명함 수정화면, 수정, 삭제 요청에서 저장된 작성자와 현재 로그인 사용자를 검증하도록 했습니다.
- 명함 사용정보 변경 시 요청 파라미터의 `emplyrId`를 신뢰하지 않고 로그인 사용자의 `uniqId`로 고정했습니다.

## 문제 상황
- 명함 수정 화면 진입 시 `ncrdVO`에 `frstRegisterId`를 설정하지만, `selectNcrdItem` SQL은 기존 코드 기준으로 `NCRD_ID`만 조건으로 사용합니다.
- `updateNcrdItem` SQL도 `NCRD_ID`만 조건으로 명함 본문을 수정합니다.
- `deleteNcrdItem` 서비스는 `deleteNcrdItemUser` 호출 뒤 `deleteNcrdItem`을 호출하는데, 명함 본문 삭제 SQL은 `NCRD_ID`만 조건으로 사용합니다.
- `updateNcrdUseInf` SQL은 `EMPLYR_ID`와 `NCRD_ID`를 조건으로 쓰지만, 컨트롤러가 기존 요청값의 `emplyrId`를 그대로 넘길 수 있었습니다.

## 수정 내용
- `/cop/ncm/selectNcrdInf.do`, `/cop/ncm/updateNcrdInf.do`, `/cop/ncm/deleteNcrdInf.do`에서 `selectNcrdItem`으로 저장된 `frstRegisterId`를 조회하고 `EgovXssChecker`로 검증합니다.
- 작성자가 아닌 사용자는 기존 공통 예외인 `EgovXssException` 경로로 차단됩니다.
- `/cop/ncm/updateNcrdUseInf.do`에서는 인증 확인 후 `ncrdUser.emplyrId`를 로그인 사용자의 `uniqId`로 설정합니다.

## 검증
- `git diff --check`
- 삭제 서비스 경로 확인: `EgovNcrdManageServiceImpl.deleteNcrdItem`이 `deleteNcrdItemUser` 후 `deleteNcrdItem` 호출
- 삭제 SQL 확인: `EgovNcrd_SQL_mysql.xml`의 `deleteNcrdItem`은 `NCRD_ID` 기준
- 수정 SQL 확인: `EgovNcrd_SQL_mysql.xml`의 `updateNcrdItem`은 `NCRD_ID` 기준
- 사용정보 SQL 확인: `updateNcrdUseInf`는 `EMPLYR_ID`와 `NCRD_ID` 기준이며, 컨트롤러에서 `EMPLYR_ID`를 로그인 사용자로 고정
- `/Users/minseok/.m2/wrapper/dists/apache-maven-3.6.3-bin/1iopthnavndlasol9gbrbg6bf2/apache-maven-3.6.3/bin/mvn -B verify --file pom.xml`
  - `BUILD SUCCESS`
  - 현재 POM 설정상 Surefire 테스트는 skipped로 처리됩니다.
  - 기존 Javadoc 경고는 남아 있지만 빌드는 성공했습니다.
