### PR TITLE
fix: 환율계산기 static StringBuffer 공유로 인한 동시성 문제 수정 (EgovEhgtCalcUtil)

### DIFF
--- a/src/main/java/egovframework/com/utl/fcc/service/EgovEhgtCalcUtil.java
+++ b/src/main/java/egovframework/com/utl/fcc/service/EgovEhgtCalcUtil.java
@@ -51,7 +51,7 @@ public class EgovEhgtCalcUtil {
 
 	static final char EGHT_KWR = 'K'; // 대한민국
 
-	static StringBuffer sb = new StringBuffer();
+	private final StringBuilder sb = new StringBuilder();
 
 	/**
 	 * 대한민국(KRW), 미국(USD), 유럽연합(EUR), 일본(JPY), 중국원화(CNY) 사이의 환율을 계산하는 기능이다 환율표 -
@@ -123,7 +123,6 @@ public class EgovEhgtCalcUtil {
 	 */
 	public static String getEhgtCalc(String srcType, long srcAmount, String cnvrType) throws Exception {
 
-		sb.setLength(0); // 일자 변경 후 재호출 시 오류 방지를 위한 초기화
 		String rtnStr = null;
 
 		JSONArray eghtStdrRt = null; // Html에서 파싱한 환율매매기준율을 저장하기 위한 문자열배열
@@ -149,18 +148,14 @@ public class EgovEhgtCalcUtil {
 		for (int i = 0; i < 10; i++) { // 비영업일/비영업시간 조회 시 전날 데이터 조회하도록 일자 변경 후 요청 반복
 			searchDate = currentDate.format(formatter);
 			parser.readHtmlParsing("?authkey=" + AUTH_KEY + "&data=AP01&searchdate=" + searchDate);
-			eghtStdrRt = new JSONArray(sb.toString());
+			eghtStdrRt = new JSONArray(parser.sb.toString());
 
 			if (eghtStdrRt.length() != 0) {
 				break;
 			}
 
-			sb.setLength(0);
+			parser.sb.setLength(0);
 			currentDate = currentDate.minusDays(1);
-		}
-
-		if (sb == null) {
-			throw new RuntimeException("StringBuffer is null!!");
 		}
 
 		if (eghtStdrRt == null || (eghtStdrRt.length() == 0)) {
@@ -334,4 +329,4 @@ public class EgovEhgtCalcUtil {
 		return rtnStr;
 	}
 
-}
+	}

--- a/src/main/java/egovframework/com/utl/fcc/service/EgovEhgtCalcUtil.java
+++ b/src/main/java/egovframework/com/utl/fcc/service/EgovEhgtCalcUtil.java
@@ -329,4 +329,4 @@ public class EgovEhgtCalcUtil {
 		return rtnStr;
 	}
 
-	}
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`EgovEhgtCalcUtil`에서 모든 스레드가 공유하는 `static StringBuffer sb`를 호출 단위로 격리된 인스턴스 필드(`StringBuilder`)로 변경했습니다.

### 문제점

- `getEhgtCalc()`는 static 메서드로, 여러 사용자가 동시에 환율 계산을 요청하면 **하나의 static 버퍼에 서로 다른 요청의 API 응답이 뒤섞여 append**됩니다.
- 그 결과 `new JSONArray(sb.toString())` 파싱 실패 또는 **잘못된 환율 계산 결과**가 발생할 수 있습니다 (경쟁 상태).
- StringBuffer의 메서드 단위 동기화는 이런 논리적 경쟁 상태를 막지 못합니다.

### 해결

- 버퍼를 `private final StringBuilder` 인스턴스 필드로 변경. `getEhgtCalc()`가 호출마다 `new EgovEhgtCalcUtil()` 인스턴스를 생성하므로 버퍼가 호출 단위로 격리됩니다.
- 지역화된 버퍼는 동기화가 불필요하므로 StringBuilder 사용 (기존 #1099, #1100과 동일한 방향).
- 인스턴스 생성 전의 불필요해진 `sb.setLength(0)` 및 항상 false인 죽은 코드 `if (sb == null)` 제거.

### 영향 범위

- public API 시그니처 변경 없음. 단일 스레드 동작 동일, 동시 호출 시에만 결과가 올바르게 격리됩니다.

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

※ 외부 환율 API 연동 유틸 특성상 자동 테스트 미수행. 수정된 파일의 컴파일 단위 구문 검증을 완료했으며, public API 시그니처 변경이 없어 기존 호출부에 영향이 없습니다.

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

서버 측 유틸 클래스 변경으로 화면(UI) 변경 사항이 없습니다.
