### PR TITLE
[test] EgovMessageUtil/EgovFormBasedFileUtil/EgovFileMngUtil 순수 유틸 단위 테스트 추가

### DIFF
--- a/src/test/java/egovframework/com/cmm/service/EgovFileMngUtilTest.java
+++ b/src/test/java/egovframework/com/cmm/service/EgovFileMngUtilTest.java
@@ -1,0 +1,121 @@
+package egovframework.com.cmm.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.lang.reflect.Proxy;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.web.multipart.MultipartFile;
+
+/**
+ * parseFileInf() 계열 메서드만 검증한다. downFile/writeFile/uploadFile 등은 클래스 로딩 시점에
+ * 고정되는 정적 Globals.fileStorePath(테스트 설정상 "C:/egovframework/upload/")에 실제 디스크
+ * 쓰기를 수행하므로, 실행 환경(OS)에 따라 프로젝트 바깥에 의도치 않은 디렉토리를 생성할 위험이 있어 제외했다.
+ * storePath에 존재하지 않는 프로퍼티 키를 넘기면 EgovProperties가 빈 문자열을 반환하고
+ * new File("")은 mkdirs()를 타지 않으므로(이미 존재하는 것으로 취급) 부작용 없이 검증할 수 있다.
+ */
+class EgovFileMngUtilTest {
+
+	private static final String NO_SUCH_STORE_PATH_KEY = "test.no.such.store.path.key";
+
+	private final EgovFileMngUtil util = new EgovFileMngUtil();
+
+	@Test
+	void parseFileInfMap_buildsFileVoFromMultipartFile() throws Exception {
+		Map<String, MultipartFile> files = new LinkedHashMap<>();
+		files.put("file1", fakeFile("hello.TXT", 11));
+
+		List<FileVO> result = util.parseFileInf(files, "KEY", 1, "ATCH001", NO_SUCH_STORE_PATH_KEY);
+
+		assertEquals(1, result.size());
+		FileVO vo = result.get(0);
+		assertEquals("TXT", vo.getFileExtsn());
+		assertEquals("hello.TXT", vo.getOrignlFileNm());
+		assertEquals("11", vo.getFileMg());
+		assertEquals("ATCH001", vo.getAtchFileId());
+		assertEquals("1", vo.getFileSn());
+		assertTrue(vo.getStreFileNm().startsWith("KEY"), "저장파일명은 keyStr로 시작해야 한다: " + vo.getStreFileNm());
+		assertTrue(vo.getStreFileNm().endsWith("1"), "저장파일명은 fileKey로 끝나야 한다: " + vo.getStreFileNm());
+	}
+
+	@Test
+	void parseFileInfMap_skipsEntryWithBlankOriginalFilename() throws Exception {
+		Map<String, MultipartFile> files = new LinkedHashMap<>();
+		files.put("blank", fakeFile("", 5));
+		files.put("valid", fakeFile("keep.txt", 5));
+
+		List<FileVO> result = util.parseFileInf(files, "KEY", 3, "ATCH002", NO_SUCH_STORE_PATH_KEY);
+
+		assertEquals(1, result.size());
+		assertEquals("keep.txt", result.get(0).getOrignlFileNm());
+		// 스킵된 항목은 fileKey를 소비하지 않으므로 최초 전달값(3)이 그대로 사용되어야 한다
+		assertEquals("3", result.get(0).getFileSn());
+	}
+
+	@Test
+	void parseFileInfMap_emptyMap_returnsEmptyListWithoutError() throws Exception {
+		List<FileVO> result = util.parseFileInf(new LinkedHashMap<String, MultipartFile>(), "KEY", 1, "ATCH003",
+				NO_SUCH_STORE_PATH_KEY);
+
+		assertTrue(result.isEmpty());
+	}
+
+	@Test
+	void parseFileInfList_incrementsFileSequenceInOrder() throws Exception {
+		List<MultipartFile> files = List.of(fakeFile("a.png", 1), fakeFile("b.jpg", 2));
+
+		List<FileVO> result = util.parseFileInf(files, "KEY", 5, "ATCH004", NO_SUCH_STORE_PATH_KEY);
+
+		assertEquals(2, result.size());
+		assertEquals("5", result.get(0).getFileSn());
+		assertEquals("PNG", result.get(0).getFileExtsn());
+		assertEquals("6", result.get(1).getFileSn());
+		assertEquals("JPG", result.get(1).getFileExtsn());
+	}
+
+	@Test
+	void parseFileInfList_skipsEntryWithBlankOriginalFilename() throws Exception {
+		List<MultipartFile> files = List.of(fakeFile("first.txt", 1), fakeFile(null, 2), fakeFile("third.txt", 3));
+
+		List<FileVO> result = util.parseFileInf(files, "KEY", 10, "ATCH005", NO_SUCH_STORE_PATH_KEY);
+
+		assertEquals(2, result.size());
+		assertEquals("first.txt", result.get(0).getOrignlFileNm());
+		assertEquals("10", result.get(0).getFileSn());
+		assertEquals("third.txt", result.get(1).getOrignlFileNm());
+		// 중간에 스킵된 항목이 있어도 fileKey는 유효한 항목 수만큼만 증가한다
+		assertEquals("11", result.get(1).getFileSn());
+	}
+
+	private static Object defaultValue(Class<?> returnType) {
+		if (!returnType.isPrimitive()) {
+			return null;
+		}
+		if (returnType == boolean.class) {
+			return false;
+		}
+		return 0L;
+	}
+
+	private static MultipartFile fakeFile(String originalFilename, long size) {
+		return (MultipartFile) Proxy.newProxyInstance(MultipartFile.class.getClassLoader(),
+				new Class<?>[] { MultipartFile.class }, (proxy, method, args) -> {
+					switch (method.getName()) {
+					case "getOriginalFilename":
+						return originalFilename;
+					case "getSize":
+						return size;
+					case "transferTo":
+						// 실제 디스크에 쓰지 않는다: parseFileInf의 반환 값 매핑만 검증 대상이다
+						return null;
+					default:
+						return defaultValue(method.getReturnType());
+					}
+				});
+	}
+}

--- a/src/test/java/egovframework/com/utl/cas/service/EgovMessageUtilTest.java
+++ b/src/test/java/egovframework/com/utl/cas/service/EgovMessageUtilTest.java
@@ -1,0 +1,76 @@
+package egovframework.com.utl.cas.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+class EgovMessageUtilTest {
+
+	@Test
+	void getErrorMsg_knownKey_returnsConfiguredMessage() {
+		assertEquals("Hello, Test~!", EgovMessageUtil.getErrorMsg("test.message"));
+	}
+
+	@Test
+	void getInfoMsg_knownKey_returnsConfiguredMessage() {
+		assertEquals("Hello, Test~!", EgovMessageUtil.getInfoMsg("test.message"));
+	}
+
+	@Test
+	void getWarnMsg_knownKey_returnsConfiguredMessage() {
+		assertEquals("Hello, Test~!", EgovMessageUtil.getWarnMsg("test.message"));
+	}
+
+	@Test
+	void getConfirmMsg_knownKey_returnsConfiguredMessage() {
+		assertEquals("Hello, Test~!", EgovMessageUtil.getConfirmMsg("test.message"));
+	}
+
+	@Test
+	void getErrorMsg_withParam_substitutesPlaceholdersInOrder() {
+		assertEquals("A : B", EgovMessageUtil.getErrorMsg("param.message", new String[] { "A", "B" }));
+	}
+
+	@Test
+	void getInfoMsg_withParam_substitutesPlaceholdersInOrder() {
+		assertEquals("A : B", EgovMessageUtil.getInfoMsg("param.message", new String[] { "A", "B" }));
+	}
+
+	@Test
+	void getWarnMsg_withParam_substitutesPlaceholdersInOrder() {
+		assertEquals("A : B", EgovMessageUtil.getWarnMsg("param.message", new String[] { "A", "B" }));
+	}
+
+	@Test
+	void getConfirmMsg_withParam_substitutesPlaceholdersInOrder() {
+		assertEquals("A : B", EgovMessageUtil.getConfirmMsg("param.message", new String[] { "A", "B" }));
+	}
+
+	@Test
+	void getErrorMsg_withParam_noPlaceholderLeavesMessageUnchanged() {
+		// test.message에는 {0} 같은 자리표시자가 없으므로 파라미터 배열은 결과에 영향을 주지 않는다
+		assertEquals("Hello, Test~!", EgovMessageUtil.getErrorMsg("test.message", new String[] { "ignored" }));
+	}
+
+	@Test
+	void getErrorMsg_unknownKey_returnsEmptyString() {
+		assertEquals("", EgovMessageUtil.getErrorMsg("no.such.key.defined"));
+	}
+
+	@Test
+	void getErrorMsg_emptyCode_returnsEmptyStringWithoutLookup() {
+		assertEquals("", EgovMessageUtil.getErrorMsg(""));
+	}
+
+	@Test
+	void getErrorMsg_blankCode_returnsEmptyStringWithoutLookup() {
+		assertEquals("", EgovMessageUtil.getErrorMsg("   "));
+	}
+
+	@Test
+	void getErrorMsg_nullCode_throwsNullPointerException() {
+		// strCode.trim() 호출 시점에 NPE가 발생하는 현재 계약을 회귀 방지 목적으로 고정한다
+		assertThrows(NullPointerException.class, () -> EgovMessageUtil.getErrorMsg(null));
+	}
+}

--- a/src/test/java/egovframework/com/utl/fcc/service/EgovFormBasedFileUtilTest.java
+++ b/src/test/java/egovframework/com/utl/fcc/service/EgovFormBasedFileUtilTest.java
@@ -1,0 +1,202 @@
+package egovframework.com.utl.fcc.service;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Proxy;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.WriteListener;
+import jakarta.servlet.http.HttpServletResponse;
+
+class EgovFormBasedFileUtilTest {
+
+	@TempDir
+	File tempDir;
+
+	@Test
+	void getTodayString_matchesCurrentDatePattern() {
+		String expected = new SimpleDateFormat("yyyyMMdd", Locale.getDefault()).format(new Date());
+
+		assertEquals(expected, EgovFormBasedFileUtil.getTodayString());
+	}
+
+	@Test
+	void getPhysicalFileName_isUppercaseHexWithoutDashes() {
+		String name = EgovFormBasedFileUtil.getPhysicalFileName();
+
+		assertEquals(32, name.length());
+		assertTrue(name.matches("[0-9A-F]+"), "물리적 파일명은 대문자 16진수여야 한다: " + name);
+	}
+
+	@Test
+	void getPhysicalFileName_generatesDistinctValues() {
+		assertNotEquals(EgovFormBasedFileUtil.getPhysicalFileName(), EgovFormBasedFileUtil.getPhysicalFileName());
+	}
+
+	@Test
+	void convert_returnsFilenameUnchanged() throws Exception {
+		assertEquals("hello.txt", EgovFormBasedFileUtil.convert("hello.txt"));
+	}
+
+	@Test
+	void getContentTypeWL_containsExpectedImageMimeTypes() {
+		Map<String, String> whitelist = EgovFormBasedFileUtil.getContentTypeWL();
+
+		assertEquals(4, whitelist.size());
+		assertEquals("image/gif", whitelist.get("gif"));
+		assertEquals("image/jpg", whitelist.get("jpg"));
+		assertEquals("image/jpeg", whitelist.get("jpeg"));
+		assertEquals("image/png", whitelist.get("png"));
+	}
+
+	@Test
+	void saveFile_writesStreamContentAndReturnsByteCount() throws IOException {
+		byte[] content = "hello world".getBytes(StandardCharsets.UTF_8);
+		File target = new File(new File(tempDir, "sub/dir"), "saved.txt");
+
+		long written;
+		try (InputStream is = new ByteArrayInputStream(content)) {
+			written = EgovFormBasedFileUtil.saveFile(is, target);
+		}
+
+		assertEquals(content.length, written);
+		assertTrue(target.exists(), "부모 디렉토리가 없어도 생성 후 파일이 저장되어야 한다");
+		assertArrayEquals(content, Files.readAllBytes(target.toPath()));
+	}
+
+	@Test
+	void downloadFile_missingFile_throwsFileNotFoundException() {
+		assertThrows(FileNotFoundException.class, () -> EgovFormBasedFileUtil.downloadFile(
+				new ResponseStub().proxy(), tempDir.getAbsolutePath(), "2026", "NOPE", "orig.txt"));
+	}
+
+	@Test
+	void downloadFile_existingFile_writesContentAndHeaders() throws Exception {
+		writeTestFile("2026", "PHYS01", "download body");
+		ResponseStub response = new ResponseStub();
+
+		EgovFormBasedFileUtil.downloadFile(response.proxy(), tempDir.getAbsolutePath(), "2026", "PHYS01",
+				"original name.txt");
+
+		assertEquals("application/octet-stream", response.contentType);
+		assertEquals("attachment; filename=\"original name.txt\";", response.headers.get("Content-Disposition"));
+		assertArrayEquals("download body".getBytes(StandardCharsets.UTF_8), response.content.toByteArray());
+	}
+
+	@Test
+	void viewFile_missingFile_throwsFileNotFoundException() {
+		assertThrows(FileNotFoundException.class, () -> EgovFormBasedFileUtil.viewFile(new ResponseStub().proxy(),
+				tempDir.getAbsolutePath(), "2026", "NOPE", "image/png"));
+	}
+
+	@Test
+	void viewFile_whitelistedMimeType_isKeptAsIs() throws Exception {
+		writeTestFile("2026", "PHYS02_upfile", "png bytes");
+		ResponseStub response = new ResponseStub();
+
+		EgovFormBasedFileUtil.viewFile(response.proxy(), tempDir.getAbsolutePath(), "2026", "PHYS02", "image/png");
+
+		assertEquals("image/png", response.contentType);
+		assertArrayEquals("png bytes".getBytes(StandardCharsets.UTF_8), response.content.toByteArray());
+	}
+
+	@Test
+	void viewFile_nonWhitelistedMimeType_fallsBackToOctetStream() throws Exception {
+		writeTestFile("2026", "PHYS03_upfile", "text bytes");
+		ResponseStub response = new ResponseStub();
+
+		EgovFormBasedFileUtil.viewFile(response.proxy(), tempDir.getAbsolutePath(), "2026", "PHYS03", "text/plain");
+
+		assertEquals("application/octet-stream;", response.contentType);
+	}
+
+	@Test
+	void viewFile_nullMimeType_fallsBackToOctetStream() throws Exception {
+		writeTestFile("2026", "PHYS04_upfile", "text bytes");
+		ResponseStub response = new ResponseStub();
+
+		EgovFormBasedFileUtil.viewFile(response.proxy(), tempDir.getAbsolutePath(), "2026", "PHYS04", null);
+
+		assertEquals("application/octet-stream;", response.contentType);
+	}
+
+	private void writeTestFile(String serverSubPath, String physicalName, String body) throws IOException {
+		File dir = new File(tempDir, serverSubPath);
+		dir.mkdirs();
+		Files.write(new File(dir, physicalName).toPath(), body.getBytes(StandardCharsets.UTF_8));
+	}
+
+	private static Object defaultValue(Class<?> returnType) {
+		if (!returnType.isPrimitive()) {
+			return null;
+		}
+		if (returnType == boolean.class) {
+			return false;
+		}
+		if (returnType == char.class) {
+			return '\0';
+		}
+		return 0;
+	}
+
+	private static class ResponseStub {
+
+		private String contentType;
+		private final Map<String, String> headers = new HashMap<>();
+		private final ByteArrayOutputStream content = new ByteArrayOutputStream();
+		private final ServletOutputStream outputStream = new ServletOutputStream() {
+			@Override
+			public void write(int value) {
+				content.write(value);
+			}
+
+			@Override
+			public boolean isReady() {
+				return true;
+			}
+
+			@Override
+			public void setWriteListener(WriteListener writeListener) {
+				// Synchronous test output stream.
+			}
+		};
+
+		private HttpServletResponse proxy() {
+			return (HttpServletResponse) Proxy.newProxyInstance(HttpServletResponse.class.getClassLoader(),
+					new Class<?>[] { HttpServletResponse.class }, (proxy, method, args) -> {
+						if ("setContentType".equals(method.getName())) {
+							contentType = (String) args[0];
+							return null;
+						}
+						if ("setHeader".equals(method.getName())) {
+							headers.put((String) args[0], (String) args[1]);
+							return null;
+						}
+						if ("getOutputStream".equals(method.getName())) {
+							return outputStream;
+						}
+						return defaultValue(method.getReturnType());
+					});
+		}
+	}
+}


### PR DESCRIPTION
## 변경 사유

세션/DI 의존이 없는 순수 유틸 클래스에 대한 단위 테스트가 없어 회귀 방지를 위해 추가했습니다.

## 변경 내용

- `EgovMessageUtil`: 메시지 조회 기능 단위 테스트 13건
- `EgovFormBasedFileUtil`: 폼 기반 파일 업로드/다운로드 유틸 단위 테스트 12건
- `EgovFileMngUtil`: `parseFileInf(Map)` / `parseFileInf(List)` 계열 단위 테스트 5건. `downFile`/`writeFile`/`uploadFile` 등은 클래스 로딩 시 고정되는 `Globals.fileStorePath` 설정값에 실제 디스크 쓰기를 수행하는 구조라, 실행 환경에 따라 의도치 않은 디렉토리가 생성될 위험이 있어 이번 범위에서 제외했습니다.

MultipartFile 등은 신규 의존성 추가 없이 `java.lang.reflect.Proxy` 기반 페이크로 처리했습니다(테스트 코드 내 기존 관례 참고).

## 테스트 방법 / 영향 범위

`mvn test`로 신규 테스트 30건 전부 통과 확인했습니다. 프로덕션 코드 변경은 없습니다.

- [x] 단일 주제만 다룸 (다른 변경 없음)
- [x] 기존 동작에 영향 없음 (테스트 코드만 추가)
- [x] 테스트 통과 확인