### PR TITLE
chore: 주석 오타 수정 4차 - 메세지→메시지 (배치·백업 컨트롤러, 공통 예외)

### DIFF
--- a/src/main/java/egovframework/com/cmm/exception/EgovFileExtensionException.java
+++ b/src/main/java/egovframework/com/cmm/exception/EgovFileExtensionException.java
@@ -26,7 +26,7 @@ public class EgovFileExtensionException extends BaseRuntimeException {
 	/**
 	 * EgovFileExtensionException 생성자.
 	 *
-	 * @param defaultMessage 메세지 지정
+	 * @param defaultMessage 메시지 지정
 	 * @param wrappedException 원인 Exception
 	 */
 	public EgovFileExtensionException(String message, String messageKey) {

--- a/src/main/java/egovframework/com/cmm/exception/EgovXssException.java
+++ b/src/main/java/egovframework/com/cmm/exception/EgovXssException.java
@@ -26,7 +26,7 @@ public class EgovXssException extends BaseRuntimeException {
 	/**
 	 * EgovXssException 생성자.
 	 *
-	 * @param defaultMessage 메세지 지정
+	 * @param defaultMessage 메시지 지정
 	 * @param wrappedException 원인 Exception
 	 */
 	public EgovXssException(String message, String messageKey) {

--- a/src/main/java/egovframework/com/sym/bat/web/EgovBatchOpertController.java
+++ b/src/main/java/egovframework/com/sym/bat/web/EgovBatchOpertController.java
@@ -57,7 +57,7 @@ public class EgovBatchOpertController {
 	@Resource(name = "propertiesService")
 	private EgovPropertyService propertyService;
 
-	/* 메세지 서비스 */
+	/* 메시지 서비스 */
 	@Resource(name = "egovMessageSource")
 	private EgovMessageSource egovMessageSource;
 

--- a/src/main/java/egovframework/com/sym/bat/web/EgovBatchResultController.java
+++ b/src/main/java/egovframework/com/sym/bat/web/EgovBatchResultController.java
@@ -48,7 +48,7 @@ public class EgovBatchResultController {
 	@Resource(name = "propertiesService")
 	private EgovPropertyService propertyService;
 
-	/*  메세지 서비스 */
+	/*  메시지 서비스 */
 	@Resource(name = "egovMessageSource")
 	private EgovMessageSource egovMessageSource;
 

--- a/src/main/java/egovframework/com/sym/bat/web/EgovBatchSchdulController.java
+++ b/src/main/java/egovframework/com/sym/bat/web/EgovBatchSchdulController.java
@@ -59,7 +59,7 @@ public class EgovBatchSchdulController {
 	@Resource(name = "propertiesService")
 	private EgovPropertyService propertyService;
 
-	/* 메세지 서비스 */
+	/* 메시지 서비스 */
 	@Resource(name = "egovMessageSource")
 	private EgovMessageSource egovMessageSource;
 

--- a/src/main/java/egovframework/com/sym/sym/bak/web/EgovBackupOpertController.java
+++ b/src/main/java/egovframework/com/sym/sym/bak/web/EgovBackupOpertController.java
@@ -60,7 +60,7 @@ public class EgovBackupOpertController {
     @Resource(name="propertiesService")
     private EgovPropertyService propertyService;
 
-    /* 메세지 서비스 */
+    /* 메시지 서비스 */
     @Resource(name="egovMessageSource")
     private EgovMessageSource egovMessageSource;
 

--- a/src/main/java/egovframework/com/sym/sym/bak/web/EgovBackupResultController.java
+++ b/src/main/java/egovframework/com/sym/sym/bak/web/EgovBackupResultController.java
@@ -49,7 +49,7 @@ public class EgovBackupResultController {
     @Resource(name="propertiesService")
     private EgovPropertyService propertyService;
 
-    /* 메세지 서비스 */
+    /* 메시지 서비스 */
     @Resource(name="egovMessageSource")
     private EgovMessageSource egovMessageSource;
 


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [X] 기타 Others

## 수정된 소스 내용 Modified source

#1125, #1126 후속으로, 주석 내 "메세지" 표기 7곳을 표준 표기 "메시지"로 수정했습니다. 주석만 변경했으며 코드·문자열 리터럴은 변경하지 않았습니다.

| 위치 | 파일 | 곳 |
|---|---|---|
| cmm/exception | `EgovFileExtensionException`, `EgovXssException` (Javadoc @param) | 2 |
| sym/bat/web | `EgovBatchOpertController`, `EgovBatchResultController`, `EgovBatchSchdulController` (필드 주석) | 3 |
| sym/sym/bak/web | `EgovBackupOpertController`, `EgovBackupResultController` (필드 주석) | 2 |

### 검증

- 변경 라인 전수(14라인)가 주석임을 확인했습니다.
- 현재 open PR들의 변경 파일과 겹치지 않습니다.

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

※ 주석만 변경(바이트코드 불변)으로 별도 테스트 미수행.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

주석 변경으로 화면(UI) 변경 사항이 없습니다.
