### PR TITLE
perf: 법정동·기관코드 수신 배치의 행별 존재확인 쿼리(N+1) 제거

### DIFF
--- a/src/main/java/egovframework/com/sym/ccm/acr/service/impl/AdministCodeRecptnDAO.java
+++ b/src/main/java/egovframework/com/sym/ccm/acr/service/impl/AdministCodeRecptnDAO.java
@@ -117,6 +117,14 @@ public class AdministCodeRecptnDAO extends EgovComAbstractDAO {
         return (Integer)selectOne("AdministCodeRecptnDAO.selectAdministCodeRecptnListTotCnt", searchVO);
     }
 
+	/**
+	 * 등록된 법정동코드(행정구역코드) 목록을 조회한다.
+	 * @return List(행정구역코드 목록)
+	 */
+	public List<String> selectExistingAdministCodes() {
+		return selectList("AdministCodeRecptnDAO.selectExistingAdministCodes");
+	}
+
     /**
 	 * 법정동코드 목록을 조회한다.
      * @param searchVO

--- a/src/main/java/egovframework/com/sym/ccm/acr/service/impl/EgovAdministCodeRecptnServiceImpl.java
+++ b/src/main/java/egovframework/com/sym/ccm/acr/service/impl/EgovAdministCodeRecptnServiceImpl.java
@@ -9,7 +9,9 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.apache.commons.io.IOUtils;
 import org.egovframe.rte.fdl.cmmn.EgovAbstractServiceImpl;
@@ -74,7 +76,11 @@ public class EgovAdministCodeRecptnServiceImpl extends EgovAbstractServiceImpl
 	 */
 	@Override
 	public void insertAdministCodeRecptn() throws Exception {
-		List<HashMap<String, String>> list = apiLink();
+		registAdministCode(apiLink());
+	}
+
+	void registAdministCode(List<HashMap<String, String>> list) throws Exception {
+		Set<String> existing = new HashSet<>(administCodeRecptnDAO.selectExistingAdministCodes());
 		for (HashMap<String, String> row : list) {
 			AdministCodeRecptn administCodeRecptn = new AdministCodeRecptn();
 
@@ -99,16 +105,13 @@ public class EgovAdministCodeRecptnServiceImpl extends EgovAbstractServiceImpl
 			administCodeRecptn.setLastUpdusrId("Batch System"); // 수정자 Batch System
 			administCodeRecptn.setUseAt("Y"); // 사용여부 >> Y
 
-			AdministCodeRecptnVO vo = new AdministCodeRecptnVO();
-			vo.setSearchCondition("CodeList");
-			vo.setAdministZoneSe("1");
-			vo.setAdministZoneCode(row.get("regionCd"));
-			int count = administCodeRecptnDAO.selectAdministCodeRecptnListTotCnt(vo);
-			if (count > 0) {
+			String code = administCodeRecptn.getAdministZoneCode();
+			if (existing.contains(code)) {
 				administCodeRecptnDAO.updateAdministCode(administCodeRecptn);
 			} else {
 				administCodeRecptnDAO.insertAdministCodeRecptn(administCodeRecptn);
 				administCodeRecptnDAO.insertAdministCode(administCodeRecptn);
+				existing.add(code);
 			}
 		}
 	}

--- a/src/main/java/egovframework/com/sym/ccm/icr/service/impl/EgovInsttCodeRecptnServiceImpl.java
+++ b/src/main/java/egovframework/com/sym/ccm/icr/service/impl/EgovInsttCodeRecptnServiceImpl.java
@@ -9,7 +9,9 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.apache.commons.io.IOUtils;
 import org.egovframe.rte.fdl.cmmn.EgovAbstractServiceImpl;
@@ -74,7 +76,11 @@ public class EgovInsttCodeRecptnServiceImpl extends EgovAbstractServiceImpl impl
 	 */
 	@Override
 	public void insertInsttCodeRecptn() throws Exception {
-		List<HashMap<String, String>> list = apiLink();
+		registInsttCode(apiLink());
+	}
+
+	void registInsttCode(List<HashMap<String, String>> list) throws Exception {
+		Set<String> existing = new HashSet<>(insttCodeRecptnDAO.selectExistingInsttCodes());
 		for (HashMap<String, String> row : list) {
 			InsttCodeRecptn insttCodeRecptn = new InsttCodeRecptn();
 			insttCodeRecptn.setOccrrDe(ObjectUtils.isEmpty(row.get("crtDe")) ? "20000101" : row.get("crtDe")); // 날짜 >> crt_de 생성일 x 20000101
@@ -107,15 +113,13 @@ public class EgovInsttCodeRecptnServiceImpl extends EgovAbstractServiceImpl impl
 			insttCodeRecptn.setFrstRegisterId("System Batch"); // 등록자 Batch System
 			insttCodeRecptn.setLastUpdusrId("System Batch"); // 수정자 Batch System
 
-			InsttCodeRecptnVO vo = new InsttCodeRecptnVO();
-			vo.setSearchCondition("CodeList");
-			vo.setInsttCode(row.get("orgCd"));
-			int count = insttCodeRecptnDAO.selectInsttCodeRecptnListTotCnt(vo);
-			if (count > 0) {
+			String code = insttCodeRecptn.getInsttCode();
+			if (existing.contains(code)) {
 				insttCodeRecptnDAO.updateInsttCode(insttCodeRecptn);
 			} else {
 				insttCodeRecptnDAO.insertInsttCodeRecptn(insttCodeRecptn);
 				insttCodeRecptnDAO.insertInsttCode(insttCodeRecptn);
+				existing.add(code);
 			}
 		}
 	}

--- a/src/main/java/egovframework/com/sym/ccm/icr/service/impl/InsttCodeRecptnDAO.java
+++ b/src/main/java/egovframework/com/sym/ccm/icr/service/impl/InsttCodeRecptnDAO.java
@@ -113,6 +113,14 @@ public class InsttCodeRecptnDAO extends EgovComAbstractDAO {
         return (Integer)selectOne("InsttCodeRecptnDAO.selectInsttCodeRecptnListTotCnt", searchVO);
     }
 
+	/**
+	 * 등록된 기관코드 목록을 조회한다.
+	 * @return List(기관코드 목록)
+	 */
+	public List<String> selectExistingInsttCodes() {
+		return selectList("InsttCodeRecptnDAO.selectExistingInsttCodes");
+	}
+
     /**
 	 * 기관코드 목록을 조회한다.
      * @param searchVO

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/acr/EgovAdministCodeRecptn_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/acr/EgovAdministCodeRecptn_SQL_altibase.xml
@@ -78,6 +78,12 @@
         </if>
     </select>
 
+    <select id="selectExistingAdministCodes" resultType="string">
+        SELECT DISTINCT ADMINIST_ZONE_CODE
+          FROM COMTCADMINISTCODERECPTNLOG
+         WHERE ADMINIST_ZONE_SE = '1'
+    </select>
+
     <select id="selectAdministCodeDetail" parameterType="egovframework.com.sym.ccm.acr.service.AdministCodeRecptn" resultType="egovframework.com.sym.ccm.acr.service.AdministCodeRecptn">
         
             SELECT  ADMINIST_ZONE_SE            administZoneSe

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/acr/EgovAdministCodeRecptn_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/acr/EgovAdministCodeRecptn_SQL_cubrid.xml
@@ -78,6 +78,12 @@
         </if>
     </select>
 
+    <select id="selectExistingAdministCodes" resultType="string">
+        SELECT DISTINCT ADMINIST_ZONE_CODE
+          FROM COMTCADMINISTCODERECPTNLOG
+         WHERE ADMINIST_ZONE_SE = '1'
+    </select>
+
     <select id="selectAdministCodeDetail" parameterType="egovframework.com.sym.ccm.acr.service.AdministCodeRecptn" resultType="egovframework.com.sym.ccm.acr.service.AdministCodeRecptn">
         
             SELECT  ADMINIST_ZONE_SE            administZoneSe

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/acr/EgovAdministCodeRecptn_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/acr/EgovAdministCodeRecptn_SQL_goldilocks.xml
@@ -78,6 +78,12 @@
         </if>
     </select>
 
+    <select id="selectExistingAdministCodes" resultType="string">
+        SELECT DISTINCT ADMINIST_ZONE_CODE
+          FROM COMTCADMINISTCODERECPTNLOG
+         WHERE ADMINIST_ZONE_SE = '1'
+    </select>
+
     <select id="selectAdministCodeDetail" parameterType="egovframework.com.sym.ccm.acr.service.AdministCodeRecptn" resultType="egovframework.com.sym.ccm.acr.service.AdministCodeRecptn">
         
             SELECT  ADMINIST_ZONE_SE            administZoneSe

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/acr/EgovAdministCodeRecptn_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/acr/EgovAdministCodeRecptn_SQL_maria.xml
@@ -64,6 +64,12 @@
         </if>
     </select>
 
+    <select id="selectExistingAdministCodes" resultType="string">
+        SELECT DISTINCT ADMINIST_ZONE_CODE
+          FROM COMTCADMINISTCODERECPTNLOG
+         WHERE ADMINIST_ZONE_SE = '1'
+    </select>
+
     <select id="selectAdministCodeDetail" parameterType="egovframework.com.sym.ccm.acr.service.AdministCodeRecptn" resultType="egovframework.com.sym.ccm.acr.service.AdministCodeRecptn">
         
             SELECT  ADMINIST_ZONE_SE            administZoneSe

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/acr/EgovAdministCodeRecptn_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/acr/EgovAdministCodeRecptn_SQL_mysql.xml
@@ -64,6 +64,12 @@
         </if>
     </select>
 
+    <select id="selectExistingAdministCodes" resultType="string">
+        SELECT DISTINCT ADMINIST_ZONE_CODE
+          FROM COMTCADMINISTCODERECPTNLOG
+         WHERE ADMINIST_ZONE_SE = '1'
+    </select>
+
     <select id="selectAdministCodeDetail" parameterType="egovframework.com.sym.ccm.acr.service.AdministCodeRecptn" resultType="egovframework.com.sym.ccm.acr.service.AdministCodeRecptn">
         
             SELECT  ADMINIST_ZONE_SE            administZoneSe

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/acr/EgovAdministCodeRecptn_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/acr/EgovAdministCodeRecptn_SQL_oracle.xml
@@ -78,6 +78,12 @@
         </if>
     </select>
 
+    <select id="selectExistingAdministCodes" resultType="string">
+        SELECT DISTINCT ADMINIST_ZONE_CODE
+          FROM COMTCADMINISTCODERECPTNLOG
+         WHERE ADMINIST_ZONE_SE = '1'
+    </select>
+
     <select id="selectAdministCodeDetail" parameterType="egovframework.com.sym.ccm.acr.service.AdministCodeRecptn" resultType="egovframework.com.sym.ccm.acr.service.AdministCodeRecptn">
         
             SELECT  ADMINIST_ZONE_SE            administZoneSe

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/acr/EgovAdministCodeRecptn_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/acr/EgovAdministCodeRecptn_SQL_postgres.xml
@@ -64,6 +64,12 @@
         </if>
     </select>
 
+    <select id="selectExistingAdministCodes" resultType="string">
+        SELECT DISTINCT ADMINIST_ZONE_CODE
+          FROM COMTCADMINISTCODERECPTNLOG
+         WHERE ADMINIST_ZONE_SE = '1'
+    </select>
+
     <select id="selectAdministCodeDetail" parameterType="egovframework.com.sym.ccm.acr.service.AdministCodeRecptn" resultType="egovframework.com.sym.ccm.acr.service.AdministCodeRecptn">
         
             SELECT  ADMINIST_ZONE_SE            administZoneSe

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/acr/EgovAdministCodeRecptn_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/acr/EgovAdministCodeRecptn_SQL_tibero.xml
@@ -78,6 +78,12 @@
         </if>
     </select>
 
+    <select id="selectExistingAdministCodes" resultType="string">
+        SELECT DISTINCT ADMINIST_ZONE_CODE
+          FROM COMTCADMINISTCODERECPTNLOG
+         WHERE ADMINIST_ZONE_SE = '1'
+    </select>
+
     <select id="selectAdministCodeDetail" parameterType="egovframework.com.sym.ccm.acr.service.AdministCodeRecptn" resultType="egovframework.com.sym.ccm.acr.service.AdministCodeRecptn">
         
             SELECT  ADMINIST_ZONE_SE            administZoneSe

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/icr/EgovInsttCodeRecptn_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/icr/EgovInsttCodeRecptn_SQL_altibase.xml
@@ -80,6 +80,11 @@
         </if>
     </select>
 
+    <select id="selectExistingInsttCodes" resultType="string">
+        SELECT DISTINCT INSTT_CODE
+          FROM COMTNINSTTCODERECPTNLOG
+    </select>
+
     <select id="selectInsttCodeDetail" parameterType="egovframework.com.sym.ccm.icr.service.InsttCodeRecptn" resultType="egovframework.com.sym.ccm.icr.service.InsttCodeRecptn">
         
             SELECT  INSTT_CODE              insttCode

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/icr/EgovInsttCodeRecptn_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/icr/EgovInsttCodeRecptn_SQL_cubrid.xml
@@ -79,6 +79,11 @@
         </if>
     </select>
 
+    <select id="selectExistingInsttCodes" resultType="string">
+        SELECT DISTINCT INSTT_CODE
+          FROM COMTNINSTTCODERECPTNLOG
+    </select>
+
     <select id="selectInsttCodeDetail" parameterType="egovframework.com.sym.ccm.icr.service.InsttCodeRecptn" resultType="egovframework.com.sym.ccm.icr.service.InsttCodeRecptn">
         
             SELECT  INSTT_CODE              insttCode

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/icr/EgovInsttCodeRecptn_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/icr/EgovInsttCodeRecptn_SQL_goldilocks.xml
@@ -80,6 +80,11 @@
         </if>
     </select>
 
+    <select id="selectExistingInsttCodes" resultType="string">
+        SELECT DISTINCT INSTT_CODE
+          FROM COMTNINSTTCODERECPTNLOG
+    </select>
+
     <select id="selectInsttCodeDetail" parameterType="egovframework.com.sym.ccm.icr.service.InsttCodeRecptn" resultType="egovframework.com.sym.ccm.icr.service.InsttCodeRecptn">
         
             SELECT  INSTT_CODE              insttCode

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/icr/EgovInsttCodeRecptn_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/icr/EgovInsttCodeRecptn_SQL_maria.xml
@@ -66,6 +66,11 @@
         </if>
     </select>
 
+    <select id="selectExistingInsttCodes" resultType="string">
+        SELECT DISTINCT INSTT_CODE
+          FROM COMTNINSTTCODERECPTNLOG
+    </select>
+
     <select id="selectInsttCodeDetail" parameterType="egovframework.com.sym.ccm.icr.service.InsttCodeRecptn" resultType="egovframework.com.sym.ccm.icr.service.InsttCodeRecptn">
         
             SELECT  INSTT_CODE              insttCode

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/icr/EgovInsttCodeRecptn_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/icr/EgovInsttCodeRecptn_SQL_mysql.xml
@@ -66,6 +66,11 @@
         </if>
     </select>
 
+    <select id="selectExistingInsttCodes" resultType="string">
+        SELECT DISTINCT INSTT_CODE
+          FROM COMTNINSTTCODERECPTNLOG
+    </select>
+
     <select id="selectInsttCodeDetail" parameterType="egovframework.com.sym.ccm.icr.service.InsttCodeRecptn" resultType="egovframework.com.sym.ccm.icr.service.InsttCodeRecptn">
         
             SELECT  INSTT_CODE              insttCode

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/icr/EgovInsttCodeRecptn_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/icr/EgovInsttCodeRecptn_SQL_oracle.xml
@@ -80,6 +80,11 @@
         </if>
     </select>
 
+    <select id="selectExistingInsttCodes" resultType="string">
+        SELECT DISTINCT INSTT_CODE
+          FROM COMTNINSTTCODERECPTNLOG
+    </select>
+
     <select id="selectInsttCodeDetail" parameterType="egovframework.com.sym.ccm.icr.service.InsttCodeRecptn" resultType="egovframework.com.sym.ccm.icr.service.InsttCodeRecptn">
         
             SELECT  INSTT_CODE              insttCode

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/icr/EgovInsttCodeRecptn_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/icr/EgovInsttCodeRecptn_SQL_postgres.xml
@@ -66,6 +66,11 @@
         </if>
     </select>
 
+    <select id="selectExistingInsttCodes" resultType="string">
+        SELECT DISTINCT INSTT_CODE
+          FROM COMTNINSTTCODERECPTNLOG
+    </select>
+
     <select id="selectInsttCodeDetail" parameterType="egovframework.com.sym.ccm.icr.service.InsttCodeRecptn" resultType="egovframework.com.sym.ccm.icr.service.InsttCodeRecptn">
         
             SELECT  INSTT_CODE              insttCode

--- a/src/main/resources/egovframework/mapper/com/sym/ccm/icr/EgovInsttCodeRecptn_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/ccm/icr/EgovInsttCodeRecptn_SQL_tibero.xml
@@ -80,6 +80,11 @@
         </if>
     </select>
 
+    <select id="selectExistingInsttCodes" resultType="string">
+        SELECT DISTINCT INSTT_CODE
+          FROM COMTNINSTTCODERECPTNLOG
+    </select>
+
     <select id="selectInsttCodeDetail" parameterType="egovframework.com.sym.ccm.icr.service.InsttCodeRecptn" resultType="egovframework.com.sym.ccm.icr.service.InsttCodeRecptn">
         
             SELECT  INSTT_CODE              insttCode

--- a/src/test/java/egovframework/com/sym/ccm/acr/service/impl/TestRegistAdministCodeNPlus1.java
+++ b/src/test/java/egovframework/com/sym/ccm/acr/service/impl/TestRegistAdministCodeNPlus1.java
@@ -1,0 +1,158 @@
+package egovframework.com.sym.ccm.acr.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import org.egovframe.rte.fdl.idgnr.EgovIdGnrService;
+import org.egovframe.rte.fdl.idgnr.EgovIdGnrStrategy;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import egovframework.com.sym.ccm.acr.service.AdministCodeRecptn;
+import egovframework.com.sym.ccm.acr.service.AdministCodeRecptnVO;
+
+/**
+ * 법정동코드 수신 배치의 N+1 제거와 등록/수정 분기를 검증한다. 단위 테스트
+ *
+ * @author 공통서비스 개발팀
+ * @since 2026.06.30
+ * @version 1.0
+ * @see
+ *
+ *      <pre>
+ *  == 개정이력(Modification Information) ==
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2026.06.30  공통서비스 개발팀   최초 생성
+ *
+ *      </pre>
+ */
+public class TestRegistAdministCodeNPlus1 {
+
+	@Test
+	public void registAdministCode_removesNPlus1AndPreservesBehavior() throws Exception {
+		FakeAdministCodeRecptnDAO dao = new FakeAdministCodeRecptnDAO(List.of("A"));
+		EgovAdministCodeRecptnServiceImpl service = newService(dao);
+
+		service.registAdministCode(List.of(row("A"), row("B"), row("C")));
+
+		assertEquals(1, dao.selectExistingCalls);
+		assertEquals(0, dao.totCntCalls);
+		assertEquals(List.of("A"), dao.updated);
+		assertEquals(List.of("B", "C"), dao.inserted);
+	}
+
+	@Test
+	public void registAdministCode_duplicateNewCode_insertsThenUpdates() throws Exception {
+		FakeAdministCodeRecptnDAO dao = new FakeAdministCodeRecptnDAO(List.of());
+		EgovAdministCodeRecptnServiceImpl service = newService(dao);
+
+		service.registAdministCode(List.of(row("D"), row("D")));
+
+		assertEquals(List.of("D"), dao.inserted);
+		assertEquals(List.of("D"), dao.updated);
+	}
+
+	private EgovAdministCodeRecptnServiceImpl newService(FakeAdministCodeRecptnDAO dao) {
+		EgovAdministCodeRecptnServiceImpl service = new EgovAdministCodeRecptnServiceImpl();
+		ReflectionTestUtils.setField(service, "administCodeRecptnDAO", dao);
+		ReflectionTestUtils.setField(service, "idgenService", new FakeEgovIdGnrService());
+		return service;
+	}
+
+	private HashMap<String, String> row(String code) {
+		HashMap<String, String> row = new HashMap<>();
+		row.put("regionCd", code);
+		return row;
+	}
+
+	private static class FakeAdministCodeRecptnDAO extends AdministCodeRecptnDAO {
+
+		private final List<String> existing;
+		private final List<String> inserted = new ArrayList<>();
+		private final List<String> updated = new ArrayList<>();
+		private int selectExistingCalls;
+		private int totCntCalls;
+
+		FakeAdministCodeRecptnDAO(List<String> existing) {
+			this.existing = existing;
+		}
+
+		@Override
+		public List<String> selectExistingAdministCodes() {
+			selectExistingCalls++;
+			return existing;
+		}
+
+		@Override
+		public int selectAdministCodeRecptnListTotCnt(AdministCodeRecptnVO searchVO) {
+			totCntCalls++;
+			return 0;
+		}
+
+		@Override
+		public void insertAdministCodeRecptn(AdministCodeRecptn administCodeRecptn) {
+			inserted.add(administCodeRecptn.getAdministZoneCode());
+		}
+
+		@Override
+		public void insertAdministCode(AdministCodeRecptn administCodeRecptn) {
+			// no-op
+		}
+
+		@Override
+		public void updateAdministCode(AdministCodeRecptn administCodeRecptn) {
+			updated.add(administCodeRecptn.getAdministZoneCode());
+		}
+	}
+
+	private static class FakeEgovIdGnrService implements EgovIdGnrService {
+
+		private int id;
+
+		@Override
+		public BigDecimal getNextBigDecimalId() {
+			return BigDecimal.ZERO;
+		}
+
+		@Override
+		public long getNextLongId() {
+			return 0;
+		}
+
+		@Override
+		public int getNextIntegerId() {
+			return ++id;
+		}
+
+		@Override
+		public short getNextShortId() {
+			return 0;
+		}
+
+		@Override
+		public byte getNextByteId() {
+			return 0;
+		}
+
+		@Override
+		public String getNextStringId() {
+			return null;
+		}
+
+		@Override
+		public String getNextStringId(String strategyId) {
+			return null;
+		}
+
+		@Override
+		public String getNextStringId(EgovIdGnrStrategy strategy) {
+			return null;
+		}
+	}
+}

--- a/src/test/java/egovframework/com/sym/ccm/icr/service/impl/TestRegistInsttCodeNPlus1.java
+++ b/src/test/java/egovframework/com/sym/ccm/icr/service/impl/TestRegistInsttCodeNPlus1.java
@@ -1,0 +1,158 @@
+package egovframework.com.sym.ccm.icr.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import org.egovframe.rte.fdl.idgnr.EgovIdGnrService;
+import org.egovframe.rte.fdl.idgnr.EgovIdGnrStrategy;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import egovframework.com.sym.ccm.icr.service.InsttCodeRecptn;
+import egovframework.com.sym.ccm.icr.service.InsttCodeRecptnVO;
+
+/**
+ * 기관코드 수신 배치의 N+1 제거와 등록/수정 분기를 검증한다. 단위 테스트
+ *
+ * @author 공통서비스 개발팀
+ * @since 2026.06.30
+ * @version 1.0
+ * @see
+ *
+ *      <pre>
+ *  == 개정이력(Modification Information) ==
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2026.06.30  공통서비스 개발팀   최초 생성
+ *
+ *      </pre>
+ */
+public class TestRegistInsttCodeNPlus1 {
+
+	@Test
+	public void registInsttCode_removesNPlus1AndPreservesBehavior() throws Exception {
+		FakeInsttCodeRecptnDAO dao = new FakeInsttCodeRecptnDAO(List.of("A"));
+		EgovInsttCodeRecptnServiceImpl service = newService(dao);
+
+		service.registInsttCode(List.of(row("A"), row("B"), row("C")));
+
+		assertEquals(1, dao.selectExistingCalls);
+		assertEquals(0, dao.totCntCalls);
+		assertEquals(List.of("A"), dao.updated);
+		assertEquals(List.of("B", "C"), dao.inserted);
+	}
+
+	@Test
+	public void registInsttCode_duplicateNewCode_insertsThenUpdates() throws Exception {
+		FakeInsttCodeRecptnDAO dao = new FakeInsttCodeRecptnDAO(List.of());
+		EgovInsttCodeRecptnServiceImpl service = newService(dao);
+
+		service.registInsttCode(List.of(row("D"), row("D")));
+
+		assertEquals(List.of("D"), dao.inserted);
+		assertEquals(List.of("D"), dao.updated);
+	}
+
+	private EgovInsttCodeRecptnServiceImpl newService(FakeInsttCodeRecptnDAO dao) {
+		EgovInsttCodeRecptnServiceImpl service = new EgovInsttCodeRecptnServiceImpl();
+		ReflectionTestUtils.setField(service, "insttCodeRecptnDAO", dao);
+		ReflectionTestUtils.setField(service, "idgenService", new FakeEgovIdGnrService());
+		return service;
+	}
+
+	private HashMap<String, String> row(String code) {
+		HashMap<String, String> row = new HashMap<>();
+		row.put("orgCd", code);
+		return row;
+	}
+
+	private static class FakeInsttCodeRecptnDAO extends InsttCodeRecptnDAO {
+
+		private final List<String> existing;
+		private final List<String> inserted = new ArrayList<>();
+		private final List<String> updated = new ArrayList<>();
+		private int selectExistingCalls;
+		private int totCntCalls;
+
+		FakeInsttCodeRecptnDAO(List<String> existing) {
+			this.existing = existing;
+		}
+
+		@Override
+		public List<String> selectExistingInsttCodes() {
+			selectExistingCalls++;
+			return existing;
+		}
+
+		@Override
+		public int selectInsttCodeRecptnListTotCnt(InsttCodeRecptnVO searchVO) {
+			totCntCalls++;
+			return 0;
+		}
+
+		@Override
+		public void insertInsttCodeRecptn(InsttCodeRecptn insttCodeRecptn) {
+			inserted.add(insttCodeRecptn.getInsttCode());
+		}
+
+		@Override
+		public void insertInsttCode(InsttCodeRecptn insttCodeRecptn) {
+			// no-op
+		}
+
+		@Override
+		public void updateInsttCode(InsttCodeRecptn insttCodeRecptn) {
+			updated.add(insttCodeRecptn.getInsttCode());
+		}
+	}
+
+	private static class FakeEgovIdGnrService implements EgovIdGnrService {
+
+		private int id;
+
+		@Override
+		public BigDecimal getNextBigDecimalId() {
+			return BigDecimal.ZERO;
+		}
+
+		@Override
+		public long getNextLongId() {
+			return 0;
+		}
+
+		@Override
+		public int getNextIntegerId() {
+			return ++id;
+		}
+
+		@Override
+		public short getNextShortId() {
+			return 0;
+		}
+
+		@Override
+		public byte getNextByteId() {
+			return 0;
+		}
+
+		@Override
+		public String getNextStringId() {
+			return null;
+		}
+
+		@Override
+		public String getNextStringId(String strategyId) {
+			return null;
+		}
+
+		@Override
+		public String getNextStringId(EgovIdGnrStrategy strategy) {
+			return null;
+		}
+	}
+}


### PR DESCRIPTION
## 변경 이유

법정동코드 수신(`EgovAdministCodeRecptnServiceImpl`)과 기관코드 수신(`EgovInsttCodeRecptnServiceImpl`) 배치는 외부 API에서 받은 코드를 한 행씩 처리하는데, 행마다 존재 여부를 확인하려고 COUNT 쿼리(`selectXxxRecptnListTotCnt`)를 호출한다. 수신 코드가 D건이면 SELECT가 D회, 쓰기가 D회 발생하는 N+1 구조다. 전국 기관코드는 수만 건 규모여서 수만 번의 불필요한 DB 왕복이 그대로 쌓인다.

## 변경 내용

루프를 돌기 전에 기존 코드를 `SELECT DISTINCT`로 한 번에 조회해 `HashSet`에 적재하고, 행마다 `set.contains(code)`로 존재를 O(1)에 확인하도록 바꿨다. 존재확인 SELECT가 D회에서 1회로 줄어든다.

동작 보존을 우선으로 두고 다음을 맞췄다.

- 신규 일괄조회의 필터, 대상 테이블, 키를 기존 COUNT 쿼리와 정확히 일치시켰다. 법정동은 `COMTCADMINISTCODERECPTNLOG`의 `ADMINIST_ZONE_SE = '1'` 조건과 `ADMINIST_ZONE_CODE`, 기관은 `COMTNINSTTCODERECPTNLOG`의 `INSTT_CODE`를 기준으로 한다.
- 수신 로그 테이블은 코드별 이력이 누적되는 append 구조이고 로그는 insert 분기에서만 추가된다. 그래서 `set.add(code)`도 insert 분기에서만 호출해, 한 배치 안에서 같은 코드가 두 번 등장하는 경우와 재실행 동작을 기존 COUNT 방식과 1:1로 보존한다.
- 행별 쓰기(insert/update)는 그대로 둔다. 목록 페이징에 쓰이는 `selectXxxRecptnListTotCnt` 쿼리와 메서드도 유지하고, 수신 루프 안의 호출만 제거했다. 서비스 인터페이스 변경은 없다.

매퍼는 8개 dialect(altibase, cubrid, goldilocks, maria, mysql, oracle, postgres, tibero) 각각에 acr/icr용 일괄조회 쿼리를 추가했다.

## 테스트 방법

수신 루프 본문을 패키지-프라이빗 메서드로 추출해 외부 API 호출 없이 검증했다. acr와 icr 각각에 대해 세 가지를 확인한다.

1. N+1 제거 — 행별 COUNT 호출이 0회, 일괄조회가 1회인지.
2. 동작 보존 — 기존에 있던 코드는 update로, 신규 코드는 insert로 분기하는지.
3. 중복 코드 처리 — 한 배치에 같은 코드가 여러 번 들어와도 기존 동작과 일치하는지.

이 모듈은 surefire가 `skipTests=true`로 하드코딩돼 있어 Maven 단계에서는 테스트가 돌지 않는다. JUnit Console Launcher로 직접 실행해 4건 모두 통과를 확인했다.

## 영향 범위

- 두 수신 배치의 존재확인 SELECT가 D회에서 1회로 감소한다(쓰기 횟수는 변동 없음).
- 서비스 인터페이스, 목록 페이징 쿼리, 행별 쓰기 동작은 변경하지 않는다.
- 배치를 동시에 두 번 실행하면 한쪽 스냅샷이 다른 쪽의 커밋을 보지 못할 수 있는데, 이는 행별 COUNT(READ COMMITTED)에도 똑같이 있던 기존 특성이지 이번 변경이 새로 만든 회귀가 아니다. 이 배치는 스케줄에서 단일 실행되는 모델이다.
