### PR TITLE
fix: 모니터링 스케줄러의 문자열 상태값을 ==(참조) 대신 equals()로 비교

### DIFF
--- a/src/main/java/egovframework/com/utl/sys/htm/service/HttpMntrngScheduling.java
+++ b/src/main/java/egovframework/com/utl/sys/htm/service/HttpMntrngScheduling.java
@@ -26,6 +26,7 @@ import jakarta.annotation.Resource;
  *    2010.09.01   박종선      최초생성
  *    2019.12.06   신용호      KISA 보안약점 조치 (부적절한 예외처리)
  *    2022.11.11   김혜준      시큐어코딩 처리
+ *    2026.07.10   EricSeokgon 문자열 상태값을 ==(참조) 대신 equals()로 비교하도록 수정(PMD/Sonar S4973)
  *
  * @author 박종선
  * @since 2010.05.01
@@ -109,7 +110,7 @@ public class HttpMntrngScheduling extends EgovAbstractServiceImpl {
 				nrmltAt = false;
 			}
 
-			if (httpSttusCd == "02") {
+			if ("02".equals(httpSttusCd)) {
 				nrmltAt = false;
 			}
 
@@ -121,7 +122,7 @@ public class HttpMntrngScheduling extends EgovAbstractServiceImpl {
 
 			// DB에 결과값 저장
 			target.setHttpSttusCd(httpSttusCd);
-			if (httpSttusCd == "02") {
+			if ("02".equals(httpSttusCd)) {
 				target.setLogInfo("Connection timed out: connect");
 			}
 

--- a/src/main/java/egovframework/com/utl/sys/prm/service/EgovProcessMonScheduling.java
+++ b/src/main/java/egovframework/com/utl/sys/prm/service/EgovProcessMonScheduling.java
@@ -30,6 +30,7 @@ import jakarta.annotation.Resource;
  *  ----------   --------   ---------------------------
  *  2019.12.06   신용호             KISA 보안약점 조치 (부적절한 예외처리)
  *  2022.11.11   김혜준             시큐어코딩 처리
+ *  2026.07.10   EricSeokgon        문자열 상태값을 ==(참조) 대신 equals()로 비교하도록 수정(PMD/Sonar S4973)
  *
  * </pre>
  */
@@ -101,7 +102,7 @@ public class EgovProcessMonScheduling extends EgovAbstractServiceImpl {
 				nrmltAt = false;
 			}
 
-			if (procsSttus == "02") {
+			if ("02".equals(procsSttus)) {
 				nrmltAt = false;
 			}
 
@@ -113,7 +114,7 @@ public class EgovProcessMonScheduling extends EgovAbstractServiceImpl {
 
 			// DB에 결과값 저장
 			target.setProcsSttus(procsSttus);
-			if (procsSttus == "02") {
+			if ("02".equals(procsSttus)) {
 				target.setLogInfo("실행 중인 작업 중 지정된 조건에 일치하는 작업이 없습니다.");
 			}
 


### PR DESCRIPTION
## 수정 사유
프로세스/HTTP 모니터링 스케줄러가 상태 코드 문자열을 `==`(참조 비교)로 검사하고 있습니다.

```java
// EgovProcessMonScheduling.java
String procsSttus = ProcessMonChecker.getProcessId(processNm); // 메서드 반환값
if (procsSttus == "02") { ... }   // 참조 비교

// HttpMntrngScheduling.java
String httpSttusCd = HttpMntrngChecker.getPrductStatus(siteUrl);
if (httpSttusCd == "02") { ... }  // 참조 비교
```

현재는 두 Checker가 상태값을 문자열 **리터럴** `"02"`로 반환해 JVM 문자열 인터닝 덕분에 우연히 동작하지만, `==`로 문자열을 비교하는 것은 정적분석 도구가 **버그로 분류**하는 항목입니다(PMD `CompareObjectsWithEquals`, SonarQube `S4973`). 반환 로직이 계산식·`substring`·`trim`·외부 입력 등 인터닝되지 않은 문자열을 돌려주도록 조금만 바뀌어도 상태 판정(정상/비정상, 알림 전송, 로그 기록)이 **조용히 실패**하게 됩니다.

## 수정 내용
문자열 비교를 `상수.equals(변수)` 형태로 변경했습니다(널 안전, 저장소 컨벤션과 동일). 값 `"02"`에 대한 결과는 동일하며 동작 회귀는 없습니다.

| 파일 | 위치 |
|---|---|
| `.../utl/sys/prm/service/EgovProcessMonScheduling.java` | 2곳 |
| `.../utl/sys/htm/service/HttpMntrngScheduling.java` | 2곳 |

코드 4곳 변경 + 각 파일 개정이력 1행 추가입니다.

## 테스트 여부
- [x] 로컬 컴파일 확인
