### PR TITLE
refactor: ArchiveOutputStream 제네릭 적용 및 deprecated API 변경

### DIFF
--- a/src/test/java/egovframework/com/sym/sym/bak/service/BackupJobFileNameCharsetTest.java
+++ b/src/test/java/egovframework/com/sym/sym/bak/service/BackupJobFileNameCharsetTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 
@@ -12,6 +13,7 @@ import org.apache.commons.compress.archivers.ArchiveOutputStream;
 import org.apache.commons.compress.archivers.ArchiveStreamFactory;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.egovframe.rte.fdl.cmmn.exception.BaseRuntimeException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -39,7 +41,7 @@ class BackupJobFileNameCharsetTest {
 
     @Test
     @DisplayName("UTF-8 인코딩과 원본 경로를 쓰면 한글 TAR 엔트리 이름이 보존된다")
-    void utf8TarPreservesKoreanEntryName() throws Exception {
+    void utf8TarPreservesKoreanEntryName() {
         String name = "백업/한글-파일.txt";
 
         ByteArrayOutputStream bos = new ByteArrayOutputStream();
@@ -49,12 +51,16 @@ class BackupJobFileNameCharsetTest {
             entry.setSize(0);
             aos.putArchiveEntry(entry);
             aos.closeArchiveEntry();
+        } catch (IOException e) {
+            throw new BaseRuntimeException(e);
         }
 
         try (TarArchiveInputStream tis = new TarArchiveInputStream(
                 new ByteArrayInputStream(bos.toByteArray()), StandardCharsets.UTF_8.name())) {
             TarArchiveEntry read = tis.getNextEntry();
             assertEquals(name, read.getName(), "UTF-8로 기록한 한글 엔트리 이름이 그대로 복원되어야 한다");
+        } catch (IOException e) {
+            throw new BaseRuntimeException(e);
         }
     }
 }

--- a/src/test/java/egovframework/com/sym/sym/bak/service/BackupJobFileNameCharsetTest.java
+++ b/src/test/java/egovframework/com/sym/sym/bak/service/BackupJobFileNameCharsetTest.java
@@ -43,7 +43,7 @@ class BackupJobFileNameCharsetTest {
         String name = "백업/한글-파일.txt";
 
         ByteArrayOutputStream bos = new ByteArrayOutputStream();
-        try (ArchiveOutputStream aos = new ArchiveStreamFactory(StandardCharsets.UTF_8.name())
+        try (ArchiveOutputStream<TarArchiveEntry> aos = new ArchiveStreamFactory(StandardCharsets.UTF_8.name())
                 .createArchiveOutputStream(ArchiveStreamFactory.TAR, bos)) {
             TarArchiveEntry entry = new TarArchiveEntry(name);
             entry.setSize(0);
@@ -53,7 +53,7 @@ class BackupJobFileNameCharsetTest {
 
         try (TarArchiveInputStream tis = new TarArchiveInputStream(
                 new ByteArrayInputStream(bos.toByteArray()), StandardCharsets.UTF_8.name())) {
-            TarArchiveEntry read = tis.getNextTarEntry();
+            TarArchiveEntry read = tis.getNextEntry();
             assertEquals(name, read.getName(), "UTF-8로 기록한 한글 엔트리 이름이 그대로 복원되어야 한다");
         }
     }


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [x] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

###  개요

`BackupJobFileNameCharsetTest`의 Commons Compress API 사용 방식을 리팩토링했습니다.

###  변경 내용

- `ArchiveOutputStream` raw type 제거
- `ArchiveOutputStream<TarArchiveEntry>` 제네릭 타입 명시
- deprecated 된 `getNextTarEntry()` 제거
- `getNextEntry()`로 변경
- `throws Exception` 불필요한 예외 제거 

###  변경 이유

- 컴파일 경고 제거
- deprecated API 사용 제거
- TAR 한글 엔트리 이름 보존 테스트 의도 유지

###  영향도

- 운영 코드 영향 없음
- 테스트 코드 리팩토링만 수행
- 한글 TAR 엔트리 이름 검증 로직은 기존과 동일

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [x] JUnit 테스트 JUnit tests
- [x] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

https://youtu.be/PvR4ngEjLqA
