### PR TITLE
refactor: indexOf 결과 -1 비교를 contains()로 개선 (6파일 32곳)

### DIFF
--- a/src/main/java/egovframework/com/cmm/EgovBrowserUtil.java
+++ b/src/main/java/egovframework/com/cmm/EgovBrowserUtil.java
@@ -48,7 +48,7 @@ public class EgovBrowserUtil {
 			return result;
 		}
 		
-		if (userAgent.indexOf("Trident/7.0") > -1) {
+		if (userAgent.contains("Trident/7.0")) {
 		    result.put(TYPEKEY,MSIE);
 		    result.put(VERSIONKEY,"11.0");
 		    return result;

--- a/src/main/java/egovframework/com/cmm/service/FileSystemUtils.java
+++ b/src/main/java/egovframework/com/cmm/service/FileSystemUtils.java
@@ -82,13 +82,13 @@ public class FileSystemUtils {
 			}
 			osName = osName.toLowerCase();
 			// match
-			if (osName.indexOf("windows") != -1) {
+			if (osName.contains("windows")) {
 				os = WINDOWS;
-			} else if (osName.indexOf("linux") != -1 || osName.indexOf("sun os") != -1 || osName.indexOf("sunos") != -1 || osName.indexOf("solaris") != -1
-					|| osName.indexOf("mpe/ix") != -1 || osName.indexOf("freebsd") != -1 || osName.indexOf("irix") != -1 || osName.indexOf("digital unix") != -1
-					|| osName.indexOf("unix") != -1 || osName.indexOf("mac os x") != -1) {
+			} else if (osName.contains("linux") || osName.contains("sun os") || osName.contains("sunos") || osName.contains("solaris")
+					|| osName.contains("mpe/ix") || osName.contains("freebsd") || osName.contains("irix") || osName.contains("digital unix")
+					|| osName.contains("unix") || osName.contains("mac os x")) {
 				os = UNIX;
-			} else if (osName.indexOf("hp-ux") != -1 || osName.indexOf("aix") != -1) {
+			} else if (osName.contains("hp-ux") || osName.contains("aix")) {
 				os = POSIX_UNIX;
 			} else {
 				os = OTHER;
@@ -314,16 +314,16 @@ public class FileSystemUtils {
 
 		// build and run the 'dir' command
 		String flags = "-";
-		if (kb && osName.indexOf("hp-ux") == -1) {
+		if (kb && !osName.contains("hp-ux")) {
 			flags += "k";
 		}
-		if (posix && osName.indexOf("hp-ux") == -1) {
+		if (posix && !osName.contains("hp-ux")) {
 			flags += "P";
 		}
 
 		String dfCommand = "df";
 
-		if (osName.indexOf("hp-ux") != -1) {
+		if (osName.contains("hp-ux")) {
 			dfCommand = "bdf";
 		}
 

--- a/src/main/java/egovframework/com/cmm/util/EgovWildcardReloadableResourceBundleMessageSource.java
+++ b/src/main/java/egovframework/com/cmm/util/EgovWildcardReloadableResourceBundleMessageSource.java
@@ -41,7 +41,7 @@ public class EgovWildcardReloadableResourceBundleMessageSource
 			for (int i = 0; i < basenames.length; i++) {
 
 				String basename = StringUtils.trimToEmpty(basenames[i]);
-				if (basename.indexOf("classpath:/") > -1) {
+				if (basename.contains("classpath:/")) {
 					baseNames.add(basename);
 				} else if (StringUtils.isNotBlank(basename)) {
 					try {
@@ -53,7 +53,7 @@ public class EgovWildcardReloadableResourceBundleMessageSource
 							String uri = resource.getURI().toString();
 							String baseName = null;
 
-							if (uri.indexOf(".properties") == -1) {
+							if (!uri.contains(".properties")) {
 								continue;
 							}
 
@@ -61,7 +61,7 @@ public class EgovWildcardReloadableResourceBundleMessageSource
 								baseName = "classpath:" + StringUtils.substringBetween(uri, "/classes/", ".properties");
 								baseName = baseName.substring(0, baseName.indexOf("_"));
 								baseName = baseName.replaceAll("classpath:", "classpath:/");
-								if (baseNames.indexOf(baseName) > -1) {
+								if (baseNames.contains(baseName)) {
 									continue;
 								}
 

--- a/src/main/java/egovframework/com/utl/sim/service/EgovClntInfo.java
+++ b/src/main/java/egovframework/com/utl/sim/service/EgovClntInfo.java
@@ -122,27 +122,27 @@ public class EgovClntInfo {
 		String ua = userAgent.toUpperCase();
 		// 웹브라우저 종류 조회
 		String webKind = "";
-		if (ua.indexOf("GECKO") != -1) {
-			if (ua.indexOf("NESCAPE") != -1) {
+		if (ua.contains("GECKO")) {
+			if (ua.contains("NESCAPE")) {
 				webKind = "Netscape (Gecko/Netscape)";
-			} else if (ua.indexOf("FIREFOX") != -1) {
+			} else if (ua.contains("FIREFOX")) {
 				webKind = "Mozilla Firefox (Gecko/Firefox)";
 			} else {
 				webKind = "Mozilla (Gecko/Mozilla)";
 			}
-		} else if (ua.indexOf("MSIE") != -1) {
-			if (ua.indexOf("OPERA") != -1) {
+		} else if (ua.contains("MSIE")) {
+			if (ua.contains("OPERA")) {
 				webKind = "Opera (MSIE/Opera/Compatible)";
 			} else {
 				webKind = "Internet Explorer (MSIE/Compatible)";
 			}
-		} else if (ua.indexOf("SAFARI") != -1) {
-			if (ua.indexOf("CHROME") != -1) {
+		} else if (ua.contains("SAFARI")) {
+			if (ua.contains("CHROME")) {
 				webKind = "Google Chrome";
 			} else {
 				webKind = "Safari";
 			}
-		} else if (userAgent.toUpperCase().indexOf("THUNDERBIRD") != -1) {
+		} else if (userAgent.toUpperCase().contains("THUNDERBIRD")) {
 			webKind = "Thunderbird";
 		} else {
 			webKind = "Other Web Browsers";

--- a/src/main/java/egovframework/com/utl/sys/fsm/service/FileSystemChecker.java
+++ b/src/main/java/egovframework/com/utl/sys/fsm/service/FileSystemChecker.java
@@ -179,17 +179,17 @@ public class FileSystemChecker {
 		// build and run the 'dir' command
 		String flags = "-";
 
-		if (osName.indexOf("hp-ux") == -1) {
+		if (!osName.contains("hp-ux")) {
 			flags += "k";
 		}
 
-		if (osName.indexOf("aix") != -1) {
+		if (osName.contains("aix")) {
 			flags += "P";
 		}
 
 		String dfCommand = "df";
 
-		if (osName.indexOf("hp-ux") != -1) {
+		if (osName.contains("hp-ux")) {
 			dfCommand = "bdf";
 		}
 

--- a/src/main/java/egovframework/com/utl/sys/pxy/service/ProxyThread.java
+++ b/src/main/java/egovframework/com/utl/sys/pxy/service/ProxyThread.java
@@ -101,7 +101,7 @@ public class ProxyThread implements Runnable {
 					strReceive = new String(request, 0, bytesRead);
 
 					// 'stop' 문자열을 받으면 스레드를 중지합니다.
-					if (strReceive.indexOf("stop") > -1) {
+					if (strReceive.contains("stop")) {
 						setIsStop(true);
 						break;
 					}


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [ ] 버그수정 Bug fixes
- [X] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

포함 여부만 확인하는 `indexOf` 결과의 -1 비교를 의도가 명확한 `contains()`로 개선했습니다 (6파일 32곳). Java 5+의 `String.contains()` 표준 관용구이며 동작은 동일합니다.

- `x.indexOf("...") != -1`, `x.indexOf("...") > -1` → `x.contains("...")`
- `x.indexOf("...") == -1` → `!x.contains("...")`

**대상 파일 (6개)**
- `com/cmm/EgovBrowserUtil.java` — 1곳
- `com/cmm/service/FileSystemUtils.java` — 16곳 (OS 이름 판별)
- `com/cmm/util/EgovWildcardReloadableResourceBundleMessageSource.java` — 3곳 (이 중 1곳은 `List<String>.indexOf(...) > -1` → `List.contains(...)`)
- `com/utl/sim/service/EgovClntInfo.java` — 8곳 (브라우저 판별)
- `com/utl/sys/fsm/service/FileSystemChecker.java` — 3곳
- `com/utl/sys/pxy/service/ProxyThread.java` — 1곳

**AS-IS**
```java
if (osName.indexOf("windows") != -1) {
...
if (uri.indexOf(".properties") == -1) {
```

**TO-BE**
```java
if (osName.contains("windows")) {
...
if (!uri.contains(".properties")) {
```

**제외한 것 (동작이 달라질 수 있어 변경하지 않음)**
- 위치 값을 실제로 사용하는 `indexOf` (`substring(0, baseName.indexOf("_"))` 등)
- `line.indexOf("GB") > 0` — 0번 위치를 제외하는 비교라 `contains`와 의미가 다름
- `stripChars.indexOf(char)` — char 인자는 `contains` 미지원

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [X] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

동일 동작의 표현 개선으로 화면 변경 사항은 없습니다.