### PR TITLE
커뮤니티 템플릿 미리보기 게시글 모델명 정정

### DIFF
--- a/src/main/java/egovframework/com/cop/cmy/web/EgovCommuManageController.java
+++ b/src/main/java/egovframework/com/cop/cmy/web/EgovCommuManageController.java
@@ -600,7 +600,7 @@ public class EgovCommuManageController {
 		    target.add(null);
 		}
 
-		model.addAttribute("boardList", target);
+		model.addAttribute("articleList", target);
 
 		model.addAttribute("preview", "true");
 


### PR DESCRIPTION
## 증상

커뮤니티 템플릿 미리보기 컨텐츠 엔드포인트인 `/cop/cmy/previewCmmntyMainContents.do`는 `egovframework/com/cop/tpl/EgovCmmntyBaseTmplContents` JSP를 반환합니다.

해당 JSP는 게시글 미리보기 영역에서 `articleList[0]`부터 `articleList[3]`까지를 참조하지만, 컨트롤러는 같은 용도로 준비한 목록을 `boardList`라는 이름으로 모델에 추가하고 있었습니다.

## 영향

이 변경은 권한 우회나 데이터 변경 오류가 아니라 미리보기 화면의 모델 속성명 정합성 수정입니다.

현재 JSP/EL 처리에서는 빈 목록 영역으로 보일 수 있지만, 컨트롤러가 JSP에서 실제로 읽는 모델명과 다른 이름을 내려주고 있어 미리보기 화면 계약이 불일치합니다.

## 수정 내용

- `previewCmmntyMainContents`에서 빈 게시글 슬롯 목록을 `boardList`가 아니라 `articleList`로 전달하도록 수정했습니다.
- 실제 커뮤니티 컨텐츠 조회 경로인 `cmmntyMainContents.do`도 `articleList`를 사용하므로, 미리보기 경로와 실제 경로의 모델명을 맞췄습니다.

## 검증

- `git diff --check`
- `rg -n "model.addAttribute\\(\"articleList\"|model.addAttribute\\(\"boardList\"|articleList\\[|boardList\\[" ...`
- `javac -proc:none -cp "target/classes:<local m2 jars>" -d /private/tmp/egov-javac src/main/java/egovframework/com/cop/cmy/web/EgovCommuManageController.java`

로컬 환경에 `mvn`/`mvnw`가 없어 전체 Maven 테스트는 실행하지 못했습니다.
