### PR TITLE
모니터링 스케줄러의 문자열 상태코드 == 비교를 equals()로 수정 (utl/sys/htm·prm)

### DIFF
--- a/src/main/java/egovframework/com/utl/sys/htm/service/HttpMntrngScheduling.java
+++ b/src/main/java/egovframework/com/utl/sys/htm/service/HttpMntrngScheduling.java
@@ -109,7 +109,7 @@ public class HttpMntrngScheduling extends EgovAbstractServiceImpl {
 				nrmltAt = false;
 			}
 
-			if (httpSttusCd == "02") {
+			if ("02".equals(httpSttusCd)) {
 				nrmltAt = false;
 			}
 
@@ -121,7 +121,7 @@ public class HttpMntrngScheduling extends EgovAbstractServiceImpl {
 
 			// DB에 결과값 저장
 			target.setHttpSttusCd(httpSttusCd);
-			if (httpSttusCd == "02") {
+			if ("02".equals(httpSttusCd)) {
 				target.setLogInfo("Connection timed out: connect");
 			}
 

--- a/src/main/java/egovframework/com/utl/sys/prm/service/EgovProcessMonScheduling.java
+++ b/src/main/java/egovframework/com/utl/sys/prm/service/EgovProcessMonScheduling.java
@@ -101,7 +101,7 @@ public class EgovProcessMonScheduling extends EgovAbstractServiceImpl {
 				nrmltAt = false;
 			}
 
-			if (procsSttus == "02") {
+			if ("02".equals(procsSttus)) {
 				nrmltAt = false;
 			}
 
@@ -113,7 +113,7 @@ public class EgovProcessMonScheduling extends EgovAbstractServiceImpl {
 
 			// DB에 결과값 저장
 			target.setProcsSttus(procsSttus);
-			if (procsSttus == "02") {
+			if ("02".equals(procsSttus)) {
 				target.setLogInfo("실행 중인 작업 중 지정된 조건에 일치하는 작업이 없습니다.");
 			}
 


### PR DESCRIPTION
## 문제 (재현)

HTTP 서비스 모니터링과 프로세스 모니터링 스케줄러에서 문자열 상태코드를 참조 동일성(`==`)으로 비교하고 있습니다 (총 4곳).

- `HttpMntrngScheduling.monitorHttp()` — `if (httpSttusCd == "02")` 2곳
- `EgovProcessMonScheduling.monitorProcess()` — `if (procsSttus == "02")` 2곳

현재는 `HttpMntrngChecker.getPrductStatus()` / `ProcessMonChecker.getProcessId()`가 문자열 리터럴("01"/"02")을 반환해 상수 풀 인터닝 덕분에 우연히 동작하지만, 반환값이 한 번이라도 연산·생성된 문자열(`new String`, substring, 외부 입력 등)로 바뀌면 **비교가 조용히 항상 false가 되어 장애(비정상) 상태를 놓치는** 잠복 결함입니다. 모니터링 코드는 장애를 알리는 최후 방어선이라 조용한 오동작의 영향이 큽니다.

또한 `procsSttus`/`httpSttusCd`는 루프 밖에 선언되어 예외 발생 시 이전 반복의 값이 남는데, `"02".equals(...)` 형태는 null(첫 반복에서 예외 시)에도 NPE 없이 안전합니다.

## 수정

`상수.equals(변수)` 관용구로 변경했습니다 — null-safe하고 값 비교 의도가 명확해집니다.

```java
- if (httpSttusCd == "02") {
+ if ("02".equals(httpSttusCd)) {
```

## 검증

- PMD `UseEqualsToCompareStrings`(errorprone) 룰로 저장소 전수 스캔 — 검출 4곳이 이 두 파일에 전부 포함되며, 그 외 소스에는 해당 패턴이 없음을 확인
- 반환 경로 추적: 두 Checker 모두 리터럴 반환이라 현재 동작은 동일(회귀 없음), 변경은 방어적 정정입니다

## 영향

- 동작 변경 없음(현행 리터럴 인터닝 하에서 동일 결과), 향후 반환 경로 변경 시의 조용한 오동작 가능성 제거
- 변경 범위: 2개 파일 4개 라인