### PR TITLE
시스템이력 ID의 중복 생성 방지

### DIFF
--- a/src/main/java/egovframework/com/sym/log/slg/service/impl/EgovSysHistoryServiceImpl.java
+++ b/src/main/java/egovframework/com/sym/log/slg/service/impl/EgovSysHistoryServiceImpl.java
@@ -10,7 +10,6 @@ import org.springframework.ui.ModelMap;
 import egovframework.com.sym.log.slg.service.EgovSysHistoryService;
 import egovframework.com.sym.log.slg.service.SysHistory;
 import egovframework.com.sym.log.slg.service.SysHistoryVO;
-import egovframework.com.utl.fcc.service.EgovStringUtil;
 import jakarta.annotation.Resource;
 
 /**
@@ -35,6 +34,8 @@ public class EgovSysHistoryServiceImpl extends EgovAbstractServiceImpl implement
 	@Resource(name="sysHistoryDAO")
 	private SysHistoryDAO sysHistoryDAO;
 
+	private final SysHistoryIdGenerator sysHistoryIdGenerator = new SysHistoryIdGenerator();
+
 	/**
 	 * 시스템 이력정보를 등록한다.
 	 * @param history - 시스템 이력정보가 담긴 모델 객체
@@ -43,10 +44,7 @@ public class EgovSysHistoryServiceImpl extends EgovAbstractServiceImpl implement
 	 */
 	@Override
 	public Map<?, ?> insertSysHistory(SysHistory history) throws Exception {
-
-//		String histId = "HIST_"+20091021144553005; yyyyMMddhhmmssSSS
-		String histId = "HT_"+EgovStringUtil.getTimeStamp();
-		history.setHistId(histId);
+		history.setHistId(sysHistoryIdGenerator.getNextId());
 
 		sysHistoryDAO.insertSysHistory(history);
 

--- a/src/main/java/egovframework/com/sym/log/slg/service/impl/EgovSysHistoryServiceImpl.java
+++ b/src/main/java/egovframework/com/sym/log/slg/service/impl/EgovSysHistoryServiceImpl.java
@@ -10,7 +10,6 @@ import org.springframework.ui.ModelMap;
 import egovframework.com.sym.log.slg.service.EgovSysHistoryService;
 import egovframework.com.sym.log.slg.service.SysHistory;
 import egovframework.com.sym.log.slg.service.SysHistoryVO;
-import egovframework.com.utl.fcc.service.EgovStringUtil;
 import jakarta.annotation.Resource;
 
 /**
@@ -32,6 +31,8 @@ import jakarta.annotation.Resource;
 public class EgovSysHistoryServiceImpl extends EgovAbstractServiceImpl implements
 		EgovSysHistoryService {
 
+	private static final SysHistoryIdGenerator SYS_HISTORY_ID_GENERATOR = new SysHistoryIdGenerator();
+
 	@Resource(name="sysHistoryDAO")
 	private SysHistoryDAO sysHistoryDAO;
 
@@ -43,10 +44,7 @@ public class EgovSysHistoryServiceImpl extends EgovAbstractServiceImpl implement
 	 */
 	@Override
 	public Map<?, ?> insertSysHistory(SysHistory history) throws Exception {
-
-//		String histId = "HIST_"+20091021144553005; yyyyMMddhhmmssSSS
-		String histId = "HT_"+EgovStringUtil.getTimeStamp();
-		history.setHistId(histId);
+		history.setHistId(SYS_HISTORY_ID_GENERATOR.getNextId());
 
 		sysHistoryDAO.insertSysHistory(history);
 

--- a/src/main/java/egovframework/com/sym/log/slg/service/impl/SysHistoryIdGenerator.java
+++ b/src/main/java/egovframework/com/sym/log/slg/service/impl/SysHistoryIdGenerator.java
@@ -1,0 +1,26 @@
+package egovframework.com.sym.log.slg.service.impl;
+
+import java.security.SecureRandom;
+import java.util.Base64;
+
+/**
+ * 시스템 이력 식별자를 생성한다.
+ */
+final class SysHistoryIdGenerator {
+
+	private static final String PREFIX = "HT_";
+	private static final int RANDOM_BYTE_LENGTH = 13;
+	private static final int ENCODED_RANDOM_LENGTH = 17;
+	private static final Base64.Encoder URL_ENCODER = Base64.getUrlEncoder().withoutPadding();
+
+	private final SecureRandom secureRandom = new SecureRandom();
+
+	String getNextId() {
+		byte[] randomBytes = new byte[RANDOM_BYTE_LENGTH];
+		secureRandom.nextBytes(randomBytes);
+
+		// 17 Base64 URL-safe characters retain 102 random bits from the 13-byte value.
+		String encodedRandom = URL_ENCODER.encodeToString(randomBytes);
+		return PREFIX + encodedRandom.substring(0, ENCODED_RANDOM_LENGTH);
+	}
+}

--- a/src/main/java/egovframework/com/sym/log/slg/service/impl/SysHistoryIdGenerator.java
+++ b/src/main/java/egovframework/com/sym/log/slg/service/impl/SysHistoryIdGenerator.java
@@ -1,0 +1,42 @@
+package egovframework.com.sym.log.slg.service.impl;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * 시스템 이력 식별자를 생성한다.
+ *
+ * <p>기존 <code>HT_yyyyMMddHHmmssSSS</code> 형식을 그대로 유지하면서, 이미 사용한
+ * 밀리초를 다시 내주지 않도록 다음 밀리초로 넘겨 동일 밀리초의 중복 생성을 막는다.</p>
+ */
+final class SysHistoryIdGenerator {
+
+	private static final String PREFIX = "HT_";
+
+	private static final DateTimeFormatter TIMESTAMP_FORMATTER =
+			DateTimeFormatter.ofPattern("yyyyMMddHHmmssSSS", Locale.KOREA);
+
+	/** 마지막으로 내준 밀리초. 시각이 뒤로 조정되어도 값이 되돌아가지 않는다. */
+	private final AtomicLong lastIssuedMillis = new AtomicLong(Long.MIN_VALUE);
+
+	String getNextId() {
+		Instant issuedAt = Instant.ofEpochMilli(nextMillis());
+
+		return PREFIX + TIMESTAMP_FORMATTER.format(issuedAt.atZone(ZoneId.systemDefault()));
+	}
+
+	private long nextMillis() {
+		long previous;
+		long next;
+
+		do {
+			previous = lastIssuedMillis.get();
+			next = Math.max(System.currentTimeMillis(), previous + 1);
+		} while (!lastIssuedMillis.compareAndSet(previous, next));
+
+		return next;
+	}
+}

--- a/src/test/java/egovframework/com/sym/log/slg/service/impl/EgovSysHistoryServiceImplTest.java
+++ b/src/test/java/egovframework/com/sym/log/slg/service/impl/EgovSysHistoryServiceImplTest.java
@@ -1,0 +1,51 @@
+package egovframework.com.sym.log.slg.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import egovframework.com.sym.log.slg.service.SysHistory;
+
+class EgovSysHistoryServiceImplTest {
+
+	@Test
+	void insertSysHistoryAssignsUniqueTwentyCharacterIdsAcrossServiceInstances() throws Exception {
+		RecordingSysHistoryDAO sysHistoryDAO = new RecordingSysHistoryDAO();
+		EgovSysHistoryServiceImpl firstService = createService(sysHistoryDAO);
+		EgovSysHistoryServiceImpl secondService = createService(sysHistoryDAO);
+
+		int insertCountPerService = 1_000;
+		for (int i = 0; i < insertCountPerService; i++) {
+			firstService.insertSysHistory(new SysHistory());
+			secondService.insertSysHistory(new SysHistory());
+		}
+
+		assertEquals(insertCountPerService * 2, sysHistoryDAO.histIds.size());
+		assertEquals(sysHistoryDAO.histIds.size(), new HashSet<>(sysHistoryDAO.histIds).size());
+		assertTrue(sysHistoryDAO.histIds.stream().allMatch(histId -> histId.length() == 20));
+		assertTrue(sysHistoryDAO.histIds.stream().allMatch(histId -> histId.matches("HT_[A-Za-z0-9_-]{17}")));
+	}
+
+	private EgovSysHistoryServiceImpl createService(RecordingSysHistoryDAO sysHistoryDAO) {
+		EgovSysHistoryServiceImpl service = new EgovSysHistoryServiceImpl();
+		ReflectionTestUtils.setField(service, "sysHistoryDAO", sysHistoryDAO);
+		return service;
+	}
+
+	private static class RecordingSysHistoryDAO extends SysHistoryDAO {
+
+		private final List<String> histIds = new ArrayList<>();
+
+		@Override
+		public int insertSysHistory(SysHistory history) {
+			histIds.add(history.getHistId());
+			return 1;
+		}
+	}
+}

--- a/src/test/java/egovframework/com/sym/log/slg/service/impl/EgovSysHistoryServiceImplTest.java
+++ b/src/test/java/egovframework/com/sym/log/slg/service/impl/EgovSysHistoryServiceImplTest.java
@@ -1,0 +1,69 @@
+package egovframework.com.sym.log.slg.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import egovframework.com.sym.log.slg.service.SysHistory;
+
+class EgovSysHistoryServiceImplTest {
+
+	private static final String HIST_ID_PATTERN = "HT_\\d{17}";
+
+	@Test
+	void insertSysHistoryKeepsTimestampIdFormat() throws Exception {
+		RecordingSysHistoryDAO sysHistoryDAO = new RecordingSysHistoryDAO();
+
+		createService(sysHistoryDAO).insertSysHistory(new SysHistory());
+
+		String histId = sysHistoryDAO.histIds.get(0);
+		assertEquals(20, histId.length());
+		assertTrue(histId.matches(HIST_ID_PATTERN), "기존 HT_yyyyMMddHHmmssSSS 형식이 유지되어야 한다: " + histId);
+	}
+
+	@Test
+	void insertSysHistoryAssignsUniqueIdsWithinSameMillisecond() throws Exception {
+		RecordingSysHistoryDAO sysHistoryDAO = new RecordingSysHistoryDAO();
+		EgovSysHistoryServiceImpl firstService = createService(sysHistoryDAO);
+		EgovSysHistoryServiceImpl secondService = createService(sysHistoryDAO);
+
+		int insertCountPerService = 1_000;
+		for (int i = 0; i < insertCountPerService; i++) {
+			firstService.insertSysHistory(new SysHistory());
+			secondService.insertSysHistory(new SysHistory());
+		}
+
+		List<String> histIds = sysHistoryDAO.histIds;
+		assertEquals(insertCountPerService * 2, histIds.size());
+		assertEquals(histIds.size(), new HashSet<>(histIds).size());
+		assertTrue(histIds.stream().allMatch(histId -> histId.matches(HIST_ID_PATTERN)));
+
+		for (int i = 1; i < histIds.size(); i++) {
+			assertTrue(histIds.get(i).compareTo(histIds.get(i - 1)) > 0,
+					"이력 ID는 등록 순서대로 증가해야 한다: " + histIds.get(i - 1) + ", " + histIds.get(i));
+		}
+	}
+
+	private EgovSysHistoryServiceImpl createService(RecordingSysHistoryDAO sysHistoryDAO) {
+		EgovSysHistoryServiceImpl service = new EgovSysHistoryServiceImpl();
+		ReflectionTestUtils.setField(service, "sysHistoryDAO", sysHistoryDAO);
+		return service;
+	}
+
+	private static class RecordingSysHistoryDAO extends SysHistoryDAO {
+
+		private final List<String> histIds = new ArrayList<>();
+
+		@Override
+		public int insertSysHistory(SysHistory history) {
+			histIds.add(history.getHistId());
+			return 1;
+		}
+	}
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

리뷰 의견을 반영해 **기존 ID 형식을 그대로 유지하는 방식으로 다시 작성했습니다.**

- `HT_yyyyMMddHHmmssSSS` 형식(`HT_` 접두어 + 17자리 타임스탬프, `CHAR(20)`)을 변경 없이 유지합니다. 목록 화면 노출 값과 기존 형식에 의존하는 연계·사용자 정의 코드의 호환성은 그대로입니다.
- 남아 있던 동일 밀리초 중복만 제거했습니다. `SysHistoryIdGenerator`가 마지막으로 사용한 밀리초를 `AtomicLong`으로 기억하고, 같은 밀리초가 다시 요청되면 다음 밀리초 값을 내줍니다(`Math.max(현재시각, 직전값 + 1)` + CAS).
- 시각이 뒤로 조정되어도(NTP 등) 값이 되돌아가지 않으며, 대기(busy-wait)나 블로킹이 없습니다. 생성 값은 등록 순서대로 증가합니다.
- 이력 ID는 `COMTHSYSHIST.HIST_ID` 기준으로 JVM 단위 유일성을 보장하도록 생성기를 `static`으로 두었습니다.
- `EgovStringUtil.getTimeStamp()`를 재사용하지 않은 이유: 시각을 지정할 수 있는 오버로드가 `utl.fcc.service` 패키지 전용(package-private)이라 외부에서 호출할 수 없습니다. 공용 유틸의 접근 범위를 넓히는 대신 패턴만 생성기 안에 두어 변경 범위를 이력 모듈로 한정했습니다.

## 남은 범위 Remaining scope

- 여러 인스턴스가 같은 DB를 공유하는 구성에서는 인스턴스 간 중복 가능성이 남습니다. `CHAR(20)`에 `HT_` + 17자리가 정확히 들어차 인스턴스 식별자를 넣을 여유 문자가 없어, **형식을 유지하는 범위에서는** 해결할 수 없는 부분입니다. 형식 호환성을 우선하는 리뷰 의견에 따라 이번 PR은 단일 인스턴스 내 동일 밀리초 중복 제거로 범위를 한정했습니다.

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [x] JUnit 테스트 JUnit tests
- [x] 수동 테스트 Manual testing

- 대상 테스트: `EgovSysHistoryServiceImplTest` (2건)
  - `insertSysHistoryKeepsTimestampIdFormat` — 생성 값이 `HT_\d{17}`, 길이 20자임을 검증(형식 유지 회귀 방지)
  - `insertSysHistoryAssignsUniqueIdsWithinSameMillisecond` — 2,000건 연속 등록 시 전건 고유 + 등록 순서대로 증가
- 기준 커밋(`upstream/main`, `bda21783`): 2,000건 중 고유 ID **45건**으로 uniqueness 테스트 실패. 형식 테스트는 통과(= 이번 변경이 형식을 바꾸지 않음을 확인)
- 수정 브랜치: 2건 모두 통과 (`Tests run: 2, Failures: 0, Errors: 0`)
- 저장소 POM의 Surefire `skipTests` 설정은 로컬 검증 중에만 일시적으로 해제했고 변경에는 포함하지 않았습니다.

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

서버 측 ID 생성 로직 변경으로 브라우저 테스트 대상이 아닙니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

화면 변경이 없어 첨부하지 않습니다. 이력 ID 형식이 기존과 동일하므로 목록·상세 화면 표시도 변경되지 않습니다.
