### PR TITLE
perf: printParameterMap 문자열 연결을 StringBuilder로 개선 및 entrySet 적용

### DIFF
--- a/src/main/java/egovframework/com/ssi/syi/ims/web/EgovCntcMessageController.java
+++ b/src/main/java/egovframework/com/ssi/syi/ims/web/EgovCntcMessageController.java
@@ -436,13 +436,14 @@ public class EgovCntcMessageController {
 	 * @return
 	 */
 	public String printParameterMap(@RequestParam Map<?, ?> commandMap) {
-		String ret = "";
-		for (Object key : commandMap.keySet()) {
-			Object value = commandMap.get(key);
+		StringBuilder ret = new StringBuilder();
+		for (Map.Entry<?, ?> entry : commandMap.entrySet()) {
+			Object key = entry.getKey();
+			Object value = entry.getValue();
 
-			ret += "key:" + key.toString() + " value:" + value.toString();
+			ret.append("key:").append(key.toString()).append(" value:").append(value.toString());
 		}
-		return ret;
+		return ret.toString();
 	}
 
 }

--- a/src/main/java/egovframework/com/ssi/syi/ist/web/EgovCntcSttusController.java
+++ b/src/main/java/egovframework/com/ssi/syi/ist/web/EgovCntcSttusController.java
@@ -109,13 +109,14 @@ public class EgovCntcSttusController {
 	 * @return
 	 */
 	public String printParameterMap(@RequestParam Map<?, ?> commandMap) {
-		String ret = "";
-		for (Object key : commandMap.keySet()) {
-			Object value = commandMap.get(key);
+		StringBuilder ret = new StringBuilder();
+		for (Map.Entry<?, ?> entry : commandMap.entrySet()) {
+			Object key = entry.getKey();
+			Object value = entry.getValue();
 
-			ret += "key:" + key.toString() + " value:" + value.toString();
+			ret.append("key:").append(key.toString()).append(" value:").append(value.toString());
 		}
-		return ret;
+		return ret.toString();
 	}
 
 }


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [ ] 버그수정 Bug fixes
- [X] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

> 반복문 내 문자열 처리 성능을 개선한 리팩터입니다(결과 동일).

## 수정된 소스 내용 Modified source

`EgovCntcMessageController` / `EgovCntcSttusController`의 `printParameterMap()`에서 두 가지 비효율을 개선했습니다.

1. **루프 내 문자열 `+=`** → 매 반복마다 새 `String`이 생성되어 O(n²) 경향. `StringBuilder`로 누적하도록 변경.
2. **`keySet()` 순회 후 `get(key)`** → 해시 조회 중복. `entrySet()` 순회로 제거.

```java
// AS-IS
String ret = "";
for (Object key : commandMap.keySet()) {
    Object value = commandMap.get(key);
    ret += "key:" + key.toString() + " value:" + value.toString();
}
return ret;
// TO-BE
StringBuilder ret = new StringBuilder();
for (Map.Entry<?, ?> entry : commandMap.entrySet()) {
    Object key = entry.getKey();
    Object value = entry.getValue();
    ret.append("key:").append(key.toString()).append(" value:").append(value.toString());
}
return ret.toString();
```

- 2개 파일. **출력 결과 동일**(동일한 key/value 문자열 누적), null 처리 동작도 기존과 동일.
- `Map` import가 이미 있어 `Map.Entry` 추가 import 불필요.

## JUnit 테스트 JUnit tests

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

> 반환 문자열이 기존과 동일함을 코드 판독으로 확인했습니다.

## 테스트 브라우저 Test Browser

해당 없음 (서버 측 리팩터)

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음