### PR TITLE
fix: 보고서통계 그래프 배율의 1000건 초과 구간 조건을 건수 기준으로 수정

### DIFF
--- a/src/main/java/egovframework/com/sts/rst/web/EgovReprtStatsController.java
+++ b/src/main/java/egovframework/com/sts/rst/web/EgovReprtStatsController.java
@@ -131,7 +131,7 @@ public class EgovReprtStatsController {
 			if (reprtStatsVO.getMaxUnit() > 0.5f) {
 				reprtStatsVO.setMaxUnit(0.5f);
 			}
-		} else if (reprtStatsVO.getMaxUnit() > 1000) {
+		} else if (totCnt > 1000) {
 			if (reprtStatsVO.getMaxUnit() > 0.05f) {
 				reprtStatsVO.setMaxUnit(0.05f);
 			}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 변경 이유

보고서통계 목록(`EgovReprtStatsController.selectReprtStatsList`)은 그래프 막대의 픽셀 배율 `maxUnit`을 집계 건수 `totCnt` 구간에 따라 단계적으로 줄입니다. 그런데 세 번째 구간의 조건이 건수가 아니라 배율 자신을 검사합니다.

```java
int totCnt = egovReprtStatsService.selectReprtStatsListBarTotCnt(reprtStatsVO);

if (totCnt > 10 && totCnt <= 100) {
    if (reprtStatsVO.getMaxUnit() > 5.0f) { reprtStatsVO.setMaxUnit(5.0f); }
} else if (totCnt > 100 && totCnt <= 1000) {
    if (reprtStatsVO.getMaxUnit() > 0.5f) { reprtStatsVO.setMaxUnit(0.5f); }
} else if (reprtStatsVO.getMaxUnit() > 1000) {   // 앞 두 구간과 달리 totCnt가 아닌 maxUnit을 검사
    if (reprtStatsVO.getMaxUnit() > 0.05f) { reprtStatsVO.setMaxUnit(0.05f); }
}
```

앞의 두 구간은 `totCnt`로 분기하는데 세 번째만 `getMaxUnit()`으로 분기합니다. `maxUnit`의 기본값은 `ReprtStatsVO`에서 `50.0f`이고, 이 화면의 조회 폼은 `maxUnit`을 전송하지 않으며 컨트롤러에 `@SessionAttributes`도 없습니다. 그래서 정상 사용에서 `maxUnit`은 항상 `50.0f`이라 `maxUnit > 1000`이 성립하지 않고, 건수가 1000을 넘어도 배율이 `0.05f`로 줄지 않습니다.

형제 통계 컨트롤러 4곳은 같은 3단 구조에서 세 구간 모두 건수 변수로 분기합니다.

- `EgovBbsStatsController`, `EgovUserStatsController`, `EgovConectStatsController`, `EgovScrinStatsController` 모두 세 번째 구간이 `} else if (iCnt > 1000) {`입니다.

세 번째 구간도 건수 기준이어야 하며, `EgovReprtStatsController`만 이 자리에서 배율을 검사하는 불일치가 결함의 근거입니다.

## 변경 내용

세 번째 구간의 조건을 앞 구간 및 형제 컨트롤러와 동일하게 건수 기준으로 맞췄습니다.

```java
// AS-IS
} else if (reprtStatsVO.getMaxUnit() > 1000) {

// TO-BE
} else if (totCnt > 1000) {
```

## 영향 범위

`EgovReprtStatsList.jsp`는 막대 폭을 `${reprtStatsBar.grpCnt * reprtStatsVO.maxUnit}`로 그립니다. 건수가 1000을 넘는 경우 화면에 표시되는 막대 폭이 달라집니다.

| totCnt | 수정 전 maxUnit | 수정 후 maxUnit | grpCnt=200일 때 막대 폭 |
|---|---|---|---|
| 1,500 | 50.0 (기본값 유지) | 0.05 | 10,000px → 10px |

건수가 1000 이하인 경우 분기 결과가 기존과 동일하므로 영향이 없습니다. 표의 `grpCnt=200`은 예시 값입니다.

같은 복사 패턴이 `EgovDtaUseStatsContoller`(`sts/dst`)에도 있으나, 해당 파일은 별도 오픈 PR(#1122)과 겹쳐 이번 변경에서 제외했습니다.

## 테스트 방법

세 배율 상한 구간은 모두 `totCnt`(총 건수) 기준이어야 일관되는데, 세 번째만 `reprtStatsVO.getMaxUnit()` 기준이었습니다.

```java
if      (totCnt > 10  && totCnt <= 100)      // 건수 기준
else if (totCnt > 100 && totCnt <= 1000)     // 건수 기준
else if (reprtStatsVO.getMaxUnit() > 1000)   // ← totCnt > 1000 이어야 함
```

막대는 `EgovReprtStatsList.jsp`에서 `<img ... width="${grpCnt * maxUnit}">`로 그려지고, `maxUnit` 기본값은 `50.0`입니다(폼은 `maxUnit`을 넘기지 않음). 세 번째 구간이 `totCnt` 대신 `maxUnit`을 보므로, 건수가 1000을 초과해도 `maxUnit`이 `0.05`로 축소되지 않아 막대폭이 과대해집니다.

로컬에 공통컴포넌트와 MySQL을 띄우고 같은 날짜의 보고서 1001건을 넣어 통계 화면을 확인했습니다.

```
수정 전  막대폭 = grpCnt × maxUnit = 1001 × 50   = 50050px   → 막대가 화면을 벗어남
수정 후  totCnt > 1000 분기 적용, maxUnit = 0.05,  1001 × 0.05 ≈ 50px    → 정상
```

**수정 전** (막대가 화면을 벗어남)

<img width="1216" height="939" alt="1174-RED-viewport" src="https://github.com/user-attachments/assets/8e224e0b-f289-4177-8536-d18452a67d16" />

**수정 후** (막대 정상)

<img width="1216" height="939" alt="1174-GREEN-viewport" src="https://github.com/user-attachments/assets/4fde7b01-4967-4d0d-b9b0-ce82e9767a24" />
