### PR TITLE
refactor: keySet() 순회 후 get() 중복 조회를 entrySet()으로 제거

### DIFF
--- a/src/main/java/egovframework/com/sym/ccm/acr/web/EgovAdministCodeRecptnController.java
+++ b/src/main/java/egovframework/com/sym/ccm/acr/web/EgovAdministCodeRecptnController.java
@@ -196,8 +196,8 @@ public class EgovAdministCodeRecptnController {
      */
 	public String printParameterMap(@RequestParam Map<?, ?> commandMap){
 		String ret = "";
-       	for(Object key:commandMap.keySet()){
-    		Object value = commandMap.get(key);
+       	for(Map.Entry<?, ?> entry:commandMap.entrySet()){
+    		Object key = entry.getKey(); Object value = entry.getValue();
 
     		ret += "key:" + key.toString() + " value:" + value.toString();
     	}

--- a/src/main/java/egovframework/com/sym/ccm/adc/web/EgovCcmAdministCodeManageController.java
+++ b/src/main/java/egovframework/com/sym/ccm/adc/web/EgovCcmAdministCodeManageController.java
@@ -280,8 +280,8 @@ public class EgovCcmAdministCodeManageController {
 	 */
 	public String printParameterMap(@RequestParam Map<?, ?> commandMap) {
 		String ret = "";
-		for (Object key : commandMap.keySet()) {
-			Object value = commandMap.get(key);
+		for (Map.Entry<?, ?> entry : commandMap.entrySet()) {
+			Object key = entry.getKey(); Object value = entry.getValue();
 
 			ret += "key:" + key.toString() + " value:" + value.toString();
 		}

--- a/src/main/java/egovframework/com/sym/ccm/icr/web/EgovInsttCodeRecptnController.java
+++ b/src/main/java/egovframework/com/sym/ccm/icr/web/EgovInsttCodeRecptnController.java
@@ -196,8 +196,8 @@ public class EgovInsttCodeRecptnController {
      */
 	public String printParameterMap(@RequestParam Map<?, ?> commandMap){
 		String ret = "";
-       	for(Object key:commandMap.keySet()){
-    		Object value = commandMap.get(key);
+       	for(Map.Entry<?, ?> entry:commandMap.entrySet()){
+    		Object key = entry.getKey(); Object value = entry.getValue();
 
     		ret += "key:" + key.toString() + " value:" + value.toString();
     	}

--- a/src/main/java/egovframework/com/utl/fcc/service/EgovFormBasedFileUtil.java
+++ b/src/main/java/egovframework/com/utl/fcc/service/EgovFormBasedFileUtil.java
@@ -241,8 +241,8 @@ public class EgovFormBasedFileUtil {
 		if (mimeType != null) {
 			Map<String, String> contentTypeWL = getContentTypeWL();
 			if (contentTypeWL != null) {
-				for (String ext : contentTypeWL.keySet()) {
-					String matchMimeType = contentTypeWL.get(ext);
+				for (Map.Entry<String, String> entry : contentTypeWL.entrySet()) {
+					String matchMimeType = entry.getValue();
 					if (matchMimeType.equals(mimeType)) {
 						response.setContentType(matchMimeType); // 지정된 값이므로 안전
 						contentTypeFlag = true;


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [ ] 버그수정 Bug fixes
- [X] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

> 동작을 그대로 유지하면서 `Map` 순회 방식을 개선(중복 해시 조회 제거)한 리팩터입니다.

## 수정된 소스 내용 Modified source

`for (K key : map.keySet()) { V v = map.get(key); ... }` 형태는 키로 한 번 순회하고 다시 `get(key)`로 값을 재조회해 **해시 룩업이 2배** 발생합니다. 이를 `entrySet()` 순회로 바꿔 중복 조회를 제거했습니다.

| 파일 | 대상 |
|---|---|
| `EgovAdministCodeRecptnController.java` | `printParameterMap()` |
| `EgovCcmAdministCodeManageController.java` | `printParameterMap()` |
| `EgovInsttCodeRecptnController.java` | `printParameterMap()` |
| `EgovFormBasedFileUtil.java` | contentType 화이트리스트 조회 루프 |

- 4개 파일, 8줄 (+8/−8). **동작·출력 결과 동일**(순수 리팩터).
- `Map` import가 이미 있어 `Map.Entry` 사용에 추가 import 불필요.
- 보안 민감 코드(XSS 필터 등)는 대상에서 제외했습니다.

## JUnit 테스트 JUnit tests

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

> 로직 변경 없는 순회 방식 리팩터로, 반복 결과(키·값 집합)가 동일합니다.

## 테스트 브라우저 Test Browser

해당 없음 (서버 측 리팩터, 화면 변경 없음)

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음