### PR TITLE
feat: 영업일(주말·공휴일 제외) 계산 유틸 EgovDateUtil.getBusinessDaysBetween 추가

### DIFF
--- a/src/main/java/egovframework/com/utl/fcc/service/EgovDateUtil.java
+++ b/src/main/java/egovframework/com/utl/fcc/service/EgovDateUtil.java
@@ -30,6 +30,7 @@ import com.ibm.icu.util.ChineseCalendar;
  *   2025.08.30  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-UselessParentheses(불필요한 괄호사용)
  *   2025.08.30  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-LocalVariableNamingConventions(final이 아닌 변수는 밑줄을 포함할 수 없음)
  *   2025.08.30  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-AvoidReassigningParameters(넘겨받는 메소드 parameter 값을 직접 변경하는 코드 탐지)
+ *   2026.06.30  z3rotig4r      영업일(주말·공휴일 제외) 계산 getBusinessDaysBetween 추가
  *
  *      </pre>
  */
@@ -890,6 +891,54 @@ public class EgovDateUtil {
 		}
 
 		return timeStr;
+	}
+
+	/**
+	 * 시작일부터 종료일까지 양끝 날짜를 포함하여 주말과 공휴일을 제외한 영업일 수를 구한다.
+	 * 공휴일은 yyyyMMdd 형식의 문자열 집합으로 전달하며, 시작일이 종료일보다 늦으면 0을 반환한다.
+	 * 공휴일 집합이 <code>null</code>이거나 비어 있으면 주말만 제외한다.
+	 *
+	 * @param fromDate 시작일(yyyyMMdd 또는 yyyy-MM-dd 형식)
+	 * @param toDate 종료일(yyyyMMdd 또는 yyyy-MM-dd 형식)
+	 * @param holidays yyyyMMdd 형식의 공휴일 문자열 집합
+	 * @return 주말과 공휴일을 제외한 영업일 수
+	 * @throws IllegalArgumentException 날짜 포맷이 정해진 바와 다르거나 입력 값이
+	 *                                  <code>null</code>인 경우
+	 */
+	public static int getBusinessDaysBetween(String fromDate, String toDate, java.util.Set<String> holidays) {
+		String f = validChkDate(fromDate);
+		String t = validChkDate(toDate);
+
+		Calendar startDay = Calendar.getInstance();
+		startDay.set(Integer.parseInt(f.substring(0, 4)), Integer.parseInt(f.substring(4, 6)) - 1,
+				Integer.parseInt(f.substring(6, 8)));
+		startDay.set(Calendar.HOUR_OF_DAY, 0);
+		startDay.set(Calendar.MINUTE, 0);
+		startDay.set(Calendar.SECOND, 0);
+		startDay.set(Calendar.MILLISECOND, 0);
+
+		Calendar endDay = Calendar.getInstance();
+		endDay.set(Integer.parseInt(t.substring(0, 4)), Integer.parseInt(t.substring(4, 6)) - 1,
+				Integer.parseInt(t.substring(6, 8)));
+		endDay.set(Calendar.HOUR_OF_DAY, 0);
+		endDay.set(Calendar.MINUTE, 0);
+		endDay.set(Calendar.SECOND, 0);
+		endDay.set(Calendar.MILLISECOND, 0);
+
+		SimpleDateFormat sdf = new SimpleDateFormat(SIMPLE_DATE_PATTERN, Locale.getDefault());
+		int count = 0;
+		while (!startDay.after(endDay)) {
+			int dow = startDay.get(Calendar.DAY_OF_WEEK);
+			if (dow != 1 && dow != 7) {
+				String cur = sdf.format(startDay.getTime());
+				if (holidays == null || holidays.isEmpty() || !holidays.contains(cur)) {
+					count++;
+				}
+			}
+			startDay.add(Calendar.DATE, 1);
+		}
+
+		return count;
 	}
 
 }

--- a/src/main/java/egovframework/com/utl/fcc/service/EgovDateUtil.java
+++ b/src/main/java/egovframework/com/utl/fcc/service/EgovDateUtil.java
@@ -31,6 +31,7 @@ import com.ibm.icu.util.ChineseCalendar;
  *   2025.08.30  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-LocalVariableNamingConventions(final이 아닌 변수는 밑줄을 포함할 수 없음)
  *   2025.08.30  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-AvoidReassigningParameters(넘겨받는 메소드 parameter 값을 직접 변경하는 코드 탐지)
  *   2026.06.30  z3rotig4r      영업일(주말·공휴일 제외) 계산 getBusinessDaysBetween 추가
+ *   2026.07.07  z3rotig4r      getBusinessDaysBetween 실제 날짜 유효성 검증 추가(존재하지 않는 날짜 lenient 롤오버 방지)
  *
  *      </pre>
  */
@@ -909,6 +910,11 @@ public class EgovDateUtil {
 		String f = validChkDate(fromDate);
 		String t = validChkDate(toDate);
 
+		// validChkDate는 길이만 확인하므로 20260230 같은 존재하지 않는 날짜가 통과한다.
+		// Calendar가 lenient 롤오버로 조용히 다른 날짜로 계산하는 것을 막기 위해 실제 날짜 유효성을 확인한다.
+		assertRealDate(f);
+		assertRealDate(t);
+
 		Calendar startDay = Calendar.getInstance();
 		startDay.set(Integer.parseInt(f.substring(0, 4)), Integer.parseInt(f.substring(4, 6)) - 1,
 				Integer.parseInt(f.substring(6, 8)));
@@ -939,6 +945,23 @@ public class EgovDateUtil {
 		}
 
 		return count;
+	}
+
+	/**
+	 * yyyyMMdd 형식의 8자리 문자열이 실제로 존재하는 날짜인지 확인한다.
+	 * 존재하지 않는 날짜(예: 20260230, 윤년이 아닌 해의 0229)이면 예외를 던진다.
+	 *
+	 * @param yyyymmdd yyyyMMdd 형식의 8자리 날짜 문자열
+	 * @throws IllegalArgumentException 실제로 존재하지 않는 날짜인 경우
+	 */
+	private static void assertRealDate(String yyyymmdd) {
+		SimpleDateFormat strict = new SimpleDateFormat(SIMPLE_DATE_PATTERN, Locale.getDefault());
+		strict.setLenient(false);
+		try {
+			strict.parse(yyyymmdd);
+		} catch (ParseException e) {
+			throw new IllegalArgumentException("Invalid date: " + yyyymmdd);
+		}
 	}
 
 }

--- a/src/test/java/egovframework/com/utl/fcc/service/EgovDateUtilBusinessDayTest.java
+++ b/src/test/java/egovframework/com/utl/fcc/service/EgovDateUtilBusinessDayTest.java
@@ -61,4 +61,17 @@ public class EgovDateUtilBusinessDayTest {
 		assertEquals(0, EgovDateUtil.getBusinessDaysBetween("20250818", "20250812", new HashSet<>()),
 				"시작일이 종료일보다 늦으면 0영업일이어야 한다");
 	}
+
+	@Test
+	void testInvalidCalendarDateRejected() {
+		assertThrows(IllegalArgumentException.class,
+				() -> EgovDateUtil.getBusinessDaysBetween("20260230", "20260305", new HashSet<>()),
+				"존재하지 않는 날짜(2월 30일)는 조용히 롤오버되지 않고 예외여야 한다");
+		assertThrows(IllegalArgumentException.class,
+				() -> EgovDateUtil.getBusinessDaysBetween("20260101", "20260229", new HashSet<>()),
+				"윤년이 아닌 해의 2월 29일은 예외여야 한다");
+		assertThrows(IllegalArgumentException.class,
+				() -> EgovDateUtil.getBusinessDaysBetween("20261301", "20261305", new HashSet<>()),
+				"13월 같은 존재하지 않는 월은 예외여야 한다");
+	}
 }

--- a/src/test/java/egovframework/com/utl/fcc/service/EgovDateUtilBusinessDayTest.java
+++ b/src/test/java/egovframework/com/utl/fcc/service/EgovDateUtilBusinessDayTest.java
@@ -1,0 +1,64 @@
+package egovframework.com.utl.fcc.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+public class EgovDateUtilBusinessDayTest {
+
+	@Test
+	void testWeekendOnly() {
+		Set<String> holidays = new HashSet<>();
+
+		assertEquals(5, EgovDateUtil.getBusinessDaysBetween("20250812", "20250818", holidays),
+				"화요일부터 다음 월요일까지는 주말을 제외하면 5영업일이어야 한다");
+		assertEquals(5, EgovDateUtil.getBusinessDaysBetween("20250812", "20250818", null),
+				"공휴일 집합이 null이면 주말만 제외한 5영업일이어야 한다");
+	}
+
+	@Test
+	void testLiberationDay() {
+		assertEquals(4, EgovDateUtil.getBusinessDaysBetween("20250812", "20250818", Set.of("20250815")),
+				"주말과 금요일인 광복절을 제외하면 4영업일이어야 한다");
+	}
+
+	@Test
+	void testHolidayOnWeekendIsNotDeductedTwice() {
+		assertEquals(5, EgovDateUtil.getBusinessDaysBetween("20250811", "20250817", Set.of("20250816")),
+				"토요일 공휴일은 주말 제외와 중복 차감되지 않아야 한다");
+	}
+
+	@Test
+	void testYearBoundary() {
+		assertEquals(3, EgovDateUtil.getBusinessDaysBetween("20251231", "20260102", new HashSet<>()),
+				"연말 수요일부터 새해 금요일까지 세 날짜가 모두 평일이므로 3영업일이어야 한다");
+	}
+
+	@Test
+	void testHyphenatedDateFormat() {
+		assertEquals(4,
+				EgovDateUtil.getBusinessDaysBetween("2025-08-12", "2025-08-18", Set.of("20250815")),
+				"yyyy-MM-dd 형식도 허용하고 주말과 광복절을 제외한 4영업일이어야 한다");
+	}
+
+	@Test
+	void testSameDate() {
+		Set<String> holidays = new HashSet<>();
+
+		assertEquals(1, EgovDateUtil.getBusinessDaysBetween("20250812", "20250812", holidays),
+				"시작일과 종료일이 같은 평일이면 1영업일이어야 한다");
+		assertEquals(0, EgovDateUtil.getBusinessDaysBetween("20250816", "20250816", holidays),
+				"시작일과 종료일이 같은 토요일이면 0영업일이어야 한다");
+		assertEquals(0, EgovDateUtil.getBusinessDaysBetween("20250815", "20250815", Set.of("20250815")),
+				"시작일과 종료일이 같은 공휴일이면 0영업일이어야 한다");
+	}
+
+	@Test
+	void testFromDateAfterToDate() {
+		assertEquals(0, EgovDateUtil.getBusinessDaysBetween("20250818", "20250812", new HashSet<>()),
+				"시작일이 종료일보다 늦으면 0영업일이어야 한다");
+	}
+}


### PR DESCRIPTION
## 변경 이유

`EgovDateUtil`은 음·양력 변환, 요일 변환, 단순 일수차(`getDaysDiff`) 등 날짜 관련 기능을 제공하지만, 주말과 공휴일을 제외한 영업일 계산 기능은 없었다. 연차 일수 산정, 근무일 계산, SLA 기한, 정산 마감일 같은 행정 업무에서 영업일 계산은 자주 필요한데, 그동안 개발자가 매번 직접 구현해야 했다.

## 변경 내용

`EgovDateUtil`에 영업일 계산 메서드를 추가했다.

```java
public static int getBusinessDaysBetween(String fromDate, String toDate, Set<String> holidays)
```

- 시작일과 종료일 양끝을 포함하여 그 사이 영업일 수를 센다.
- 주말(토·일)을 제외한다.
- 공휴일은 `yyyyMMdd` 형식의 문자열 집합으로 전달받아 제외한다.
- 시작일이 종료일보다 늦으면 0을 반환한다.
- 공휴일 집합이 `null`이거나 비어 있으면 주말만 제외한다.

공휴일 집합은 호출자가 주입한다. 예를 들어 공휴일 관리 테이블(`COMTNRESTDE`) 조회 결과를 넘기면 된다. 따라서 유틸 자체는 DB에 의존하지 않는 순수 함수다.

설계는 기존 `EgovDateUtil`의 관례를 따랐다. static 메서드로 두고, 입력 날짜는 `validChkDate`로 `yyyyMMdd`·`yyyy-MM-dd` 두 형식을 모두 받아 정규화하며, 날짜 포맷은 기존 `SIMPLE_DATE_PATTERN` 상수를 재사용한다. `SimpleDateFormat`은 메서드 지역 변수로 두어 스레드 안전성을 확보했다.

## 테스트 방법

`EgovDateUtilBusinessDayTest`로 단위테스트 7건을 추가했다.

- 광복절을 포함한 연차 계산: `getBusinessDaysBetween("20250812","20250818",{"20250815"})` = 4
- 공휴일 빈 집합일 때 같은 구간: = 5
- 주말과 공휴일이 겹치는 경우 중복 제외
- 연/월 경계를 넘는 구간
- `yyyy-MM-dd` 포맷 입력
- 시작일 == 종료일
- 시작일 > 종료일 = 0, 공휴일 `null`

이 모듈의 surefire 설정은 `skipTests=true`로 고정되어 있어 일반 빌드에서 테스트가 실행되지 않는다. JUnit Console Launcher로 직접 구동하여 7건 모두 통과를 확인했다.

## 영향 범위

신규 메서드 추가뿐이다. 기존 메서드의 동작과 시그니처는 바뀌지 않으며 완전히 후방 호환된다.
