### PR TITLE
refactor: 프로토콜 비교 시 toLowerCase().equals() 대신 equalsIgnoreCase() 사용 (…

### DIFF
--- a/src/main/java/egovframework/com/cmm/util/EgovUrlRewriteFilter.java
+++ b/src/main/java/egovframework/com/cmm/util/EgovUrlRewriteFilter.java
@@ -78,7 +78,7 @@ public class EgovUrlRewriteFilter implements Filter {
 
 			if (pm.match(uriPattern.trim(), uri)) {
 
-				if (getProtocol.toLowerCase().equals("http")) {
+				if ("http".equalsIgnoreCase(getProtocol)) {
 
 					response.setContentType("text/html");
 
@@ -88,7 +88,7 @@ public class EgovUrlRewriteFilter implements Filter {
 
 				}
 
-			} else if (getProtocol.toLowerCase().equals("https")) {
+			} else if ("https".equalsIgnoreCase(getProtocol)) {
 
 				response.setContentType("text/html");
 


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [ ] 버그수정 Bug fixes
- [X] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`EgovUrlRewriteFilter`의 프로토콜 비교 2곳을 `getProtocol.toLowerCase().equals("http")` → `"http".equalsIgnoreCase(getProtocol)` 형태로 변경했습니다.

### 개선 효과

- `toLowerCase()` 호출이 만들던 불필요한 임시 String 객체 생성 제거 (필터는 매 요청마다 실행되므로 누적 효과 있음)
- 상수 리터럴을 앞에 두는 비교로 NPE 가능성 원천 차단
- SonarSource 규칙 java:S1157 (Case insensitive string comparisons should be made without intermediate upper or lower casing) 준수

동일 패턴 잔여 건은 이 파일 2곳이 전부입니다. 동작(대소문자 무시 비교)은 기존과 동일합니다.

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

※ 동일 의미의 표준 API 치환(동작 불변)으로 별도 테스트 미수행. 수정 파일 구문 검증 완료.

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

서버 측 필터 클래스 변경으로 화면(UI) 변경 사항이 없습니다.
