### PR TITLE
FileSystemUtils.openProcess()가 IOException 대신 unchecked 예외를 던져 모니터링 스케줄러가 비정상 종료되는 문제 수정

### DIFF
--- a/src/main/java/egovframework/com/cmm/service/FileSystemUtils.java
+++ b/src/main/java/egovframework/com/cmm/service/FileSystemUtils.java
@@ -453,10 +453,13 @@ public class FileSystemUtils {
 	private Process openProcess(String[] cmdAttribs) throws IOException {
 		//return Runtime.getRuntime().exec(cmdAttribs);
 		// Runtime.exec 사용 시 Command Injection 위험이 있으므로 사용하지 말 것...
-		// 현재는 빈 프로세스를 리턴하게 구성함...
-		ProcessBuilder processBuilder = new ProcessBuilder();
-		Process process = processBuilder.start();
-		return process;
+		// 명령 실행은 비활성화된 상태임.
+		// 기존의 new ProcessBuilder().start()는 커맨드 목록이 비어 있어
+		// IOException이 아닌 IndexOutOfBoundsException(unchecked)을 던지므로,
+		// 호출부의 catch (IOException) 블록을 우회해 예외가 그대로 전파됨.
+		// 선언된 IOException을 던져 호출부(ProcessMonChecker 등)가 기존
+		// 오류 처리 경로로 정상 동작하도록 함.
+		throw new IOException("Process execution is disabled (command injection prevention). command=" + Arrays.toString(cmdAttribs));
 	}
 
 	/**


### PR DESCRIPTION
## 문제 (재현)

`openProcess()`는 명령 실행을 보안상 비활성화하면서 주석에 "빈 프로세스를 리턴하게 구성함"이라고 의도를 밝히고 있습니다. 그러나 커맨드가 비어 있는 `new ProcessBuilder().start()`는 `IOException`이 아니라 **`ArrayIndexOutOfBoundsException`(unchecked)** 을 던집니다.

JDK 17.0.19 재현:

```java
try {
    new ProcessBuilder().start();
} catch (Throwable t) {
    System.out.println(t.getClass().getName());
    // => java.lang.ArrayIndexOutOfBoundsException (IOException 아님)
}
```

이로 인해 호출 경로의 `catch (IOException)` 블록이 전부 우회됩니다.

- `ProcessMonChecker.getProcessId()` — `catch (IOException)`에서 "02"(비정상)를 반환하도록 설계됐지만, unchecked 예외가 그대로 전파되어 `EgovProcessMonScheduling`의 스케줄 작업이 비정상 종료됩니다.
- `EgovNetworkState` 각 메서드 — 동일하게 catch가 우회되어 원시 예외가 전파됩니다.
- `performCommand()`(freeSpaceKb 계열) — 메서드가 선언한 IOException 계약이 깨집니다.

## 수정

선언된 `IOException`을 던지도록 변경했습니다. 모든 호출부의 기존 오류 처리 경로(catch IOException)가 설계 의도대로 동작하게 됩니다. 명령 실행을 비활성화한 기존 보안 조치(2022.11.11 시큐어코딩 처리)는 그대로 유지됩니다.

## 검증

- 위 재현 코드로 기존 동작이 `ArrayIndexOutOfBoundsException`임을 실측 확인 (JDK 17.0.19, ProcessBuilder.start() Javadoc의 명세와 일치)
- 변경 후 호출부 3곳(`processOperate` 경유 포함)의 catch(IOException) 경로 전수 검토
- PMD correctness 룰 스캔 + 호출부 추적 과정에서 발견한 결함입니다

## 영향

- 프로세스 모니터링(utl/sys/prm) 스케줄러가 크래시 대신 "비정상(02)" 상태를 정상 보고합니다.
- 변경 범위는 openProcess() 1개 메서드이며, 명령 실행이 이미 비활성화된 상태이므로 기능 저하는 없습니다.