### PR TITLE
refactor: 파일업로드 유틸리티 InputStream을 try-with-resources로 전환

### DIFF
--- a/src/main/java/egovframework/com/utl/fcc/service/EgovFileUploadUtil.java
+++ b/src/main/java/egovframework/com/utl/fcc/service/EgovFileUploadUtil.java
@@ -27,6 +27,7 @@ import jakarta.servlet.http.HttpServletRequest;
  *  2020.08.05   신용호            uploadFilesExt Parameter 수정
  *  2021.02.16   신용호            WebUtils.getNativeRequest(request,MultipartHttpServletRequest.class);
  *  2022.11.11   김혜준            시큐어코딩 처리
+ *  2026.07.10   EricSeokgon      InputStream 자원 처리를 try-with-resources로 변경(자원 누수 방지, java:S2093)
  *
  * @author 공통컴포넌트 개발팀 한성곤
  * @since 2009.08.26
@@ -80,16 +81,9 @@ public class EgovFileUploadUtil extends EgovFormBasedFileUtil {
 					}
 
 					if (mFile.getSize() > 0) {
-						InputStream is = null;
-
-						try {
-							is = mFile.getInputStream();
+						try (InputStream is = mFile.getInputStream()) {
 							saveFile(is, new File(EgovWebUtil.filePathBlackList(
 								where + SEPERATOR + vo.getServerSubPath() + SEPERATOR + vo.getPhysicalName())));
-						} finally {
-							if (is != null) {
-								is.close();
-							}
 						}
 						list.add(vo);
 					}
@@ -159,16 +153,9 @@ public class EgovFileUploadUtil extends EgovFormBasedFileUtil {
 					}
 
 					if (fileSize > 0) {
-						InputStream is = null;
-
-						try {
-							is = mFile.getInputStream();
+						try (InputStream is = mFile.getInputStream()) {
 							String fullPath = where + SEPERATOR + vo.getServerSubPath() + SEPERATOR + vo.getPhysicalName() + "_upfile";
 							saveFile(is, new File(EgovWebUtil.filePathBlackList( fullPath )));
-						} finally {
-							if (is != null) {
-								is.close();
-							}
 						}
 						list.add(vo);
 					}


### PR DESCRIPTION
## 수정 사유
`EgovFileUploadUtil`의 파일 저장 로직 2곳이 `InputStream`을 `try/finally`에서 수동으로 닫고 있습니다. 이 패턴은 자원 누수를 완전히 막지 못할 수 있고(널 체크·중첩 예외 처리 누락 위험), PMD/Sonar의 `java:S2093`(try-with-resources 사용 권장)가 지적하는 항목입니다.

## 수정 내용
- `InputStream is = null; try { is = mFile.getInputStream(); ... } finally { if(is!=null) is.close(); }` 패턴 2곳을 `try (InputStream is = mFile.getInputStream()) { ... }`로 전환
- 자원은 정확히 한 번 닫히며 동작은 동일합니다. `close()` 중 예외는 try-with-resources가 표준 방식(suppressed)으로 처리하므로 안전성이 오히려 향상됩니다.
- 두 메서드 모두 기존에 `throws Exception`을 선언하고 있어 시그니처 변경은 없습니다.

| 파일 | 메서드 |
|---|---|
| `.../utl/fcc/service/EgovFileUploadUtil.java` | `uploadFiles(...)`, `uploadFilesExt(...)` |

개정이력 1행 추가.

## 테스트 여부
- [x] 로컬 컴파일 확인
- [x] 변경 전후 자원 종료·예외 전파 동작 동일성 검토