### PR TITLE
refactor: cmm 패키지 SessionVO/ComDefaultVO/FileVO Lombok @Getter/@Setter 적용

### DIFF
--- a/src/main/java/egovframework/com/cmm/ComDefaultVO.java
+++ b/src/main/java/egovframework/com/cmm/ComDefaultVO.java
@@ -4,6 +4,9 @@ import java.io.Serializable;
 
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * @Class Name : ComDefaultVO.java
  * @Description : ComDefaultVO class
@@ -16,27 +19,30 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
  *  @author 공통서비스 개발팀 조재영
  *  @since 2009.02.01
  *  @version 1.0
- *  @see 
- *  
+ *  @see
+ *
  */
 @SuppressWarnings("serial")
 public class ComDefaultVO implements Serializable {
-	
+
 	/** 검색조건 */
+	@Getter @Setter
     private String searchCondition = "";
-    
+
     /** 검색Keyword */
+	@Getter @Setter
     private String searchKeyword = "";
-    
+
     /** 검색사용여부 */
+	@Getter @Setter
     private String searchUseYn = "";
-    
+
     /** 현재페이지 */
     private Integer pageIndex = 1;
-    
+
     /** 페이지개수 */
     private Integer pageUnit = 10;
-    
+
     /** 페이지사이즈 */
     private Integer pageSize = 10;
 
@@ -48,13 +54,15 @@ public class ComDefaultVO implements Serializable {
 
     /** recordCountPerPage */
     private Integer recordCountPerPage = 10;
-    
+
     /** 검색KeywordFrom */
-    private String searchKeywordFrom = "";    
+	@Getter @Setter
+    private String searchKeywordFrom = "";
 
 	/** 검색KeywordTo */
-    private String searchKeywordTo = "";  
-    
+	@Getter @Setter
+    private String searchKeywordTo = "";
+
 	public Integer getFirstIndex() {
 		return firstIndex == null ? 1 : firstIndex;
 	}
@@ -79,31 +87,7 @@ public class ComDefaultVO implements Serializable {
 		this.recordCountPerPage = recordCountPerPage == null ? 10 : recordCountPerPage;
 	}
 
-	public String getSearchCondition() {
-        return searchCondition;
-    }
-
-    public void setSearchCondition(String searchCondition) {
-        this.searchCondition = searchCondition;
-    }
-
-    public String getSearchKeyword() {
-        return searchKeyword;
-    }
-
-    public void setSearchKeyword(String searchKeyword) {
-        this.searchKeyword = searchKeyword;
-    }
-
-    public String getSearchUseYn() {
-        return searchUseYn;
-    }
-
-    public void setSearchUseYn(String searchUseYn) {
-        this.searchUseYn = searchUseYn;
-    }
-
-    public Integer getPageIndex() {
+	public Integer getPageIndex() {
         return pageIndex == null ? 1 : pageIndex;
     }
 
@@ -131,36 +115,4 @@ public class ComDefaultVO implements Serializable {
         return ToStringBuilder.reflectionToString(this);
     }
 
-    
-    /**
-	 * searchKeywordFrom attribute를 리턴한다.
-	 * @return String
-	 */
-	public String getSearchKeywordFrom() {
-		return searchKeywordFrom;
-	}
-
-	/**
-	 * searchKeywordFrom attribute 값을 설정한다.
-	 * @param searchKeywordFrom String
-	 */
-	public void setSearchKeywordFrom(String searchKeywordFrom) {
-		this.searchKeywordFrom = searchKeywordFrom;
-	}
-
-	/**
-	 * searchKeywordTo attribute를 리턴한다.
-	 * @return String
-	 */
-	public String getSearchKeywordTo() {
-		return searchKeywordTo;
-	}
-
-	/**
-	 * searchKeywordTo attribute 값을 설정한다.
-	 * @param searchKeywordTo String
-	 */
-	public void setSearchKeywordTo(String searchKeywordTo) {
-		this.searchKeywordTo = searchKeywordTo;
-	}
 }

--- a/src/main/java/egovframework/com/cmm/SessionVO.java
+++ b/src/main/java/egovframework/com/cmm/SessionVO.java
@@ -2,25 +2,30 @@ package egovframework.com.cmm;
 
 import java.io.Serializable;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * 세션 VO 클래스
  * @author 공통서비스 개발팀 박지욱
  * @since 2009.03.06
  * @version 1.0
  * @see
- *  
+ *
  * <pre>
  * << 개정이력(Modification Information) >>
- * 
+ *
  *   수정일      수정자          수정내용
  *  -------    --------    ---------------------------
- *  2009.03.06  박지욱          최초 생성 
- *  
+ *  2009.03.06  박지욱          최초 생성
+ *
  *  </pre>
  */
 @SuppressWarnings("serial")
+@Getter
+@Setter
 public class SessionVO implements Serializable {
-	
+
 	/** 아이디 */
 	private String sUserId;
 	/** 이름 */
@@ -33,88 +38,4 @@ public class SessionVO implements Serializable {
 	private String orgnztId;
 	/** 고유아이디 */
 	private String uniqId;
-	/**
-	 * sUserId attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getSUserId() {
-		return sUserId;
-	}
-	/**
-	 * sUserId attribute 값을 설정한다.
-	 * @param sUserId String
-	 */
-	public void setSUserId(String userId) {
-		sUserId = userId;
-	}
-	/**
-	 * sUserNm attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getSUserNm() {
-		return sUserNm;
-	}
-	/**
-	 * sUserNm attribute 값을 설정한다.
-	 * @param sUserNm String
-	 */
-	public void setSUserNm(String userNm) {
-		sUserNm = userNm;
-	}
-	/**
-	 * sEmail attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getSEmail() {
-		return sEmail;
-	}
-	/**
-	 * sEmail attribute 값을 설정한다.
-	 * @param sEmail String
-	 */
-	public void setSEmail(String email) {
-		sEmail = email;
-	}
-	/**
-	 * sUserSe attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getSUserSe() {
-		return sUserSe;
-	}
-	/**
-	 * sUserSe attribute 값을 설정한다.
-	 * @param sUserSe String
-	 */
-	public void setSUserSe(String userSe) {
-		sUserSe = userSe;
-	}
-	/**
-	 * orgnztId attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getOrgnztId() {
-		return orgnztId;
-	}
-	/**
-	 * orgnztId attribute 값을 설정한다.
-	 * @param orgnztId String
-	 */
-	public void setOrgnztId(String orgnztId) {
-		this.orgnztId = orgnztId;
-	}
-	/**
-	 * uniqId attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getUniqId() {
-		return uniqId;
-	}
-	/**
-	 * uniqId attribute 값을 설정한다.
-	 * @param uniqId String
-	 */
-	public void setUniqId(String uniqId) {
-		this.uniqId = uniqId;
-	}
 }

--- a/src/main/java/egovframework/com/cmm/service/FileVO.java
+++ b/src/main/java/egovframework/com/cmm/service/FileVO.java
@@ -2,6 +2,9 @@ package egovframework.com.cmm.service;
 
 import egovframework.com.cmm.ComDefaultVO;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * @Class Name : FileVO.java
  * @Description : 파일정보 처리를 위한 VO 클래스
@@ -18,214 +21,45 @@ import egovframework.com.cmm.ComDefaultVO;
  *
  */
 @SuppressWarnings("serial")
+@Getter
+@Setter
 public class FileVO extends ComDefaultVO {
 
     /**
      * 첨부파일 아이디
      */
-    public String atchFileId = "";
+    private String atchFileId = "";
     /**
      * 생성일자
      */
-    public String creatDt = "";
+    private String creatDt = "";
     /**
      * 파일내용
      */
-    public String fileCn = "";
+    private String fileCn = "";
     /**
      * 파일확장자
      */
-    public String fileExtsn = "";
+    private String fileExtsn = "";
     /**
      * 파일크기
      */
-    public String fileMg = "";
+    private String fileMg = "";
     /**
      * 파일연번
      */
-    public String fileSn = "";
+    private String fileSn = "";
     /**
      * 파일저장경로
      */
-    public String fileStreCours = "";
+    private String fileStreCours = "";
     /**
      * 원파일명
      */
-    public String orignlFileNm = "";
+    private String orignlFileNm = "";
     /**
      * 저장파일명
      */
-    public String streFileNm = "";
+    private String streFileNm = "";
 
-    /**
-     * atchFileId attribute를 리턴한다.
-     * 
-     * @return the atchFileId
-     */
-    public String getAtchFileId() {
-	return atchFileId;
-    }
-
-    /**
-     * atchFileId attribute 값을 설정한다.
-     * 
-     * @param atchFileId
-     *            the atchFileId to set
-     */
-    public void setAtchFileId(String atchFileId) {
-	this.atchFileId = atchFileId;
-    }
-
-    /**
-     * creatDt attribute를 리턴한다.
-     * 
-     * @return the creatDt
-     */
-    public String getCreatDt() {
-	return creatDt;
-    }
-
-    /**
-     * creatDt attribute 값을 설정한다.
-     * 
-     * @param creatDt
-     *            the creatDt to set
-     */
-    public void setCreatDt(String creatDt) {
-	this.creatDt = creatDt;
-    }
-
-    /**
-     * fileCn attribute를 리턴한다.
-     * 
-     * @return the fileCn
-     */
-    public String getFileCn() {
-	return fileCn;
-    }
-
-    /**
-     * fileCn attribute 값을 설정한다.
-     * 
-     * @param fileCn
-     *            the fileCn to set
-     */
-    public void setFileCn(String fileCn) {
-	this.fileCn = fileCn;
-    }
-
-    /**
-     * fileExtsn attribute를 리턴한다.
-     * 
-     * @return the fileExtsn
-     */
-    public String getFileExtsn() {
-	return fileExtsn;
-    }
-
-    /**
-     * fileExtsn attribute 값을 설정한다.
-     * 
-     * @param fileExtsn
-     *            the fileExtsn to set
-     */
-    public void setFileExtsn(String fileExtsn) {
-	this.fileExtsn = fileExtsn;
-    }
-
-    /**
-     * fileMg attribute를 리턴한다.
-     * 
-     * @return the fileMg
-     */
-    public String getFileMg() {
-	return fileMg;
-    }
-
-    /**
-     * fileMg attribute 값을 설정한다.
-     * 
-     * @param fileMg
-     *            the fileMg to set
-     */
-    public void setFileMg(String fileMg) {
-	this.fileMg = fileMg;
-    }
-
-    /**
-     * fileSn attribute를 리턴한다.
-     * 
-     * @return the fileSn
-     */
-    public String getFileSn() {
-	return fileSn;
-    }
-
-    /**
-     * fileSn attribute 값을 설정한다.
-     * 
-     * @param fileSn
-     *            the fileSn to set
-     */
-    public void setFileSn(String fileSn) {
-	this.fileSn = fileSn;
-    }
-
-    /**
-     * fileStreCours attribute를 리턴한다.
-     * 
-     * @return the fileStreCours
-     */
-    public String getFileStreCours() {
-	return fileStreCours;
-    }
-
-    /**
-     * fileStreCours attribute 값을 설정한다.
-     * 
-     * @param fileStreCours
-     *            the fileStreCours to set
-     */
-    public void setFileStreCours(String fileStreCours) {
-	this.fileStreCours = fileStreCours;
-    }
-
-    /**
-     * orignlFileNm attribute를 리턴한다.
-     * 
-     * @return the orignlFileNm
-     */
-    public String getOrignlFileNm() {
-	return orignlFileNm;
-    }
-
-    /**
-     * orignlFileNm attribute 값을 설정한다.
-     * 
-     * @param orignlFileNm
-     *            the orignlFileNm to set
-     */
-    public void setOrignlFileNm(String orignlFileNm) {
-	this.orignlFileNm = orignlFileNm;
-    }
-
-    /**
-     * streFileNm attribute를 리턴한다.
-     * 
-     * @return the streFileNm
-     */
-    public String getStreFileNm() {
-	return streFileNm;
-    }
-
-    /**
-     * streFileNm attribute 값을 설정한다.
-     * 
-     * @param streFileNm
-     *            the streFileNm to set
-     */
-    public void setStreFileNm(String streFileNm) {
-	this.streFileNm = streFileNm;
-    }
-	
 }

--- a/src/main/java/egovframework/com/cmm/web/EgovFileMngController.java
+++ b/src/main/java/egovframework/com/cmm/web/EgovFileMngController.java
@@ -84,7 +84,7 @@ public class EgovFileMngController {
 		// FileId를 유추하지 못하도록 세션ID와 함께 암호화하여 표시한다. (2022.12.06 추가) - 파일아이디가 유추 불가능하도록 조치
 		for (FileVO file : result) {
 			String sessionId = request.getSession().getId();
-			String toEncrypt = sessionId + "|" + file.atchFileId;
+			String toEncrypt = sessionId + "|" + file.getAtchFileId();
 			file.setAtchFileId(Base64.getEncoder().encodeToString(cryptoService.encrypt(toEncrypt).getBytes()));
 		}
 
@@ -126,7 +126,7 @@ public class EgovFileMngController {
 		// FileId를 유추하지 못하도록 세션ID와 함께 암호화하여 표시한다. (2022.12.06 추가) - 파일아이디가 유추 불가능하도록 조치
 		for (FileVO file : result) {
 			String sessionId = request.getSession().getId();
-			String toEncrypt = sessionId + "|" + file.atchFileId;
+			String toEncrypt = sessionId + "|" + file.getAtchFileId();
 			file.setAtchFileId(Base64.getEncoder().encodeToString(cryptoService.encrypt(toEncrypt).getBytes()));
 		}
 


### PR DESCRIPTION
## 변경 내용

`egovframework.com.cmm` 패키지의 잔여 VO 3개에 Lombok을 적용했습니다.

- `SessionVO`: 전체 6개 필드가 단순 위임 getter/setter뿐이라 클래스 레벨 `@Getter @Setter`로 전환.
- `ComDefaultVO`: `searchCondition/searchKeyword/searchUseYn/searchKeywordFrom/searchKeywordTo` 5개 필드만 필드 레벨로 전환. `pageIndex/pageUnit/pageSize/firstIndex/lastIndex/recordCountPerPage`는 null 방어 커스텀 로직(`xxx == null ? 기본값 : xxx`)이 있어 기존 수동 getter/setter를 그대로 유지했습니다. `toString()`도 그대로 유지.
- `FileVO`: 9개 필드 전부 단순 위임이라 Lombok 전환. 필드가 `public`으로 잘못 노출돼 있던 것도 이 기회에 `private`으로 정리(캡슐화 정상화). 이로 인해 `EgovFileMngController`에서 `file.atchFileId` 직접 접근하던 두 곳을 `file.getAtchFileId()`로 수정했습니다.

기존 Javadoc 헤더(@author, 개정이력)는 손대지 않았습니다.

## 테스트
- [x] `mvn compile` 통과
- [x] `mvn test` 통과 (기존 테스트 영향 없음)

- [ ] 단일 주제만 다룸 (다른 변경 없음)
- [ ] 기존 동작에 영향 없음 (FileVO 필드 접근 방식만 getter/setter로 변경, 동작 동일)