### PR TITLE
커뮤니티 수정 및 삭제 시 관리자 검증 추가

### DIFF
--- a/src/main/java/egovframework/com/cop/cmy/web/EgovCommuMasterController.java
+++ b/src/main/java/egovframework/com/cop/cmy/web/EgovCommuMasterController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 
 import egovframework.com.cmm.LoginVO;
 import egovframework.com.cmm.annotation.IncludedInfo;
+import egovframework.com.cmm.exception.EgovXssException;
 import egovframework.com.cmm.util.EgovUserDetailsHelper;
 import egovframework.com.cop.cmy.service.Community;
 import egovframework.com.cop.cmy.service.CommunityUserVO;
@@ -191,6 +192,15 @@ public class EgovCommuMasterController {
     public String updateCommuMasterView(@ModelAttribute("searchVO") CommunityVO cmmntyVO, ModelMap model)
 	    throws Exception {
 
+		LoginVO user = (LoginVO)EgovUserDetailsHelper.getAuthenticatedUser();
+		Boolean isAuthenticated = EgovUserDetailsHelper.isAuthenticated();
+		// KISA 보안취약점 조치 (2018-12-10, 신용호)
+        if(!isAuthenticated) {
+            return "redirect:/uat/uia/egovLoginUsr.do";
+        }
+
+		checkCommuAdmin(cmmntyVO.getCmmntyId(), user);
+
 		CommunityVO result = egovCommuMasterService.selectCommuMaster(cmmntyVO);
 
 		model.addAttribute("commuMasterVO", result);
@@ -217,6 +227,8 @@ public class EgovCommuMasterController {
         if(!isAuthenticated) {
             return "redirect:/uat/uia/egovLoginUsr.do";
         }
+
+		checkCommuAdmin(getCmmntyId(community, cmmntyVO), user);
 
 		if (bindingResult.hasErrors()) {
 
@@ -249,12 +261,43 @@ public class EgovCommuMasterController {
     	LoginVO user = (LoginVO)EgovUserDetailsHelper.getAuthenticatedUser();
     	Boolean isAuthenticated = EgovUserDetailsHelper.isAuthenticated();
 
-    	if (isAuthenticated) {
-    		community.setLastUpdusrId(user == null ? "" : EgovStringUtil.isNullToString(user.getUniqId()));
-    	    egovCommuMasterService.deleteBBSMasterInf(community);
-    	}
-    	return "forward:/cop/cmy/selectCommuMasterList.do";
+        if(!isAuthenticated) {
+            return "redirect:/uat/uia/egovLoginUsr.do";
         }
+
+		checkCommuAdmin(getCmmntyId(community, cmmntyVO), user);
+
+		community.setLastUpdusrId(user == null ? "" : EgovStringUtil.isNullToString(user.getUniqId()));
+		egovCommuMasterService.deleteBBSMasterInf(community);
+
+		return "forward:/cop/cmy/selectCommuMasterList.do";
+    }
+
+	private String getCmmntyId(Community community, CommunityVO cmmntyVO) {
+		String cmmntyId = community == null ? "" : EgovStringUtil.isNullToString(community.getCmmntyId());
+
+		if ("".equals(cmmntyId)) {
+			cmmntyId = cmmntyVO == null ? "" : EgovStringUtil.isNullToString(cmmntyVO.getCmmntyId());
+		}
+
+		return cmmntyId;
+	}
+
+	private void checkCommuAdmin(String cmmntyId, LoginVO user) throws Exception {
+		String uniqId = user == null ? "" : EgovStringUtil.isNullToString(user.getUniqId());
+
+		if ("".equals(EgovStringUtil.isNullToString(cmmntyId)) || "".equals(uniqId)) {
+			throw new EgovXssException("XSS00001", "errors.xss.checkerUser");
+		}
+
+		CommunityUserVO userVO = new CommunityUserVO();
+		userVO.setCmmntyId(cmmntyId);
+		userVO.setEmplyrId(uniqId);
+
+		if (!Boolean.TRUE.equals(egovCommuManageService.selectIsCommuAdmin(userVO))) {
+			throw new EgovXssException("XSS00002", "errors.xss.checkerUser");
+		}
+	}
 
     /**
      * 포트릿을 위한 커뮤니티 정보 목록 정보를 조회한다.


### PR DESCRIPTION
## 증상

커뮤니티 정보 수정/삭제 흐름에서 서버 측 커뮤니티 관리자 검증이 빠져 있습니다.

- `/cop/cmy/updateCommuMasterView.do`는 기존에 커뮤니티 수정 화면을 조회할 때 로그인 여부나 커뮤니티 관리자 여부를 확인하지 않았습니다.
- `/cop/cmy/updateCommuMaster.do`와 `/cop/cmy/deleteCommuMaster.do`는 로그인 여부만 확인한 뒤 쓰기 서비스로 진행했습니다.
- `updateCommuMaster`, `deleteCommuMaster` SQL은 `CMMNTY_ID`만 조건으로 `COMTNCMMNTY`를 수정합니다.
- 샘플 보안 DML은 기본적으로 `\A/.*\.do.*\Z`를 `ROLE_USER`에도 매핑하므로, 일반 로그인 사용자가 별도 커뮤니티 관리자 검증 없이 직접 요청을 보낼 수 있는 구조입니다.

## 발생 가능한 요청

커뮤니티 관리자가 아닌 로그인 사용자가 다른 커뮤니티의 `cmmntyId`를 알고 있으면 다음 요청으로 수정 화면 조회 또는 쓰기 요청을 시도할 수 있습니다.

- `GET /cop/cmy/updateCommuMasterView.do?cmmntyId={커뮤니티ID}`
- `POST /cop/cmy/updateCommuMaster.do`
- `POST /cop/cmy/deleteCommuMaster.do`

`@RequestMapping`에 HTTP method 제한이 없어 환경에 따라 GET/POST 직접 호출이 모두 매핑될 수 있습니다.

## 영향

커뮤니티 관리자가 아닌 로그인 사용자가 다른 커뮤니티의 이름, 소개, 템플릿, 사용 여부를 변경하거나 삭제 처리할 수 있습니다. 삭제는 물리 삭제가 아니라 `USE_AT='N'` 갱신이지만, 해당 커뮤니티를 비활성화할 수 있습니다.

## 수정 내용

- 수정 화면 조회, 수정 저장, 삭제 처리 전에 `selectIsCommuAdmin`으로 현재 로그인 사용자가 해당 커뮤니티 관리자인지 확인하도록 했습니다.
- `cmmntyId` 또는 로그인 사용자 고유 ID가 없으면 `EgovXssException("XSS00001", "errors.xss.checkerUser")`로 차단합니다.
- 커뮤니티 관리자가 아니면 `EgovXssException("XSS00002", "errors.xss.checkerUser")`로 차단합니다.
- 정상 경로에서는 기존처럼 커뮤니티 관리자의 수정/삭제 흐름이 이어집니다.

## 검증

- `git diff --check`
- `javac -proc:none -cp "target/classes:<local m2 jars>" -d /private/tmp/egov-javac src/main/java/egovframework/com/cop/cmy/web/EgovCommuMasterController.java`

로컬 환경에 `mvn`과 `mvnw`가 없어 전체 Maven 테스트는 실행하지 못했습니다.
