### PR TITLE
perf: EgovBrowserUtil 브라우저 판별 정규식을 static final로 호이스팅 (전후 측정 3~4배 개선)

### DIFF
--- a/src/main/java/egovframework/com/cmm/EgovBrowserUtil.java
+++ b/src/main/java/egovframework/com/cmm/EgovBrowserUtil.java
@@ -14,6 +14,7 @@ import java.util.regex.Pattern;
  *   수정일              수정자              수정내용
  *  -----------  --------    ---------------------------
  *   2018.08.27  신용호              최초 생성
+ *   2026.07.11  이석곤              브라우저 판별 정규식을 static final로 호이스팅 (호출마다 재컴파일 제거)
  *
  * </pre>
  */
@@ -32,15 +33,21 @@ public class EgovBrowserUtil {
 	public static final String TYPEKEY = "type";
 	public static final String VERSIONKEY = "version";
 
+	// 브라우저 판별 정규식 — 호출마다 재컴파일하지 않도록 클래스 로딩 시 1회만 컴파일한다.
+	private static final Pattern MSIE_PATTERN = Pattern.compile("MSIE ([0-9]{1,2}.[0-9])");
+	private static final Pattern EDGE_PATTERN = Pattern.compile("Edge/([0-9]{1,3}.[0-9]{1,5})");
+	private static final Pattern FIREFOX_PATTERN = Pattern.compile("Firefox/([0-9]{1,3}.[0-9]{1,3})");
+	private static final Pattern OPERA_PATTERN = Pattern.compile("OPR/([0-9]{1,3}.[0-9]{1,3})");
+	private static final Pattern WHALE_PATTERN = Pattern.compile("Whale/([0-9]{1,3}\\.[0-9]{1,3})");
+	private static final Pattern CHROME_PATTERN = Pattern.compile("Chrome/([0-9]{1,3}.[0-9]{1,3})");
+	private static final Pattern SAFARI_PATTERN = Pattern.compile("Version/([0-9]{1,2}.[0-9]{1,3})");
+
 	public static HashMap<String,String> getBrowser(String userAgent) {
 		
 		HashMap<String,String> result = new HashMap<String,String>();
-		Pattern pattern = null;
 		Matcher matcher = null;
-		//System.out.println("=====>>>>> userAgent = "+userAgent);
-		
-		pattern = Pattern.compile("MSIE ([0-9]{1,2}.[0-9])");
-		matcher = pattern.matcher(userAgent);
+
+		matcher = MSIE_PATTERN.matcher(userAgent);
 		if (matcher.find())
 		{
 		    result.put(TYPEKEY,MSIE);
@@ -54,8 +61,7 @@ public class EgovBrowserUtil {
 		    return result;
 		}
 		
-		pattern = Pattern.compile("Edge/([0-9]{1,3}.[0-9]{1,5})");
-		matcher = pattern.matcher(userAgent);
+		matcher = EDGE_PATTERN.matcher(userAgent);
 		if (matcher.find())
 		{
 		    result.put(TYPEKEY,EDGE);
@@ -63,8 +69,7 @@ public class EgovBrowserUtil {
 			return result;
 		}
 		
-		pattern = Pattern.compile("Firefox/([0-9]{1,3}.[0-9]{1,3})");
-		matcher = pattern.matcher(userAgent);
+		matcher = FIREFOX_PATTERN.matcher(userAgent);
 		if (matcher.find())
 		{
 		    result.put(TYPEKEY,FIREFOX);
@@ -72,8 +77,7 @@ public class EgovBrowserUtil {
 			return result;		    
 		}
 
-		pattern = Pattern.compile("OPR/([0-9]{1,3}.[0-9]{1,3})");
-		matcher = pattern.matcher(userAgent);
+		matcher = OPERA_PATTERN.matcher(userAgent);
 		if (matcher.find())
 		{
 		    result.put(TYPEKEY,OPERA);
@@ -81,16 +85,14 @@ public class EgovBrowserUtil {
 			return result;		    
 		}
 
-		pattern = Pattern.compile("Whale/([0-9]{1,3}\\.[0-9]{1,3})");
-		matcher = pattern.matcher(userAgent);
+		matcher = WHALE_PATTERN.matcher(userAgent);
 		if (matcher.find()) {
 			result.put(TYPEKEY, WHALE);
 			result.put(VERSIONKEY, matcher.group(1));
 			return result;
 		}
 
-		pattern = Pattern.compile("Chrome/([0-9]{1,3}.[0-9]{1,3})");
-		matcher = pattern.matcher(userAgent);
+		matcher = CHROME_PATTERN.matcher(userAgent);
 		if (matcher.find())
 		{
 		    result.put(TYPEKEY,CHROME);
@@ -98,8 +100,7 @@ public class EgovBrowserUtil {
 			return result;		    
 		}
 		
-		pattern = Pattern.compile("Version/([0-9]{1,2}.[0-9]{1,3})");
-		matcher = pattern.matcher(userAgent);
+		matcher = SAFARI_PATTERN.matcher(userAgent);
 		if (matcher.find())
 		{
 		    result.put(TYPEKEY,SAFARI);


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [ ] 버그수정 Bug fixes
- [x] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

`EgovBrowserUtil.getBrowser()`가 호출될 때마다 브라우저 판별용 정규식을 **최대 7개까지 매번 `Pattern.compile()`** 합니다. 이 메서드는 `getDisposition()`을 통해 파일 다운로드 응답 등 요청 처리 경로에서 호출되므로, 동일한 정규식이 요청마다 반복 컴파일됩니다. `Pattern`은 불변(스레드 안전)이므로 클래스 로딩 시 1회만 컴파일하면 됩니다. 정적분석 도구도 권장하는 항목입니다(SonarQube `java:S4248` — Regex patterns should not be created needlessly).

## 수정된 소스 내용 Modified source

- 정규식 7개를 `private static final Pattern` 상수로 호이스팅하고 `getBrowser()`는 상수의 `matcher()`만 호출하도록 변경했습니다. 정규식 문자열·판별 순서·반환 값은 일절 변경하지 않았습니다.
- 사용하지 않게 된 지역 변수 `Pattern pattern`과 주석 처리된 `System.out.println` 1행을 정리했습니다.

## 전후 성능 측정 (JDK 17, 1,000,000회 호출 평균, 워밍업 200,000회 후 3라운드)

| 시나리오 | 변경 전 | 변경 후 | 개선 |
| --- | --- | --- | --- |
| Chrome UA (패턴 6개 통과 후 매칭) | 4,636~6,228 ns/호출 | 1,351~1,516 ns/호출 | **약 3.4~4.3배** |
| MSIE UA (첫 패턴 매칭) | 601~703 ns/호출 | 179~226 ns/호출 | **약 3.1~3.5배** |

## JUnit 테스트 JUnit tests

- [ ] JUnit 테스트 JUnit tests
- [x] 수동 테스트 Manual testing

- 로컬 컴파일 확인 (JDK 17)
- 동작 동일성 검증: 대표 UA 10종(Chrome·MSIE 10/11(Trident)·Firefox·Edge·Safari·Opera·Whale·curl·빈 문자열)에 대해 변경 전/후 `getBrowser()` 반환 Map 완전 일치 확인

## 테스트 브라우저 Test Browser

해당 없음 (서버 측 유틸리티, 화면 변경 없음)

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음
