### PR TITLE
fix: fileInjectPathReplaceAll 상위 경로 제거 결함 수정 (정규식 오타 + 치환 순서)

### DIFF
--- a/src/main/java/egovframework/com/cmm/EgovWebUtil.java
+++ b/src/main/java/egovframework/com/cmm/EgovWebUtil.java
@@ -139,8 +139,8 @@ public class EgovWebUtil {
 		}
 
 		returnValue = returnValue.replaceAll("/", "");
-		returnValue = returnValue.replaceAll("\\.\\.", ""); // ..
 		returnValue = returnValue.replaceAll("\\\\", "");// \
+		returnValue = returnValue.replaceAll("\\.\\.", ""); // ..
 		returnValue = returnValue.replaceAll("&", "");
 
 		return returnValue;

--- a/src/main/java/egovframework/com/cmm/EgovWebUtil.java
+++ b/src/main/java/egovframework/com/cmm/EgovWebUtil.java
@@ -22,6 +22,7 @@ import java.util.regex.Pattern;
  *  2023.08.10   신용호      removeLDAPInjectionRisk() 오류 수정
  *  2024.12.04   신용호      filePathBlackList() basePath 추가
  *  2026.07.10   유지보수    NCSC 보안점검 반영 (XSS/SSRF/세션고정 대응 유틸 추가)
+ *  2026.07.15   EricSeokgon fileInjectPathReplaceAll() 상위 경로 정규식 수정
  * </pre>
  */
 
@@ -138,7 +139,7 @@ public class EgovWebUtil {
 		}
 
 		returnValue = returnValue.replaceAll("/", "");
-		returnValue = returnValue.replaceAll("\\..", ""); // ..
+		returnValue = returnValue.replaceAll("\\.\\.", ""); // ..
 		returnValue = returnValue.replaceAll("\\\\", "");// \
 		returnValue = returnValue.replaceAll("&", "");
 

--- a/src/main/java/egovframework/com/cmm/EgovWebUtil.java
+++ b/src/main/java/egovframework/com/cmm/EgovWebUtil.java
@@ -142,6 +142,10 @@ public class EgovWebUtil {
 		returnValue = returnValue.replaceAll("\\\\", "");// \
 		returnValue = returnValue.replaceAll("\\.\\.", ""); // ..
 		returnValue = returnValue.replaceAll("&", "");
+		// mochoping review: strip any ".." created after separator/& removal (e.g. ".&." otherwise becomes "..")
+		while (returnValue.contains("..")) {
+			returnValue = returnValue.replace("..", "");
+		}
 
 		return returnValue;
 	}

--- a/src/test/java/egovframework/com/cmm/EgovWebUtilTest.java
+++ b/src/test/java/egovframework/com/cmm/EgovWebUtilTest.java
@@ -54,4 +54,14 @@ public class EgovWebUtilTest {
 		assertEquals("", EgovWebUtil.removeLDAPInjectionRisk(null));
 		assertEquals("", EgovWebUtil.removeLDAPInjectionRisk("   "));
 	}
+
+	@Test
+	public void fileInjectPathReplaceAll_removesParentDirectorySequence() {
+		assertEquals("etcpasswd", EgovWebUtil.fileInjectPathReplaceAll("../etc/passwd"));
+	}
+
+	@Test
+	public void fileInjectPathReplaceAll_keepsSingleDotAndFollowingCharacter() {
+		assertEquals("report.txt", EgovWebUtil.fileInjectPathReplaceAll("report.txt"));
+	}
 }

--- a/src/test/java/egovframework/com/cmm/EgovWebUtilTest.java
+++ b/src/test/java/egovframework/com/cmm/EgovWebUtilTest.java
@@ -64,4 +64,17 @@ public class EgovWebUtilTest {
 	public void fileInjectPathReplaceAll_keepsSingleDotAndFollowingCharacter() {
 		assertEquals("report.txt", EgovWebUtil.fileInjectPathReplaceAll("report.txt"));
 	}
+
+	/**
+	 * 구분자 제거 후 ".." 가 복원되지 않아야 한다.
+	 *
+	 * <p>정규식 오타만 고치면 ".\\." 처럼 구분자가 끼어든 입력은 ".." 가 인접하지 않아
+	 * 통과한 뒤, 역슬래시가 제거되면서 ".." 가 되살아난다. 같은 클래스의
+	 * filePathReplaceAll() 과 동일하게 구분자를 먼저 제거해야 한다.</p>
+	 */
+	@Test
+	public void fileInjectPathReplaceAll_doesNotReconstructParentSequence() {
+		assertEquals("", EgovWebUtil.fileInjectPathReplaceAll(".\\."));
+		assertEquals("etc", EgovWebUtil.fileInjectPathReplaceAll(".\\./etc"));
+	}
 }

--- a/src/test/java/egovframework/com/cmm/EgovWebUtilTest.java
+++ b/src/test/java/egovframework/com/cmm/EgovWebUtilTest.java
@@ -66,6 +66,20 @@ public class EgovWebUtilTest {
 	}
 
 	/**
+	 * '&' 제거 후에도 ".." 가 최종 결과에 남지 않아야 한다 (mochoping 리뷰).
+	 *
+	 * <p>기존 구현은 '&' 제거를 ".." 제거 이후에 수행해, ".&." 이 ".." 제거 단계에서는
+	 * 인접하지 않다가 '&' 가 빠지며 ".." 로 되살아났다. 구분자 제거 뒤 ".."를 반복 제거해 보완한다.</p>
+	 */
+	@Test
+	public void fileInjectPathReplaceAll_doesNotReconstructParentSequenceViaAmpersand() {
+		assertEquals("", EgovWebUtil.fileInjectPathReplaceAll(".&."));
+		assertEquals("etc", EgovWebUtil.fileInjectPathReplaceAll(".&./etc"));
+		assertFalse(EgovWebUtil.fileInjectPathReplaceAll(".&.").contains(".."),
+				"'&' 제거 후 '..' 가 최종 결과에 남으면 안 된다");
+	}
+
+	/**
 	 * 구분자 제거 후 ".." 가 복원되지 않아야 한다.
 	 *
 	 * <p>정규식 오타만 고치면 ".\\." 처럼 구분자가 끼어든 입력은 ".." 가 인접하지 않아


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`EgovWebUtil.fileInjectPathReplaceAll()`의 상위 경로(`..`) 제거 로직에서 **결함 2건**을 수정했습니다.

### 문제 1 — 정규식 오타

기존 패턴 `\\..`는 정규식에서 **리터럴 점 1개 + 임의 문자 1개**를 뜻합니다. 따라서 정상 파일명의 점과 다음 문자도 함께 제거합니다.

- 입력: `report.txt`
- 기존 결과: `reportxt`
- 기대 결과: `report.txt`

```java
// AS-IS
returnValue = returnValue.replaceAll("\\..", "");

// TO-BE
returnValue = returnValue.replaceAll("\\.\\.", "");
```

### 문제 2 — 치환 순서 (오타 수정만으로는 부족)

오타를 고쳐도 결함이 남습니다. 이 메서드는 `..` 를 제거한 **뒤에** 역슬래시를 제거합니다. 그래서 구분자가 끼어든 입력은 `..` 가 인접하지 않아 필터를 **통과한 뒤**, 역슬래시가 사라지면서 `..` 가 **복원**됩니다.

| 입력 | 오타만 수정 시 | 순서까지 수정 시 |
| --- | --- | --- |
| `.\.` | `..` | (빈 문자열) |
| `.\./etc` | `..etc` | `etc` |
| `.\.\./etc` | `...etc` | `.etc` |

```java
// AS-IS — '..' 제거 후 역슬래시 제거 → '..' 복원 가능
returnValue = returnValue.replaceAll("/", "");
returnValue = returnValue.replaceAll("\\.\\.", "");
returnValue = returnValue.replaceAll("\\\\", "");

// TO-BE — 구분자를 먼저 제거
returnValue = returnValue.replaceAll("/", "");
returnValue = returnValue.replaceAll("\\\\", "");
returnValue = returnValue.replaceAll("\\.\\.", "");
```

**같은 클래스의 `filePathReplaceAll()` 은 이미 `/` → `\` → `..` 순서**라 이 문제가 없습니다. `fileInjectPathReplaceAll()` 도 동일한 순서로 맞췄습니다. 새로운 규칙을 도입한 것이 아니라 **기존 구현과의 정합성을 맞춘 것**입니다.

## 회귀 테스트

`EgovWebUtilTest` 에 다음을 추가했습니다.

- `../etc/passwd` 에서 상위 경로·구분자가 제거되는지 확인
- `report.txt` 의 정상 단일 점과 다음 문자가 보존되는지 확인
- **`.\.` · `.\./etc` 에서 구분자 제거 후 `..` 가 복원되지 않는지 확인** (신규)

## JUnit 테스트 JUnit tests

- [x] JUnit 테스트 JUnit tests
- [x] 수동 테스트 Manual testing

**로컬 실행 결과** (JDK 17 / Maven):

```
[INFO] Running egovframework.com.cmm.EgovWebUtilTest
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

> ⚠️ **CI 체크만으로는 이 테스트가 검증되지 않습니다.**
>
> `pom.xml` 의 `maven-surefire-plugin` 설정에 `<skipTests>true</skipTests>` 가 지정되어 있어, CI(`mvn -B verify`)에서는 테스트가 실행되지 않고 `Tests are skipped.` 로 넘어갑니다. 따라서 위 결과는 해당 설정을 로컬에서 임시 해제하고 확인한 것입니다.
>
> 이전 본문에 "로컬에 Java/Maven 실행기가 없어 정적 검증했으며 GitHub Actions 결과를 확인하겠다"고 적었으나, CI가 테스트를 실행하지 않아 확인이 불가능했습니다. 로컬 환경을 구성해 직접 실행한 결과로 대체합니다.

## 테스트 브라우저 Test Browser

해당 없음 (서버 측 경로 정제 유틸리티, 화면 변경 없음)

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

서버 측 경로 정제 유틸리티 수정으로 화면(UI) 변경 사항은 없습니다.