### PR TITLE
docs: GitHub Copilot용 저장소 지침 copilot-instructions.md 추가

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,31 @@
+# GitHub Copilot 지침 — 표준프레임워크 공통컴포넌트
+
+이 저장소는 전자정부 표준프레임워크 **공통컴포넌트**(Spring MVC + MyBatis 기반 단일 WAR)입니다.
+상세 컨텍스트는 저장소 루트의 [AGENTS.md](../AGENTS.md)를 참고하세요.
+
+## 빌드·테스트
+
+- JDK 17, Maven. 검증 명령: `mvn -B verify` (CI와 동일)
+- 버전 등 공통 설정은 부모 POM(`egovframe-web-config-parent`)에서 상속 — 임의로 버전을 명시하지 않기
+
+## 구조·네이밍 규칙
+
+- 패키지: `egovframework.com.{cmm|cop|dam|ext|sec|ssi|sts|sym|uat|uss|utl}`
+- 계층: `web/EgovXxxController` → `service/EgovXxxService`(+ `XxxVO`) → `service/impl/EgovXxxServiceImpl`(`EgovAbstractServiceImpl` 상속) → `service/impl/XxxDAO`(`EgovAbstractMapper` 상속)
+- 클래스 접두어 `Egov`, 매퍼 XML은 `Egov<기능>_SQL_<db>.xml`
+- **매퍼 XML 수정 시 8개 DB 변형 파일(altibase, cubrid, goldilocks, maria, mysql, oracle, postgres, tibero)을 모두 함께 수정**
+
+## 코드 작성 규칙
+
+- 디버그 출력: `System.out.println` 금지 → SLF4J `LOGGER.debug("... {}", value)`
+- 지역 문자열 버퍼: `StringBuffer` 대신 `StringBuilder`, static 가변 버퍼 공유 금지(동시성)
+- 대소문자 무시 비교: `toLowerCase().equals()` 대신 `"상수".equalsIgnoreCase(변수)`
+- 들여쓰기는 탭(tab), 인코딩 UTF-8. 기존 포맷을 불필요하게 재정렬하지 않기
+- 클래스 상단 Javadoc의 개정이력(Modification Information) 표 유지 — 기존 이력 수정 금지, 의미 있는 변경 시 행 추가
+- 기존 보안 처리 패턴 유지 (입력 검증, `EgovWebUtil.removeCRLF` 등)
+
+## 하지 말 것
+
+- 라이선스 헤더·개정이력·컴포넌트 고유 명칭 임의 변경
+- 대규모 일괄 리포맷(리뷰 불가능한 diff)
+- 부모 POM에서 관리되는 의존성 버전 재정의


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [X] 기타 Others

## 수정된 소스 내용 Modified source

#1119 제안의 2단계 실행으로, `.github/copilot-instructions.md`를 추가했습니다. (소스코드 변경 없음, 문서 1개 신규 추가)

- GitHub Copilot은 저장소의 `.github/copilot-instructions.md`를 **커스텀 지침으로 자동 인식**하여 코드 제안 시 반영합니다.
- 내용은 #1121(AGENTS.md)의 요약본으로, 빌드 명령·계층 구조·네이밍 규칙·코드 작성 규칙(LOGGER, StringBuilder, DB별 매퍼 8종 동시 수정 등)·금지 사항을 담았습니다.
- #1121과 상호 보완 관계이며(참조 링크 포함), 유지보수 조직에서 한쪽으로 통합을 원하시면 리뷰 의견에 따라 조정하겠습니다.

문서 내용은 모두 이 저장소의 실제 설정(pom.xml, CI 워크플로, 디렉터리 구조)에서 확인한 사실 기반입니다.

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

※ 마크다운 문서 1개 추가로 코드·빌드에 영향이 없습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

문서 추가로 화면(UI) 변경 사항이 없습니다.
