### PR TITLE
refactor: getXMLToClass의 사용되지 않는 FileInputStream 제거 (EgovXMLDoc)

### DIFF
--- a/src/main/java/egovframework/com/utl/sim/service/EgovXMLDoc.java
+++ b/src/main/java/egovframework/com/utl/sim/service/EgovXMLDoc.java
@@ -60,23 +60,16 @@ public class EgovXMLDoc {
 	 * @return SndngMailDocument mailDoc 메일발송 클래스(XML스키마를 통해 생성된 자바클래스)
 	 */
 	public static SndngMailDocument getXMLToClass(String file) throws Exception {
-		FileInputStream fis = null;
 		SndngMailDocument mailDoc = null;
 
 		String storePathString = EgovProperties.getProperty("Globals.fileStorePath");
-		try {
-			File xmlFile = new File(storePathString,FilenameUtils.getName(file));
-			if (xmlFile.exists() && xmlFile.isFile()) {
-				fis = new FileInputStream(xmlFile);
-				// XXE 방지: DOCTYPE 선언 차단 및 외부 DTD 로딩 비활성화 (getXMLDocument/getXMLFile와 동일 수준)
-				XmlOptions xmlOptions = new XmlOptions();
-				xmlOptions.setDisallowDocTypeDeclaration(true);
-				xmlOptions.setLoadExternalDTD(false);
-				mailDoc = (SndngMailDocument) SndngMailDocument.Factory.parse(xmlFile, xmlOptions);
-
-			}
-		} finally {
-			EgovResourceCloseHelper.close(fis);
+		File xmlFile = new File(storePathString,FilenameUtils.getName(file));
+		if (xmlFile.exists() && xmlFile.isFile()) {
+			// XXE 방지: DOCTYPE 선언 차단 및 외부 DTD 로딩 비활성화 (getXMLDocument/getXMLFile와 동일 수준)
+			XmlOptions xmlOptions = new XmlOptions();
+			xmlOptions.setDisallowDocTypeDeclaration(true);
+			xmlOptions.setLoadExternalDTD(false);
+			mailDoc = (SndngMailDocument) SndngMailDocument.Factory.parse(xmlFile, xmlOptions);
 		}
 
 		return mailDoc;


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [ ] 버그수정 Bug fixes
- [X] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`EgovXMLDoc.getXMLToClass()`에서 열기만 하고 한 번도 사용하지 않는 `FileInputStream`을 제거했습니다.

### 배경

- 실제 파싱은 `SndngMailDocument.Factory.parse(xmlFile, xmlOptions)`가 **File 객체로 직접** 수행합니다.
- `fis = new FileInputStream(xmlFile)`은 파일 핸들만 점유한 뒤 어디에도 쓰이지 않고 finally에서 닫히기만 했습니다.

### 변경

- 미사용 `FileInputStream` 선언·생성 제거
- `fis`를 닫는 용도뿐이던 `try-finally` 블록 제거 및 들여쓰기 정리
- 동작 변경 없음 (같은 클래스의 `getXMLDocument()`는 스트림을 실제 파싱에 사용하므로 그대로 유지)

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

※ 미사용 자원 제거(동작 불변). 수정 파일 구문 검증 완료.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

서버 측 유틸 변경으로 화면(UI) 변경 사항이 없습니다.
