### PR TITLE
refactor: BigDecimal.divide() deprecated 메서드 대체

### DIFF
--- a/src/main/java/egovframework/com/utl/fcc/service/EgovEhgtCalcUtil.java
+++ b/src/main/java/egovframework/com/utl/fcc/service/EgovEhgtCalcUtil.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -36,6 +37,7 @@ import twitter4j.JSONObject;
  *   2023.08.25  김혜준          외환은행 제공 환율 api에서 한국수출입은행 제공 환율 api로 변경
  *   2025.08.30  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-CloseResource(부적절한 자원 해제)
  *   2025.08.30  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-UselessParentheses(불필요한 괄호사용)
+ *   2026.07.08  이백행          [2026년 컨트리뷰션] BigDecimal.divide() deprecated 메서드 대체
  *
  *      </pre>
  */
@@ -251,10 +253,10 @@ public class EgovEhgtCalcUtil {
 				sCnvrAmount = bSrcAmount.toString();
 			} else if (cnvrChr == 'J') {
 				// 변환금액 = (변환대상금액 / 변환매매비율) * 100;
-				sCnvrAmount = bSrcAmount.divide(bCnvrStdrRt, 4, 4).multiply(bStdr).setScale(2, 4).toString();
+				sCnvrAmount = bSrcAmount.divide(bCnvrStdrRt, 4, RoundingMode.HALF_UP).multiply(bStdr).setScale(2, RoundingMode.HALF_UP).toString();
 			} else {
 				// 변환금액 = (변환대상금액 / 변환매매비율);
-				sCnvrAmount = bSrcAmount.divide(bCnvrStdrRt, 2, 4).toString();
+				sCnvrAmount = bSrcAmount.divide(bCnvrStdrRt, 2, RoundingMode.HALF_UP).toString();
 			}
 			break;
 
@@ -264,14 +266,14 @@ public class EgovEhgtCalcUtil {
 				sCnvrAmount = bSrcAmount.toString();
 			} else if (cnvrChr == 'K') {
 				// 변환금액 = 변환대상금액 * 원래 매매 비율;
-				sCnvrAmount = bSrcAmount.multiply(bSrcStdrRt).setScale(2, 4).toString();
+				sCnvrAmount = bSrcAmount.multiply(bSrcStdrRt).setScale(2, RoundingMode.HALF_UP).toString();
 			} else if (cnvrChr == 'J') {
 				// cnvrAmount = ((변환대상금액 * 원래 매매 비율) / 변환 매매 비율) * 100;
-				sCnvrAmount = bSrcAmount.multiply(bSrcStdrRt).setScale(4, 4).divide(bCnvrStdrRt, 2, 4).multiply(bStdr)
-						.setScale(2, 4).toString();
+				sCnvrAmount = bSrcAmount.multiply(bSrcStdrRt).setScale(4, RoundingMode.HALF_UP).divide(bCnvrStdrRt, 2, RoundingMode.HALF_UP).multiply(bStdr)
+						.setScale(2, RoundingMode.HALF_UP).toString();
 			} else {
 				// cnvrAmount = (변환대상금액 * 원래 매매 비율) / 변환 매매 비율;
-				sCnvrAmount = bSrcAmount.multiply(bSrcStdrRt).setScale(4, 4).divide(bCnvrStdrRt, 2, 4).toString();
+				sCnvrAmount = bSrcAmount.multiply(bSrcStdrRt).setScale(4, RoundingMode.HALF_UP).divide(bCnvrStdrRt, 2, RoundingMode.HALF_UP).toString();
 			}
 			break;
 
@@ -281,14 +283,14 @@ public class EgovEhgtCalcUtil {
 				sCnvrAmount = bSrcAmount.toString();
 			} else if (cnvrChr == 'K') {
 				// cnvrAmount = 변환대상금액 * 원래 매매 비율;
-				sCnvrAmount = bSrcAmount.multiply(bSrcStdrRt).setScale(2, 4).toString();
+				sCnvrAmount = bSrcAmount.multiply(bSrcStdrRt).setScale(2, RoundingMode.HALF_UP).toString();
 			} else if (cnvrChr == 'J') {
 				// cnvrAmount = ((변환대상금액 * 원래 매매 비율) / 변환 매매 비율) * 100;
-				sCnvrAmount = bSrcAmount.multiply(bSrcStdrRt).setScale(4, 4).divide(bCnvrStdrRt, 2, 4).multiply(bStdr)
-						.setScale(2, 4).toString();
+				sCnvrAmount = bSrcAmount.multiply(bSrcStdrRt).setScale(4, RoundingMode.HALF_UP).divide(bCnvrStdrRt, 2, RoundingMode.HALF_UP).multiply(bStdr)
+						.setScale(2, RoundingMode.HALF_UP).toString();
 			} else {
 				// cnvrAmount = (변환대상금액 * 원래 매매 비율) / 변환 매매 비율;
-				sCnvrAmount = bSrcAmount.multiply(bSrcStdrRt).setScale(4, 4).divide(bCnvrStdrRt, 2, 4).toString();
+				sCnvrAmount = bSrcAmount.multiply(bSrcStdrRt).setScale(4, RoundingMode.HALF_UP).divide(bCnvrStdrRt, 2, RoundingMode.HALF_UP).toString();
 			}
 			break;
 
@@ -298,11 +300,11 @@ public class EgovEhgtCalcUtil {
 				sCnvrAmount = bSrcAmount.toString();
 			} else if (cnvrChr == 'K') {
 				// cnvrAmount = (변환대상금액 * 원래 매매 비율) / 100;
-				sCnvrAmount = bSrcAmount.multiply(bSrcStdrRt).setScale(4, 4).divide(bStdr, 2, 4).toString();
+				sCnvrAmount = bSrcAmount.multiply(bSrcStdrRt).setScale(4, RoundingMode.HALF_UP).divide(bStdr, 2, RoundingMode.HALF_UP).toString();
 			} else {
 				// cnvrAmount = ((변환대상금액 * 원래 매매 비율) / 100) / 변환 매매 비율;
-				sCnvrAmount = bSrcAmount.multiply(bSrcStdrRt).setScale(4, 4).divide(bStdr, 2, 4)
-						.divide(bCnvrStdrRt, 2, 4).toString();
+				sCnvrAmount = bSrcAmount.multiply(bSrcStdrRt).setScale(4, RoundingMode.HALF_UP).divide(bStdr, 2, RoundingMode.HALF_UP)
+						.divide(bCnvrStdrRt, 2, RoundingMode.HALF_UP).toString();
 			}
 			break;
 
@@ -312,20 +314,20 @@ public class EgovEhgtCalcUtil {
 				sCnvrAmount = bSrcAmount.toString();
 			} else if (cnvrChr == 'K') {
 				// cnvrAmount = 변환대상금액 * 원래 매매 비율;
-				sCnvrAmount = bSrcAmount.multiply(bSrcStdrRt).setScale(2, 4).toString();
+				sCnvrAmount = bSrcAmount.multiply(bSrcStdrRt).setScale(2, RoundingMode.HALF_UP).toString();
 			} else if (cnvrChr == 'J') {
 				// cnvrAmount = ((변환대상금액 * 원래 매매 비율) / 변환 매매 비율) * 100;
-				sCnvrAmount = bSrcAmount.multiply(bSrcStdrRt).setScale(4, 4).divide(bCnvrStdrRt, 2, 4).multiply(bStdr)
-						.setScale(2, 4).toString();
+				sCnvrAmount = bSrcAmount.multiply(bSrcStdrRt).setScale(4, RoundingMode.HALF_UP).divide(bCnvrStdrRt, 2, RoundingMode.HALF_UP).multiply(bStdr)
+						.setScale(2, RoundingMode.HALF_UP).toString();
 			} else {
 				// cnvrAmount = (변환대상금액 * 원래 매매 비율) / 변환 매매 비율;
-				sCnvrAmount = bSrcAmount.multiply(bSrcStdrRt).setScale(4, 4).divide(bCnvrStdrRt, 2, 4).toString();
+				sCnvrAmount = bSrcAmount.multiply(bSrcStdrRt).setScale(4, RoundingMode.HALF_UP).divide(bCnvrStdrRt, 2, RoundingMode.HALF_UP).toString();
 			}
 			break;
 
 		default:
 			// 변환금액 = (변환대상금액 / 변환매매비율);
-			sCnvrAmount = bSrcAmount.divide(bCnvrStdrRt, 2, 4).toString();
+			sCnvrAmount = bSrcAmount.divide(bCnvrStdrRt, 2, RoundingMode.HALF_UP).toString();
 			break;
 		}
 


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [x] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

### 개요

Java 9부터 Deprecated 된 `BigDecimal.divide(BigDecimal, int, int)` 메서드를 최신 API로 변경했습니다.

### 변경 목적

- Java 9 이상 Deprecated API 제거
- 최신 `RoundingMode` Enum 사용
- 향후 JDK 업그레이드 시 호환성 향상
- 컴파일 Warning 제거

### 영향도

- 기능 변경 없음
- Deprecated Warning 제거

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [x] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.
