### PR TITLE
fix: 팝업 프로토콜 상대 URL 검증 우회 차단

### DIFF
--- a/src/main/java/egovframework/com/cmm/EgovWebUtil.java
+++ b/src/main/java/egovframework/com/cmm/EgovWebUtil.java
@@ -22,6 +22,7 @@ import java.util.regex.Pattern;
  *  2023.08.10   신용호      removeLDAPInjectionRisk() 오류 수정
  *  2024.12.04   신용호      filePathBlackList() basePath 추가
  *  2026.07.10   유지보수    NCSC 보안점검 반영 (XSS/SSRF/세션고정 대응 유틸 추가)
+ *  2026.07.15   EricSeokgon 팝업 프로토콜 상대 URL 검증 강화
  * </pre>
  */
 
@@ -186,7 +187,8 @@ public class EgovWebUtil {
 			throw new IllegalArgumentException("requestUrl is required");
 		}
 		String trimmed = requestUrl.trim();
-		if (!trimmed.startsWith("/") || trimmed.contains("://") || trimmed.contains("..")
+		if (!trimmed.startsWith("/") || trimmed.startsWith("//") || trimmed.startsWith("/\\")
+				|| trimmed.contains("://") || trimmed.contains("..")
 				|| trimmed.contains("\"") || trimmed.contains("'") || trimmed.contains("<")
 				|| trimmed.contains(">") || trimmed.contains("\r") || trimmed.contains("\n")) {
 			throw new IllegalArgumentException("Invalid requestUrl");

--- a/src/main/java/egovframework/com/cmm/EgovWebUtil.java
+++ b/src/main/java/egovframework/com/cmm/EgovWebUtil.java
@@ -186,7 +186,8 @@ public class EgovWebUtil {
 		if (requestUrl == null || requestUrl.isBlank()) {
 			throw new IllegalArgumentException("requestUrl is required");
 		}
-		String trimmed = requestUrl.trim();
+		// mochoping 리뷰: 브라우저가 URL 해석 전 제거하는 탭/개행(0x09/0x0A/0x0D)을 먼저 제거한 뒤 검증한다 (예: "/[TAB]/evil" 은 브라우저에서 "//evil" 로 해석됨)
+		String trimmed = requestUrl.replace("\t", "").replace("\n", "").replace("\r", "").trim();
 		if (!trimmed.startsWith("/") || trimmed.startsWith("//") || trimmed.startsWith("/\\")
 				|| trimmed.contains("://") || trimmed.contains("..")
 				|| trimmed.contains("\"") || trimmed.contains("'") || trimmed.contains("<")

--- a/src/test/java/egovframework/com/cmm/EgovWebUtilTest.java
+++ b/src/test/java/egovframework/com/cmm/EgovWebUtilTest.java
@@ -2,6 +2,7 @@ package egovframework.com.cmm;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
 
@@ -53,5 +54,23 @@ public class EgovWebUtilTest {
 	public void removeLDAPInjectionRisk_nullOrBlankReturnsEmpty() {
 		assertEquals("", EgovWebUtil.removeLDAPInjectionRisk(null));
 		assertEquals("", EgovWebUtil.removeLDAPInjectionRisk("   "));
+	}
+
+	@Test
+	public void sanitizeRelativeRequestUrl_acceptsContextRelativePath() {
+		assertEquals("/cop/bbs/SelectBBSMasterInfsPop.do",
+				EgovWebUtil.sanitizeRelativeRequestUrl("/cop/bbs/SelectBBSMasterInfsPop.do"));
+	}
+
+	@Test
+	public void sanitizeRelativeRequestUrl_rejectsProtocolRelativeUrl() {
+		assertThrows(IllegalArgumentException.class,
+				() -> EgovWebUtil.sanitizeRelativeRequestUrl("//evil.example/popup"));
+	}
+
+	@Test
+	public void sanitizeRelativeRequestUrl_rejectsBackslashProtocolRelativeUrl() {
+		assertThrows(IllegalArgumentException.class,
+				() -> EgovWebUtil.sanitizeRelativeRequestUrl("/\\evil.example/popup"));
 	}
 }

--- a/src/test/java/egovframework/com/cmm/EgovWebUtilTest.java
+++ b/src/test/java/egovframework/com/cmm/EgovWebUtilTest.java
@@ -73,4 +73,13 @@ public class EgovWebUtilTest {
 		assertThrows(IllegalArgumentException.class,
 				() -> EgovWebUtil.sanitizeRelativeRequestUrl("/\\evil.example/popup"));
 	}
+
+	@Test
+	public void sanitizeRelativeRequestUrl_rejectsTabBypassProtocolRelativeUrl() {
+		// 브라우저는 URL 해석 전 탭(0x09)을 제거하므로 "/[TAB]/evil.example/popup" 은 "//evil.example/popup" 로 해석된다 (mochoping 리뷰)
+		assertThrows(IllegalArgumentException.class,
+				() -> EgovWebUtil.sanitizeRelativeRequestUrl("/\t/evil.example/popup"));
+		assertThrows(IllegalArgumentException.class,
+				() -> EgovWebUtil.sanitizeRelativeRequestUrl("/\t\t/evil.example/popup"));
+	}
 }


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`EgovWebUtil.sanitizeRelativeRequestUrl()`이 프로토콜 상대 URL을 상대경로로 오인해 허용하는 문제를 수정했습니다.

### 문제

기존 검증은 문자열이 `/`로 시작하고 `://`가 없으면 통과시킵니다. 따라서 다음 입력이 허용됩니다.

- `//evil.example/popup`
- `/\evil.example/popup` (브라우저가 역슬래시를 슬래시로 정규화할 수 있음)

이 값은 팝업 iframe의 `src`로 사용됩니다. 애플리케이션이 루트 컨텍스트에 배포된 경우 외부 호스트를 로드할 수 있어, 상대경로만 허용하려는 검증 목적을 우회합니다.

### 수정

```java
if (!trimmed.startsWith("/")
        || trimmed.startsWith("//")
        || trimmed.startsWith("/\\")
        || ...) {
    throw new IllegalArgumentException("Invalid requestUrl");
}
```

정상 컨텍스트 상대경로(`/cop/bbs/SelectBBSMasterInfsPop.do`)는 그대로 허용합니다.

### 회귀 테스트

`EgovWebUtilTest`에 다음 3건을 추가했습니다.

1. 정상 컨텍스트 상대경로 허용
2. `//host` 프로토콜 상대 URL 거부
3. `/\host` 역슬래시 변형 거부

## JUnit 테스트 JUnit tests

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

※ 로컬 환경에 Java/Maven 실행기가 없어 JUnit 실행은 못 했으며, 입력별 조건 판정과 diff를 수동 검증했습니다. GitHub Actions에서 컴파일 결과를 확인하겠습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

서버 측 URL 검증 로직 수정으로 화면(UI) 변경 사항은 없습니다.