### PR TITLE
refactor: List.size()==0 대신 isEmpty() 사용 (PMD UseCollectionIsEmpty)

### DIFF
--- a/src/main/java/egovframework/com/sym/mnu/mcm/web/EgovMenuCreateManageController.java
+++ b/src/main/java/egovframework/com/sym/mnu/mcm/web/EgovMenuCreateManageController.java
@@ -45,6 +45,7 @@ import jakarta.validation.Valid;
  *   2018.08.09  신용호          X-XSS 관련 크롬에서 오탐되는 부분 수정
  *   2018.09.10  신용호          selectMenuCreatManagList 불필요한 로직 제거
  *   2025.07.17  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-LocalVariableNamingConventions(final이 아닌 변수는 밑줄을 포함할 수 없음)
+ *   2026.07.09  EricSeokgon      PMD UseCollectionIsEmpty: size() == 0 대신 isEmpty() 사용
  *
  *      </pre>
  */
@@ -111,7 +112,7 @@ public class EgovMenuCreateManageController {
 		 * searchVO.setSearchKeyword(vo.getAuthorCode()); } }
 		 */
 		List<EgovMap> resultList = menuCreateManageService.selectMenuCreatManagList(searchVO);
-		if (resultList.size() == 0) {
+		if (resultList.isEmpty()) {
 			resultMsg = egovMessageSource.getMessage("info.nodata.msg");
 		}
 		model.addAttribute("resultList", resultList);

--- a/src/main/java/egovframework/com/utl/sys/fsm/service/FileSystemChecker.java
+++ b/src/main/java/egovframework/com/utl/sys/fsm/service/FileSystemChecker.java
@@ -271,7 +271,7 @@ public class FileSystemChecker {
 				// os command problem, throw exception
 				throw new IOException("Command line returned OS error code '" + p.exitValue() + "' for command " + Arrays.asList(cmdAttribs));
 			}
-			if (lines.size() == 0) {
+			if (lines.isEmpty()) {
 				// unknown problem, throw exception
 				throw new IOException("Command line did not return any info " + "for command " + Arrays.asList(cmdAttribs));
 			}


### PR DESCRIPTION
## 수정 사유
컬렉션이 비었는지 확인할 때 `size() == 0` 대신 `isEmpty()`를 사용하는 것이 의도가 더 명확하고, 일부 컬렉션 구현에서는 size() 계산 비용을 피할 수 있습니다. 정적분석 도구(PMD UseCollectionIsEmpty, Sonar S1155)에서 권장하는 관용구입니다.

## 수정 내용
`List.size() == 0` → `List.isEmpty()`

| 파일 | 위치 |
|---|---|
| `.../utl/sys/fsm/service/FileSystemChecker.java` | `lines.size() == 0` |
| `.../sym/mnu/mcm/web/EgovMenuCreateManageController.java` | `resultList.size() == 0` |

동작은 완전히 동일하며(두 변수 모두 `List`), 코드 2줄 변경 + 개정이력 1행 추가입니다. Apache 라이선스 파생 파일(FileSystemUtils)은 대상에서 제외했습니다.

## 테스트 여부
- [x] 로컬 컴파일 확인
