### PR TITLE
refactor: 지역 StringBuffer를 StringBuilder로 변경 (불필요한 동기화 제거)

### DIFF
--- a/src/main/java/egovframework/com/uss/ion/noi/service/impl/EgovNotificationServiceImpl.java
+++ b/src/main/java/egovframework/com/uss/ion/noi/service/impl/EgovNotificationServiceImpl.java
@@ -28,6 +28,7 @@ import jakarta.annotation.Resource;
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.06.08  한성곤          최초 생성
+ *   2026.07.09  EricSeokgon      지역 StringBuffer를 StringBuilder로 변경(불필요한 동기화 제거)
  *
  * </pre>
  */
@@ -50,14 +51,14 @@ public class EgovNotificationServiceImpl extends EgovAbstractServiceImpl impleme
 
     @Override
     public void insertNotificationInf(NotificationVO notificationVO) throws Exception {
-        StringBuffer time = new StringBuffer();
+        StringBuilder time = new StringBuilder();
         time.append(notificationVO.getNtfcDate().replaceAll("-", ""));
         time.append(notificationVO.getNtfcHH().length() == 1 ? "0" + notificationVO.getNtfcHH() : notificationVO.getNtfcHH());
         time.append(notificationVO.getNtfcMM().length() == 1 ? "0" + notificationVO.getNtfcMM() : notificationVO.getNtfcMM());
         time.append("00");
         notificationVO.setNtfcTime(time.toString());
 
-        StringBuffer interval = new StringBuffer();
+        StringBuilder interval = new StringBuilder();
         String[] array = notificationVO.getBhNtfcIntrvl();
         if (array == null) {
             throw new RuntimeException("Method insertNotificationInf : array is null\n");
@@ -80,14 +81,14 @@ public class EgovNotificationServiceImpl extends EgovAbstractServiceImpl impleme
 
     @Override
     public void updateNotifictionInf(NotificationVO notificationVO) throws Exception {
-        StringBuffer time = new StringBuffer();
+        StringBuilder time = new StringBuilder();
         time.append(notificationVO.getNtfcDate().replaceAll("-", ""));
         time.append(notificationVO.getNtfcHH().length() == 1 ? "0" + notificationVO.getNtfcHH() : notificationVO.getNtfcHH());
         time.append(notificationVO.getNtfcMM().length() == 1 ? "0" + notificationVO.getNtfcMM() : notificationVO.getNtfcMM());
         time.append("00");
         notificationVO.setNtfcTime(time.toString());
 
-        StringBuffer interval = new StringBuffer();
+        StringBuilder interval = new StringBuilder();
         String[] array = notificationVO.getBhNtfcIntrvl();
         if (array != null) {
             for (int i = 0; i < array.length; i++) {
@@ -109,7 +110,7 @@ public class EgovNotificationServiceImpl extends EgovAbstractServiceImpl impleme
 
     @Override
     public boolean checkNotification(NotificationVO notificationVO) throws Exception {
-        StringBuffer time = new StringBuffer();
+        StringBuilder time = new StringBuilder();
         time.append(notificationVO.getNtfcDate().replaceAll("-", ""));
         time.append(notificationVO.getNtfcHH().length() == 1 ? "0" + notificationVO.getNtfcHH() : notificationVO.getNtfcHH());
         time.append(notificationVO.getNtfcMM().length() == 1 ? "0" + notificationVO.getNtfcMM() : notificationVO.getNtfcMM());

--- a/src/main/java/egovframework/com/utl/fcc/service/EgovNumberUtil.java
+++ b/src/main/java/egovframework/com/utl/fcc/service/EgovNumberUtil.java
@@ -6,6 +6,7 @@
  *     수정일         수정자                   수정내용
  *     -------          --------        ---------------------------
  *   2009.02.13       이삼섭                  최초 생성
+ *   2026.07.09       EricSeokgon             지역 StringBuffer를 StringBuilder로 변경(불필요한 동기화 제거)
  *
  * @author 공통 서비스 개발팀 이삼섭
  * @since 2009. 02. 13
@@ -176,7 +177,7 @@ public class EgovNumberUtil {
 		String subject = String.valueOf(cnvrSrcNumber);
 		String object = String.valueOf(cnvrTrgtNumber);
 
-		StringBuffer rtnStr = new StringBuffer();
+		StringBuilder rtnStr = new StringBuilder();
 		String preStr = "";
 		String nextStr = source;
 

--- a/src/main/java/egovframework/com/utl/wed/filter/DirectoryPathManager.java
+++ b/src/main/java/egovframework/com/utl/wed/filter/DirectoryPathManager.java
@@ -64,7 +64,7 @@ public class DirectoryPathManager {
 	public static String getDirectoryPathByDateType(DIR_DATE_TYPE policy) {
 
 		Calendar calendar = Calendar.getInstance();
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append(calendar.get(Calendar.YEAR)).append(File.separator);
 		if (policy.ordinal() <= DIR_DATE_TYPE.DATE_POLICY_YYYY_MM.ordinal()) {
 			sb.append(StringUtils.leftPad(String.valueOf(calendar.get(Calendar.MONTH)+1), 2, '0')).append(File.separator);


### PR DESCRIPTION
## 수정 사유
단일 스레드 메서드 내부에서만 사용하는 지역 변수에 동기화 비용이 있는 `StringBuffer` 대신 `StringBuilder`를 사용하도록 변경했습니다. 저장소 코딩 컨벤션(지역 문자열 버퍼는 StringBuilder 사용)과 일치하며, 정적분석 도구에서도 권장하는 개선입니다.

## 수정 내용
메서드 지역 변수 `StringBuffer` → `StringBuilder` (append/toString 용도만 사용, 필드·반환형·파라미터 아님)

| 파일 | 변경 수 |
|---|---|
| `.../utl/fcc/service/EgovNumberUtil.java` | 1곳 |
| `.../utl/wed/filter/DirectoryPathManager.java` | 1곳 |
| `.../uss/ion/noi/service/impl/EgovNotificationServiceImpl.java` | 5곳 |

모든 대상은 메서드 내부 지역 변수로, 외부 노출(필드/반환/파라미터)이 없어 동작은 완전히 동일합니다.

## 테스트 여부
- [x] 로컬 컴파일 확인
