### PR TITLE
쪽지 입력값 검증 전 첨부파일 저장 방지

### DIFF
--- a/src/main/java/egovframework/com/uss/ion/ntm/web/EgovNoteManageController.java
+++ b/src/main/java/egovframework/com/uss/ion/ntm/web/EgovNoteManageController.java
@@ -161,18 +161,6 @@ public class EgovNoteManageController {
 		noteManage.setFrstRegisterId(loginVO == null ? "" : EgovStringUtil.isNullToString(loginVO.getUniqId()));
 		noteManage.setLastUpdusrId(loginVO == null ? "" : EgovStringUtil.isNullToString(loginVO.getUniqId()));
 
-		// 첨부파일 관련 첨부파일ID 생성
-		List<FileVO> fvoList = null;
-		String atchFileId = "";
-
-		final Map<String, MultipartFile> files = multiRequest.getFileMap();
-
-		if (!files.isEmpty()) {
-			fvoList = fileUtil.parseFileInf(files, "DSCH_", 0, "", "");
-			atchFileId = fileMngService.insertFileInfs(fvoList); // 파일이 생성되고나면 생성된 첨부파일 ID를 리턴한다.
-		}
-		noteManage.setAtchFileId(atchFileId);
-
 		String recptnEmpList = (String) commandMap.get("recptnEmpList");
 		if (recptnEmpList != null && recptnEmpList.trim().isEmpty()) {
 			noteManage.setRecptnEmpList(null);
@@ -206,6 +194,18 @@ public class EgovNoteManageController {
 			model.addAttribute("noteManage", noteManage);
 			return sLocationUrl;
 		}
+
+		// 첨부파일 관련 첨부파일ID 생성
+		List<FileVO> fvoList = null;
+		String atchFileId = "";
+
+		final Map<String, MultipartFile> files = multiRequest.getFileMap();
+
+		if (!files.isEmpty()) {
+			fvoList = fileUtil.parseFileInf(files, "DSCH_", 0, "", "");
+			atchFileId = fileMngService.insertFileInfs(fvoList); // 파일이 생성되고나면 생성된 첨부파일 ID를 리턴한다.
+		}
+		noteManage.setAtchFileId(atchFileId);
 
 		// 쪽지등록
 		egovNoteManageService.insertNoteManage(noteManage, commandMap);

--- a/src/test/java/egovframework/com/uss/ion/ntm/web/EgovNoteManageControllerTest.java
+++ b/src/test/java/egovframework/com/uss/ion/ntm/web/EgovNoteManageControllerTest.java
@@ -1,0 +1,141 @@
+package egovframework.com.uss.ion.ntm.web;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.lang.reflect.Proxy;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.ui.ModelMap;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.multipart.MultipartHttpServletRequest;
+
+import egovframework.com.cmm.ComDefaultCodeVO;
+import egovframework.com.cmm.LoginVO;
+import egovframework.com.cmm.service.CmmnDetailCode;
+import egovframework.com.cmm.service.EgovCmmUseService;
+import egovframework.com.cmm.service.EgovFileMngService;
+import egovframework.com.cmm.service.EgovFileMngUtil;
+import egovframework.com.cmm.service.EgovUserDetailsService;
+import egovframework.com.cmm.service.FileVO;
+import egovframework.com.cmm.util.EgovUserDetailsHelper;
+import egovframework.com.uss.ion.ntm.service.NoteManageVO;
+
+class EgovNoteManageControllerTest {
+
+	private final AtomicInteger parsedFileCount = new AtomicInteger();
+	private final AtomicInteger insertedFileCount = new AtomicInteger();
+	private EgovUserDetailsService originalUserDetailsService;
+
+	@BeforeEach
+	void setUpAuthenticatedUser() {
+		LoginVO loginVO = new LoginVO();
+		loginVO.setUniqId("USRCNFRM_00000000000");
+
+		EgovUserDetailsHelper helper = new EgovUserDetailsHelper();
+		originalUserDetailsService = helper.getEgovUserDetailsService();
+		helper.setEgovUserDetailsService(new EgovUserDetailsService() {
+			@Override
+			public Object getAuthenticatedUser() {
+				return loginVO;
+			}
+
+			@Override
+			public List<String> getAuthorities() {
+				return Collections.emptyList();
+			}
+
+			@Override
+			public Boolean isAuthenticated() {
+				return true;
+			}
+		});
+	}
+
+	@AfterEach
+	void restoreUserDetailsService() {
+		new EgovUserDetailsHelper().setEgovUserDetailsService(originalUserDetailsService);
+	}
+
+	@Test
+	void validationErrorsDoNotPersistAttachments() throws Exception {
+		EgovNoteManageController controller = new EgovNoteManageController();
+		ReflectionTestUtils.setField(controller, "fileUtil", new CountingFileMngUtil());
+		ReflectionTestUtils.setField(controller, "fileMngService", fileMngService());
+		ReflectionTestUtils.setField(controller, "cmmUseService", cmmUseService());
+
+		MultipartFile multipartFile = new MockMultipartFile("file_1", "note.txt", "text/plain",
+				"content".getBytes(StandardCharsets.UTF_8));
+		Map<String, MultipartFile> files = Collections.singletonMap("file_1", multipartFile);
+		MultipartHttpServletRequest request = (MultipartHttpServletRequest) Proxy.newProxyInstance(
+				MultipartHttpServletRequest.class.getClassLoader(), new Class<?>[] { MultipartHttpServletRequest.class },
+				(proxy, method, args) -> "getFileMap".equals(method.getName()) ? files : null);
+
+		NoteManageVO noteManage = new NoteManageVO();
+		BindingResult bindingResult = new BeanPropertyBindingResult(noteManage, "noteManage");
+		bindingResult.rejectValue("noteSj", "required");
+
+		Map<String, Object> commandMap = new HashMap<>();
+		String viewName = controller.EgovNoteRecptnRegist(request, commandMap, noteManage, bindingResult,
+				new ModelMap());
+
+		assertEquals("egovframework/com/uss/ion/ntm/EgovNoteManage", viewName);
+		assertEquals(0, parsedFileCount.get());
+		assertEquals(0, insertedFileCount.get());
+	}
+
+	private EgovFileMngService fileMngService() {
+		return (EgovFileMngService) Proxy.newProxyInstance(EgovFileMngService.class.getClassLoader(),
+				new Class<?>[] { EgovFileMngService.class }, (proxy, method, args) -> {
+					if ("insertFileInfs".equals(method.getName())) {
+						insertedFileCount.incrementAndGet();
+						return "FILE_1";
+					}
+					return null;
+				});
+	}
+
+	private EgovCmmUseService cmmUseService() {
+		return new EgovCmmUseService() {
+			@Override
+			public List<CmmnDetailCode> selectCmmCodeDetail(ComDefaultCodeVO comDefaultCodeVO) {
+				return Collections.emptyList();
+			}
+
+			@Override
+			public Map<String, List<CmmnDetailCode>> selectCmmCodeDetails(List<ComDefaultCodeVO> comDefaultCodeVOs) {
+				return Collections.emptyMap();
+			}
+
+			@Override
+			public List<CmmnDetailCode> selectOgrnztIdDetail(ComDefaultCodeVO comDefaultCodeVO) {
+				return Collections.emptyList();
+			}
+
+			@Override
+			public List<CmmnDetailCode> selectGroupIdDetail(ComDefaultCodeVO comDefaultCodeVO) {
+				return Collections.emptyList();
+			}
+		};
+	}
+
+	private class CountingFileMngUtil extends EgovFileMngUtil {
+		@Override
+		public List<FileVO> parseFileInf(Map<String, MultipartFile> files, String keyStr, int fileKeyParam,
+				String atchFileId, String storePath) {
+			parsedFileCount.addAndGet(files.size());
+			return Collections.singletonList(new FileVO());
+		}
+	}
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

쪽지 발송 요청의 입력값 검증이 실패해도 첨부파일 파싱과 파일 메타데이터 저장이 먼저 수행되는 문제를 수정했습니다.

- `BindingResult` 오류 처리가 끝난 뒤에만 첨부파일을 파싱하고 저장하도록 처리 순서를 이동했습니다.
- 정상 요청의 첨부파일 처리와 쪽지 등록 흐름은 변경하지 않았습니다.
- 검증 실패 시 파일 파싱과 메타데이터 저장이 호출되지 않는 회귀 테스트를 추가했습니다.

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [x] JUnit 테스트 JUnit tests
- [x] 수동 테스트 Manual testing

`EgovNoteManageControllerTest.validationErrorsDoNotPersistAttachments`를 동일하게 실행했습니다.

- 수정 전 `upstream/main`: `Tests run: 1, Failures: 1` (`expected: <0> but was: <1>`)
- 수정 후: `Tests run: 1, Failures: 0, Errors: 0`, `BUILD SUCCESS`
- 실행 명령: `mvn -B -Dtest=EgovNoteManageControllerTest test`
- 테스트 실행 중에만 `pom.xml`의 `skipTests`를 해제했고 변경 사항은 원복했습니다.
- `git diff --check` 통과

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음 (서버 측 검증 실패 경로에 대한 회귀 테스트로 확인)
