### PR TITLE
주소록 수정 및 삭제 시 작성자 검증 추가

### DIFF
--- a/src/main/java/egovframework/com/cop/adb/web/EgovAddressBookController.java
+++ b/src/main/java/egovframework/com/cop/adb/web/EgovAddressBookController.java
@@ -445,9 +445,6 @@ public class EgovAddressBookController {
             return "redirect:/uat/uia/egovLoginUsr.do";
         }
 
-        AddressBookVO savedAdbk = adbkService.selectAdressBook(adbkVO);
-        checkAddressBookWriter(savedAdbk, user);
-
         // 구성원 정보 로드
         String[] tempId = EgovStringUtil.isNullToString(adbkUserVO.getUserId()).split(",");
 
@@ -495,6 +492,9 @@ public class EgovAddressBookController {
         if(!isAuthenticated) {
             return "redirect:/uat/uia/egovLoginUsr.do";
         }
+
+        AddressBookVO savedAdbk = adbkService.selectAdressBook(adbkVO);
+        checkAddressBookWriter(savedAdbk, user);
 
         // 구성원 정보 로드
         String[] tempId = EgovStringUtil.isNullToString(adbkUserVO.getUserId()).split(",");

--- a/src/main/java/egovframework/com/cop/adb/web/EgovAddressBookController.java
+++ b/src/main/java/egovframework/com/cop/adb/web/EgovAddressBookController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 
 import egovframework.com.cmm.LoginVO;
 import egovframework.com.cmm.annotation.IncludedInfo;
+import egovframework.com.cmm.exception.EgovXssException;
 import egovframework.com.cmm.util.EgovUserDetailsHelper;
 import egovframework.com.cop.adb.service.AddressBook;
 import egovframework.com.cop.adb.service.AddressBookUser;
@@ -182,7 +183,13 @@ public class EgovAddressBookController {
 
         Boolean isAuthenticated = EgovUserDetailsHelper.isAuthenticated();
 
+        if(!isAuthenticated) {
+            return "redirect:/uat/uia/egovLoginUsr.do";
+        }
+
         AddressBook adbk = adbkService.selectAdressBook(adbkVO);
+        checkAddressBookWriter(adbk, user);
+
         adbk.setUseAt("N");
         adbk.setLastUpdusrId(user == null ? "" : EgovStringUtil.isNullToString(user.getId()));
         adbkService.deleteAdressBook(adbk);
@@ -438,6 +445,9 @@ public class EgovAddressBookController {
             return "redirect:/uat/uia/egovLoginUsr.do";
         }
 
+        AddressBookVO savedAdbk = adbkService.selectAdressBook(adbkVO);
+        checkAddressBookWriter(savedAdbk, user);
+
         // 구성원 정보 로드
         String[] tempId = EgovStringUtil.isNullToString(adbkUserVO.getUserId()).split(",");
 
@@ -506,6 +516,19 @@ public class EgovAddressBookController {
         adbkService.updateAdressBook(adbkVO);
 
         return "forward:/cop/adb/selectAdbkList.do";
+    }
+
+    private void checkAddressBookWriter(AddressBook adbk, LoginVO user) {
+        String wrterId = adbk == null ? null : adbk.getWrterId();
+        String userId = user == null ? null : EgovStringUtil.isNullToString(user.getId());
+
+        if (wrterId == null || userId == null || userId.equals("")) {
+            throw new EgovXssException("XSS00001", "errors.xss.checkerUser");
+        }
+
+        if (!wrterId.equals(userId)) {
+            throw new EgovXssException("XSS00002", "errors.xss.checkerUser");
+        }
     }
 
 }


### PR DESCRIPTION
## 요약
- 주소록 삭제와 수정 저장 시 저장된 작성자와 현재 로그인 사용자를 검증하도록 했습니다.
- 회사/부서 공개 주소록의 조회는 유지하고, 쓰기 동작만 작성자에게 제한했습니다.

## 문제 상황
- 주소록 목록은 회사/부서 공개 범위 또는 작성자 조건으로 조회됩니다.
- 수정 화면은 writer 모델 값으로 입력 UI를 제한하지만, 서버의 `/cop/adb/UpdateAddressBook.do`는 기존 코드 기준으로 인증 후 `ADBK_ID`만으로 수정할 수 있었습니다.
- 삭제도 `/cop/adb/deleteAdbkInf.do`에서 `ADBK_ID`로 주소록을 조회한 뒤 삭제 처리를 호출했고, 수정 SQL은 `ADBK_ID`만 조건으로 사용합니다.

## 수정 내용
- 삭제 처리 전에 `selectAdressBook`으로 저장된 `WRTER_ID`를 조회하고 로그인 사용자의 id와 비교합니다.
- 수정 저장 전에 동일한 작성자 검증을 수행합니다.
- 신규 등록 경로는 저장된 주소록이 아직 없으므로 작성자 검증 대상에서 제외했습니다.
- `WRTER_ID` 또는 로그인 사용자 id가 없거나 서로 다르면 기존 XSS 차단 계열과 같은 `EgovXssException`을 던집니다.
- 공유 주소록 조회 및 수정 화면의 읽기 전용 표시 흐름은 변경하지 않았습니다.

## 검증
- `git diff --check`
- 수정 UI 제한 확인: `EgovAddressBookUpdt.jsp`의 writer 조건
- 삭제 요청 경로 확인: `EgovAddressBookList.jsp`의 `/cop/adb/deleteAdbkInf.do` 폼
- 수정/삭제 SQL 확인: `EgovAdbk_SQL_mysql.xml`의 `updateAdressBook`은 `ADBK_ID` 기준
- 작성자 조회 SQL 확인: `selectAdressBook`은 `ADBK_ID`로 `WRTER_ID`를 조회
- `/Users/minseok/.m2/wrapper/dists/apache-maven-3.6.3-bin/1iopthnavndlasol9gbrbg6bf2/apache-maven-3.6.3/bin/mvn -B verify --file pom.xml`
  - `BUILD SUCCESS`
  - 현재 POM 설정상 Surefire 테스트는 skipped로 처리됩니다.
  - 기존 Javadoc 경고는 남아 있지만 빌드는 성공했습니다.
