### PR TITLE
fix: 대용량 파일 다운로드 Content-Length 오버플로 방지

### DIFF
--- a/src/main/java/egovframework/com/cmm/service/EgovFileMngUtil.java
+++ b/src/main/java/egovframework/com/cmm/service/EgovFileMngUtil.java
@@ -369,7 +369,7 @@ public class EgovFileMngUtil {
 			throw new FileNotFoundException(downFilePath);
 		}
 
-		int fSize = (int) file.length();
+		long fSize = file.length();
 		if (fSize > 0) {
 			try (BufferedInputStream in = new BufferedInputStream(new FileInputStream(file));) {
 				String mimetype = "application/x-msdownload";
@@ -377,7 +377,7 @@ public class EgovFileMngUtil {
 				// response.setBufferSize(fSize);
 				response.setContentType(mimetype);
 				response.setHeader("Content-Disposition:", "attachment; filename=" + orgFileName);
-				response.setContentLength(fSize);
+				response.setContentLengthLong(fSize);
 				// response.setHeader("Content-Transfer-Encoding","binary");
 				// response.setHeader("Pragma","no-cache");
 				// response.setHeader("Expires","0");


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`EgovFileMngUtil.downFile()`이 `File.length()`의 `long` 반환값을 `int`로 강제 변환하고 있습니다.

2,147,483,647바이트를 초과하는 파일은 변환 과정에서 음수 또는 잘못된 길이가 될 수 있습니다. 이 경우 `fSize > 0` 조건을 통과하지 못해 다운로드가 시작되지 않거나 잘못된 `Content-Length`가 전달될 수 있습니다.

### 수정

1. 파일 크기를 `int`로 축소하지 않고 `long`으로 유지합니다.
2. Servlet API의 `setContentLengthLong()`으로 전체 파일 크기를 응답에 설정합니다.
3. 기존 파일 스트리밍 방식과 다운로드 헤더 구성은 변경하지 않습니다.

## JUnit 테스트 JUnit tests

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`git diff --check`를 통과했습니다. 로컬 환경에는 Maven 실행기가 없어 컴파일 검증은 GitHub Actions에서 확인할 예정입니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음 (서버 측 파일 다운로드 유틸리티 변경)

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

서버 측 파일 다운로드 유틸리티 수정으로 화면(UI) 변경 사항은 없습니다.

## 영향 범위 Impact

- 2 GiB 이하 파일의 동작은 기존과 동일합니다.
- 2 GiB 초과 파일도 길이 오버플로 없이 다운로드 처리할 수 있습니다.
