### PR TITLE
refactor: 문자열 공백 검사 trim().equals("")를 trim().isEmpty()로 단순화 (2차, 4파일)

### DIFF
--- a/src/main/java/egovframework/com/cmm/EgovWebUtil.java
+++ b/src/main/java/egovframework/com/cmm/EgovWebUtil.java
@@ -24,7 +24,7 @@ import java.util.regex.Pattern;
 
 public class EgovWebUtil {
 	public static String clearXSSMinimum(String value) {
-		if (value == null || value.trim().equals("")) {
+		if (value == null || value.trim().isEmpty()) {
 			return "";
 		}
 
@@ -60,7 +60,7 @@ public class EgovWebUtil {
 	}
 
 	public static String clearXSS(String value) {
-		if (value == null || value.trim().equals("")) {
+		if (value == null || value.trim().isEmpty()) {
 			return "";
 		}
 
@@ -78,7 +78,7 @@ public class EgovWebUtil {
 
 	public static String filePathBlackList(String value) {
 		String returnValue = value;
-		if (returnValue == null || returnValue.trim().equals("")) {
+		if (returnValue == null || returnValue.trim().isEmpty()) {
 			return "";
 		}
 
@@ -116,7 +116,7 @@ public class EgovWebUtil {
 	 */
 	public static String filePathReplaceAll(String value) {
 		String returnValue = value;
-		if (returnValue == null || returnValue.trim().equals("")) {
+		if (returnValue == null || returnValue.trim().isEmpty()) {
 			return "";
 		}
 
@@ -130,7 +130,7 @@ public class EgovWebUtil {
 
 	public static String fileInjectPathReplaceAll(String value) {
 		String returnValue = value;
-		if (returnValue == null || returnValue.trim().equals("")) {
+		if (returnValue == null || returnValue.trim().isEmpty()) {
 			return "";
 		}
 
@@ -172,7 +172,7 @@ public class EgovWebUtil {
 	public static String removeLDAPInjectionRisk(String value) {
 
 		String returnValue = value;
-		if (returnValue == null || returnValue.trim().equals("")) {
+		if (returnValue == null || returnValue.trim().isEmpty()) {
 			return "";
 		}
 

--- a/src/main/java/egovframework/com/cop/bbs/web/EgovArticleController.java
+++ b/src/main/java/egovframework/com/cop/bbs/web/EgovArticleController.java
@@ -112,7 +112,7 @@ public class EgovArticleController {
 	 * @return
 	 */
 	protected String unscript(String data) {
-		if (data == null || data.trim().equals("")) {
+		if (data == null || data.trim().isEmpty()) {
 			return "";
 		}
 

--- a/src/main/java/egovframework/com/cop/sms/service/impl/EgovSmsBasicServiceImpl.java
+++ b/src/main/java/egovframework/com/cop/sms/service/impl/EgovSmsBasicServiceImpl.java
@@ -88,7 +88,7 @@ public class EgovSmsBasicServiceImpl implements EgovSmsInfoService {
 	private String getPhoneNumber(String number) {
 		String result = number;
 
-		if (number == null || number.trim().equals("")) {
+		if (number == null || number.trim().isEmpty()) {
 			return "";
 		}
 
@@ -101,7 +101,7 @@ public class EgovSmsBasicServiceImpl implements EgovSmsInfoService {
 	}
 
 	private String formatPhoneNumber(String number) throws ParseException {
-		if (number == null || number.trim().equals("")) {
+		if (number == null || number.trim().isEmpty()) {
 			return "";
 		}
 

--- a/src/main/java/egovframework/com/cop/sms/service/impl/EgovSmsInfoServiceImpl.java
+++ b/src/main/java/egovframework/com/cop/sms/service/impl/EgovSmsInfoServiceImpl.java
@@ -59,7 +59,7 @@ public class EgovSmsInfoServiceImpl extends EgovAbstractServiceImpl implements E
     private String getPhoneNumber(String number) {
 	String result = number;
 
-	if (number == null || number.trim().equals("")) {
+	if (number == null || number.trim().isEmpty()) {
 	    return "";
 	}
 
@@ -72,7 +72,7 @@ public class EgovSmsInfoServiceImpl extends EgovAbstractServiceImpl implements E
     }
 
     private String formatPhoneNumber(String number) throws ParseException {
-	if (number == null || number.trim().equals("")) {
+	if (number == null || number.trim().isEmpty()) {
 	    return "";
 	}
 


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [ ] 버그수정 Bug fixes
- [X] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

#1095(컬렉션 isEmpty)에 이어, 문자열 공백 검사의 `trim().equals("")` 패턴을 `trim().isEmpty()`로 단순화했습니다 (11곳, 4파일). PMD의 UseIsEmpty 계열 권고에 해당하며, 빈 문자열 객체와의 비교 대신 길이 검사를 수행하므로 의미가 더 명확하고 미세하게 더 빠릅니다.

**대상 파일 (4개, 11곳)**
- `com/cmm/EgovWebUtil.java` — 6곳
- `com/cop/sms/service/impl/EgovSmsInfoServiceImpl.java` — 2곳
- `com/cop/sms/service/impl/EgovSmsBasicServiceImpl.java` — 2곳
- `com/cop/bbs/web/EgovArticleController.java` — 1곳

**AS-IS**
```java
if (value == null || value.trim().equals("")) {
```

**TO-BE**
```java
if (value == null || value.trim().isEmpty()) {
```

11곳 모두 null 체크가 선행되는 동일한 형태로, 동작 변화가 없습니다. `trim()`의 반환 타입이 String으로 보장되어 컴파일 안전합니다.

참고: 동일 패턴이 있는 `EgovNetworkState.java`, `EgovPrivacyLogAspect.java`는 진행 중인 #1101, #1104와의 충돌을 피하기 위해 이번 PR에서 제외했습니다.

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [X] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

동일 동작의 표현 단순화로 화면 변경 사항은 없습니다.