### PR TITLE
refactor: 지역 StringBuffer를 StringBuilder로 변경 2차 (불필요한 동기화 제거)

### DIFF
--- a/src/main/java/egovframework/com/cmm/filter/HTMLTagFilterRequestWrapper.java
+++ b/src/main/java/egovframework/com/cmm/filter/HTMLTagFilterRequestWrapper.java
@@ -37,6 +37,7 @@ import jakarta.servlet.http.HttpServletRequestWrapper;
  *   2018.03.21  신용호          getParameterMap()구현 추가
  *   2019.01.31  신용호          whiteList 태그 추가
  *   2025.05.24  이백행          PMD로 소프트웨어 보안약점 진단하고 제거하기-SimplifyBooleanExpressions(부울 표현식 단순화), AvoidReassigningParameters(매개변수 재할당 방지)
+ *   2026.07.09  EricSeokgon      지역 StringBuffer를 StringBuilder로 변경(불필요한 동기화 제거)
  *
  *      </pre>
  */
@@ -114,7 +115,7 @@ public class HTMLTagFilterRequestWrapper extends HttpServletRequestWrapper {
 	}
 
 	private String getSafeParamData(String value) {
-		StringBuffer strBuff = new StringBuffer();
+		StringBuilder strBuff = new StringBuilder();
 
 		for (int i = 0; i < value.length(); i++) {
 			char c = value.charAt(i);

--- a/src/main/java/egovframework/com/utl/fcc/service/EgovStringUtil.java
+++ b/src/main/java/egovframework/com/utl/fcc/service/EgovStringUtil.java
@@ -8,6 +8,7 @@
  *   2009.01.13     박정규          최초 생성
  *   2009.02.13     이삼섭          내용 추가
  *   2024.10.29		Chung10Kr		명사에 맞는 조사 반환 기능 개발
+ *   2026.07.09     EricSeokgon     지역 StringBuffer를 StringBuilder로 변경(불필요한 동기화 제거)
  *
  * @author 공통 서비스 개발팀 박정규
  * @since 2009. 01. 13
@@ -194,7 +195,7 @@ public class EgovStringUtil {
 	 * @return sb.toString() 새로운 문자열로 변환된 문자열
 	 */
 	public static String replace(String source, String subject, String object) {
-		StringBuffer rtnStr = new StringBuffer();
+		StringBuilder rtnStr = new StringBuilder();
 		String preStr = "";
 		String nextStr = source;
 		String srcStr = source;
@@ -218,7 +219,7 @@ public class EgovStringUtil {
 	 * @return sb.toString() 새로운 문자열로 변환된 문자열 / source 특정문자열이 없는 경우 원본 문자열
 	 */
 	public static String replaceOnce(String source, String subject, String object) {
-		StringBuffer rtnStr = new StringBuffer();
+		StringBuilder rtnStr = new StringBuilder();
 		String preStr = "";
 		String nextStr = source;
 		if (source.indexOf(subject) >= 0) {
@@ -241,7 +242,7 @@ public class EgovStringUtil {
 	 * @return sb.toString() 새로운 문자열로 변환된 문자열
 	 */
 	public static String replaceChar(String source, String subject, String object) {
-		StringBuffer rtnStr = new StringBuffer();
+		StringBuilder rtnStr = new StringBuilder();
 		String preStr = "";
 		String nextStr = source;
 		String srcStr = source;
@@ -509,7 +510,7 @@ public class EgovStringUtil {
 	public static String checkHtmlView(String strString) {
 		String strNew = "";
 
-		StringBuffer strTxt = new StringBuffer("");
+		StringBuilder strTxt = new StringBuilder("");
 
 		char chrBuff;
 		int len = strString.length();
@@ -826,7 +827,7 @@ public class EgovStringUtil {
 
 		String rtnStr = null;
 
-		StringBuffer strTxt = new StringBuffer("");
+		StringBuilder strTxt = new StringBuilder("");
 
 		char chrBuff;
 		int len = srcString.length();

--- a/src/main/java/egovframework/com/utl/sim/service/EgovFileTool.java
+++ b/src/main/java/egovframework/com/utl/sim/service/EgovFileTool.java
@@ -52,6 +52,7 @@ import egovframework.com.utl.fcc.service.EgovStringUtil;
  *  2022.11.11   김혜준       시큐어코딩 처리
  *  2024.10.29   win777	    디렉토리 생성 성공 시 생성된 절대경로를 리턴하도록 변경
  *  2025.02.06   신용호       deleteFile() KISA 시큐어코딩 처리
+ *  2026.07.09   EricSeokgon  지역 StringBuffer를 StringBuilder로 변경(불필요한 동기화 제거)
  *
  * </pre>
  */
@@ -366,9 +367,9 @@ public class EgovFileTool {
 			// 파일이며, 존재하면 파싱 시작
 			if (file.exists() && file.isFile()) {
 
-				// 1. 파일 텍스트 내용을 읽어서 StringBuffer에 쌓는다.
+				// 1. 파일 텍스트 내용을 읽어서 StringBuilder에 쌓는다.
 				br = new BufferedReader(new InputStreamReader(new FileInputStream(file)));
-				StringBuffer strBuff = new StringBuffer();
+				StringBuilder strBuff = new StringBuilder();
 				String line = "";
 				while ((line = br.readLine()) != null) {
 					if (line.length() < MAX_STR_LEN) {


### PR DESCRIPTION
## 수정 사유
단일 스레드 메서드 내부에서만 사용하는 지역 변수를 동기화 비용이 있는 `StringBuffer` 대신 `StringBuilder`로 변경했습니다. 저장소 코딩 컨벤션과 일치하는 개선입니다. (#1138의 후속)

## 수정 내용
메서드 지역 변수 `StringBuffer` → `StringBuilder`

| 파일 | 변경 수 |
|---|---|
| `.../utl/fcc/service/EgovStringUtil.java` | 5곳 |
| `.../cmm/filter/HTMLTagFilterRequestWrapper.java` | 1곳 |
| `.../utl/sim/service/EgovFileTool.java` | 1곳 (+주석 표기 1) |

모든 대상은 메서드 내부 지역 변수(필드·반환형·파라미터 아님)로 동작은 완전히 동일합니다.

## 테스트 여부
- [x] 로컬 컴파일 확인
