### PR TITLE
fix: 코드수신 서비스 외부 OpenAPI 호출에 연결/읽기 타임아웃 추가

### DIFF
--- a/src/main/java/egovframework/com/sym/ccm/acr/service/impl/EgovAdministCodeRecptnServiceImpl.java
+++ b/src/main/java/egovframework/com/sym/ccm/acr/service/impl/EgovAdministCodeRecptnServiceImpl.java
@@ -55,6 +55,7 @@ import jakarta.annotation.Resource;
  *   2025.07.05  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-InefficientStringBuffering(StringBuffer 함수내에서 비문자열 연산 이용하여 직접 결합하는 코드 사용을 탐지. append 메소드 사용을 권장)
  *   2025.07.05  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-CloseResource(부적절한 자원 해제)
  *   2025.07.05  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-AssignmentInOperand(피연산자내에 할당문이 사용됨. 해당 코드를 복잡하고 가독성이 떨어지게 만듬)
+ *   2026.07.08  EricSeokgon      외부 OpenAPI 호출 시 응답 지연에 대비한 연결/읽기 타임아웃 설정 추가(CWE-400 자원 고갈 방지)
  *
  *      </pre>
  */
@@ -174,6 +175,8 @@ public class EgovAdministCodeRecptnServiceImpl extends EgovAbstractServiceImpl
 		conn.setRequestProperty("Accept", "*/*;q=0.9");
 		conn.setDoOutput(true);
 		conn.setUseCaches(false);
+		conn.setConnectTimeout(10000);
+		conn.setReadTimeout(30000);
 
 		if (conn.getResponseCode() >= 200 && conn.getResponseCode() <= 300) {
 			StringBuilder sb = new StringBuilder();
@@ -220,6 +223,8 @@ public class EgovAdministCodeRecptnServiceImpl extends EgovAbstractServiceImpl
 			conn.setRequestProperty("Accept", "*/*;q=0.9");
 			conn.setDoOutput(true);
 			conn.setUseCaches(false);
+			conn.setConnectTimeout(10000);
+			conn.setReadTimeout(30000);
 
 			if (conn.getResponseCode() >= 200 && conn.getResponseCode() <= 300) {
 				StringBuilder sb = new StringBuilder();

--- a/src/main/java/egovframework/com/sym/ccm/icr/service/impl/EgovInsttCodeRecptnServiceImpl.java
+++ b/src/main/java/egovframework/com/sym/ccm/icr/service/impl/EgovInsttCodeRecptnServiceImpl.java
@@ -56,6 +56,7 @@ import jakarta.annotation.Resource;
  *   2025.07.08  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-InefficientStringBuffering(StringBuffer 함수내에서 비문자열 연산 이용하여 직접 결합하는 코드 사용을 탐지. append 메소드 사용을 권장)
  *   2025.07.08  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-CloseResource(부적절한 자원 해제)
  *   2025.07.08  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-AssignmentInOperand(피연산자내에 할당문이 사용됨. 해당 코드를 복잡하고 가독성이 떨어지게 만듬)
+ *   2026.07.08  EricSeokgon      외부 OpenAPI 호출 시 응답 지연에 대비한 연결/읽기 타임아웃 설정 추가(CWE-400 자원 고갈 방지)
  *
  *      </pre>
  */
@@ -188,6 +189,8 @@ public class EgovInsttCodeRecptnServiceImpl extends EgovAbstractServiceImpl impl
 		conn.setRequestProperty("Accept", "*/*;q=0.9");
 		conn.setDoOutput(true);
 		conn.setUseCaches(false);
+		conn.setConnectTimeout(10000);
+		conn.setReadTimeout(30000);
 
 		if (conn.getResponseCode() >= 200 && conn.getResponseCode() <= 300) {
 			JSONParser jsonParser = new JSONParser();
@@ -234,6 +237,8 @@ public class EgovInsttCodeRecptnServiceImpl extends EgovAbstractServiceImpl impl
 			conn.setRequestProperty("Accept", "*/*;q=0.9");
 			conn.setDoOutput(true);
 			conn.setUseCaches(false);
+			conn.setConnectTimeout(10000);
+			conn.setReadTimeout(30000);
 
 			if (conn.getResponseCode() >= 200 && conn.getResponseCode() <= 300) {
 				JSONParser jsonParser = new JSONParser();


### PR DESCRIPTION
## 수정 사유
법정동코드/기관코드 수신 서비스가 공공데이터포털 OpenAPI를 `HttpURLConnection`으로 호출할 때 **연결/읽기 타임아웃을 설정하지 않아**, 외부 API가 응답하지 않거나 지연되면 호출 스레드가 무기한 대기(block)합니다. 배치·수신 처리 중 외부 지연이 그대로 애플리케이션 스레드 고갈로 이어질 수 있습니다(CWE-400 Uncontrolled Resource Consumption).

## 수정 내용
`openConnection()` 이후 연결/읽기 타임아웃을 명시적으로 설정했습니다.

- `conn.setConnectTimeout(10000)` (연결 10초)
- `conn.setReadTimeout(30000)` (읽기 30초)

적용 파일 (각 파일의 `numberOfRows()`, `apiLink()` 두 호출 지점):
- `EgovAdministCodeRecptnServiceImpl` (법정동코드 수신)
- `EgovInsttCodeRecptnServiceImpl` (기관코드 수신)

기존 요청 헤더·응답 처리 로직은 변경하지 않았고, 각 클래스 상단 개정이력(Modification Information) 표에 변경 행만 추가했습니다. 순수 추가 변경(10줄 추가, 0줄 삭제)입니다.

## 테스트 여부
- [x] 로컬 빌드/컴파일 확인
- [ ] 실 외부 API 연동 테스트 (타임아웃 값은 관례적 기본값이며 운영 환경에 맞춰 조정 가능)
