### PR TITLE
fix: MAC 조회 문자열 조립의 null 접두사 버그 수정 및 StringBuilder 적용 (EgovNetworkState)

### DIFF
--- a/src/main/java/egovframework/com/utl/sim/service/EgovNetworkState.java
+++ b/src/main/java/egovframework/com/utl/sim/service/EgovNetworkState.java
@@ -83,12 +83,13 @@ public class EgovNetworkState {
 				FileSystemUtils util = new FileSystemUtils();
 				Process p = util.processOperate("EgovNetworkState", execStr);
 				InputStream in = p.getInputStream();
-				String out = null;
+				StringBuilder outBuf = new StringBuilder();
 				int c;
 				while ((c = in.read()) != -1) {
-					out = out + new String(new Character((char) c).toString());
+					outBuf.append((char) c);
 				}
 				in.close();
+				String out = outBuf.toString();
 				if (out == null || out.indexOf("MAC Address = ") == -1) {
 					throw new IllegalArgumentException("String Split Error!");
 				}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`EgovNetworkState.getMyMACAddress()`의 `nbtstat` 출력 읽기 루프에 있던 버그·비효율을 함께 수정했습니다.

**AS-IS**
```java
String out = null;
int c;
while ((c = in.read()) != -1) {
    out = out + new String(new Character((char) c).toString());
}
```
1. **버그**: `out`이 `null`로 시작해 첫 연결이 `null + "x"` → 결과 문자열에 불필요한 `"null"` 접두사가 붙습니다.
2. **성능**: 매 문자마다 String을 재생성(O(n²))하고, deprecated `new Character(char)` 및 불필요한 `new String(...)`을 사용합니다.

**TO-BE**
```java
StringBuilder outBuf = new StringBuilder();
int c;
while ((c = in.read()) != -1) {
    outBuf.append((char) c);
}
in.close();
String out = outBuf.toString();
```
- `StringBuilder`로 O(n) 조립, deprecated/불필요 객체 생성 제거, `"null"` 접두사 버그 제거.
- 이후 `out.indexOf("MAC Address = ")` / `out.substring(...)` 은 인덱스를 재계산하므로 **최종 MAC 추출 결과는 기존과 동일**합니다.

## JUnit 테스트 JUnit tests

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

> `nbtstat` 출력에서 `MAC Address = ` 이후 값을 추출하는 최종 결과가 동일함을 코드 판독으로 확인했습니다.

## 테스트 브라우저 Test Browser

해당 없음 (서버 측 유틸리티)

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음