### PR TITLE
fix: spring-websocket managed version override 제거

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,6 @@
 	<groupId>egovframework</groupId>
 	<artifactId>egovframe-template-common-components</artifactId>
 	<packaging>war</packaging>
-	<version>5.0.0</version>
 	<name>egovframe-template-common-components</name>
 	<url>http://www.egovframe.go.kr</url>
 
@@ -349,7 +348,6 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-websocket</artifactId>
-			<version>6.2.13</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>
@@ -570,12 +568,12 @@
 							<type>embedded</type>
 						</container>
 						<configuration>
-							<properties>
+							<!--<properties>
 								<property>
 									<name>cargo.servlet.port</name>
 									<value>8080</value>
 								</property>
-							</properties>
+							</properties>-->
 						</configuration>
 					</configuration>
 				</plugin>


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

###  변경 내용

- `spring-websocket`의 명시적인 `version` 속성을 제거했습니다.
- `dependencyManagement`에서 관리하는 Spring Framework 버전을 사용하도록 수정했습니다.
- Maven의 `Overriding managed version` 경고를 해결했습니다.

---

`<version>5.0.0</version>` 삭제
```
Multiple markers at this line
- Version is duplicate of parent version
- Version is duplicate of parent version [DuplicationOfParentVersion]
```

---

cargo-maven3-plugin properties 주석
```
Invalid plugin configuration: properties
```

###  변경 이유

`spring-websocket`은 상위 `dependencyManagement`에서 버전이 관리되고 있으므로
개별 dependency에서 버전을 지정할 필요가 없습니다.

중복 버전 지정은 Maven에서 `Overriding managed version` 경고를 발생시키므로
관리되는 버전을 사용하도록 정리했습니다.

###  영향 범위

- 기능 변경 없음
- 의존성 관리 방식 개선
- Maven 경고 제거

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [x] 수동 테스트 Manual testing

mvn clean package

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

https://youtu.be/Xzz5hpFZ4LQ
