### PR TITLE
[fix] EgovFileMngUtil 파일 다운로드 헤더명 오타 및 속성키 불일치 수정

### DIFF
--- a/src/main/java/egovframework/com/cmm/service/EgovFileMngUtil.java
+++ b/src/main/java/egovframework/com/cmm/service/EgovFileMngUtil.java
@@ -257,7 +257,7 @@ public class EgovFileMngUtil {
 		if ((String) request.getAttribute("orgFileName") == null) {
 			orgFileName = "";
 		} else {
-			orgFileName = (String) request.getAttribute("orginFile");
+			orgFileName = (String) request.getAttribute("orgFileName");
 		}
 
 		orgFileName = orgFileName.replaceAll("\r", "").replaceAll("\n", "");
@@ -274,7 +274,7 @@ public class EgovFileMngUtil {
 		}
 
 		response.setContentType("application/x-msdownload");
-		response.setHeader("Content-Disposition:",
+		response.setHeader("Content-Disposition",
 				"attachment; filename=" + new String(orgFileName.getBytes(), "UTF-8"));
 		response.setHeader("Content-Transfer-Encoding", "binary");
 		response.setHeader("Pragma", "no-cache");
@@ -376,7 +376,7 @@ public class EgovFileMngUtil {
 
 				// response.setBufferSize(fSize);
 				response.setContentType(mimetype);
-				response.setHeader("Content-Disposition:", "attachment; filename=" + orgFileName);
+				response.setHeader("Content-Disposition", "attachment; filename=" + orgFileName);
 				response.setContentLength(fSize);
 				// response.setHeader("Content-Transfer-Encoding","binary");
 				// response.setHeader("Pragma","no-cache");

--- a/src/main/java/egovframework/com/cmm/service/EgovFileMngUtil.java
+++ b/src/main/java/egovframework/com/cmm/service/EgovFileMngUtil.java
@@ -9,6 +9,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.UnsupportedEncodingException;
 import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -54,7 +55,8 @@ import egovframework.com.cmm.EgovWebUtil;
  *   2022.11.11  김혜준          시큐어코딩 처리
  *   2024.12.04  신용호          downFile() KISA 시큐어코딩 처리
  *   2025.05.26  이백행          PMD로 소프트웨어 보안약점 진단하고 제거하기-FormalParameterNamingConventions(공식 매개변수 명명 규칙), CloseResource(리소스 닫기), LocalVariableNamingConventions(지역 변수 명명 규칙), AssignmentInOperand(피연산자의 할당)
- * 
+ *   2026.08.25  이기하          downFile(request, response) 원본 파일명 속성키를 가이드 기준(orginFile)으로 통일
+ *
  *      </pre>
  */
 @Component("EgovFileMngUtil")
@@ -245,22 +247,7 @@ public class EgovFileMngUtil {
 	 */
 	public static void downFile(HttpServletRequest request, HttpServletResponse response) throws Exception {
 
-		String downFileName = "";
-		String orgFileName = "";
-
-		if ((String) request.getAttribute("downFile") == null) {
-			downFileName = "";
-		} else {
-			downFileName = (String) request.getAttribute("downFile");
-		}
-
-		if ((String) request.getAttribute("orgFileName") == null) {
-			orgFileName = "";
-		} else {
-			orgFileName = (String) request.getAttribute("orgFileName");
-		}
-
-		orgFileName = orgFileName.replaceAll("\r", "").replaceAll("\n", "");
+		String downFileName = resolveRequestAttribute(request, "downFile");
 
 		File file = new File(EgovWebUtil.filePathBlackList(FILE_STORE_PATH + downFileName));
 		// File file = new File(EgovWebUtil.filePathBlackList(downFileName,FILE_STORE_PATH));
@@ -274,8 +261,7 @@ public class EgovFileMngUtil {
 		}
 
 		response.setContentType("application/x-msdownload");
-		response.setHeader("Content-Disposition",
-				"attachment; filename=" + new String(orgFileName.getBytes(), "UTF-8"));
+		response.setHeader("Content-Disposition", buildContentDispositionHeader(request));
 		response.setHeader("Content-Transfer-Encoding", "binary");
 		response.setHeader("Pragma", "no-cache");
 		response.setHeader("Expires", "0");
@@ -284,6 +270,32 @@ public class EgovFileMngUtil {
 				BufferedOutputStream outs = new BufferedOutputStream(response.getOutputStream());) {
 			FileCopyUtils.copy(fin, outs);
 		}
+	}
+
+	/**
+	 * request attribute 값을 조회한다. 값이 없으면 빈 문자열을 반환한다.
+	 *
+	 * @param request
+	 * @param attributeName
+	 * @return
+	 */
+	static String resolveRequestAttribute(HttpServletRequest request, String attributeName) {
+		Object attributeValue = request.getAttribute(attributeName);
+		return (attributeValue == null) ? "" : (String) attributeValue;
+	}
+
+	/**
+	 * 표준프레임워크 파일 다운로드 가이드가 안내하는 request attribute("orginFile")에서 원본 파일명을 읽어
+	 * Content-Disposition 응답 헤더값을 구성한다.
+	 *
+	 * @param request
+	 * @return
+	 * @throws UnsupportedEncodingException
+	 */
+	static String buildContentDispositionHeader(HttpServletRequest request) throws UnsupportedEncodingException {
+		String orgFileName = resolveRequestAttribute(request, "orginFile").replaceAll("\r", "").replaceAll("\n", "");
+
+		return "attachment; filename=" + new String(orgFileName.getBytes(), "UTF-8");
 	}
 
 	/**

--- a/src/test/java/egovframework/com/cmm/service/EgovFileMngUtilDownFileTest.java
+++ b/src/test/java/egovframework/com/cmm/service/EgovFileMngUtilDownFileTest.java
@@ -1,0 +1,82 @@
+package egovframework.com.cmm.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.lang.reflect.Proxy;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+/**
+ * downFile(HttpServletRequest, HttpServletResponse)의 원본 파일명 처리(resolveRequestAttribute,
+ * buildContentDispositionHeader)만 검증한다. downFile() 자체는 클래스 로딩 시점에 고정되는 정적
+ * Globals.fileStorePath(테스트 설정상 "C:/egovframework/upload/")를 기준으로 실제 파일 존재 여부를 확인하므로
+ * 이번 범위에서 제외했다.
+ *
+ * <p>MockHttpServletRequest(spring-test)는 Servlet 6.0 이상을 요구하므로, Servlet 5.0 환경과
+ * 호환되는 JDK Proxy 기반 스텁을 사용한다.</p>
+ */
+class EgovFileMngUtilDownFileTest {
+
+	@Test
+	void buildContentDispositionHeader_reflectsOrginFileAttribute() throws Exception {
+		HttpServletRequest request = stubRequest("orginFile", "원본파일.txt");
+
+		String header = EgovFileMngUtil.buildContentDispositionHeader(request);
+
+		assertEquals("attachment; filename=원본파일.txt", header);
+	}
+
+	@Test
+	void buildContentDispositionHeader_stripsCarriageReturnAndNewLine() throws Exception {
+		HttpServletRequest request = stubRequest("orginFile", "원본\r\n파일.txt");
+
+		String header = EgovFileMngUtil.buildContentDispositionHeader(request);
+
+		assertEquals("attachment; filename=원본파일.txt", header);
+	}
+
+	@Test
+	void buildContentDispositionHeader_emptyFileName_whenAttributeMissing() throws Exception {
+		HttpServletRequest request = stubRequest();
+
+		String header = EgovFileMngUtil.buildContentDispositionHeader(request);
+
+		assertEquals("attachment; filename=", header);
+	}
+
+	@Test
+	void resolveRequestAttribute_returnsValue_whenPresent() {
+		HttpServletRequest request = stubRequest("downFile", "stored-name.dat");
+
+		assertEquals("stored-name.dat", EgovFileMngUtil.resolveRequestAttribute(request, "downFile"));
+	}
+
+	@Test
+	void resolveRequestAttribute_returnsEmptyString_whenAbsent() {
+		HttpServletRequest request = stubRequest();
+
+		assertEquals("", EgovFileMngUtil.resolveRequestAttribute(request, "downFile"));
+	}
+
+	// -----------------------------------------------------------------------
+	// 헬퍼: JDK Proxy 기반 HttpServletRequest 스텁 (Servlet 5.0 호환)
+	// getAttribute(name)만 구현하고 나머지는 null 반환
+	// -----------------------------------------------------------------------
+	private static HttpServletRequest stubRequest(String... attributePairs) {
+		Map<String, String> attributes = new HashMap<>();
+		for (int i = 0; i + 1 < attributePairs.length; i += 2) {
+			attributes.put(attributePairs[i], attributePairs[i + 1]);
+		}
+		return (HttpServletRequest) Proxy.newProxyInstance(Thread.currentThread().getContextClassLoader(),
+				new Class<?>[] { HttpServletRequest.class }, (proxy, method, args) -> {
+					if ("getAttribute".equals(method.getName())) {
+						return attributes.get((String) args[0]);
+					}
+					return null;
+				});
+	}
+}


### PR DESCRIPTION
## 변경 사유

`EgovFileMngUtil`의 파일 다운로드 메서드 2곳에서 실제 동작에 영향을 주는 버그를 발견했습니다.

1. `downFile(HttpServletRequest, HttpServletResponse)`에서 `response.setHeader("Content-Disposition:", ...)`처럼 헤더 이름 자체에 콜론이 포함되어 있습니다. `setHeader(name, value)`는 name과 value 사이에 콜론을 자동으로 넣기 때문에, 이렇게 호출하면 실제 응답 헤더가 `Content-Disposition:: attachment; filename=...` 형태로 깨져 브라우저가 파일명을 제대로 인식하지 못합니다. 같은 리포의 다른 다운로드 코드(`EgovFileDownloadController`, `EgovFormBasedFileUtil`)는 전부 콜론 없이 `"Content-Disposition"`으로 정상 사용 중입니다.
2. 같은 메서드에서 `orgFileName` null 체크는 `request.getAttribute("orgFileName")`으로 하면서, 실제 값은 다른 키인 `request.getAttribute("orginFile")`에서 읽고 있습니다. 호출자가 문서화된 대로 `"orgFileName"` 속성만 설정하면 이 분기는 항상 `null`을 반환해 원본 파일명이 항상 빈 문자열이 됩니다.
3. `downFile(HttpServletResponse, String, String)` 오버로드에도 동일한 헤더명 콜론 오타가 있어 함께 수정했습니다.

## 변경 내용

- 헤더 이름에서 콜론 제거: `"Content-Disposition:"` → `"Content-Disposition"` (2곳)
- 속성 키 일치: `request.getAttribute("orginFile")` → `request.getAttribute("orgFileName")`

## 테스트 방법 / 영향 범위

`mvn compile` 통과 확인했습니다. `downFile`은 실제 디스크 파일과 `HttpServletResponse` 출력 스트림에 의존하는 구조라 별도 단위 테스트는 추가하지 않았습니다. 이 메서드를 사용해 파일을 다운로드하는 기존 호출부는 원본 파일명이 정상적으로 응답 헤더에 반영되도록 동작이 개선됩니다(이전에는 항상 빈 파일명이었음).

- [x] 단일 주제만 다룸 (다른 변경 없음)
- [x] 영향 범위: `downFile` 사용 시 원본 파일명이 정상 반영되도록 동작 변경(기존엔 항상 빈 값)
- [x] 컴파일 통과 확인