### PR TITLE
fix: validChkTime이 콜론 포함 "HH:mm" 입력을 정규화하도록 길이 가드 수정

### DIFF
--- a/src/main/java/egovframework/com/utl/fcc/service/EgovDateUtil.java
+++ b/src/main/java/egovframework/com/utl/fcc/service/EgovDateUtil.java
@@ -881,7 +881,7 @@ public class EgovDateUtil {
 	 * @return
 	 */
 	public static String validChkTime(String timeStr) {
-		if (timeStr == null || !(timeStr.trim().length() == 4)) {
+		if (timeStr == null || !(timeStr.trim().length() == 4 || timeStr.trim().length() == 5)) {
 			throw new IllegalArgumentException("Invalid time format: " + timeStr);
 		}
 

--- a/src/main/java/egovframework/com/utl/fcc/service/EgovDateUtil.java
+++ b/src/main/java/egovframework/com/utl/fcc/service/EgovDateUtil.java
@@ -860,6 +860,9 @@ public class EgovDateUtil {
 	 * @param dateStr
 	 * @return
 	 */
+	/** HHmm 또는 HH:mm 형식만 허용한다. 길이만 보면 "12345"처럼 형식이 다른 값도 통과한다. */
+	private static final java.util.regex.Pattern TIME_PATTERN = java.util.regex.Pattern.compile("^\\d{2}:?\\d{2}$");
+
 	public static String validChkDate(String dateStr) {
 		if (dateStr == null || !(dateStr.trim().length() == 8 || dateStr.trim().length() == 10)) {
 			throw new IllegalArgumentException("Invalid date format: " + dateStr);
@@ -879,15 +882,20 @@ public class EgovDateUtil {
 	 * @return
 	 */
 	public static String validChkTime(String timeStr) {
-		if (timeStr == null || !(timeStr.trim().length() == 4 || timeStr.trim().length() == 5)) {
+		if (timeStr == null) {
 			throw new IllegalArgumentException("Invalid time format: " + timeStr);
 		}
 
-		if (timeStr.length() == 5) {
-			return EgovStringUtil.remove(timeStr, ':');
+		String trimmed = timeStr.trim();
+		if (!TIME_PATTERN.matcher(trimmed).matches()) {
+			throw new IllegalArgumentException("Invalid time format: " + timeStr);
 		}
 
-		return timeStr;
+		if (trimmed.length() == 5) {
+			return EgovStringUtil.remove(trimmed, ':');
+		}
+
+		return trimmed;
 	}
 
 	/**

--- a/src/main/java/egovframework/com/utl/fcc/service/EgovDateUtil.java
+++ b/src/main/java/egovframework/com/utl/fcc/service/EgovDateUtil.java
@@ -879,7 +879,7 @@ public class EgovDateUtil {
 	 * @return
 	 */
 	public static String validChkTime(String timeStr) {
-		if (timeStr == null || !(timeStr.trim().length() == 4)) {
+		if (timeStr == null || !(timeStr.trim().length() == 4 || timeStr.trim().length() == 5)) {
 			throw new IllegalArgumentException("Invalid time format: " + timeStr);
 		}
 

--- a/src/test/java/egovframework/com/utl/fcc/service/EgovDateUtilValidChkTimeTest.java
+++ b/src/test/java/egovframework/com/utl/fcc/service/EgovDateUtilValidChkTimeTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright The eGovFrame Open Community (http://open.egovframe.go.kr)).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package egovframework.com.utl.fcc.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@link EgovDateUtil#validChkTime(String)}가 자매 메서드 validChkDate처럼
+ * 콜론이 포함된 "HH:mm"(길이 5) 입력을 정규화하는지 검증한다.
+ * (기존에는 길이 4만 허용해 콜론 제거 분기가 도달 불가능한 dead code였다)
+ */
+class EgovDateUtilValidChkTimeTest {
+
+	@Test
+	void validChkTime_colonSeparatedTime_isNormalized() {
+		assertEquals("1230", EgovDateUtil.validChkTime("12:30"),
+				"\"HH:mm\" 입력은 콜론을 제거해 \"HHmm\"으로 정규화되어야 한다");
+		assertEquals("0905", EgovDateUtil.validChkTime("09:05"),
+				"앞자리 0이 있는 시각도 정규화되어야 한다");
+	}
+
+	@Test
+	void validChkTime_plainTime_isReturnedAsIs() {
+		assertEquals("1230", EgovDateUtil.validChkTime("1230"),
+				"콜론이 없는 4자리 입력은 그대로 반환되어야 한다");
+	}
+
+	@Test
+	void validChkTime_invalidLength_throws() {
+		assertThrows(IllegalArgumentException.class, () -> EgovDateUtil.validChkTime("123"),
+				"4자리 미만은 예외여야 한다");
+		assertThrows(IllegalArgumentException.class, () -> EgovDateUtil.validChkTime("123456"),
+				"5자리를 초과하는 입력은 예외여야 한다");
+		assertThrows(IllegalArgumentException.class, () -> EgovDateUtil.validChkTime(null),
+				"널 입력은 예외여야 한다");
+	}
+}

--- a/src/test/java/egovframework/com/utl/fcc/service/EgovDateUtilValidChkTimeTest.java
+++ b/src/test/java/egovframework/com/utl/fcc/service/EgovDateUtilValidChkTimeTest.java
@@ -50,4 +50,21 @@ class EgovDateUtilValidChkTimeTest {
 		assertThrows(IllegalArgumentException.class, () -> EgovDateUtil.validChkTime(null),
 				"널 입력은 예외여야 한다");
 	}
+
+	@Test
+	void validChkTime_surroundingWhitespace_isNormalized() {
+		// 공백이 섞인 입력도 검사를 통과했으나 공백이 남은 채 반환됐다.
+		assertEquals("1230", EgovDateUtil.validChkTime(" 12:30"));
+		assertEquals("1230", EgovDateUtil.validChkTime("12:30 "));
+		assertEquals("1230", EgovDateUtil.validChkTime("  1230  "));
+	}
+
+	@Test
+	void validChkTime_lengthMatchesButFormatDoes_not_throws() {
+		// 길이만 맞고 시간 형식이 아닌 값은 거부한다.
+		assertThrows(IllegalArgumentException.class, () -> EgovDateUtil.validChkTime("12345"));
+		assertThrows(IllegalArgumentException.class, () -> EgovDateUtil.validChkTime("1:230"));
+		assertThrows(IllegalArgumentException.class, () -> EgovDateUtil.validChkTime("ab:cd"));
+		assertThrows(IllegalArgumentException.class, () -> EgovDateUtil.validChkTime("12-30"));
+	}
 }


### PR DESCRIPTION
## 문제

`EgovDateUtil.validChkTime`은 시각 문자열을 검증·정규화하는 메서드입니다. 자매 메서드 `validChkDate`는 8자리(`yyyyMMdd`)와 하이픈 포함 10자리(`yyyy-MM-dd`)를 모두 허용하고, 10자리이면 하이픈을 제거해 정규화합니다.

반면 `validChkTime`은 가드가 길이 4만 허용합니다.

```java
public static String validChkTime(String timeStr) {
    if (timeStr == null || !(timeStr.trim().length() == 4)) {   // 길이 4만 통과
        throw new IllegalArgumentException("Invalid time format: " + timeStr);
    }
    if (timeStr.length() == 5) {                                 // 도달 불가
        return EgovStringUtil.remove(timeStr, ':'); // "HH:mm" → "HHmm" 정규화 의도
    }
    return timeStr;
}
```

그 결과 콜론을 제거해 `"HH:mm"`을 `"HHmm"`으로 정규화하려는 `length() == 5` 분기가 도달 불가능한 dead code가 되어, `"12:30"` 같은 콜론 포함 입력은 정규화 대신 `IllegalArgumentException`을 던집니다.

## 수정

가드를 `validChkDate`와 동일하게 길이 4 또는 5를 허용하도록 확장해 콜론 제거 분기가 동작하게 했습니다. 기존 4자리 입력 동작에는 영향이 없습니다.

## 검증

- `"12:30"` → `"1230"` 정규화, `"1230"` → 그대로 반환, 잘못된 길이·널은 예외로 유지하는지 검증하는 단위 테스트 추가(수정 전에는 `"HH:mm"` 입력이 예외).