### PR TITLE
refactor(EgovWebApplicationInitializer): Lombok @Slf4j를 적용하여 Logger 선언 간소화

### DIFF
--- a/src/main/java/egovframework/com/cmm/config/EgovWebApplicationInitializer.java
+++ b/src/main/java/egovframework/com/cmm/config/EgovWebApplicationInitializer.java
@@ -1,7 +1,5 @@
 package egovframework.com.cmm.config;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.util.ObjectUtils;
 import org.springframework.web.WebApplicationInitializer;
 import org.springframework.web.context.ContextLoaderListener;
@@ -22,6 +20,7 @@ import jakarta.servlet.MultipartConfigElement;
 import jakarta.servlet.ServletContext;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletRegistration;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * EgovWebApplicationInitializer 클래스
@@ -46,14 +45,14 @@ import jakarta.servlet.ServletRegistration;
  *   2018.10.26  신용호          EgovLoginPolicyFilter 추가 (IP접근처리)
  *   2018.12.03  신용호          springMultipartFilter,HTMLTagFilter 추가 (XSS방지처리)
  *   2025.05.23  이백행          PMD로 소프트웨어 보안약점 진단하고 제거하기-CloseResource(리소스 닫기)
- *   2026.04.01  유지보수        MultipartConfigElement를 globals.properties 값으로 생성
- *   2026.04.01  유지보수        Security Fiter 추가
+ *   2026.04.01  유지보수         MultipartConfigElement를 globals.properties 값으로 생성
+ *   2026.04.01  유지보수         Security Fiter 추가
+ *   2026.07.06  이백행          [2026년 컨트리뷰션] Lombok @Slf4j를 적용하여 Logger 선언 간소화
  *
  *      </pre>
  */
+@Slf4j
 public class EgovWebApplicationInitializer implements WebApplicationInitializer {
-
-	private static final Logger LOGGER = LoggerFactory.getLogger(EgovWebApplicationInitializer.class);
 
     private static final String TMP_LOCATION = "";						// 업로드 임시 디렉터리, 빈 문자열이면 컨테이너 기본 tmp 사용
     private static final long DEFAULT_MAX_SIZE = 104857600L;			// 개별파일 최대크기 (100MB)
@@ -63,7 +62,7 @@ public class EgovWebApplicationInitializer implements WebApplicationInitializer 
 	@Override
 	public void onStartup(ServletContext servletContext) throws ServletException {
 
-		LOGGER.debug("EgovWebApplicationInitializer START-============================================");
+		log.debug("EgovWebApplicationInitializer START-============================================");
 
 		//-------------------------------------------------------------
 		// Egov Web ServletContextListener 설정
@@ -189,7 +188,7 @@ public class EgovWebApplicationInitializer implements WebApplicationInitializer 
 		//-------------------------------------------------------------
 		servletContext.addListener(new org.springframework.web.context.request.RequestContextListener());
 
-		LOGGER.debug("EgovWebApplicationInitializer END-============================================");
+		log.debug("EgovWebApplicationInitializer END-============================================");
 
 	}
 
@@ -202,7 +201,7 @@ public class EgovWebApplicationInitializer implements WebApplicationInitializer 
 		long maxRequestSize = parseLongProperty("Globals.fileUpload.maxRequestSize", DEFAULT_MAX_REQUEST_SIZE);
 		int fileSizeThreshold = parseIntProperty("Globals.fileUpload.fileSizeThreshold", DEFAULT_FILE_SIZE_THRESHOLD);
 
-		LOGGER.debug( "MultipartConfigElement: maxFileSize={}, maxRequestSize={}, fileSizeThreshold={}", maxFileSize, maxRequestSize, fileSizeThreshold);
+		log.debug( "MultipartConfigElement: maxFileSize={}, maxRequestSize={}, fileSizeThreshold={}", maxFileSize, maxRequestSize, fileSizeThreshold);
 
 		return new MultipartConfigElement(TMP_LOCATION, maxFileSize, maxRequestSize, fileSizeThreshold);
 	}


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [x] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

### 변경 내용

- `Logger` 및 `LoggerFactory` 직접 선언 제거
- Lombok `@Slf4j` 어노테이션 적용
- `LOGGER` → `log`로 변경
- 기존 로그 메시지 및 동작은 그대로 유지

### 기대 효과

- Logger 선언 코드 제거로 코드 간결성 향상
- Lombok 기반 로깅 방식으로 프로젝트 전반의 일관성 확보
- 보일러플레이트 코드 감소
- 유지보수성 및 가독성 향상

### 영향 범위

- 로그 출력 방식만 변경되며 기능상의 변경은 없음

### 테스트

- [x] 프로젝트 빌드 성공
- [x] 애플리케이션 실행 확인
- [x] 기존 DEBUG 로그 정상 출력 확인

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [x] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

https://youtu.be/KM349zYqYnY
