### PR TITLE
fix: 다운로드 Content-Disposition 헤더 이름의 콜론 제거

### DIFF
--- a/src/main/java/egovframework/com/cmm/service/EgovFileMngUtil.java
+++ b/src/main/java/egovframework/com/cmm/service/EgovFileMngUtil.java
@@ -54,6 +54,7 @@ import egovframework.com.cmm.EgovWebUtil;
  *   2022.11.11  김혜준          시큐어코딩 처리
  *   2024.12.04  신용호          downFile() KISA 시큐어코딩 처리
  *   2025.05.26  이백행          PMD로 소프트웨어 보안약점 진단하고 제거하기-FormalParameterNamingConventions(공식 매개변수 명명 규칙), CloseResource(리소스 닫기), LocalVariableNamingConventions(지역 변수 명명 규칙), AssignmentInOperand(피연산자의 할당)
+ *   2026.07.15  EricSeokgon     다운로드 Content-Disposition 헤더 이름 수정
  * 
  *      </pre>
  */
@@ -274,7 +275,7 @@ public class EgovFileMngUtil {
 		}
 
 		response.setContentType("application/x-msdownload");
-		response.setHeader("Content-Disposition:",
+		response.setHeader("Content-Disposition",
 				"attachment; filename=" + new String(orgFileName.getBytes(), "UTF-8"));
 		response.setHeader("Content-Transfer-Encoding", "binary");
 		response.setHeader("Pragma", "no-cache");
@@ -376,7 +377,7 @@ public class EgovFileMngUtil {
 
 				// response.setBufferSize(fSize);
 				response.setContentType(mimetype);
-				response.setHeader("Content-Disposition:", "attachment; filename=" + orgFileName);
+				response.setHeader("Content-Disposition", "attachment; filename=" + orgFileName);
 				response.setContentLength(fSize);
 				// response.setHeader("Content-Transfer-Encoding","binary");
 				// response.setHeader("Pragma","no-cache");
@@ -416,7 +417,7 @@ public class EgovFileMngUtil {
 
 		/*
 		 * response.setContentType("application/x-msdownload");
-		 * response.setHeader("Content-Disposition:", "attachment; filename=" + new
+		 * response.setHeader("Content-Disposition", "attachment; filename=" + new
 		 * String(orgFileName.getBytes(),"UTF-8" ));
 		 * response.setHeader("Content-Transfer-Encoding","binary");
 		 * response.setHeader("Pragma","no-cache"); response.setHeader("Expires","0");


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`EgovFileMngUtil`의 두 다운로드 메서드가 HTTP 응답 헤더 이름을 `Content-Disposition:`으로 전달하는 오류를 수정했습니다.

### 문제

`HttpServletResponse.setHeader(name, value)`의 `name`에는 콜론을 제외한 헤더 이름만 전달해야 합니다. 기존 코드는 콜론까지 이름에 포함해 Servlet 컨테이너에 따라 잘못된 헤더로 처리되거나 요청이 거부될 수 있습니다.

```java
// AS-IS
response.setHeader("Content-Disposition:", "attachment; filename=" + orgFileName);

// TO-BE
response.setHeader("Content-Disposition", "attachment; filename=" + orgFileName);
```

### 변경 범위

- `downFile(HttpServletRequest, HttpServletResponse)`
- `downFile(HttpServletResponse, String, String)`
- 같은 클래스의 주석 예제 1곳

헤더 값과 파일 스트리밍 로직은 변경하지 않았습니다.

## JUnit 테스트 JUnit tests

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

※ 헤더 이름 리터럴 2곳과 주석 예제 1곳을 점검했으며, 실행 코드에 `setHeader("Content-Disposition:"` 패턴이 남지 않은 것을 확인했습니다. GitHub Actions에서 컴파일 결과를 확인하겠습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

서버 측 다운로드 응답 헤더 수정으로 화면(UI) 변경 사항은 없습니다.