### PR TITLE
커뮤니티 사용자 목록 조회 시 관리자 검증 추가

### DIFF
--- a/src/main/java/egovframework/com/cop/cmy/web/EgovCommuManageController.java
+++ b/src/main/java/egovframework/com/cop/cmy/web/EgovCommuManageController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import egovframework.com.cmm.EgovMessageSource;
 import egovframework.com.cmm.EgovWebUtil;
 import egovframework.com.cmm.LoginVO;
+import egovframework.com.cmm.exception.EgovXssException;
 import egovframework.com.cmm.util.EgovUserDetailsHelper;
 import egovframework.com.cop.bbs.service.BoardMasterVO;
 import egovframework.com.cop.bbs.service.BoardVO;
@@ -292,6 +293,15 @@ public class EgovCommuManageController {
      */
     @RequestMapping("/cop/cmy/selectCommuUserList.do")
     public String selectCommuUserList(@ModelAttribute("searchVO") CommunityUserVO cmmntyUserVO, ModelMap model) throws Exception {
+		LoginVO user = (LoginVO)EgovUserDetailsHelper.getAuthenticatedUser();
+		Boolean isAuthenticated = EgovUserDetailsHelper.isAuthenticated();
+		// KISA 보안취약점 조치 (2018-12-10, 신용호)
+        if(!isAuthenticated) {
+            return "redirect:/uat/uia/egovLoginUsr.do";
+        }
+
+		checkCommuAdmin(cmmntyUserVO.getCmmntyId(), user);
+
 		cmmntyUserVO.setPageUnit(propertyService.getInt("pageUnit"));
 		cmmntyUserVO.setPageSize(propertyService.getInt("pageSize"));
 
@@ -456,6 +466,22 @@ public class EgovCommuManageController {
 
 		return "forward:/cop/cmy/selectCommuUserList.do";
     }
+
+	private void checkCommuAdmin(String cmmntyId, LoginVO user) throws Exception {
+		String uniqId = user == null ? "" : EgovStringUtil.isNullToString(user.getUniqId());
+
+		if ("".equals(EgovStringUtil.isNullToString(cmmntyId)) || "".equals(uniqId)) {
+			throw new EgovXssException("XSS00001", "errors.xss.checkerUser");
+		}
+
+		CommunityUserVO userVO = new CommunityUserVO();
+		userVO.setCmmntyId(cmmntyId);
+		userVO.setEmplyrId(uniqId);
+
+		if (!Boolean.TRUE.equals(egovCommuManageService.selectIsCommuAdmin(userVO))) {
+			throw new EgovXssException("XSS00002", "errors.xss.checkerUser");
+		}
+	}
 
     /**
      * 미리보기 커뮤니티 메인페이지를 조회한다.


### PR DESCRIPTION
## 증상

커뮤니티 사용자 관리 목록 화면은 UI에서 커뮤니티 관리자에게만 노출되지만, 서버의 목록 조회 컨트롤러에는 같은 관리자 검증이 없습니다.

- `EgovCommuMain.jsp`는 `cmmntyUser.mngrAt == 'Y'`일 때만 사용자관리 메뉴를 표시합니다.
- `/cop/cmy/selectCommuUserList.do`는 기존에 로그인 여부와 커뮤니티 관리자 여부를 확인하지 않고 `cmmntyId`만으로 사용자 목록을 조회했습니다.
- 목록 SQL은 `COMTNCMMNTYUSER`와 사용자 마스터를 조인해 사용자 ID, 이름, 회원 상태 등을 조회합니다.
- 샘플 보안 DML은 기본적으로 `\A/.*\.do.*\Z`를 `ROLE_USER`에도 매핑하므로, 일반 로그인 사용자가 URL-level 접근을 통과할 수 있는 구조입니다.

## 발생 가능한 요청

커뮤니티 관리자가 아닌 로그인 사용자가 다른 커뮤니티의 `cmmntyId`를 알고 있으면 다음 요청으로 사용자 관리 목록 조회를 시도할 수 있습니다.

- `GET /cop/cmy/selectCommuUserList.do?cmmntyId={커뮤니티ID}`
- `POST /cop/cmy/selectCommuUserList.do`

`@RequestMapping`에 HTTP method 제한이 없어 환경에 따라 GET/POST 직접 호출이 모두 매핑될 수 있습니다.

## 영향

쓰기 엔드포인트는 이미 `selectIsCommuAdmin`으로 보호되어 있어 가입 승인, 탈퇴, 관리자 등록/해제까지 바로 수행되지는 않습니다. 다만 비관리자가 관리용 목록을 직접 조회해 커뮤니티 사용자 ID, 이름, 회원 상태를 볼 수 있습니다.

## 수정 내용

- `selectCommuUserList` 진입 시 로그인 여부를 확인합니다.
- 목록 조회 전에 `selectIsCommuAdmin`으로 현재 로그인 사용자가 해당 커뮤니티 관리자인지 확인합니다.
- `cmmntyId` 또는 로그인 사용자 고유 ID가 없으면 `EgovXssException("XSS00001", "errors.xss.checkerUser")`로 차단합니다.
- 커뮤니티 관리자가 아니면 `EgovXssException("XSS00002", "errors.xss.checkerUser")`로 차단합니다.
- 기존 member/admin write endpoint 동작은 변경하지 않았습니다.

## 검증

- `git diff --check`
- `javac -proc:none -cp "target/classes:<local m2 jars>" -d /private/tmp/egov-javac src/main/java/egovframework/com/cop/cmy/web/EgovCommuManageController.java`

로컬 환경에 `mvn`과 `mvnw`가 없어 전체 Maven 테스트는 실행하지 못했습니다.
