### PR TITLE
chore: 디버그용 System.out.println을 LOGGER로 대체 (2차, 2파일)

### DIFF
--- a/src/main/java/egovframework/com/cmm/interceptor/IpObtainInterceptor.java
+++ b/src/main/java/egovframework/com/cmm/interceptor/IpObtainInterceptor.java
@@ -1,5 +1,7 @@
 package egovframework.com.cmm.interceptor;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.web.servlet.HandlerInterceptor;
 
 import egovframework.com.cmm.LoginVO;
@@ -26,11 +28,13 @@ import jakarta.servlet.http.HttpServletResponse;
 
 public class IpObtainInterceptor implements HandlerInterceptor {
 
+	private static final Logger LOGGER = LoggerFactory.getLogger(IpObtainInterceptor.class);
+
 	@Override
 	public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
 
-		System.out.println("### IpObtainInterceptor start... ");
-		
+		LOGGER.debug("IpObtainInterceptor start...");
+
 		LoginVO loginVO = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();
 
 		if (loginVO != null) {

--- a/src/main/java/egovframework/com/uss/olp/qtm/web/EgovQustnrTmplatManageController.java
+++ b/src/main/java/egovframework/com/uss/olp/qtm/web/EgovQustnrTmplatManageController.java
@@ -391,7 +391,7 @@ public class EgovQustnrTmplatManageController {
 		}
 		// 유효성 검증, 실패시 포워딩
 				if(bindingResult.hasErrors()) {
-					System.out.println("####파라미터검증에러"+ bindingResult.getAllErrors());//확인용 로그
+					LOGGER.debug("파라미터 검증 에러: {}", bindingResult.getAllErrors());
 					return "egovframework/com/uss/olp/qtm/EgovQustnrTmplatManageRegist";
 				}
 				


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [ ] 버그수정 Bug fixes
- [X] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

#1097(EgovVcatnManageController) 후속 작업으로, 실행 코드에 남아 있던 디버그용 표준출력 2곳을 SLF4J LOGGER로 대체했습니다.

| 파일 | 변경 |
|---|---|
| `IpObtainInterceptor` | 매 요청마다 stdout으로 출력되던 `"### IpObtainInterceptor start..."`를 `LOGGER.debug`로 대체 (Logger 필드 신규 추가) |
| `EgovQustnrTmplatManageController` | 검증 오류 확인용 출력(`"####파라미터검증에러"...`)을 기존 LOGGER의 `debug` 레벨 + `{}` 파라미터 바인딩 방식으로 대체 |

### 개선 효과

- 운영 환경에서 제어 불가능한 stdout 출력 제거, 로그 레벨로 on/off 가능
- 특히 `IpObtainInterceptor`는 인터셉터 특성상 **모든 요청마다** 출력되어 운영 로그 오염이 컸음

이 PR과 #1097이 반영되면 `src/main/java` 실행 코드 내 디버그용 `System.out.println`은 모두 제거됩니다(나머지는 주석 블록 내부).

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

※ 로깅 방식 치환(비즈니스 로직 불변)으로 별도 테스트 미수행. 수정 파일 구문 검증 완료.

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

서버 측 로깅 변경으로 화면(UI) 변경 사항이 없습니다.
