### PR TITLE
refactor: srm ServerResrceMntrngVO 부분 Lombok @Getter/@Setter 적용

### DIFF
--- a/src/main/java/egovframework/com/utl/sys/srm/service/ServerResrceMntrngVO.java
+++ b/src/main/java/egovframework/com/utl/sys/srm/service/ServerResrceMntrngVO.java
@@ -3,6 +3,9 @@ package egovframework.com.utl.sys.srm.service;
 import java.util.Collections;
 import java.util.List;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * 개요
  * - 서버자원모니터링에 대한 Vo 클래스를 정의한다.
@@ -19,55 +22,25 @@ public class ServerResrceMntrngVO extends ServerResrceMntrng {
 	/**
 	 * 서버자원모니터링 서버명 조회조건
 	 */
+	@Getter
+	@Setter
 	private String strServerNm;
 	/**
 	 * 시작일자 검색조건
 	 */
+	@Getter
+	@Setter
 	private String strStartDt;
 	/**
 	 * 종료일자 검색조건
 	 */
+	@Getter
+	@Setter
 	private String strEndDt;
 	/**
 	 * 서버자원모니터링 목록
 	 */
 	private List<ServerResrceMntrngVO> serverResrceMntrngList;
-	/**
-	 * @return the strServerNm
-	 */
-	public String getStrServerNm() {
-		return strServerNm;
-	}
-	/**
-	 * @param strServerNm the strServerNm to set
-	 */
-	public void setStrServerNm(String strServerNm) {
-		this.strServerNm = strServerNm;
-	}
-	/**
-	 * @return the strStartDt
-	 */
-	public String getStrStartDt() {
-		return strStartDt;
-	}
-	/**
-	 * @param strStartDt the strStartDt to set
-	 */
-	public void setStrStartDt(String strStartDt) {
-		this.strStartDt = strStartDt;
-	}
-	/**
-	 * @return the strEndDt
-	 */
-	public String getStrEndDt() {
-		return strEndDt;
-	}
-	/**
-	 * @param strEndDt the strEndDt to set
-	 */
-	public void setStrEndDt(String strEndDt) {
-		this.strEndDt = strEndDt;
-	}
 	/**
 	 * @return the serverResrceMntrngList
 	 */


### PR DESCRIPTION
## 변경 내용

`egovframework.com.utl.sys.srm.service.ServerResrceMntrngVO`의 단순 필드 3개(`strServerNm`, `strStartDt`, `strEndDt`)에 필드 레벨 `@Getter @Setter`를 적용했습니다.

`serverResrceMntrngList` 필드는 setter에서 `Collections.unmodifiableList(...)`로 방어적 불변화를 하고 있어 기존 수동 getter/setter를 그대로 유지했습니다.

## 테스트
- [x] `mvn compile` 통과
- [x] `mvn test` 통과

- [ ] 단일 주제만 다룸 (다른 변경 없음)
- [ ] 기존 동작에 영향 없음