### PR TITLE
perf: 지역 변수 StringBuffer를 StringBuilder로 변경 (동기화 오버헤드 제거)

### DIFF
--- a/src/main/java/egovframework/com/cmm/web/EgovValidationControllerAdvice.java
+++ b/src/main/java/egovframework/com/cmm/web/EgovValidationControllerAdvice.java
@@ -165,7 +165,7 @@ public class EgovValidationControllerAdvice {
 		// {키이름} 패턴을 찾아서 대체
 		Pattern pattern = java.util.regex.Pattern.compile("\\{([^}]+)\\}");
 		Matcher matcher = pattern.matcher(message);
-		StringBuffer result = new StringBuffer();
+		StringBuilder result = new StringBuilder();
 
 		while (matcher.find()) {
 			String messageKey = matcher.group(1);

--- a/src/main/java/egovframework/com/cop/sms/service/impl/EgovSmsBasicServiceImpl.java
+++ b/src/main/java/egovframework/com/cop/sms/service/impl/EgovSmsBasicServiceImpl.java
@@ -105,7 +105,7 @@ public class EgovSmsBasicServiceImpl implements EgovSmsInfoService {
 			return "";
 		}
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 
 		if (number.length() == 9) { // 02-500-1234 형식
 			buffer.append(number.substring(0, 2));

--- a/src/main/java/egovframework/com/cop/sms/service/impl/EgovSmsInfoServiceImpl.java
+++ b/src/main/java/egovframework/com/cop/sms/service/impl/EgovSmsInfoServiceImpl.java
@@ -76,7 +76,7 @@ public class EgovSmsInfoServiceImpl extends EgovAbstractServiceImpl implements E
 	    return "";
 	}
 
-	StringBuffer buffer = new StringBuffer();
+	StringBuilder buffer = new StringBuilder();
 
 
 	if (number.length() == 9) {	// 02-500-1234 형식

--- a/src/main/java/egovframework/com/utl/fcc/service/EgovNumberUtil.java
+++ b/src/main/java/egovframework/com/utl/fcc/service/EgovNumberUtil.java
@@ -176,7 +176,7 @@ public class EgovNumberUtil {
 		String subject = String.valueOf(cnvrSrcNumber);
 		String object = String.valueOf(cnvrTrgtNumber);
 
-		StringBuffer rtnStr = new StringBuffer();
+		StringBuilder rtnStr = new StringBuilder();
 		String preStr = "";
 		String nextStr = source;
 

--- a/src/main/java/egovframework/com/utl/wed/filter/DirectoryPathManager.java
+++ b/src/main/java/egovframework/com/utl/wed/filter/DirectoryPathManager.java
@@ -64,7 +64,7 @@ public class DirectoryPathManager {
 	public static String getDirectoryPathByDateType(DIR_DATE_TYPE policy) {
 
 		Calendar calendar = Calendar.getInstance();
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append(calendar.get(Calendar.YEAR)).append(File.separator);
 		if (policy.ordinal() <= DIR_DATE_TYPE.DATE_POLICY_YYYY_MM.ordinal()) {
 			sb.append(StringUtils.leftPad(String.valueOf(calendar.get(Calendar.MONTH)+1), 2, '0')).append(File.separator);


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [ ] 버그수정 Bug fixes
- [X] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

> 지역 변수의 불필요한 동기화 오버헤드를 제거한 성능 리팩터입니다(동작 동일).

## 수정된 소스 내용 Modified source

메서드 내부 지역 변수로만 사용되는 `StringBuffer`(모든 메서드가 `synchronized`)를 단일 스레드 컨텍스트에 적합한 `StringBuilder`로 변경했습니다.

**대상 (5파일)**
- `EgovValidationControllerAdvice.java`
- `EgovSmsBasicServiceImpl.java`
- `EgovSmsInfoServiceImpl.java`
- `EgovNumberUtil.java`
- `DirectoryPathManager.java`

**안전성 근거**
- 각 파일에서 `StringBuffer`가 지역 선언 한 줄에만 존재(필드·파라미터·반환 타입 없음).
- 저장소 전체에 `StringBuffer`를 인자로 받는 메서드가 없어 다른 코드에 전파되지 않음.
- `append()`/`toString()` API가 동일해 **컴파일·동작 결과 변화 없음**.

## JUnit 테스트 JUnit tests

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

> 타입만 변경(동기화 제거)으로 반환 문자열 결과가 기존과 동일합니다.

## 테스트 브라우저 Test Browser

해당 없음 (서버 측 리팩터)

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음