### PR TITLE
perf: 모니터링 스케줄러 이메일 본문 생성 시 문자열 연결(+=)을 StringBuilder로 변경

### DIFF
--- a/src/main/java/egovframework/com/utl/sys/fsm/service/EgovFileSystemMntrngScheduling.java
+++ b/src/main/java/egovframework/com/utl/sys/fsm/service/EgovFileSystemMntrngScheduling.java
@@ -38,6 +38,7 @@ import jakarta.annotation.Resource;
  *  2017.03.03 	 조성원 	시큐어코딩(ES)-Null Pointer 역참조[CWE-476]
  *  2022.11.11   김혜준   시큐어코딩 처리
  *  2024.05.02   김수용   NSR 보안조치 (파일시스템명에서 악의적인 문자열 제거)
+ *  2026.07.10   EricSeokgon   이메일 본문 생성 시 문자열 연결(+=)을 StringBuilder로 변경(불필요한 중간 String 생성 제거)
  *
  */
 
@@ -164,36 +165,38 @@ public class EgovFileSystemMntrngScheduling extends EgovAbstractServiceImpl {
         // 2022.11.11 시큐어코딩 처리
      	if (StringUtils.isNotEmpty(text)) {
 	        text = EgovStringUtil.replace(text, "{모니터링종류}", "파일시스템모니터링");
-	        errorContents = "파일시스템명 : ";
-	        errorContents += target.getFileSysNm();
-	        errorContents += "\n";
-	        errorContents += "파일시스템관리명 : ";
-	        errorContents += target.getFileSysManageNm();
-	        errorContents += "\n";
+	        StringBuilder errorContentsBuilder = new StringBuilder();
+	        errorContentsBuilder.append("파일시스템명 : ");
+	        errorContentsBuilder.append(target.getFileSysNm());
+	        errorContentsBuilder.append("\n");
+	        errorContentsBuilder.append("파일시스템관리명 : ");
+	        errorContentsBuilder.append(target.getFileSysManageNm());
+	        errorContentsBuilder.append("\n");
 	        if(target.getLogInfo() != null && !target.getLogInfo().equals("")){
-	        	errorContents += "해당파일의 파일시스템 정보를 가져오는중 에러가 발생하였습니다.";
+	        	errorContentsBuilder.append("해당파일의 파일시스템 정보를 가져오는중 에러가 발생하였습니다.");
 	        }else{
-		        errorContents += "크기 : ";
-		        errorContents += target.getFileSysMg();
-		        errorContents += "GB\n";
-		        errorContents += "임계치 : ";
-		        errorContents += target.getFileSysThrhld();
-		        errorContents += "GB\n";
-		        errorContents += "사용량 : ";
-		        errorContents += target.getFileSysUsgQty();
-		        errorContents += "GB\n";
+		        errorContentsBuilder.append("크기 : ");
+		        errorContentsBuilder.append(target.getFileSysMg());
+		        errorContentsBuilder.append("GB\n");
+		        errorContentsBuilder.append("임계치 : ");
+		        errorContentsBuilder.append(target.getFileSysThrhld());
+		        errorContentsBuilder.append("GB\n");
+		        errorContentsBuilder.append("사용량 : ");
+		        errorContentsBuilder.append(target.getFileSysUsgQty());
+		        errorContentsBuilder.append("GB\n");
 	        }
-	        errorContents += "상태 : ";
-	        errorContents += target.getMntrngSttus();
-	        errorContents += "\n";
-	        errorContents += "모니터링 시각 : ";
-	        errorContents += EgovDateUtil.convertDate(target.getCreatDt(), "", "", "");
-	        errorContents += "\n";
+	        errorContentsBuilder.append("상태 : ");
+	        errorContentsBuilder.append(target.getMntrngSttus());
+	        errorContentsBuilder.append("\n");
+	        errorContentsBuilder.append("모니터링 시각 : ");
+	        errorContentsBuilder.append(EgovDateUtil.convertDate(target.getCreatDt(), "", "", ""));
+	        errorContentsBuilder.append("\n");
 	        if(target.getLogInfo() != null && !target.getLogInfo().equals("")){
-	        	errorContents += target.getFileSysManageNm() + " 의 파일시스템 상태가 비정상입니다.  \n로그를 확인해주세요.";
+	        	errorContentsBuilder.append(target.getFileSysManageNm()).append(" 의 파일시스템 상태가 비정상입니다.  \n로그를 확인해주세요.");
 	        }else{
-	        	errorContents += target.getFileSysManageNm() + " 의 파일시스템이 임계치를 넘었습니다.";
+	        	errorContentsBuilder.append(target.getFileSysManageNm()).append(" 의 파일시스템이 임계치를 넘었습니다.");
 	        }
+	        errorContents = errorContentsBuilder.toString();
 	        text = EgovStringUtil.replace(text, "{에러내용}", errorContents);
 	        msg.setText(text);
      	}

--- a/src/main/java/egovframework/com/utl/sys/srm/service/EgovServerResrceMntrngScheduling.java
+++ b/src/main/java/egovframework/com/utl/sys/srm/service/EgovServerResrceMntrngScheduling.java
@@ -46,6 +46,7 @@ import jakarta.annotation.Resource;
  *  ----------   ---------   ---------------------------
  *  2020.11.02   신용호              불필요한 멤버변수 지역변수로 변경
  *  2022.11.11   김혜준              시큐어코딩 처리
+ *  2026.07.10   EricSeokgon         이메일 본문 생성 시 문자열 연결(+=)을 StringBuilder로 변경(불필요한 중간 String 생성 제거)
  *
  * </pre>
  */
@@ -221,27 +222,29 @@ public class EgovServerResrceMntrngScheduling extends EgovAbstractServiceImpl {
 		// 2022.11.11 시큐어코딩 처리
 		if (StringUtils.isNotEmpty(text)) {
 			text = EgovStringUtil.replace(text, "{모니터링종류}", "서버자원서비스모니터링");
-			errorContents = "서버명 : ";
-			errorContents += serverResrceMntrng.getServerNm();
-			errorContents += "\n";
-			errorContents += "서버IP : ";
-			errorContents += serverResrceMntrng.getServerEqpmnIp();
-			errorContents += "\n";
-			errorContents += "CPU사용률 : ";
-			errorContents += serverResrceMntrng.getCpuUseRt();
-			errorContents += "\n";
-			errorContents += "메모리사용률 : ";
-			errorContents += serverResrceMntrng.getMoryUseRt();
-			errorContents += "\n";
-			errorContents += "서비스상태 : 비정상";
-			errorContents += "\n";
-			errorContents += "내용 : ";
-			errorContents += serverResrceMntrng.getLogInfo();
-			errorContents += "\n";
-			errorContents += "생성일시 : ";
-			errorContents += EgovDateUtil.convertDate(serverResrceMntrng.getCreatDt(), "", "", "");
-			errorContents += "\n";
-			errorContents += serverResrceMntrng.getServerNm() + " 의 서버자원 서비스 상태가 비정상입니다. \n로그를 확인해주세요.";
+			StringBuilder errorContentsBuilder = new StringBuilder();
+			errorContentsBuilder.append("서버명 : ");
+			errorContentsBuilder.append(serverResrceMntrng.getServerNm());
+			errorContentsBuilder.append("\n");
+			errorContentsBuilder.append("서버IP : ");
+			errorContentsBuilder.append(serverResrceMntrng.getServerEqpmnIp());
+			errorContentsBuilder.append("\n");
+			errorContentsBuilder.append("CPU사용률 : ");
+			errorContentsBuilder.append(serverResrceMntrng.getCpuUseRt());
+			errorContentsBuilder.append("\n");
+			errorContentsBuilder.append("메모리사용률 : ");
+			errorContentsBuilder.append(serverResrceMntrng.getMoryUseRt());
+			errorContentsBuilder.append("\n");
+			errorContentsBuilder.append("서비스상태 : 비정상");
+			errorContentsBuilder.append("\n");
+			errorContentsBuilder.append("내용 : ");
+			errorContentsBuilder.append(serverResrceMntrng.getLogInfo());
+			errorContentsBuilder.append("\n");
+			errorContentsBuilder.append("생성일시 : ");
+			errorContentsBuilder.append(EgovDateUtil.convertDate(serverResrceMntrng.getCreatDt(), "", "", ""));
+			errorContentsBuilder.append("\n");
+			errorContentsBuilder.append(serverResrceMntrng.getServerNm()).append(" 의 서버자원 서비스 상태가 비정상입니다. \n로그를 확인해주세요.");
+			errorContents = errorContentsBuilder.toString();
 			text = EgovStringUtil.replace(text, "{에러내용}", errorContents);
 			msg.setText(text);
 		}


### PR DESCRIPTION
## 수정 사유
파일시스템·서버자원 모니터링 스케줄러의 `sendEmail(...)`은 알림 메일 본문(`errorContents`)을 만들 때 지역 `String`에 `+=`로 20여 회 연속 연결합니다. 자바에서 `String += ...`는 매 문장마다 새 `StringBuilder`를 만들고 기존 문자열 전체를 복사해 새 `String`을 생성하므로, 연결 횟수에 따라 중간 `String` 객체가 반복 생성됩니다(문자 복사량 기준 O(n²)). PMD `ConsecutiveAppendsShouldReuse`·`InefficientStringBuffering`, Sonar가 지적하는 항목입니다.

## 수정 내용
- 각 메서드 내에서 단일 `StringBuilder`(`errorContentsBuilder`)에 `append`로 누적한 뒤 마지막에 `errorContents = errorContentsBuilder.toString()`으로 대입하도록 변경
- 출력 문자열·분기 로직은 그대로이며 결과 메일 본문은 동일합니다(널 값도 기존과 같이 `"null"`로 처리 — `Integer` 게터는 `append(Object)` 오버로드가 선택되어 `+=`와 동작 동일)

| 파일 | 위치 |
|---|---|
| `.../utl/sys/fsm/service/EgovFileSystemMntrngScheduling.java` | `sendEmail(FileSysMntrng)` |
| `.../utl/sys/srm/service/EgovServerResrceMntrngScheduling.java` | `sendEmail(ServerResrceMntrng)` |

각 파일 개정이력 1행 추가.

## 테스트 여부
- [x] 로컬 컴파일 확인
- [x] 변경 전후 생성 문자열 동일성 검토(문구·개행·분기 보존)