### PR TITLE
fix: 설문관리 삭제 요청 인증 검증 추가

### DIFF
--- a/src/main/java/egovframework/com/uss/olp/qmc/web/EgovQustnrManageController.java
+++ b/src/main/java/egovframework/com/uss/olp/qmc/web/EgovQustnrManageController.java
@@ -87,6 +87,10 @@ public class EgovQustnrManageController {
 
 		String sCmd = commandMap.get("cmd") == null ? "" : (String) commandMap.get("cmd");
 		if (sCmd.equals("del")) {
+			if (!EgovUserDetailsHelper.isAuthenticated()) {
+				model.addAttribute("message", egovMessageSource.getMessage("fail.common.login"));
+				return "redirect:/uat/uia/egovLoginUsr.do";
+			}
 			egovQustnrManageService.deleteQustnrManage(qustnrManageVO);
 		}
 
@@ -136,6 +140,10 @@ public class EgovQustnrManageController {
 
 		String sCmd = commandMap.get("cmd") == null ? "" : (String) commandMap.get("cmd");
 		if (sCmd.equals("del")) {
+			if (!EgovUserDetailsHelper.isAuthenticated()) {
+				model.addAttribute("message", egovMessageSource.getMessage("fail.common.login"));
+				return "redirect:/uat/uia/egovLoginUsr.do";
+			}
 			egovQustnrManageService.deleteQustnrManage(qustnrManageVO);
 		}
 
@@ -187,6 +195,10 @@ public class EgovQustnrManageController {
 		String sCmd = commandMap.get("cmd") == null ? "" : (String) commandMap.get("cmd");
 
 		if (sCmd.equals("del")) {
+			if (!EgovUserDetailsHelper.isAuthenticated()) {
+				model.addAttribute("message", egovMessageSource.getMessage("fail.common.login"));
+				return "redirect:/uat/uia/egovLoginUsr.do";
+			}
 			egovQustnrManageService.deleteQustnrManage(qustnrManageVO);
 			sLocationUrl = "redirect:/uss/olp/qmc/EgovQustnrManageList.do";
 		} else {

--- a/src/test/java/egovframework/com/uss/olp/qmc/web/EgovQustnrManageControllerTest.java
+++ b/src/test/java/egovframework/com/uss/olp/qmc/web/EgovQustnrManageControllerTest.java
@@ -1,0 +1,203 @@
+package egovframework.com.uss.olp.qmc.web;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import org.egovframe.rte.fdl.property.EgovPropertyService;
+import org.egovframe.rte.psl.dataaccess.util.EgovMap;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.ui.ModelMap;
+
+import egovframework.com.cmm.ComDefaultVO;
+import egovframework.com.cmm.EgovMessageSource;
+import egovframework.com.cmm.service.EgovUserDetailsService;
+import egovframework.com.cmm.util.EgovUserDetailsHelper;
+import egovframework.com.uss.olp.qmc.service.EgovQustnrManageService;
+import egovframework.com.uss.olp.qmc.service.QustnrManageVO;
+
+class EgovQustnrManageControllerTest {
+
+	private final EgovUserDetailsHelper userDetailsHelper = new EgovUserDetailsHelper();
+
+	private EgovUserDetailsService originalUserDetailsService;
+
+	private EgovQustnrManageController controller;
+
+	private RecordingQustnrManageService qustnrManageService;
+
+	@BeforeEach
+	void setUp() {
+		originalUserDetailsService = userDetailsHelper.getEgovUserDetailsService();
+		userDetailsHelper.setEgovUserDetailsService(new FixedUserDetailsService(false));
+
+		controller = new EgovQustnrManageController();
+		qustnrManageService = new RecordingQustnrManageService();
+
+		ReflectionTestUtils.setField(controller, "egovMessageSource", new FixedMessageSource());
+		ReflectionTestUtils.setField(controller, "egovQustnrManageService", qustnrManageService);
+		ReflectionTestUtils.setField(controller, "propertiesService", fixedPropertyService());
+	}
+
+	@AfterEach
+	void tearDown() {
+		userDetailsHelper.setEgovUserDetailsService(originalUserDetailsService);
+	}
+
+	@Test
+	void listPopupDeleteRequiresAuthentication() throws Exception {
+		ModelMap model = new ModelMap();
+
+		String viewName = controller.egovQustnrManageListPopup(new ComDefaultVO(), deleteCommand(),
+				new QustnrManageVO(), model);
+
+		assertEquals(0, qustnrManageService.deleteCount);
+		assertLoginRedirect(viewName, model);
+	}
+
+	@Test
+	void listDeleteRequiresAuthentication() throws Exception {
+		ModelMap model = new ModelMap();
+
+		String viewName = controller.egovQustnrManageList(new ComDefaultVO(), deleteCommand(), new QustnrManageVO(),
+				model);
+
+		assertEquals(0, qustnrManageService.deleteCount);
+		assertLoginRedirect(viewName, model);
+	}
+
+	@Test
+	void detailDeleteRequiresAuthentication() throws Exception {
+		ModelMap model = new ModelMap();
+
+		String viewName = controller.egovQustnrManageDetail(new ComDefaultVO(), new QustnrManageVO(), deleteCommand(),
+				model);
+
+		assertEquals(0, qustnrManageService.deleteCount);
+		assertLoginRedirect(viewName, model);
+	}
+
+	private static Map<String, String> deleteCommand() {
+		return Collections.singletonMap("cmd", "del");
+	}
+
+	private static void assertLoginRedirect(String viewName, ModelMap model) {
+		assertEquals("redirect:/uat/uia/egovLoginUsr.do", viewName);
+		assertEquals("fail.common.login", model.get("message"));
+	}
+
+	private static EgovPropertyService fixedPropertyService() {
+		return (EgovPropertyService) java.lang.reflect.Proxy.newProxyInstance(
+				EgovPropertyService.class.getClassLoader(),
+				new Class<?>[] { EgovPropertyService.class },
+				(proxy, method, args) -> {
+					Class<?> returnType = method.getReturnType();
+					if (returnType == boolean.class) {
+						return false;
+					}
+					if (returnType == int.class) {
+						return 10;
+					}
+					if (returnType == long.class) {
+						return 0L;
+					}
+					if (returnType == float.class) {
+						return 0F;
+					}
+					if (returnType == double.class) {
+						return 0D;
+					}
+					if (returnType == String.class) {
+						return "";
+					}
+					if (returnType == String[].class) {
+						return new String[0];
+					}
+					if (Iterator.class.isAssignableFrom(returnType)) {
+						return Collections.emptyIterator();
+					}
+					return null;
+				});
+	}
+
+	private static class FixedMessageSource extends EgovMessageSource {
+
+		@Override
+		public String getMessage(String code) {
+			return code;
+		}
+	}
+
+	private static class FixedUserDetailsService implements EgovUserDetailsService {
+
+		private final boolean authenticated;
+
+		FixedUserDetailsService(boolean authenticated) {
+			this.authenticated = authenticated;
+		}
+
+		@Override
+		public Object getAuthenticatedUser() {
+			return null;
+		}
+
+		@Override
+		public List<String> getAuthorities() {
+			return Collections.emptyList();
+		}
+
+		@Override
+		public Boolean isAuthenticated() {
+			return authenticated;
+		}
+	}
+
+	private static class RecordingQustnrManageService implements EgovQustnrManageService {
+
+		private int deleteCount;
+
+		@Override
+		public List<EgovMap> selectQustnrTmplatManageList(QustnrManageVO qustnrManageVO) {
+			return Collections.emptyList();
+		}
+
+		@Override
+		public List<EgovMap> selectQustnrManageList(ComDefaultVO searchVO) {
+			return Collections.emptyList();
+		}
+
+		@Override
+		public List<EgovMap> selectQustnrManageDetail(QustnrManageVO qustnrManageVO) {
+			return Collections.emptyList();
+		}
+
+		@Override
+		public QustnrManageVO selectQustnrManageDetailModel(QustnrManageVO qustnrManageVO) {
+			return new QustnrManageVO();
+		}
+
+		@Override
+		public int selectQustnrManageListCnt(ComDefaultVO searchVO) {
+			return 0;
+		}
+
+		@Override
+		public void insertQustnrManage(QustnrManageVO qustnrManageVO) {
+		}
+
+		@Override
+		public void updateQustnrManage(QustnrManageVO qustnrManageVO) {
+		}
+
+		@Override
+		public void deleteQustnrManage(QustnrManageVO qustnrManageVO) {
+			deleteCount++;
+		}
+	}
+}


### PR DESCRIPTION
## 개요
- 설문관리 목록 팝업, 목록, 상세 화면의 `cmd=del` 삭제 요청에서 인증 상태를 먼저 확인하도록 보완했습니다.
- 미인증 삭제 요청은 기존 등록/수정 경로와 동일하게 로그인 화면으로 이동시킵니다.
- 세 삭제 경로가 미인증 상태에서 삭제 서비스로 내려가지 않는지 단위 테스트를 추가했습니다.

## 필수성 검증
- 기존 컨트롤러는 `cmd=del` 요청을 받으면 인증 확인 전에 `deleteQustnrManage(...)`를 호출했습니다.
- 설문 삭제는 설문관리 데이터와 연결된 설문 항목, 문항, 응답자, 결과 데이터까지 영향을 주는 파괴적 동작이므로 조회 엔드포인트에 붙은 삭제 분기는 컨트롤러 레벨에서 직접 보호되어야 합니다.
- 동일 테스트를 `upstream/main`에 얹어 실행하면 세 경로 모두 삭제 서비스가 호출되어 `expected: <0> but was: <1>`로 실패했습니다.
- 이 브랜치에서는 같은 테스트가 통과하여 미인증 삭제 요청이 삭제 서비스에 도달하지 않음을 확인했습니다.

## 검증
- `git diff --check`
- `mvn -B -Dtest=EgovQustnrManageControllerTest test`
  - 수정 브랜치: Tests run: 3, Failures: 0, Errors: 0
  - `upstream/main` + 동일 테스트: Tests run: 3, Failures: 3, Errors: 0 (기존 코드에서 삭제 서비스 호출 확인)
