### PR TITLE
fix: 웹메신저 세션 집합 순회 경로의 동기화 일관화

### DIFF
--- a/src/main/java/egovframework/com/ext/msg/server/ChatServerEndPoint.java
+++ b/src/main/java/egovframework/com/ext/msg/server/ChatServerEndPoint.java
@@ -58,6 +58,7 @@ import jakarta.websocket.server.ServerEndpoint;
  *   2014.11.27  이영지          최초 생성
  *   2023.06.09  김장하          NSR 보안조치 (사용자목록 크로스사이트 스크립트 방지)
  *   2025.06.21  이백행          PMD로 소프트웨어 보안약점 진단하고 제거하기-ImmutableField(불변필드), CloseResource(리소스 닫기)
+ *   2026.07.17  z3rotig4r      synchronizedSet 순회 경로 동기화 일관화(브로드캐스트·handleClose·getUsers 순회를 synchronized 블록으로 보호)
  *
  *      </pre>
  */
@@ -114,8 +115,10 @@ public class ChatServerEndPoint {
 			outgoingChatMessage.setName(username);
 			outgoingChatMessage.setMessage(filteredIncommingMessage);
 
-			for (Session session : chatroomUsers) { // NOPMD-CloseResource
-				session.getBasicRemote().sendObject(outgoingChatMessage);
+			synchronized (chatroomUsers) {
+				for (Session session : chatroomUsers) { // NOPMD-CloseResource
+					session.getBasicRemote().sendObject(outgoingChatMessage);
+				}
 			}
 		}
 	}
@@ -126,8 +129,10 @@ public class ChatServerEndPoint {
 			throws IOException, EncodeException {
 		chatroomUsers.remove(userSession);
 
-		for (Session session : chatroomUsers) { // NOPMD-CloseResource
-			session.getBasicRemote().sendObject(new UsersMessage(getUsers()));
+		synchronized (chatroomUsers) {
+			for (Session session : chatroomUsers) { // NOPMD-CloseResource
+				session.getBasicRemote().sendObject(new UsersMessage(getUsers()));
+			}
 		}
 	}
 
@@ -153,9 +158,11 @@ public class ChatServerEndPoint {
 	private Set<String> getUsers() {
 		HashSet<String> returnSet = new HashSet<String>();
 
-		for (Session session : chatroomUsers) { // NOPMD-CloseResource
-			if (session.getUserProperties().get("username") != null) {
-				returnSet.add(session.getUserProperties().get("username").toString());
+		synchronized (chatroomUsers) {
+			for (Session session : chatroomUsers) { // NOPMD-CloseResource
+				if (session.getUserProperties().get("username") != null) {
+					returnSet.add(session.getUserProperties().get("username").toString());
+				}
 			}
 		}
 		return returnSet;

--- a/src/main/java/egovframework/com/ext/msg/server/ChatServerEndPoint.java
+++ b/src/main/java/egovframework/com/ext/msg/server/ChatServerEndPoint.java
@@ -119,8 +119,10 @@ public class ChatServerEndPoint {
 			outgoingChatMessage.setName(username);
 			outgoingChatMessage.setMessage(filteredIncommingMessage);
 
-			for (Session session : chatroomUsers) { // NOPMD-CloseResource
-				session.getBasicRemote().sendObject(outgoingChatMessage);
+			synchronized (chatroomUsers) {
+				for (Session session : chatroomUsers) { // NOPMD-CloseResource
+					session.getBasicRemote().sendObject(outgoingChatMessage);
+				}
 			}
 		}
 	}
@@ -131,8 +133,10 @@ public class ChatServerEndPoint {
 			throws IOException, EncodeException {
 		chatroomUsers.remove(userSession);
 
-		for (Session session : chatroomUsers) { // NOPMD-CloseResource
-			session.getBasicRemote().sendObject(new UsersMessage(getUsers()));
+		synchronized (chatroomUsers) {
+			for (Session session : chatroomUsers) { // NOPMD-CloseResource
+				session.getBasicRemote().sendObject(new UsersMessage(getUsers()));
+			}
 		}
 	}
 
@@ -158,9 +162,11 @@ public class ChatServerEndPoint {
 	private Set<String> getUsers() {
 		HashSet<String> returnSet = new HashSet<String>();
 
-		for (Session session : chatroomUsers) { // NOPMD-CloseResource
-			if (session.getUserProperties().get("username") != null) {
-				returnSet.add(session.getUserProperties().get("username").toString());
+		synchronized (chatroomUsers) {
+			for (Session session : chatroomUsers) { // NOPMD-CloseResource
+				if (session.getUserProperties().get("username") != null) {
+					returnSet.add(session.getUserProperties().get("username").toString());
+				}
 			}
 		}
 		return returnSet;

--- a/src/test/java/egovframework/com/ext/msg/server/ChatServerEndPointConcurrencyTest.java
+++ b/src/test/java/egovframework/com/ext/msg/server/ChatServerEndPointConcurrencyTest.java
@@ -1,0 +1,327 @@
+/*
+ * Copyright The eGovFrame Open Community (http://open.egovframe.go.kr)).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package egovframework.com.ext.msg.server;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.Writer;
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.security.Principal;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Test;
+
+import egovframework.com.ext.msg.server.model.ChatMessage;
+import jakarta.websocket.CloseReason;
+import jakarta.websocket.EncodeException;
+import jakarta.websocket.Extension;
+import jakarta.websocket.MessageHandler;
+import jakarta.websocket.RemoteEndpoint;
+import jakarta.websocket.Session;
+import jakarta.websocket.WebSocketContainer;
+
+/**
+ * {@link ChatServerEndPoint}가 방 세션 집합(Collections.synchronizedSet)을 순회하는 모든 경로에서
+ * 동시 멤버십 변경 중 ConcurrentModificationException 없이 동작하는지 검증한다.
+ * (브로드캐스트·handleClose·getUsers 순회가 synchronized 블록 밖에 있으면 예외가 발생했다)
+ */
+class ChatServerEndPointConcurrencyTest {
+
+	private static final int SEED_SESSIONS = 8;
+
+	@Test
+	void broadcast_concurrentWithMembershipChange_noConcurrentModification() throws Exception {
+		final String room = "room";
+		ChatServerEndPoint endpoint = new ChatServerEndPoint();
+
+		Session sender = new FakeSession();
+		sender.getUserProperties().put("username", "sender");
+		endpoint.handleOpen(sender, room);
+		for (int i = 0; i < SEED_SESSIONS; i++) {
+			Session seed = new FakeSession();
+			seed.getUserProperties().put("username", "seed" + i);
+			endpoint.handleOpen(seed, room);
+		}
+
+		AtomicReference<Throwable> failure = new AtomicReference<>();
+		CountDownLatch start = new CountDownLatch(1);
+		CountDownLatch done = new CountDownLatch(2);
+		final int iterations = 500;
+
+		// 순회 스레드: 브로드캐스트(else 분기)가 방 세션 집합을 반복 순회한다.
+		Thread iterator = new Thread(() -> {
+			try {
+				start.await();
+				ChatMessage message = new ChatMessage();
+				message.setMessage("hello");
+				for (int i = 0; i < iterations && failure.get() == null; i++) {
+					endpoint.handleMessage(message, sender, room);
+				}
+			} catch (Throwable e) {
+				failure.compareAndSet(null, e);
+			} finally {
+				done.countDown();
+			}
+		}, "chat-broadcast");
+
+		// 변경 스레드: 동일 방에 세션을 계속 add/remove 하여 구조적 변경을 유발한다.
+		Thread mutator = new Thread(() -> {
+			try {
+				start.await();
+				for (int i = 0; i < iterations && failure.get() == null; i++) {
+					Session churn = new FakeSession();
+					churn.getUserProperties().put("username", "churn" + i);
+					endpoint.handleOpen(churn, room);
+					endpoint.handleClose(churn, room);
+				}
+			} catch (Throwable e) {
+				failure.compareAndSet(null, e);
+			} finally {
+				done.countDown();
+			}
+		}, "chat-mutator");
+
+		iterator.start();
+		mutator.start();
+		start.countDown();
+		done.await();
+
+		// 동기화되지 않은 순회는 ConcurrentModificationException을 던진다.
+		assertNull(failure.get(), "동시 멤버십 변경 중 순회에서 예외가 발생하면 안 된다: " + failure.get());
+	}
+
+	private static final class FakeSession implements Session {
+
+		private final Map<String, Object> userProperties = new HashMap<>();
+		private final RemoteEndpoint.Basic basicRemote = new NoOpBasicRemote();
+
+		@Override
+		public Map<String, Object> getUserProperties() {
+			return userProperties;
+		}
+
+		@Override
+		public RemoteEndpoint.Basic getBasicRemote() {
+			return basicRemote;
+		}
+
+		@Override
+		public WebSocketContainer getContainer() {
+			return null;
+		}
+
+		@Override
+		public void addMessageHandler(MessageHandler handler) {
+			// no-op
+		}
+
+		@Override
+		public <T> void addMessageHandler(Class<T> clazz, MessageHandler.Whole<T> handler) {
+			// no-op
+		}
+
+		@Override
+		public <T> void addMessageHandler(Class<T> clazz, MessageHandler.Partial<T> handler) {
+			// no-op
+		}
+
+		@Override
+		public Set<MessageHandler> getMessageHandlers() {
+			return null;
+		}
+
+		@Override
+		public void removeMessageHandler(MessageHandler handler) {
+			// no-op
+		}
+
+		@Override
+		public String getProtocolVersion() {
+			return null;
+		}
+
+		@Override
+		public String getNegotiatedSubprotocol() {
+			return null;
+		}
+
+		@Override
+		public List<Extension> getNegotiatedExtensions() {
+			return null;
+		}
+
+		@Override
+		public boolean isSecure() {
+			return false;
+		}
+
+		@Override
+		public boolean isOpen() {
+			return false;
+		}
+
+		@Override
+		public long getMaxIdleTimeout() {
+			return 0;
+		}
+
+		@Override
+		public void setMaxIdleTimeout(long milliseconds) {
+			// no-op
+		}
+
+		@Override
+		public void setMaxBinaryMessageBufferSize(int length) {
+			// no-op
+		}
+
+		@Override
+		public int getMaxBinaryMessageBufferSize() {
+			return 0;
+		}
+
+		@Override
+		public void setMaxTextMessageBufferSize(int length) {
+			// no-op
+		}
+
+		@Override
+		public int getMaxTextMessageBufferSize() {
+			return 0;
+		}
+
+		@Override
+		public RemoteEndpoint.Async getAsyncRemote() {
+			return null;
+		}
+
+		@Override
+		public String getId() {
+			return null;
+		}
+
+		@Override
+		public void close() throws IOException {
+			// no-op
+		}
+
+		@Override
+		public void close(CloseReason closeReason) throws IOException {
+			// no-op
+		}
+
+		@Override
+		public URI getRequestURI() {
+			return null;
+		}
+
+		@Override
+		public Map<String, List<String>> getRequestParameterMap() {
+			return null;
+		}
+
+		@Override
+		public String getQueryString() {
+			return null;
+		}
+
+		@Override
+		public Map<String, String> getPathParameters() {
+			return null;
+		}
+
+		@Override
+		public Principal getUserPrincipal() {
+			return null;
+		}
+
+		@Override
+		public Set<Session> getOpenSessions() {
+			return null;
+		}
+	}
+
+	private static final class NoOpBasicRemote implements RemoteEndpoint.Basic {
+
+		@Override
+		public void sendText(String text) throws IOException {
+			// no-op
+		}
+
+		@Override
+		public void sendText(String partialMessage, boolean isLast) throws IOException {
+			// no-op
+		}
+
+		@Override
+		public void sendBinary(ByteBuffer data) throws IOException {
+			// no-op
+		}
+
+		@Override
+		public void sendBinary(ByteBuffer partialByte, boolean isLast) throws IOException {
+			// no-op
+		}
+
+		@Override
+		public void sendObject(Object data) throws IOException, EncodeException {
+			// no-op
+		}
+
+		@Override
+		public OutputStream getSendStream() throws IOException {
+			return null;
+		}
+
+		@Override
+		public Writer getSendWriter() throws IOException {
+			return null;
+		}
+
+		@Override
+		public void setBatchingAllowed(boolean allowed) throws IOException {
+			// no-op
+		}
+
+		@Override
+		public boolean getBatchingAllowed() {
+			return false;
+		}
+
+		@Override
+		public void flushBatch() throws IOException {
+			// no-op
+		}
+
+		@Override
+		public void sendPing(ByteBuffer applicationData) throws IOException {
+			// no-op
+		}
+
+		@Override
+		public void sendPong(ByteBuffer applicationData) throws IOException {
+			// no-op
+		}
+	}
+}

--- a/src/test/java/egovframework/com/ext/msg/server/ChatServerEndPointConcurrencyTest.java
+++ b/src/test/java/egovframework/com/ext/msg/server/ChatServerEndPointConcurrencyTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright The eGovFrame Open Community (http://open.egovframe.go.kr)).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package egovframework.com.ext.msg.server;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import egovframework.com.ext.msg.server.config.ChatServerAppConfig;
+import jakarta.websocket.EndpointConfig;
+import jakarta.websocket.Session;
+
+/**
+ * 세션 집합을 순회하는 경로가 동시 접속·해제 중에도 안전한지 검증한다.
+ *
+ * <p>{@code Collections.synchronizedSet}은 개별 연산만 보호하고 순회는 호출자가 감싸야 한다.
+ * 감싸지 않으면 순회 중 다른 스레드가 집합을 바꿀 때 {@code ConcurrentModificationException}이
+ * 발생한다.</p>
+ */
+class ChatServerEndPointConcurrencyTest {
+
+    private static final int THREADS = 8;
+    private static final int ROUNDS = 200;
+
+    /** 필요한 메서드만 응답하는 Session 대역. */
+    private Session session(String username) {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("username", username);
+
+        InvocationHandler handler = (proxy, method, args) -> {
+            switch (method.getName()) {
+                case "getUserProperties":
+                    return properties;
+                case "getBasicRemote":
+                    return null;
+                case "equals":
+                    return proxy == args[0];
+                case "hashCode":
+                    return System.identityHashCode(proxy);
+                case "toString":
+                    return "session-" + username;
+                default:
+                    return null;
+            }
+        };
+        return (Session) Proxy.newProxyInstance(Session.class.getClassLoader(),
+                new Class<?>[] { Session.class }, handler);
+    }
+
+    /** 핸드셰이크가 검증한 사용자명을 담은 EndpointConfig 대역. */
+    private EndpointConfig config(String username) {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(ChatServerAppConfig.AUTHENTICATED_USERNAME_PROPERTY, username);
+
+        InvocationHandler handler = (proxy, method, args) ->
+                "getUserProperties".equals(method.getName()) ? properties : null;
+        return (EndpointConfig) Proxy.newProxyInstance(EndpointConfig.class.getClassLoader(),
+                new Class<?>[] { EndpointConfig.class }, handler);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Set<Session> chatroomUsers(ChatServerEndPoint endPoint) throws Exception {
+        Field field = ChatServerEndPoint.class.getDeclaredField("chatroomUsers");
+        field.setAccessible(true);
+        return (Set<Session>) field.get(endPoint);
+    }
+
+    private Set<String> callGetUsers(ChatServerEndPoint endPoint) throws Exception {
+        Method method = ChatServerEndPoint.class.getDeclaredMethod("getUsers");
+        method.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        Set<String> users = (Set<String>) method.invoke(endPoint);
+        return users;
+    }
+
+    @Test
+    @DisplayName("핸드셰이크에서 검증한 사용자명이 세션에 바인딩된다")
+    void handleOpenBindsAuthenticatedUsername() throws Exception {
+        ChatServerEndPoint endPoint = new ChatServerEndPoint();
+        Session userSession = session(null);
+
+        endPoint.handleOpen(userSession, config("hong"), "room1");
+
+        assertEquals("hong", userSession.getUserProperties().get("username"));
+        assertEquals("room1", userSession.getUserProperties().get("room"));
+        assertEquals(1, chatroomUsers(endPoint).size());
+    }
+
+    @Test
+    @DisplayName("사용자 목록 순회 중 접속·해제가 일어나도 예외가 발생하지 않는다")
+    void getUsersIsSafeWhileSessionsChange() throws Exception {
+        ChatServerEndPoint endPoint = new ChatServerEndPoint();
+        Set<Session> sessions = chatroomUsers(endPoint);
+        for (int i = 0; i < 50; i++) {
+            sessions.add(session("user" + i));
+        }
+
+        ExecutorService pool = Executors.newFixedThreadPool(THREADS);
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(THREADS);
+        AtomicInteger failures = new AtomicInteger();
+
+        for (int t = 0; t < THREADS; t++) {
+            final boolean mutating = t % 2 == 0;
+            pool.execute(() -> {
+                try {
+                    start.await();
+                    for (int i = 0; i < ROUNDS; i++) {
+                        if (mutating) {
+                            Session added = session("temp" + i);
+                            sessions.add(added);
+                            sessions.remove(added);
+                        } else {
+                            callGetUsers(endPoint);
+                        }
+                    }
+                } catch (Exception e) {
+                    failures.incrementAndGet();
+                } finally {
+                    done.countDown();
+                }
+            });
+        }
+
+        start.countDown();
+        assertTrue(done.await(60, TimeUnit.SECONDS), "테스트 스레드가 제한 시간 안에 끝나야 한다");
+        pool.shutdownNow();
+
+        assertEquals(0, failures.get(), "순회 중 발생한 예외 횟수");
+    }
+}


### PR DESCRIPTION
## 변경 이유

`Collections.synchronizedSet`은 개별 연산만 보호하고 순회는 호출자가 감싸야 합니다. 순회 중 다른 스레드가 집합을 바꾸면 `ConcurrentModificationException`이 발생합니다.

`ChatServerEndPoint`에서 `handleMessage()`의 사용자 목록 전송만 `synchronized` 블록으로 보호돼 있고, 나머지 세 경로는 보호되지 않았습니다.

- 채팅 브로드캐스트
- `handleClose()`의 목록 갱신 전송
- `getUsers()`의 사용자명 수집

접속과 해제가 겹치는 상황에서 예외가 나면 해당 전송이 끊깁니다.

## 변경 내용

세 경로의 순회 구간을 `synchronized (chatroomUsers)` 블록으로 감쌌습니다. 순회 밖 처리 흐름은 그대로입니다.

## 테스트 방법

이 저장소는 `pom.xml`에서 surefire `skipTests`가 고정돼 있어 junit-console로 확인했습니다.

```
mvn -B compile test-compile
java -jar junit-platform-console-standalone-1.12.1.jar execute \
  -cp "target/classes:target/test-classes:<의존성>" \
  -c egovframework.com.ext.msg.server.ChatServerEndPointConcurrencyTest
```

2건이 통과합니다.

- 8개 스레드가 세션 집합을 바꾸고 동시에 `getUsers()`를 200회씩 호출해 예외가 없는지
- 핸드셰이크에서 검증한 사용자명이 세션에 바인딩되는지(`handleOpen(Session, EndpointConfig, String)`)

`getUsers()`의 `synchronized`만 되돌리면 첫 번째가 실패합니다.

## 이전 범위에서 달라진 점

처음 올릴 때는 `ChatServerAppConfig`를 무상태로 바꾸고 방별 세션 레지스트리를 두는 내용이 함께 있었습니다. 그 부분은 이후 main에 반영된 보안 변경이 핸드셰이크에서 검증한 사용자명을 `EndpointConfig`로 넘기는 방식으로 이미 해소했습니다. 중복이라 제외했습니다.

브랜치는 현재 main 기준으로 다시 작성했고, 테스트도 바뀐 `handleOpen()` 시그니처에 맞췄습니다.

## 영향 범위

- 수정 파일은 `ChatServerEndPoint.java`(순회 3곳)와 신규 테스트 1개입니다.
- 공개 API, 설정, 의존성 변경은 없습니다.
