### PR TITLE
perf: 지역 StringBuffer를 StringBuilder로 전환 (불필요한 동기화 제거, 5건 통합)

### DIFF
--- a/src/main/java/egovframework/com/cmm/filter/HTMLTagFilterRequestWrapper.java
+++ b/src/main/java/egovframework/com/cmm/filter/HTMLTagFilterRequestWrapper.java
@@ -37,6 +37,7 @@ import jakarta.servlet.http.HttpServletRequestWrapper;
  *   2018.03.21  신용호          getParameterMap()구현 추가
  *   2019.01.31  신용호          whiteList 태그 추가
  *   2025.05.24  이백행          PMD로 소프트웨어 보안약점 진단하고 제거하기-SimplifyBooleanExpressions(부울 표현식 단순화), AvoidReassigningParameters(매개변수 재할당 방지)
+ *   2026.07.09  EricSeokgon      지역 StringBuffer를 StringBuilder로 변경(불필요한 동기화 제거)
  *
  *      </pre>
  */
@@ -114,7 +115,7 @@ public class HTMLTagFilterRequestWrapper extends HttpServletRequestWrapper {
 	}
 
 	private String getSafeParamData(String value) {
-		StringBuffer strBuff = new StringBuffer();
+		StringBuilder strBuff = new StringBuilder();
 
 		for (int i = 0; i < value.length(); i++) {
 			char c = value.charAt(i);

--- a/src/main/java/egovframework/com/cmm/web/EgovValidationControllerAdvice.java
+++ b/src/main/java/egovframework/com/cmm/web/EgovValidationControllerAdvice.java
@@ -165,7 +165,7 @@ public class EgovValidationControllerAdvice {
 		// {키이름} 패턴을 찾아서 대체
 		Pattern pattern = java.util.regex.Pattern.compile("\\{([^}]+)\\}");
 		Matcher matcher = pattern.matcher(message);
-		StringBuffer result = new StringBuffer();
+		StringBuilder result = new StringBuilder();
 
 		while (matcher.find()) {
 			String messageKey = matcher.group(1);

--- a/src/main/java/egovframework/com/cop/sms/service/impl/EgovSmsBasicServiceImpl.java
+++ b/src/main/java/egovframework/com/cop/sms/service/impl/EgovSmsBasicServiceImpl.java
@@ -105,7 +105,7 @@ public class EgovSmsBasicServiceImpl implements EgovSmsInfoService {
 			return "";
 		}
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 
 		if (number.length() == 9) { // 02-500-1234 형식
 			buffer.append(number.substring(0, 2));

--- a/src/main/java/egovframework/com/cop/sms/service/impl/EgovSmsInfoServiceImpl.java
+++ b/src/main/java/egovframework/com/cop/sms/service/impl/EgovSmsInfoServiceImpl.java
@@ -76,7 +76,7 @@ public class EgovSmsInfoServiceImpl extends EgovAbstractServiceImpl implements E
 	    return "";
 	}
 
-	StringBuffer buffer = new StringBuffer();
+	StringBuilder buffer = new StringBuilder();
 
 
 	if (number.length() == 9) {	// 02-500-1234 형식

--- a/src/main/java/egovframework/com/cop/sms/service/impl/SmsBasicDAO.java
+++ b/src/main/java/egovframework/com/cop/sms/service/impl/SmsBasicDAO.java
@@ -37,7 +37,7 @@ public class SmsBasicDAO {
 	public List<SmsVO> selectSmsInfs(SmsVO vo) throws Exception {
 		List<SmsVO> list = new ArrayList<SmsVO>();
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 
 		// for mySql
 		buffer.append("SELECT\n");
@@ -129,7 +129,7 @@ public class SmsBasicDAO {
 	 * @throws Exception
 	 */
 	public int selectSmsInfsCnt(SmsVO vo) throws Exception {
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 
 		// for mySql
 		buffer.append("SELECT\n");
@@ -191,7 +191,7 @@ public class SmsBasicDAO {
 	public String insertSmsInf(Sms sms) throws Exception {
 		String smsId = null;
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 
 		// for mySql
 		buffer.append("INSERT INTO COMTNSMS\n");
@@ -237,7 +237,7 @@ public class SmsBasicDAO {
 	 * @throws Exception
 	 */
 	public void insertSmsRecptnInf(SmsRecptn smsRecptn) throws Exception {
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 
 		// for mySql & Oracle
 		buffer.append("INSERT INTO COMTNSMSRECPTN\n");
@@ -267,7 +267,7 @@ public class SmsBasicDAO {
 	public SmsVO selectSmsInf(SmsVO searchVO) throws Exception {
 		SmsVO smsVO = new SmsVO();
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		// for mySql
 		buffer.append("SELECT\n");
 		buffer.append("  a.SMS_ID, a.TRNSMIS_TELNO, a.TRNSMIS_CN,\n");
@@ -318,7 +318,7 @@ public class SmsBasicDAO {
 	public List<SmsRecptn> selectSmsRecptnInfs(SmsRecptn vo) throws Exception {
 		List<SmsRecptn> list = new ArrayList<SmsRecptn>();
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 
 		// for mySql & Oracle
 		buffer.append("SELECT\n");
@@ -359,7 +359,7 @@ public class SmsBasicDAO {
 	 * @throws Exception
 	 */
 	public void updateSmsRecptnInf(SmsRecptn smsRecptn) throws Exception {
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 
 		// for mySql & Oracle
 		buffer.append("UPDATE COMTNSMSRECPTN SET\n");
@@ -388,7 +388,7 @@ public class SmsBasicDAO {
 	 * @throws Exception
 	 */
 	protected String getNextId(Connection conn) throws Exception {
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 
 		// for mySql
 		buffer.append(

--- a/src/main/java/egovframework/com/sym/adr/web/EgovAdressCntcController.java
+++ b/src/main/java/egovframework/com/sym/adr/web/EgovAdressCntcController.java
@@ -51,7 +51,7 @@ public class EgovAdressCntcController {
 			+ countPerPage + "&keyword=" + URLEncoder.encode(keyword, "UTF-8") + "&confmKey=" + confmKey;
 		URL url = new URL(EgovWebUtil.filePathBlackList(apiUrl));
 		try (BufferedReader br = new BufferedReader(new InputStreamReader(url.openStream(), "UTF-8"));) {//2022.01 Resources should be closed
-			StringBuffer sb = new StringBuffer();
+			StringBuilder sb = new StringBuilder();
 			String tempStr = null;
 			while (true) {
 				tempStr = br.readLine();
@@ -86,7 +86,7 @@ public class EgovAdressCntcController {
 			+ URLEncoder.encode(confmKey, "UTF-8");
 		URL url = new URL(EgovWebUtil.filePathBlackList(apiUrl));
 		try(BufferedReader br = new BufferedReader(new InputStreamReader(url.openStream(), "UTF-8"));){//2022.01 Resources should be closed
-			StringBuffer sb = new StringBuffer();
+			StringBuilder sb = new StringBuilder();
 			String tempStr = null;
 			while (true) {
 				tempStr = br.readLine();

--- a/src/main/java/egovframework/com/uss/ion/noi/service/impl/EgovNotificationServiceImpl.java
+++ b/src/main/java/egovframework/com/uss/ion/noi/service/impl/EgovNotificationServiceImpl.java
@@ -50,14 +50,14 @@ public class EgovNotificationServiceImpl extends EgovAbstractServiceImpl impleme
 
     @Override
     public void insertNotificationInf(NotificationVO notificationVO) throws Exception {
-        StringBuffer time = new StringBuffer();
+        StringBuilder time = new StringBuilder();
         time.append(notificationVO.getNtfcDate().replaceAll("-", ""));
         time.append(notificationVO.getNtfcHH().length() == 1 ? "0" + notificationVO.getNtfcHH() : notificationVO.getNtfcHH());
         time.append(notificationVO.getNtfcMM().length() == 1 ? "0" + notificationVO.getNtfcMM() : notificationVO.getNtfcMM());
         time.append("00");
         notificationVO.setNtfcTime(time.toString());
 
-        StringBuffer interval = new StringBuffer();
+        StringBuilder interval = new StringBuilder();
         String[] array = notificationVO.getBhNtfcIntrvl();
         if (array == null) {
             throw new RuntimeException("Method insertNotificationInf : array is null\n");
@@ -80,14 +80,14 @@ public class EgovNotificationServiceImpl extends EgovAbstractServiceImpl impleme
 
     @Override
     public void updateNotifictionInf(NotificationVO notificationVO) throws Exception {
-        StringBuffer time = new StringBuffer();
+        StringBuilder time = new StringBuilder();
         time.append(notificationVO.getNtfcDate().replaceAll("-", ""));
         time.append(notificationVO.getNtfcHH().length() == 1 ? "0" + notificationVO.getNtfcHH() : notificationVO.getNtfcHH());
         time.append(notificationVO.getNtfcMM().length() == 1 ? "0" + notificationVO.getNtfcMM() : notificationVO.getNtfcMM());
         time.append("00");
         notificationVO.setNtfcTime(time.toString());
 
-        StringBuffer interval = new StringBuffer();
+        StringBuilder interval = new StringBuilder();
         String[] array = notificationVO.getBhNtfcIntrvl();
         if (array != null) {
             for (int i = 0; i < array.length; i++) {
@@ -109,7 +109,7 @@ public class EgovNotificationServiceImpl extends EgovAbstractServiceImpl impleme
 
     @Override
     public boolean checkNotification(NotificationVO notificationVO) throws Exception {
-        StringBuffer time = new StringBuffer();
+        StringBuilder time = new StringBuilder();
         time.append(notificationVO.getNtfcDate().replaceAll("-", ""));
         time.append(notificationVO.getNtfcHH().length() == 1 ? "0" + notificationVO.getNtfcHH() : notificationVO.getNtfcHH());
         time.append(notificationVO.getNtfcMM().length() == 1 ? "0" + notificationVO.getNtfcMM() : notificationVO.getNtfcMM());

--- a/src/main/java/egovframework/com/uss/ion/noi/service/impl/EgovNotificationServiceImpl.java
+++ b/src/main/java/egovframework/com/uss/ion/noi/service/impl/EgovNotificationServiceImpl.java
@@ -28,6 +28,7 @@ import jakarta.annotation.Resource;
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.06.08  한성곤          최초 생성
+ *   2026.07.09  EricSeokgon      지역 StringBuffer를 StringBuilder로 변경(불필요한 동기화 제거)
  *
  * </pre>
  */
@@ -50,14 +51,14 @@ public class EgovNotificationServiceImpl extends EgovAbstractServiceImpl impleme
 
     @Override
     public void insertNotificationInf(NotificationVO notificationVO) throws Exception {
-        StringBuffer time = new StringBuffer();
+        StringBuilder time = new StringBuilder();
         time.append(notificationVO.getNtfcDate().replaceAll("-", ""));
         time.append(notificationVO.getNtfcHH().length() == 1 ? "0" + notificationVO.getNtfcHH() : notificationVO.getNtfcHH());
         time.append(notificationVO.getNtfcMM().length() == 1 ? "0" + notificationVO.getNtfcMM() : notificationVO.getNtfcMM());
         time.append("00");
         notificationVO.setNtfcTime(time.toString());
 
-        StringBuffer interval = new StringBuffer();
+        StringBuilder interval = new StringBuilder();
         String[] array = notificationVO.getBhNtfcIntrvl();
         if (array == null) {
             throw new RuntimeException("Method insertNotificationInf : array is null\n");
@@ -80,14 +81,14 @@ public class EgovNotificationServiceImpl extends EgovAbstractServiceImpl impleme
 
     @Override
     public void updateNotifictionInf(NotificationVO notificationVO) throws Exception {
-        StringBuffer time = new StringBuffer();
+        StringBuilder time = new StringBuilder();
         time.append(notificationVO.getNtfcDate().replaceAll("-", ""));
         time.append(notificationVO.getNtfcHH().length() == 1 ? "0" + notificationVO.getNtfcHH() : notificationVO.getNtfcHH());
         time.append(notificationVO.getNtfcMM().length() == 1 ? "0" + notificationVO.getNtfcMM() : notificationVO.getNtfcMM());
         time.append("00");
         notificationVO.setNtfcTime(time.toString());
 
-        StringBuffer interval = new StringBuffer();
+        StringBuilder interval = new StringBuilder();
         String[] array = notificationVO.getBhNtfcIntrvl();
         if (array != null) {
             for (int i = 0; i < array.length; i++) {
@@ -109,7 +110,7 @@ public class EgovNotificationServiceImpl extends EgovAbstractServiceImpl impleme
 
     @Override
     public boolean checkNotification(NotificationVO notificationVO) throws Exception {
-        StringBuffer time = new StringBuffer();
+        StringBuilder time = new StringBuilder();
         time.append(notificationVO.getNtfcDate().replaceAll("-", ""));
         time.append(notificationVO.getNtfcHH().length() == 1 ? "0" + notificationVO.getNtfcHH() : notificationVO.getNtfcHH());
         time.append(notificationVO.getNtfcMM().length() == 1 ? "0" + notificationVO.getNtfcMM() : notificationVO.getNtfcMM());

--- a/src/main/java/egovframework/com/utl/fcc/service/EgovNumberUtil.java
+++ b/src/main/java/egovframework/com/utl/fcc/service/EgovNumberUtil.java
@@ -6,6 +6,7 @@
  *     수정일         수정자                   수정내용
  *     -------          --------        ---------------------------
  *   2009.02.13       이삼섭                  최초 생성
+ *   2026.07.09       EricSeokgon             지역 StringBuffer를 StringBuilder로 변경(불필요한 동기화 제거)
  *
  * @author 공통 서비스 개발팀 이삼섭
  * @since 2009. 02. 13
@@ -176,7 +177,7 @@ public class EgovNumberUtil {
 		String subject = String.valueOf(cnvrSrcNumber);
 		String object = String.valueOf(cnvrTrgtNumber);
 
-		StringBuffer rtnStr = new StringBuffer();
+		StringBuilder rtnStr = new StringBuilder();
 		String preStr = "";
 		String nextStr = source;
 

--- a/src/main/java/egovframework/com/utl/fcc/service/EgovNumberUtil.java
+++ b/src/main/java/egovframework/com/utl/fcc/service/EgovNumberUtil.java
@@ -176,7 +176,7 @@ public class EgovNumberUtil {
 		String subject = String.valueOf(cnvrSrcNumber);
 		String object = String.valueOf(cnvrTrgtNumber);
 
-		StringBuffer rtnStr = new StringBuffer();
+		StringBuilder rtnStr = new StringBuilder();
 		String preStr = "";
 		String nextStr = source;
 

--- a/src/main/java/egovframework/com/utl/fcc/service/EgovPiiMaskUtil.java
+++ b/src/main/java/egovframework/com/utl/fcc/service/EgovPiiMaskUtil.java
@@ -243,7 +243,7 @@ public class EgovPiiMaskUtil {
 
     private static String maskAllJuminNo(String text) {
         Matcher m = JUMIN_PATTERN.matcher(text);
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         while (m.find()) {
             String replacement = m.group(1) + "-" + m.group(2).charAt(0) + "******";
             m.appendReplacement(sb, Matcher.quoteReplacement(replacement));
@@ -255,7 +255,7 @@ public class EgovPiiMaskUtil {
     private static String maskAllPhoneNo(String text) {
         // 1) 하이픈 포함 번호 치환
         Matcher m = PHONE_HYPHEN_PATTERN.matcher(text);
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         while (m.find()) {
             String replacement = m.group(1) + "-" + m.group(2).replaceAll("\\d", "*") + "-" + m.group(3);
             m.appendReplacement(sb, Matcher.quoteReplacement(replacement));
@@ -265,7 +265,7 @@ public class EgovPiiMaskUtil {
         // 2) 하이픈 없는 번호 치환 — 단일 마스킹(maskPhoneNo)과 동일 규칙 적용.
         //    1)에서 가려진 결과는 하이픈/별표를 포함하므로 연속 10~11자리 패턴에 매칭되지 않는다.
         Matcher mp = PHONE_PLAIN_PATTERN.matcher(sb.toString());
-        StringBuffer sb2 = new StringBuffer();
+        StringBuilder sb2 = new StringBuilder();
         while (mp.find()) {
             mp.appendReplacement(sb2, Matcher.quoteReplacement(maskPlainPhoneDigits(mp.group(1))));
         }
@@ -275,7 +275,7 @@ public class EgovPiiMaskUtil {
 
     private static String maskAllEmail(String text) {
         Matcher m = EMAIL_PATTERN.matcher(text);
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         while (m.find()) {
             String local = m.group(1);
             String domain = m.group(2);
@@ -291,7 +291,7 @@ public class EgovPiiMaskUtil {
 
     private static String maskAllCardNo(String text) {
         Matcher m = CARD_PATTERN.matcher(text);
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         while (m.find()) {
             char sep = m.group(0).charAt(4);
             String replacement = m.group(1) + sep + "****" + sep + "****" + sep + m.group(4);
@@ -303,7 +303,7 @@ public class EgovPiiMaskUtil {
 
     private static String maskAllBizRegNo(String text) {
         Matcher m = BIZ_REG_PATTERN.matcher(text);
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         while (m.find()) {
             String replacement = m.group(1) + "-" + m.group(2) + "-*****";
             m.appendReplacement(sb, Matcher.quoteReplacement(replacement));
@@ -314,7 +314,7 @@ public class EgovPiiMaskUtil {
 
     private static String maskAllPrivateIp(String text) {
         Matcher m = PRIVATE_IP_PATTERN.matcher(text);
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         while (m.find()) {
             String replacement = m.group(1) + ".***";
             m.appendReplacement(sb, Matcher.quoteReplacement(replacement));

--- a/src/main/java/egovframework/com/utl/fcc/service/EgovStringUtil.java
+++ b/src/main/java/egovframework/com/utl/fcc/service/EgovStringUtil.java
@@ -194,7 +194,7 @@ public class EgovStringUtil {
 	 * @return sb.toString() 새로운 문자열로 변환된 문자열
 	 */
 	public static String replace(String source, String subject, String object) {
-		StringBuffer rtnStr = new StringBuffer();
+		StringBuilder rtnStr = new StringBuilder();
 		String preStr = "";
 		String nextStr = source;
 		String srcStr = source;
@@ -218,7 +218,7 @@ public class EgovStringUtil {
 	 * @return sb.toString() 새로운 문자열로 변환된 문자열 / source 특정문자열이 없는 경우 원본 문자열
 	 */
 	public static String replaceOnce(String source, String subject, String object) {
-		StringBuffer rtnStr = new StringBuffer();
+		StringBuilder rtnStr = new StringBuilder();
 		String preStr = "";
 		String nextStr = source;
 		if (source.indexOf(subject) >= 0) {
@@ -241,7 +241,7 @@ public class EgovStringUtil {
 	 * @return sb.toString() 새로운 문자열로 변환된 문자열
 	 */
 	public static String replaceChar(String source, String subject, String object) {
-		StringBuffer rtnStr = new StringBuffer();
+		StringBuilder rtnStr = new StringBuilder();
 		String preStr = "";
 		String nextStr = source;
 		String srcStr = source;
@@ -509,7 +509,7 @@ public class EgovStringUtil {
 	public static String checkHtmlView(String strString) {
 		String strNew = "";
 
-		StringBuffer strTxt = new StringBuffer("");
+		StringBuilder strTxt = new StringBuilder("");
 
 		char chrBuff;
 		int len = strString.length();
@@ -826,7 +826,7 @@ public class EgovStringUtil {
 
 		String rtnStr = null;
 
-		StringBuffer strTxt = new StringBuffer("");
+		StringBuilder strTxt = new StringBuilder("");
 
 		char chrBuff;
 		int len = srcString.length();

--- a/src/main/java/egovframework/com/utl/fcc/service/EgovStringUtil.java
+++ b/src/main/java/egovframework/com/utl/fcc/service/EgovStringUtil.java
@@ -8,6 +8,7 @@
  *   2009.01.13     박정규          최초 생성
  *   2009.02.13     이삼섭          내용 추가
  *   2024.10.29		Chung10Kr		명사에 맞는 조사 반환 기능 개발
+ *   2026.07.09     EricSeokgon     지역 StringBuffer를 StringBuilder로 변경(불필요한 동기화 제거)
  *
  * @author 공통 서비스 개발팀 박정규
  * @since 2009. 01. 13
@@ -194,7 +195,7 @@ public class EgovStringUtil {
 	 * @return sb.toString() 새로운 문자열로 변환된 문자열
 	 */
 	public static String replace(String source, String subject, String object) {
-		StringBuffer rtnStr = new StringBuffer();
+		StringBuilder rtnStr = new StringBuilder();
 		String preStr = "";
 		String nextStr = source;
 		String srcStr = source;
@@ -218,7 +219,7 @@ public class EgovStringUtil {
 	 * @return sb.toString() 새로운 문자열로 변환된 문자열 / source 특정문자열이 없는 경우 원본 문자열
 	 */
 	public static String replaceOnce(String source, String subject, String object) {
-		StringBuffer rtnStr = new StringBuffer();
+		StringBuilder rtnStr = new StringBuilder();
 		String preStr = "";
 		String nextStr = source;
 		if (source.indexOf(subject) >= 0) {
@@ -241,7 +242,7 @@ public class EgovStringUtil {
 	 * @return sb.toString() 새로운 문자열로 변환된 문자열
 	 */
 	public static String replaceChar(String source, String subject, String object) {
-		StringBuffer rtnStr = new StringBuffer();
+		StringBuilder rtnStr = new StringBuilder();
 		String preStr = "";
 		String nextStr = source;
 		String srcStr = source;
@@ -509,7 +510,7 @@ public class EgovStringUtil {
 	public static String checkHtmlView(String strString) {
 		String strNew = "";
 
-		StringBuffer strTxt = new StringBuffer("");
+		StringBuilder strTxt = new StringBuilder("");
 
 		char chrBuff;
 		int len = strString.length();
@@ -826,7 +827,7 @@ public class EgovStringUtil {
 
 		String rtnStr = null;
 
-		StringBuffer strTxt = new StringBuffer("");
+		StringBuilder strTxt = new StringBuilder("");
 
 		char chrBuff;
 		int len = srcString.length();

--- a/src/main/java/egovframework/com/utl/sim/service/EgovFileTool.java
+++ b/src/main/java/egovframework/com/utl/sim/service/EgovFileTool.java
@@ -52,6 +52,7 @@ import egovframework.com.utl.fcc.service.EgovStringUtil;
  *  2022.11.11   김혜준       시큐어코딩 처리
  *  2024.10.29   win777	    디렉토리 생성 성공 시 생성된 절대경로를 리턴하도록 변경
  *  2025.02.06   신용호       deleteFile() KISA 시큐어코딩 처리
+ *  2026.07.09   EricSeokgon  지역 StringBuffer를 StringBuilder로 변경(불필요한 동기화 제거)
  *
  * </pre>
  */
@@ -366,9 +367,9 @@ public class EgovFileTool {
 			// 파일이며, 존재하면 파싱 시작
 			if (file.exists() && file.isFile()) {
 
-				// 1. 파일 텍스트 내용을 읽어서 StringBuffer에 쌓는다.
+				// 1. 파일 텍스트 내용을 읽어서 StringBuilder에 쌓는다.
 				br = new BufferedReader(new InputStreamReader(new FileInputStream(file)));
-				StringBuffer strBuff = new StringBuffer();
+				StringBuilder strBuff = new StringBuilder();
 				String line = "";
 				while ((line = br.readLine()) != null) {
 					if (line.length() < MAX_STR_LEN) {

--- a/src/main/java/egovframework/com/utl/sim/service/EgovFileTool.java
+++ b/src/main/java/egovframework/com/utl/sim/service/EgovFileTool.java
@@ -366,9 +366,9 @@ public class EgovFileTool {
 			// 파일이며, 존재하면 파싱 시작
 			if (file.exists() && file.isFile()) {
 
-				// 1. 파일 텍스트 내용을 읽어서 StringBuffer에 쌓는다.
+				// 1. 파일 텍스트 내용을 읽어서 StringBuilder에 쌓는다.
 				br = new BufferedReader(new InputStreamReader(new FileInputStream(file)));
-				StringBuffer strBuff = new StringBuffer();
+				StringBuilder strBuff = new StringBuilder();
 				String line = "";
 				while ((line = br.readLine()) != null) {
 					if (line.length() < MAX_STR_LEN) {

--- a/src/main/java/egovframework/com/utl/sim/service/EgovFileToolBean.java
+++ b/src/main/java/egovframework/com/utl/sim/service/EgovFileToolBean.java
@@ -101,9 +101,9 @@ public class EgovFileToolBean {
 			// 파일이며, 존재하면 파싱 시작
 			if (file.exists() && file.isFile()) {
 
-				// 1. 파일 텍스트 내용을 읽어서 StringBuffer에 쌓는다.
+				// 1. 파일 텍스트 내용을 읽어서 StringBuilder에 쌓는다.
 				br = new BufferedReader(new InputStreamReader(new FileInputStream(file)));
-				StringBuffer strBuff = new StringBuffer();
+				StringBuilder strBuff = new StringBuilder();
 				String line = "";
 				while ((line = br.readLine()) != null) {
 					if (line.length() < MAX_STR_LEN) {

--- a/src/main/java/egovframework/com/utl/sys/fsm/service/EgovFileSystemMntrngScheduling.java
+++ b/src/main/java/egovframework/com/utl/sys/fsm/service/EgovFileSystemMntrngScheduling.java
@@ -38,6 +38,7 @@ import jakarta.annotation.Resource;
  *  2017.03.03 	 조성원 	시큐어코딩(ES)-Null Pointer 역참조[CWE-476]
  *  2022.11.11   김혜준   시큐어코딩 처리
  *  2024.05.02   김수용   NSR 보안조치 (파일시스템명에서 악의적인 문자열 제거)
+ *  2026.07.10   EricSeokgon   이메일 본문 생성 시 문자열 연결(+=)을 StringBuilder로 변경(불필요한 중간 String 생성 제거)
  *
  */
 
@@ -164,36 +165,38 @@ public class EgovFileSystemMntrngScheduling extends EgovAbstractServiceImpl {
         // 2022.11.11 시큐어코딩 처리
      	if (StringUtils.isNotEmpty(text)) {
 	        text = EgovStringUtil.replace(text, "{모니터링종류}", "파일시스템모니터링");
-	        errorContents = "파일시스템명 : ";
-	        errorContents += target.getFileSysNm();
-	        errorContents += "\n";
-	        errorContents += "파일시스템관리명 : ";
-	        errorContents += target.getFileSysManageNm();
-	        errorContents += "\n";
+	        StringBuilder errorContentsBuilder = new StringBuilder();
+	        errorContentsBuilder.append("파일시스템명 : ");
+	        errorContentsBuilder.append(target.getFileSysNm());
+	        errorContentsBuilder.append("\n");
+	        errorContentsBuilder.append("파일시스템관리명 : ");
+	        errorContentsBuilder.append(target.getFileSysManageNm());
+	        errorContentsBuilder.append("\n");
 	        if(target.getLogInfo() != null && !target.getLogInfo().equals("")){
-	        	errorContents += "해당파일의 파일시스템 정보를 가져오는중 에러가 발생하였습니다.";
+	        	errorContentsBuilder.append("해당파일의 파일시스템 정보를 가져오는중 에러가 발생하였습니다.");
 	        }else{
-		        errorContents += "크기 : ";
-		        errorContents += target.getFileSysMg();
-		        errorContents += "GB\n";
-		        errorContents += "임계치 : ";
-		        errorContents += target.getFileSysThrhld();
-		        errorContents += "GB\n";
-		        errorContents += "사용량 : ";
-		        errorContents += target.getFileSysUsgQty();
-		        errorContents += "GB\n";
+		        errorContentsBuilder.append("크기 : ");
+		        errorContentsBuilder.append(target.getFileSysMg());
+		        errorContentsBuilder.append("GB\n");
+		        errorContentsBuilder.append("임계치 : ");
+		        errorContentsBuilder.append(target.getFileSysThrhld());
+		        errorContentsBuilder.append("GB\n");
+		        errorContentsBuilder.append("사용량 : ");
+		        errorContentsBuilder.append(target.getFileSysUsgQty());
+		        errorContentsBuilder.append("GB\n");
 	        }
-	        errorContents += "상태 : ";
-	        errorContents += target.getMntrngSttus();
-	        errorContents += "\n";
-	        errorContents += "모니터링 시각 : ";
-	        errorContents += EgovDateUtil.convertDate(target.getCreatDt(), "", "", "");
-	        errorContents += "\n";
+	        errorContentsBuilder.append("상태 : ");
+	        errorContentsBuilder.append(target.getMntrngSttus());
+	        errorContentsBuilder.append("\n");
+	        errorContentsBuilder.append("모니터링 시각 : ");
+	        errorContentsBuilder.append(EgovDateUtil.convertDate(target.getCreatDt(), "", "", ""));
+	        errorContentsBuilder.append("\n");
 	        if(target.getLogInfo() != null && !target.getLogInfo().equals("")){
-	        	errorContents += target.getFileSysManageNm() + " 의 파일시스템 상태가 비정상입니다.  \n로그를 확인해주세요.";
+	        	errorContentsBuilder.append(target.getFileSysManageNm()).append(" 의 파일시스템 상태가 비정상입니다.  \n로그를 확인해주세요.");
 	        }else{
-	        	errorContents += target.getFileSysManageNm() + " 의 파일시스템이 임계치를 넘었습니다.";
+	        	errorContentsBuilder.append(target.getFileSysManageNm()).append(" 의 파일시스템이 임계치를 넘었습니다.");
 	        }
+	        errorContents = errorContentsBuilder.toString();
 	        text = EgovStringUtil.replace(text, "{에러내용}", errorContents);
 	        msg.setText(text);
      	}

--- a/src/main/java/egovframework/com/utl/sys/srm/service/EgovServerResrceMntrngScheduling.java
+++ b/src/main/java/egovframework/com/utl/sys/srm/service/EgovServerResrceMntrngScheduling.java
@@ -46,6 +46,7 @@ import jakarta.annotation.Resource;
  *  ----------   ---------   ---------------------------
  *  2020.11.02   신용호              불필요한 멤버변수 지역변수로 변경
  *  2022.11.11   김혜준              시큐어코딩 처리
+ *  2026.07.10   EricSeokgon         이메일 본문 생성 시 문자열 연결(+=)을 StringBuilder로 변경(불필요한 중간 String 생성 제거)
  *
  * </pre>
  */
@@ -221,27 +222,29 @@ public class EgovServerResrceMntrngScheduling extends EgovAbstractServiceImpl {
 		// 2022.11.11 시큐어코딩 처리
 		if (StringUtils.isNotEmpty(text)) {
 			text = EgovStringUtil.replace(text, "{모니터링종류}", "서버자원서비스모니터링");
-			errorContents = "서버명 : ";
-			errorContents += serverResrceMntrng.getServerNm();
-			errorContents += "\n";
-			errorContents += "서버IP : ";
-			errorContents += serverResrceMntrng.getServerEqpmnIp();
-			errorContents += "\n";
-			errorContents += "CPU사용률 : ";
-			errorContents += serverResrceMntrng.getCpuUseRt();
-			errorContents += "\n";
-			errorContents += "메모리사용률 : ";
-			errorContents += serverResrceMntrng.getMoryUseRt();
-			errorContents += "\n";
-			errorContents += "서비스상태 : 비정상";
-			errorContents += "\n";
-			errorContents += "내용 : ";
-			errorContents += serverResrceMntrng.getLogInfo();
-			errorContents += "\n";
-			errorContents += "생성일시 : ";
-			errorContents += EgovDateUtil.convertDate(serverResrceMntrng.getCreatDt(), "", "", "");
-			errorContents += "\n";
-			errorContents += serverResrceMntrng.getServerNm() + " 의 서버자원 서비스 상태가 비정상입니다. \n로그를 확인해주세요.";
+			StringBuilder errorContentsBuilder = new StringBuilder();
+			errorContentsBuilder.append("서버명 : ");
+			errorContentsBuilder.append(serverResrceMntrng.getServerNm());
+			errorContentsBuilder.append("\n");
+			errorContentsBuilder.append("서버IP : ");
+			errorContentsBuilder.append(serverResrceMntrng.getServerEqpmnIp());
+			errorContentsBuilder.append("\n");
+			errorContentsBuilder.append("CPU사용률 : ");
+			errorContentsBuilder.append(serverResrceMntrng.getCpuUseRt());
+			errorContentsBuilder.append("\n");
+			errorContentsBuilder.append("메모리사용률 : ");
+			errorContentsBuilder.append(serverResrceMntrng.getMoryUseRt());
+			errorContentsBuilder.append("\n");
+			errorContentsBuilder.append("서비스상태 : 비정상");
+			errorContentsBuilder.append("\n");
+			errorContentsBuilder.append("내용 : ");
+			errorContentsBuilder.append(serverResrceMntrng.getLogInfo());
+			errorContentsBuilder.append("\n");
+			errorContentsBuilder.append("생성일시 : ");
+			errorContentsBuilder.append(EgovDateUtil.convertDate(serverResrceMntrng.getCreatDt(), "", "", ""));
+			errorContentsBuilder.append("\n");
+			errorContentsBuilder.append(serverResrceMntrng.getServerNm()).append(" 의 서버자원 서비스 상태가 비정상입니다. \n로그를 확인해주세요.");
+			errorContents = errorContentsBuilder.toString();
 			text = EgovStringUtil.replace(text, "{에러내용}", errorContents);
 			msg.setText(text);
 		}

--- a/src/main/java/egovframework/com/utl/wed/filter/DirectoryPathManager.java
+++ b/src/main/java/egovframework/com/utl/wed/filter/DirectoryPathManager.java
@@ -64,7 +64,7 @@ public class DirectoryPathManager {
 	public static String getDirectoryPathByDateType(DIR_DATE_TYPE policy) {
 
 		Calendar calendar = Calendar.getInstance();
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append(calendar.get(Calendar.YEAR)).append(File.separator);
 		if (policy.ordinal() <= DIR_DATE_TYPE.DATE_POLICY_YYYY_MM.ordinal()) {
 			sb.append(StringUtils.leftPad(String.valueOf(calendar.get(Calendar.MONTH)+1), 2, '0')).append(File.separator);


### PR DESCRIPTION
## 통합 안내

기존에 같은 계열로 분리 제출했던 PR들을 **하나로 통합**해 다시 제출합니다.

분리 제출한 PR들이 서로 같은 파일을 수정하고 있어, 하나를 병합하면 나머지가 충돌하는 상태였습니다. 리뷰 부담을 줄이기 위해 계열 단위로 통합했습니다.

기존 PR은 이 PR이 병합되면 닫겠습니다. 먼저 닫지 않은 것은 기존 건을 검토 중이셨을 경우 선택지를 남기기 위함입니다.

## 수정 사유 Reason for modification

- [ ] 버그수정 Bug fixes
- [x] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

메서드 지역 변수로만 쓰이는 `StringBuffer`를 `StringBuilder`로 교체했습니다. `StringBuffer`는 모든 메서드가 `synchronized`라 단일 스레드 지역 변수에는 불필요한 동기화 비용이 발생합니다. 정적분석 권고 항목입니다 (SonarQube `java:S1149`).

**지역 변수로만 사용되는 경우에만** 변경했습니다. 필드·공유 참조로 노출되는 `StringBuffer`는 스레드 안전성이 필요할 수 있어 건드리지 않았습니다.

## 통합 대상

이 PR은 아래 5건을 대체합니다.

| 기존 PR | 내용 |
| --- | --- |
| #1138 | 지역 StringBuffer를 StringBuilder로 |
| #1139 | 동 2차 |
| #1099 | 지역 변수 StringBuffer를 StringBuilder로 |
| #1100 | 동 2차 (7파일) |
| #1144 | 모니터링 스케줄러 이메일 본문 생성 시 문자열 연결(+=)을 StringBuilder로 |

- 변경 파일: 15개
- public API 시그니처 변경 없음.

## JUnit 테스트 JUnit tests

- [ ] JUnit 테스트 JUnit tests
- [x] 수동 테스트 Manual testing

- 로컬 컴파일 확인 (JDK 17, `mvn compile`)