### PR TITLE
fix: 문자열 상태코드 비교를 ==에서 equals()로 수정 (참조 비교 버그)

### DIFF
--- a/src/main/java/egovframework/com/utl/sys/htm/service/HttpMntrngScheduling.java
+++ b/src/main/java/egovframework/com/utl/sys/htm/service/HttpMntrngScheduling.java
@@ -109,7 +109,7 @@ public class HttpMntrngScheduling extends EgovAbstractServiceImpl {
 				nrmltAt = false;
 			}
 
-			if (httpSttusCd == "02") {
+			if ("02".equals(httpSttusCd)) {
 				nrmltAt = false;
 			}
 
@@ -121,7 +121,7 @@ public class HttpMntrngScheduling extends EgovAbstractServiceImpl {
 
 			// DB에 결과값 저장
 			target.setHttpSttusCd(httpSttusCd);
-			if (httpSttusCd == "02") {
+			if ("02".equals(httpSttusCd)) {
 				target.setLogInfo("Connection timed out: connect");
 			}
 

--- a/src/main/java/egovframework/com/utl/sys/prm/service/EgovProcessMonScheduling.java
+++ b/src/main/java/egovframework/com/utl/sys/prm/service/EgovProcessMonScheduling.java
@@ -101,7 +101,7 @@ public class EgovProcessMonScheduling extends EgovAbstractServiceImpl {
 				nrmltAt = false;
 			}
 
-			if (procsSttus == "02") {
+			if ("02".equals(procsSttus)) {
 				nrmltAt = false;
 			}
 
@@ -113,7 +113,7 @@ public class EgovProcessMonScheduling extends EgovAbstractServiceImpl {
 
 			// DB에 결과값 저장
 			target.setProcsSttus(procsSttus);
-			if (procsSttus == "02") {
+			if ("02".equals(procsSttus)) {
 				target.setLogInfo("실행 중인 작업 중 지정된 조건에 일치하는 작업이 없습니다.");
 			}
 


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

상태 모니터링 스케줄러에서 상태코드 문자열을 `==`(참조 비교)로 검사하고 있어 `equals()`(값 비교)로 수정했습니다.

```java
// AS-IS (참조 비교 — 잠재 버그)
if (procsSttus == "02") { ... }
// TO-BE (값 비교 + null-safe)
if ("02".equals(procsSttus)) { ... }
```

**대상 (2파일, 4곳)**
- `EgovProcessMonScheduling.java` : `procsSttus == "02"` × 2
- `HttpMntrngScheduling.java` : `httpSttusCd == "02"` × 2

**배경**
- 두 변수는 `ProcessMonChecker.getProcessId()` / `HttpMntrngChecker.getPrductStatus()`의 반환값입니다.
- 현재 해당 메서드가 컴파일타임 리터럴 `"01"`/`"02"`를 반환해 문자열 인터닝 덕분에 `==`가 우연히 동작하지만, 반환 로직이 동적으로 생성된 문자열을 반환하도록 바뀌면 **즉시 오작동**하는 잠재 버그입니다.
- `"02".equals(...)` 형태는 **현재 동작과 완전히 동일**하며(리터럴은 ==/equals 모두 동일 판정), 추가로 `null` 안전합니다.

## JUnit 테스트 JUnit tests

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

> 리터럴 반환값 특성상 기존 동작과 결과가 동일함을 코드 판독으로 확인했습니다.

## 테스트 브라우저 Test Browser

해당 없음 (서버 측 스케줄러 로직)

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음