### PR TITLE
fix: 중복 제출 토큰 검증 동시성 보완

### DIFF
--- a/src/main/java/egovframework/com/cmm/taglibs/DoubleSubmitTag.java
+++ b/src/main/java/egovframework/com/cmm/taglibs/DoubleSubmitTag.java
@@ -56,25 +56,30 @@ public class DoubleSubmitTag extends TagSupport {
 		HttpServletRequest request = (HttpServletRequest)pageContext.getRequest();
 		HttpSession session = request.getSession();
 
-		Map<String, String> map = null;
+		String token = null;
 
-		if (session.getAttribute(EgovDoubleSubmitHelper.SESSION_TOKEN_KEY) == null) {
-			map = new HashMap<>();
+		synchronized (session) {
+			Map<String, String> map = null;
 
-			session.setAttribute(EgovDoubleSubmitHelper.SESSION_TOKEN_KEY, map);
-		} else {
-			map = (Map<String, String>) session.getAttribute(EgovDoubleSubmitHelper.SESSION_TOKEN_KEY);
+			if (session.getAttribute(EgovDoubleSubmitHelper.SESSION_TOKEN_KEY) == null) {
+				map = new HashMap<>();
+
+				session.setAttribute(EgovDoubleSubmitHelper.SESSION_TOKEN_KEY, map);
+			} else {
+				map = (Map<String, String>) session.getAttribute(EgovDoubleSubmitHelper.SESSION_TOKEN_KEY);
+			}
+
+			// First call (check session)
+			if (map.get(tokenKey) == null) {
+
+				map.put(tokenKey, EgovDoubleSubmitHelper.getNewUUID());
+
+				LOGGER.debug("[Double Submit] session token created({}) : {}", tokenKey, map.get(tokenKey));
+			}
+			token = map.get(tokenKey);
 		}
 
-		// First call (check session)
-		if (map.get(tokenKey) == null) {
-
-			map.put(tokenKey, EgovDoubleSubmitHelper.getNewUUID());
-
-			LOGGER.debug("[Double Submit] session token created({}) : {}", tokenKey, map.get(tokenKey));
-		}
-
-		buffer.append("<input type='hidden' name='").append(EgovDoubleSubmitHelper.PARAMETER_NAME).append("' value='").append(map.get(tokenKey)).append("'/>");
+		buffer.append("<input type='hidden' name='").append(EgovDoubleSubmitHelper.PARAMETER_NAME).append("' value='").append(token).append("'/>");
 
 		try {
 			pageContext.getOut().print(buffer.toString());

--- a/src/main/java/egovframework/com/cmm/util/EgovDoubleSubmitHelper.java
+++ b/src/main/java/egovframework/com/cmm/util/EgovDoubleSubmitHelper.java
@@ -48,33 +48,39 @@ public class EgovDoubleSubmitHelper {
 
 		HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
 		HttpSession session = request.getSession();
-		Object sessionTokenAttr = session.getAttribute(EgovDoubleSubmitHelper.SESSION_TOKEN_KEY);
-		// check session...
-		if (sessionTokenAttr == null) {
-			throw new RuntimeException("Double Submit Preventer TagLig isn't set. Check JSP.");
-		}
-
 		String parameter = request.getParameter(EgovDoubleSubmitHelper.PARAMETER_NAME);
 
-		// check parameter
-		if (parameter == null) {
-			throw new RuntimeException("Double Submit Preventer parameter isn't set. Check JSP.");
+		return checkAndSaveToken(session, tokenKey, parameter);
+	}
+
+	static boolean checkAndSaveToken(HttpSession session, String tokenKey, String parameter) {
+		synchronized (session) {
+			Object sessionTokenAttr = session.getAttribute(EgovDoubleSubmitHelper.SESSION_TOKEN_KEY);
+			// check session...
+			if (sessionTokenAttr == null) {
+				throw new RuntimeException("Double Submit Preventer TagLig isn't set. Check JSP.");
+			}
+
+			// check parameter
+			if (parameter == null) {
+				throw new RuntimeException("Double Submit Preventer parameter isn't set. Check JSP.");
+			}
+
+			@SuppressWarnings("unchecked")
+			Map<String, String> map = (Map<String, String>) sessionTokenAttr;
+
+			if (parameter.equals(map.get(tokenKey))) {
+
+				LOGGER.debug("[Double Submit] session token ({}) equals to parameter token.", tokenKey);
+
+				map.put(tokenKey, getNewUUID());
+
+				return true;
+			}
+
+			LOGGER.debug("[Double Submit] session token ({}) isn't equal to parameter token.", tokenKey);
+
+			return false;
 		}
-
-		@SuppressWarnings("unchecked")
-		Map<String, String> map = (Map<String, String>) sessionTokenAttr;
-
-		if (parameter.equals(map.get(tokenKey))) {
-
-			LOGGER.debug("[Double Submit] session token ({}) equals to parameter token.", tokenKey);
-
-			map.put(tokenKey, getNewUUID());
-
-			return true;
-		}
-
-		LOGGER.debug("[Double Submit] session token ({}) isn't equal to parameter token.", tokenKey);
-
-		return false;
 	}
 }

--- a/src/test/java/egovframework/com/cmm/util/EgovDoubleSubmitHelperTest.java
+++ b/src/test/java/egovframework/com/cmm/util/EgovDoubleSubmitHelperTest.java
@@ -1,0 +1,141 @@
+package egovframework.com.cmm.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.lang.reflect.Proxy;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.jupiter.api.Test;
+
+import jakarta.servlet.http.HttpSession;
+
+class EgovDoubleSubmitHelperTest {
+
+	@Test
+	void checkAndSaveToken_allowsOnlyOneConcurrentSubmitForSameToken()
+			throws InterruptedException, ExecutionException, TimeoutException {
+		final String token = "TOKEN";
+		Map<String, String> tokenMap = new CoordinatedTokenMap(EgovDoubleSubmitHelper.DEFAULT_TOKEN_KEY);
+		tokenMap.put(EgovDoubleSubmitHelper.DEFAULT_TOKEN_KEY, token);
+		HttpSession session = fakeSessionWithTokenMap(tokenMap);
+
+		ExecutorService pool = Executors.newFixedThreadPool(2);
+		CountDownLatch start = new CountDownLatch(1);
+		try {
+			Future<Boolean> first = pool.submit(() -> checkTokenAfterStart(session, token, start));
+			Future<Boolean> second = pool.submit(() -> checkTokenAfterStart(session, token, start));
+
+			start.countDown();
+
+			int successCount = (first.get(5, TimeUnit.SECONDS) ? 1 : 0)
+					+ (second.get(5, TimeUnit.SECONDS) ? 1 : 0);
+
+			assertEquals(1, successCount, "same token must be accepted only once under concurrent submit");
+		} finally {
+			pool.shutdownNow();
+		}
+	}
+
+	private static boolean checkTokenAfterStart(HttpSession session, String token, CountDownLatch start)
+			throws InterruptedException {
+		start.await();
+
+		return EgovDoubleSubmitHelper.checkAndSaveToken(session, EgovDoubleSubmitHelper.DEFAULT_TOKEN_KEY, token);
+	}
+
+	private static HttpSession fakeSessionWithTokenMap(Map<String, String> tokenMap) {
+		Map<String, Object> attributes = new ConcurrentHashMap<>();
+		attributes.put(EgovDoubleSubmitHelper.SESSION_TOKEN_KEY, tokenMap);
+
+		return (HttpSession) Proxy.newProxyInstance(
+				EgovDoubleSubmitHelperTest.class.getClassLoader(),
+				new Class<?>[] { HttpSession.class },
+				(proxy, method, args) -> {
+					String name = method.getName();
+					if ("getAttribute".equals(name)) {
+						return attributes.get(args[0]);
+					}
+					if ("setAttribute".equals(name)) {
+						attributes.put((String) args[0], args[1]);
+						return null;
+					}
+					if ("removeAttribute".equals(name)) {
+						attributes.remove(args[0]);
+						return null;
+					}
+					if ("getAttributeNames".equals(name)) {
+						return Collections.enumeration(attributes.keySet());
+					}
+					if ("invalidate".equals(name)) {
+						attributes.clear();
+						return null;
+					}
+					if ("equals".equals(name)) {
+						return proxy == args[0];
+					}
+					if ("hashCode".equals(name)) {
+						return System.identityHashCode(proxy);
+					}
+					if ("toString".equals(name)) {
+						return "FakeHttpSession";
+					}
+
+					Class<?> returnType = method.getReturnType();
+					if (returnType == boolean.class) {
+						return false;
+					}
+					if (returnType == int.class) {
+						return 0;
+					}
+					if (returnType == long.class) {
+						return 0L;
+					}
+					return null;
+				});
+	}
+
+	private static final class CoordinatedTokenMap extends HashMap<String, String> {
+		private static final long serialVersionUID = 1L;
+
+		private final String tokenKey;
+		private final CountDownLatch readAttempts = new CountDownLatch(2);
+		private final AtomicBoolean coordinateReads = new AtomicBoolean(true);
+
+		private CoordinatedTokenMap(String tokenKey) {
+			this.tokenKey = tokenKey;
+		}
+
+		@Override
+		public String get(Object key) {
+			String value = super.get(key);
+			if (coordinateReads.get() && tokenKey.equals(key)) {
+				readAttempts.countDown();
+				try {
+					if (!readAttempts.await(200, TimeUnit.MILLISECONDS)) {
+						coordinateReads.set(false);
+					}
+				} catch (InterruptedException e) {
+					Thread.currentThread().interrupt();
+				}
+			}
+			return value;
+		}
+
+		@Override
+		public String put(String key, String value) {
+			coordinateReads.set(false);
+			return super.put(key, value);
+		}
+	}
+}


### PR DESCRIPTION
## 변경 이유

`EgovDoubleSubmitHelper.checkAndSaveToken`은 세션에 저장된 토큰을 읽고, 요청 파라미터와 비교한 뒤, 새 토큰으로 교체합니다.

이 과정이 `get -> compare -> put`으로 분리되어 있어 같은 세션에서 동일 토큰을 가진 요청이 동시에 들어오면 두 요청이 모두 기존 토큰을 읽고 `true`로 통과할 수 있습니다. 또한 `DoubleSubmitTag`의 세션 토큰 맵 초기화도 동기화되어 있지 않아, 같은 세션에서 여러 화면이 동시에 렌더링될 때 토큰 맵이 덮어써질 수 있습니다.

## 변경 내용

- `DoubleSubmitTag`에서 세션 토큰 맵 생성과 tokenKey별 토큰 생성을 같은 세션 락 안에서 수행하도록 보완했습니다.
- `EgovDoubleSubmitHelper.checkAndSaveToken`에서 세션 토큰 조회, 파라미터 비교, 새 토큰 저장을 같은 세션 락 안에서 처리하도록 보완했습니다.
- 동일 토큰으로 동시 submit이 들어와도 한 요청만 통과하는지 검증하는 단위 테스트를 추가했습니다.

## 영향 범위

- 대상: 공통 Double Submit Preventer 유틸과 JSP 태그
- public API 변경 없음
- 단일 요청 흐름의 기존 동작은 유지하고, 같은 세션의 동시 접근 경합만 보완합니다.

## 검증

- `mvn -B verify` 성공
- 로컬 검증에서 Surefire `skipTests` 설정을 임시 해제한 뒤 `EgovDoubleSubmitHelperTest` 1건 통과 확인
