### PR TITLE
perf: 지역 변수 StringBuffer를 StringBuilder로 변경 (2차, 7파일)

### DIFF
--- a/src/main/java/egovframework/com/cop/sms/service/impl/SmsBasicDAO.java
+++ b/src/main/java/egovframework/com/cop/sms/service/impl/SmsBasicDAO.java
@@ -37,7 +37,7 @@ public class SmsBasicDAO {
 	public List<SmsVO> selectSmsInfs(SmsVO vo) throws Exception {
 		List<SmsVO> list = new ArrayList<SmsVO>();
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 
 		// for mySql
 		buffer.append("SELECT\n");
@@ -129,7 +129,7 @@ public class SmsBasicDAO {
 	 * @throws Exception
 	 */
 	public int selectSmsInfsCnt(SmsVO vo) throws Exception {
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 
 		// for mySql
 		buffer.append("SELECT\n");
@@ -191,7 +191,7 @@ public class SmsBasicDAO {
 	public String insertSmsInf(Sms sms) throws Exception {
 		String smsId = null;
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 
 		// for mySql
 		buffer.append("INSERT INTO COMTNSMS\n");
@@ -237,7 +237,7 @@ public class SmsBasicDAO {
 	 * @throws Exception
 	 */
 	public void insertSmsRecptnInf(SmsRecptn smsRecptn) throws Exception {
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 
 		// for mySql & Oracle
 		buffer.append("INSERT INTO COMTNSMSRECPTN\n");
@@ -267,7 +267,7 @@ public class SmsBasicDAO {
 	public SmsVO selectSmsInf(SmsVO searchVO) throws Exception {
 		SmsVO smsVO = new SmsVO();
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		// for mySql
 		buffer.append("SELECT\n");
 		buffer.append("  a.SMS_ID, a.TRNSMIS_TELNO, a.TRNSMIS_CN,\n");
@@ -318,7 +318,7 @@ public class SmsBasicDAO {
 	public List<SmsRecptn> selectSmsRecptnInfs(SmsRecptn vo) throws Exception {
 		List<SmsRecptn> list = new ArrayList<SmsRecptn>();
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 
 		// for mySql & Oracle
 		buffer.append("SELECT\n");
@@ -359,7 +359,7 @@ public class SmsBasicDAO {
 	 * @throws Exception
 	 */
 	public void updateSmsRecptnInf(SmsRecptn smsRecptn) throws Exception {
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 
 		// for mySql & Oracle
 		buffer.append("UPDATE COMTNSMSRECPTN SET\n");
@@ -388,7 +388,7 @@ public class SmsBasicDAO {
 	 * @throws Exception
 	 */
 	protected String getNextId(Connection conn) throws Exception {
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 
 		// for mySql
 		buffer.append(

--- a/src/main/java/egovframework/com/sym/adr/web/EgovAdressCntcController.java
+++ b/src/main/java/egovframework/com/sym/adr/web/EgovAdressCntcController.java
@@ -51,7 +51,7 @@ public class EgovAdressCntcController {
 			+ countPerPage + "&keyword=" + URLEncoder.encode(keyword, "UTF-8") + "&confmKey=" + confmKey;
 		URL url = new URL(EgovWebUtil.filePathBlackList(apiUrl));
 		try (BufferedReader br = new BufferedReader(new InputStreamReader(url.openStream(), "UTF-8"));) {//2022.01 Resources should be closed
-			StringBuffer sb = new StringBuffer();
+			StringBuilder sb = new StringBuilder();
 			String tempStr = null;
 			while (true) {
 				tempStr = br.readLine();
@@ -86,7 +86,7 @@ public class EgovAdressCntcController {
 			+ URLEncoder.encode(confmKey, "UTF-8");
 		URL url = new URL(EgovWebUtil.filePathBlackList(apiUrl));
 		try(BufferedReader br = new BufferedReader(new InputStreamReader(url.openStream(), "UTF-8"));){//2022.01 Resources should be closed
-			StringBuffer sb = new StringBuffer();
+			StringBuilder sb = new StringBuilder();
 			String tempStr = null;
 			while (true) {
 				tempStr = br.readLine();

--- a/src/main/java/egovframework/com/uss/ion/noi/service/impl/EgovNotificationServiceImpl.java
+++ b/src/main/java/egovframework/com/uss/ion/noi/service/impl/EgovNotificationServiceImpl.java
@@ -50,14 +50,14 @@ public class EgovNotificationServiceImpl extends EgovAbstractServiceImpl impleme
 
     @Override
     public void insertNotificationInf(NotificationVO notificationVO) throws Exception {
-        StringBuffer time = new StringBuffer();
+        StringBuilder time = new StringBuilder();
         time.append(notificationVO.getNtfcDate().replaceAll("-", ""));
         time.append(notificationVO.getNtfcHH().length() == 1 ? "0" + notificationVO.getNtfcHH() : notificationVO.getNtfcHH());
         time.append(notificationVO.getNtfcMM().length() == 1 ? "0" + notificationVO.getNtfcMM() : notificationVO.getNtfcMM());
         time.append("00");
         notificationVO.setNtfcTime(time.toString());
 
-        StringBuffer interval = new StringBuffer();
+        StringBuilder interval = new StringBuilder();
         String[] array = notificationVO.getBhNtfcIntrvl();
         if (array == null) {
             throw new RuntimeException("Method insertNotificationInf : array is null\n");
@@ -80,14 +80,14 @@ public class EgovNotificationServiceImpl extends EgovAbstractServiceImpl impleme
 
     @Override
     public void updateNotifictionInf(NotificationVO notificationVO) throws Exception {
-        StringBuffer time = new StringBuffer();
+        StringBuilder time = new StringBuilder();
         time.append(notificationVO.getNtfcDate().replaceAll("-", ""));
         time.append(notificationVO.getNtfcHH().length() == 1 ? "0" + notificationVO.getNtfcHH() : notificationVO.getNtfcHH());
         time.append(notificationVO.getNtfcMM().length() == 1 ? "0" + notificationVO.getNtfcMM() : notificationVO.getNtfcMM());
         time.append("00");
         notificationVO.setNtfcTime(time.toString());
 
-        StringBuffer interval = new StringBuffer();
+        StringBuilder interval = new StringBuilder();
         String[] array = notificationVO.getBhNtfcIntrvl();
         if (array != null) {
             for (int i = 0; i < array.length; i++) {
@@ -109,7 +109,7 @@ public class EgovNotificationServiceImpl extends EgovAbstractServiceImpl impleme
 
     @Override
     public boolean checkNotification(NotificationVO notificationVO) throws Exception {
-        StringBuffer time = new StringBuffer();
+        StringBuilder time = new StringBuilder();
         time.append(notificationVO.getNtfcDate().replaceAll("-", ""));
         time.append(notificationVO.getNtfcHH().length() == 1 ? "0" + notificationVO.getNtfcHH() : notificationVO.getNtfcHH());
         time.append(notificationVO.getNtfcMM().length() == 1 ? "0" + notificationVO.getNtfcMM() : notificationVO.getNtfcMM());

--- a/src/main/java/egovframework/com/utl/fcc/service/EgovPiiMaskUtil.java
+++ b/src/main/java/egovframework/com/utl/fcc/service/EgovPiiMaskUtil.java
@@ -243,7 +243,7 @@ public class EgovPiiMaskUtil {
 
     private static String maskAllJuminNo(String text) {
         Matcher m = JUMIN_PATTERN.matcher(text);
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         while (m.find()) {
             String replacement = m.group(1) + "-" + m.group(2).charAt(0) + "******";
             m.appendReplacement(sb, Matcher.quoteReplacement(replacement));
@@ -255,7 +255,7 @@ public class EgovPiiMaskUtil {
     private static String maskAllPhoneNo(String text) {
         // 1) 하이픈 포함 번호 치환
         Matcher m = PHONE_HYPHEN_PATTERN.matcher(text);
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         while (m.find()) {
             String replacement = m.group(1) + "-" + m.group(2).replaceAll("\\d", "*") + "-" + m.group(3);
             m.appendReplacement(sb, Matcher.quoteReplacement(replacement));
@@ -265,7 +265,7 @@ public class EgovPiiMaskUtil {
         // 2) 하이픈 없는 번호 치환 — 단일 마스킹(maskPhoneNo)과 동일 규칙 적용.
         //    1)에서 가려진 결과는 하이픈/별표를 포함하므로 연속 10~11자리 패턴에 매칭되지 않는다.
         Matcher mp = PHONE_PLAIN_PATTERN.matcher(sb.toString());
-        StringBuffer sb2 = new StringBuffer();
+        StringBuilder sb2 = new StringBuilder();
         while (mp.find()) {
             mp.appendReplacement(sb2, Matcher.quoteReplacement(maskPlainPhoneDigits(mp.group(1))));
         }
@@ -275,7 +275,7 @@ public class EgovPiiMaskUtil {
 
     private static String maskAllEmail(String text) {
         Matcher m = EMAIL_PATTERN.matcher(text);
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         while (m.find()) {
             String local = m.group(1);
             String domain = m.group(2);
@@ -291,7 +291,7 @@ public class EgovPiiMaskUtil {
 
     private static String maskAllCardNo(String text) {
         Matcher m = CARD_PATTERN.matcher(text);
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         while (m.find()) {
             char sep = m.group(0).charAt(4);
             String replacement = m.group(1) + sep + "****" + sep + "****" + sep + m.group(4);
@@ -303,7 +303,7 @@ public class EgovPiiMaskUtil {
 
     private static String maskAllBizRegNo(String text) {
         Matcher m = BIZ_REG_PATTERN.matcher(text);
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         while (m.find()) {
             String replacement = m.group(1) + "-" + m.group(2) + "-*****";
             m.appendReplacement(sb, Matcher.quoteReplacement(replacement));
@@ -314,7 +314,7 @@ public class EgovPiiMaskUtil {
 
     private static String maskAllPrivateIp(String text) {
         Matcher m = PRIVATE_IP_PATTERN.matcher(text);
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         while (m.find()) {
             String replacement = m.group(1) + ".***";
             m.appendReplacement(sb, Matcher.quoteReplacement(replacement));

--- a/src/main/java/egovframework/com/utl/fcc/service/EgovStringUtil.java
+++ b/src/main/java/egovframework/com/utl/fcc/service/EgovStringUtil.java
@@ -194,7 +194,7 @@ public class EgovStringUtil {
 	 * @return sb.toString() 새로운 문자열로 변환된 문자열
 	 */
 	public static String replace(String source, String subject, String object) {
-		StringBuffer rtnStr = new StringBuffer();
+		StringBuilder rtnStr = new StringBuilder();
 		String preStr = "";
 		String nextStr = source;
 		String srcStr = source;
@@ -218,7 +218,7 @@ public class EgovStringUtil {
 	 * @return sb.toString() 새로운 문자열로 변환된 문자열 / source 특정문자열이 없는 경우 원본 문자열
 	 */
 	public static String replaceOnce(String source, String subject, String object) {
-		StringBuffer rtnStr = new StringBuffer();
+		StringBuilder rtnStr = new StringBuilder();
 		String preStr = "";
 		String nextStr = source;
 		if (source.indexOf(subject) >= 0) {
@@ -241,7 +241,7 @@ public class EgovStringUtil {
 	 * @return sb.toString() 새로운 문자열로 변환된 문자열
 	 */
 	public static String replaceChar(String source, String subject, String object) {
-		StringBuffer rtnStr = new StringBuffer();
+		StringBuilder rtnStr = new StringBuilder();
 		String preStr = "";
 		String nextStr = source;
 		String srcStr = source;
@@ -509,7 +509,7 @@ public class EgovStringUtil {
 	public static String checkHtmlView(String strString) {
 		String strNew = "";
 
-		StringBuffer strTxt = new StringBuffer("");
+		StringBuilder strTxt = new StringBuilder("");
 
 		char chrBuff;
 		int len = strString.length();
@@ -826,7 +826,7 @@ public class EgovStringUtil {
 
 		String rtnStr = null;
 
-		StringBuffer strTxt = new StringBuffer("");
+		StringBuilder strTxt = new StringBuilder("");
 
 		char chrBuff;
 		int len = srcString.length();

--- a/src/main/java/egovframework/com/utl/sim/service/EgovFileTool.java
+++ b/src/main/java/egovframework/com/utl/sim/service/EgovFileTool.java
@@ -366,9 +366,9 @@ public class EgovFileTool {
 			// 파일이며, 존재하면 파싱 시작
 			if (file.exists() && file.isFile()) {
 
-				// 1. 파일 텍스트 내용을 읽어서 StringBuffer에 쌓는다.
+				// 1. 파일 텍스트 내용을 읽어서 StringBuilder에 쌓는다.
 				br = new BufferedReader(new InputStreamReader(new FileInputStream(file)));
-				StringBuffer strBuff = new StringBuffer();
+				StringBuilder strBuff = new StringBuilder();
 				String line = "";
 				while ((line = br.readLine()) != null) {
 					if (line.length() < MAX_STR_LEN) {

--- a/src/main/java/egovframework/com/utl/sim/service/EgovFileToolBean.java
+++ b/src/main/java/egovframework/com/utl/sim/service/EgovFileToolBean.java
@@ -101,9 +101,9 @@ public class EgovFileToolBean {
 			// 파일이며, 존재하면 파싱 시작
 			if (file.exists() && file.isFile()) {
 
-				// 1. 파일 텍스트 내용을 읽어서 StringBuffer에 쌓는다.
+				// 1. 파일 텍스트 내용을 읽어서 StringBuilder에 쌓는다.
 				br = new BufferedReader(new InputStreamReader(new FileInputStream(file)));
-				StringBuffer strBuff = new StringBuffer();
+				StringBuilder strBuff = new StringBuilder();
 				String line = "";
 				while ((line = br.readLine()) != null) {
 					if (line.length() < MAX_STR_LEN) {


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [ ] 버그수정 Bug fixes
- [X] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

> 지역 변수의 불필요한 동기화 오버헤드를 제거한 성능 리팩터입니다(동작 동일). #1099 후속(2차).

## 수정된 소스 내용 Modified source

메서드 내부 지역 변수로만 사용되는 `StringBuffer`(모든 메서드가 `synchronized`)를 `StringBuilder`로 변경했습니다.

**대상 (7파일)**
- `SmsBasicDAO.java`
- `EgovAdressCntcController.java`
- `EgovNotificationServiceImpl.java`
- `EgovPiiMaskUtil.java`
- `EgovStringUtil.java`
- `EgovFileTool.java`
- `EgovFileToolBean.java`

**안전성 근거**
- 대상 파일에서 `StringBuffer`가 지역 변수로만 사용(필드·파라미터·반환 타입 아님).
- 저장소 전체에 `StringBuffer`를 인자로 받는 메서드가 없어 다른 코드로 전파되지 않음.
- `append()`/`insert()`/`toString()` 등 API가 동일해 **컴파일·동작 결과 변화 없음**.

## JUnit 테스트 JUnit tests

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

> 타입만 변경(동기화 제거)으로 결과가 기존과 동일합니다.

## 테스트 브라우저 Test Browser

해당 없음 (서버 측 리팩터)

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음