### PR TITLE
refactor: 컬렉션 size() 비교를 isEmpty()로 단순화

### DIFF
--- a/src/main/java/egovframework/com/cmm/service/FileSystemUtils.java
+++ b/src/main/java/egovframework/com/cmm/service/FileSystemUtils.java
@@ -421,7 +421,7 @@ public class FileSystemUtils {
 				// os command problem, throw exception
 				throw new IOException("Command line returned OS error code '" + proc.exitValue() + "' for command " + Arrays.asList(cmdAttribs));
 			}
-			if (lines.size() == 0) {
+			if (lines.isEmpty()) {
 				// unknown problem, throw exception
 				throw new IOException("Command line did not return any info " + "for command " + Arrays.asList(cmdAttribs));
 			}

--- a/src/main/java/egovframework/com/cmm/service/impl/EgovFileMngServiceImpl.java
+++ b/src/main/java/egovframework/com/cmm/service/impl/EgovFileMngServiceImpl.java
@@ -67,7 +67,7 @@ public class EgovFileMngServiceImpl extends EgovAbstractServiceImpl implements E
 	public String insertFileInfs(List<FileVO> fvoList) throws Exception {
 		String atchFileId = "";
 
-		if (fvoList.size() != 0) {
+		if (!fvoList.isEmpty()) {
 			atchFileId = fileMngDAO.insertFileInfs(fvoList);
 		}
 		if (StringUtils.isEmpty(atchFileId)) {

--- a/src/main/java/egovframework/com/sym/bat/service/BatchSchdul.java
+++ b/src/main/java/egovframework/com/sym/bat/service/BatchSchdul.java
@@ -378,7 +378,7 @@ public class BatchSchdul extends ComDefaultVO implements Serializable {
 		// 요일출력
 		if (this.executCycle.equals("02")) {
 			// 실행주기가 매주인 경우에만 출력한다.
-			if (dfkSeList.size() != 0) {
+			if (!dfkSeList.isEmpty()) {
 				for (int i = 0; i < dfkSeList.size(); i++) {
 					if (i != 0) {
 						executSchdul = executSchdul + ",";

--- a/src/main/java/egovframework/com/sym/mnu/mcm/web/EgovMenuCreateManageController.java
+++ b/src/main/java/egovframework/com/sym/mnu/mcm/web/EgovMenuCreateManageController.java
@@ -111,7 +111,7 @@ public class EgovMenuCreateManageController {
 		 * searchVO.setSearchKeyword(vo.getAuthorCode()); } }
 		 */
 		List<EgovMap> resultList = menuCreateManageService.selectMenuCreatManagList(searchVO);
-		if (resultList.size() == 0) {
+		if (resultList.isEmpty()) {
 			resultMsg = egovMessageSource.getMessage("info.nodata.msg");
 		}
 		model.addAttribute("resultList", resultList);

--- a/src/main/java/egovframework/com/sym/sym/bak/service/BackupOpert.java
+++ b/src/main/java/egovframework/com/sym/sym/bak/service/BackupOpert.java
@@ -394,7 +394,7 @@ public class BackupOpert extends ComDefaultVO implements Serializable {
 		// 요일출력
 		if (this.executCycle.equals("02")) {
 			// 실행주기가 매주인 경우에만 출력한다.
-			if (dfkSeList.size() != 0) {
+			if (!dfkSeList.isEmpty()) {
 				for (int i = 0; i < dfkSeList.size(); i++) {
 					if (i != 0) {
 						executSchdul = executSchdul + ",";

--- a/src/main/java/egovframework/com/utl/sys/fsm/service/FileSystemChecker.java
+++ b/src/main/java/egovframework/com/utl/sys/fsm/service/FileSystemChecker.java
@@ -271,7 +271,7 @@ public class FileSystemChecker {
 				// os command problem, throw exception
 				throw new IOException("Command line returned OS error code '" + p.exitValue() + "' for command " + Arrays.asList(cmdAttribs));
 			}
-			if (lines.size() == 0) {
+			if (lines.isEmpty()) {
 				// unknown problem, throw exception
 				throw new IOException("Command line did not return any info " + "for command " + Arrays.asList(cmdAttribs));
 			}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [ ] 버그수정 Bug fixes
- [X] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

> 동작을 그대로 유지하는 가독성 리팩터입니다.

## 수정된 소스 내용 Modified source

`List`의 비어있음 검사를 `size()` 비교 대신 `isEmpty()`로 단순화했습니다. 의미가 더 명확하고 관용적입니다.

| 변경 | 파일 |
|---|---|
| `lines.size() == 0` → `lines.isEmpty()` | FileSystemUtils, FileSystemChecker |
| `resultList.size() == 0` → `resultList.isEmpty()` | EgovMenuCreateManageController |
| `fvoList.size() != 0` → `!fvoList.isEmpty()` | EgovFileMngServiceImpl |
| `dfkSeList.size() != 0` → `!dfkSeList.isEmpty()` | BatchSchdul, BackupOpert |

- 6개 파일, 6줄 (+6/−6). 대상은 모두 `List` 타입으로 확인. **동작 완전 동일**.
- `.size() > 0` 형태는 이 PR에서 제외(후속 검토).

## JUnit 테스트 JUnit tests

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

> 로직 변경 없는 표현 단순화로 결과가 동일합니다.

## 테스트 브라우저 Test Browser

해당 없음 (서버 측 리팩터)

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음