### PR TITLE
fix: convertWeek() 목요일 코드 "THU" 미인식 오류 수정

### DIFF
--- a/src/main/java/egovframework/com/utl/fcc/service/EgovDateUtil.java
+++ b/src/main/java/egovframework/com/utl/fcc/service/EgovDateUtil.java
@@ -640,19 +640,19 @@ public class EgovDateUtil {
 	public static String convertWeek(String sWeek) {
 		String retStr = null;
 
-		if (sWeek.equals("SUN")) {
+		if (sWeek.equalsIgnoreCase("SUN")) {
 			retStr = "일요일";
-		} else if (sWeek.equals("MON")) {
+		} else if (sWeek.equalsIgnoreCase("MON")) {
 			retStr = "월요일";
-		} else if (sWeek.equals("TUE")) {
+		} else if (sWeek.equalsIgnoreCase("TUE")) {
 			retStr = "화요일";
-		} else if (sWeek.equals("WED")) {
+		} else if (sWeek.equalsIgnoreCase("WED")) {
 			retStr = "수요일";
-		} else if (sWeek.equals("THR") || sWeek.equals("THU")) {
+		} else if (sWeek.equalsIgnoreCase("THR") || sWeek.equalsIgnoreCase("THU")) {
 			retStr = "목요일";
-		} else if (sWeek.equals("FRI")) {
+		} else if (sWeek.equalsIgnoreCase("FRI")) {
 			retStr = "금요일";
-		} else if (sWeek.equals("SAT")) {
+		} else if (sWeek.equalsIgnoreCase("SAT")) {
 			retStr = "토요일";
 		}
 

--- a/src/main/java/egovframework/com/utl/fcc/service/EgovDateUtil.java
+++ b/src/main/java/egovframework/com/utl/fcc/service/EgovDateUtil.java
@@ -648,7 +648,7 @@ public class EgovDateUtil {
 			retStr = "화요일";
 		} else if (sWeek.equals("WED")) {
 			retStr = "수요일";
-		} else if (sWeek.equals("THR")) {
+		} else if (sWeek.equals("THR") || sWeek.equals("THU")) {
 			retStr = "목요일";
 		} else if (sWeek.equals("FRI")) {
 			retStr = "금요일";

--- a/src/test/java/egovframework/com/utl/fcc/service/EgovDateUtilTest.java
+++ b/src/test/java/egovframework/com/utl/fcc/service/EgovDateUtilTest.java
@@ -18,21 +18,23 @@ public class EgovDateUtilTest {
 	class ConvertWeek {
 
 		// -------------------------------------------------------------------
-		// 정상 입력: 지원되는 요일 코드 -> 국문 요일명
-		//   THR: 기존 지원 값(하위호환) / THU: 이번 수정으로 추가된 표준 3글자 대문자 약어
-		//   ※ addYMDtoWeek() 의 실제 출력값인 "Thu"(첫 글자만 대문자)는 아직 미지원 —
-		//     sWeek.equals("THU") 는 대소문자를 구분하므로 "Thu" 입력 시 여전히 null 반환됨
+		// 정상 입력: 지원되는 요일 코드 -> 국문 요일명 (대소문자 구분 없이 인식)
+		//   THR: 기존 지원 값(하위호환) / THU, Thu, thu: 대소문자 무관하게 목요일로 인식
+		//   addYMDtoWeek() 의 실제 출력값인 "Thu"(첫 글자만 대문자)도 이제 정상 인식됨
 		// -------------------------------------------------------------------
 
 		@ParameterizedTest(name = "{0} -> {1}")
 		@DisplayName("지원되는 요일 코드 -> 국문 요일명")
 		@CsvSource({
 			"SUN, 일요일",
+			"Sun, 일요일",
 			"MON, 월요일",
 			"TUE, 화요일",
 			"WED, 수요일",
 			"THR, 목요일",
 			"THU, 목요일",
+			"Thu, 목요일",
+			"Thu, 목요일",
 			"FRI, 금요일",
 			"SAT, 토요일"
 		})
@@ -50,6 +52,28 @@ public class EgovDateUtilTest {
 		@DisplayName("존재하지 않는 요일 문자열 -> null 반환")
 		void unknownStringReturnsNull() {
 			assertNull(EgovDateUtil.convertWeek("XXX"));
+		}
+
+	}
+
+	@Nested
+	@DisplayName("addYMDtoWeek()")
+	class AddYMDtoWeek {
+
+
+		@ParameterizedTest(name = "{0}일 후 -> {1}")
+		@DisplayName("월요일부터 일요일까지 -> 요일 문자열(Mon~Sun)")
+		@CsvSource({
+			"0, Mon",
+			"1, Tue",
+			"2, Wed",
+			"3, Thu",
+			"4, Fri",
+			"5, Sat",
+			"6, Sun"
+		})
+		void mondayToSunday(int dayOffset, String expected) {
+			assertEquals(expected, EgovDateUtil.addYMDtoWeek("20240101", 0, 0, dayOffset));
 		}
 
 	}

--- a/src/test/java/egovframework/com/utl/fcc/service/EgovDateUtilTest.java
+++ b/src/test/java/egovframework/com/utl/fcc/service/EgovDateUtilTest.java
@@ -1,0 +1,56 @@
+package egovframework.com.utl.fcc.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+/**
+ * EgovDateUtil 단위 테스트
+ */
+public class EgovDateUtilTest {
+
+	@Nested
+	@DisplayName("convertWeek()")
+	class ConvertWeek {
+
+		// -------------------------------------------------------------------
+		// 정상 입력: 지원되는 요일 코드 -> 국문 요일명
+		//   THR: 기존 지원 값(하위호환) / THU: 이번 수정으로 추가된 표준 3글자 대문자 약어
+		//   ※ addYMDtoWeek() 의 실제 출력값인 "Thu"(첫 글자만 대문자)는 아직 미지원 —
+		//     sWeek.equals("THU") 는 대소문자를 구분하므로 "Thu" 입력 시 여전히 null 반환됨
+		// -------------------------------------------------------------------
+
+		@ParameterizedTest(name = "{0} -> {1}")
+		@DisplayName("지원되는 요일 코드 -> 국문 요일명")
+		@CsvSource({
+			"SUN, 일요일",
+			"MON, 월요일",
+			"TUE, 화요일",
+			"WED, 수요일",
+			"THR, 목요일",
+			"THU, 목요일",
+			"FRI, 금요일",
+			"SAT, 토요일"
+		})
+		void supportedWeekCodes(String input, String expected) {
+			assertEquals(expected, EgovDateUtil.convertWeek(input));
+		}
+
+		@Test
+		@DisplayName("빈 문자열 입력 -> null 반환")
+		void emptyStringReturnsNull() {
+			assertNull(EgovDateUtil.convertWeek(""));
+		}
+
+		@Test
+		@DisplayName("존재하지 않는 요일 문자열 -> null 반환")
+		void unknownStringReturnsNull() {
+			assertNull(EgovDateUtil.convertWeek("XXX"));
+		}
+
+	}
+}

--- a/src/test/java/egovframework/com/utl/fcc/service/EgovDateUtilTest.java
+++ b/src/test/java/egovframework/com/utl/fcc/service/EgovDateUtilTest.java
@@ -34,7 +34,6 @@ public class EgovDateUtilTest {
 			"THR, 목요일",
 			"THU, 목요일",
 			"Thu, 목요일",
-			"Thu, 목요일",
 			"FRI, 금요일",
 			"SAT, 토요일"
 		})


### PR DESCRIPTION
## 수정 사유 Reason for modification
- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

EgovDateUtil.convertWeek(String sWeek)는 영문 요일 약어를 국문 요일명으로 변환하는 메서드입니다. 두 가지 문제가 있었습니다.

  1. 목요일만 비표준 약어 "THR"로 체크하고 있었음
  2. 같은 클래스의 addYMDtoWeek()는 new SimpleDateFormat("E", Locale.ENGLISH)로 요일 문자열을 생성하는데, 목요일의 경우 "Thu"(첫글자만 대문자)를 반환합니다. 즉 EgovDateUtil 자체적으로 생성하는 표준 요일 문자열을 convertWeek()에 그대로 넣으면 인식 불가능

#### 수정 내용
  1. "THR" 외 "THU"도 목요일로 인식하도록 조건 추가 (하위호환 유지)
  2. 모든 요일 비교를 equals() → equalsIgnoreCase()로 변경해 대소문자 조합과 무관하게 인식하도록 일반화

```java
  -             if (sWeek.equals("SUN")) {
  +             if (sWeek.equalsIgnoreCase("SUN")) {
                        retStr = "일요일";
  -             } else if (sWeek.equals("MON")) {
  +             } else if (sWeek.equalsIgnoreCase("MON")) {
  ...
  -             } else if (sWeek.equals("THR")) {
  +             } else if (sWeek.equalsIgnoreCase("THR") || sWeek.equalsIgnoreCase("THU")) {
                        retStr = "목요일";
```
  이 변경으로 addYMDtoWeek()가 생성하는 "Thu"를 포함해 "sun", "Mon", "THU" 등 모든 대소문자 조합이 정상적으로 국문 요일명으로
  변환됩니다.



## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [x] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing



## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

<img width="729" height="593" alt="스크린샷 2026-07-12 오전 1 47 50" src="https://github.com/user-attachments/assets/9043b760-ca10-4010-babf-3247940fbc7e" />
