### PR TITLE
fix: 비밀번호 경과일 조회가 계정 미존재 시 selectOne null 언박싱으로 NPE 발생하는 문제 방지

### DIFF
--- a/src/main/java/egovframework/com/uat/uia/service/impl/LoginDAO.java
+++ b/src/main/java/egovframework/com/uat/uia/service/impl/LoginDAO.java
@@ -112,7 +112,8 @@ public class LoginDAO extends EgovComAbstractDAO {
 	 * @return LoginVO
 	 */
     public int selectPassedDayChangePWD(LoginVO vo) {
-    	return selectOne("LoginUsr.selectPassedDayChangePWD", vo);
+    	Integer passedDay = (Integer) selectOne("LoginUsr.selectPassedDayChangePWD", vo);
+    	return passedDay == null ? 0 : passedDay;
     }
 
 	/**

--- a/src/test/java/egovframework/com/uat/uia/service/impl/LoginDAOPassedDayTest.java
+++ b/src/test/java/egovframework/com/uat/uia/service/impl/LoginDAOPassedDayTest.java
@@ -1,0 +1,29 @@
+package egovframework.com.uat.uia.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import egovframework.com.cmm.LoginVO;
+
+class LoginDAOPassedDayTest {
+
+	// selectOne이 결과 0건에서 null을 반환하는 상황(계정 미존재)을 재현
+	static class NullSelectOneLoginDAO extends LoginDAO {
+		@Override
+		@SuppressWarnings("unchecked")
+		public <T> T selectOne(String queryId, Object parameterObject) {
+			return null;
+		}
+	}
+
+	@Test
+	void 계정이_없으면_NPE_없이_0을_반환한다() {
+		LoginDAO dao = new NullSelectOneLoginDAO();
+		LoginVO vo = new LoginVO();
+		vo.setId("nonexistent-id");
+		vo.setUserSe("GNR");
+
+		assertEquals(0, dao.selectPassedDayChangePWD(vo));
+	}
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 변경 이유

`LoginDAO.selectPassedDayChangePWD(LoginVO)`는 반환형이 `int`인데 MyBatis `selectOne` 결과를 그대로 반환합니다.

```java
public int selectPassedDayChangePWD(LoginVO vo) {
    return selectOne("LoginUsr.selectPassedDayChangePWD", vo);
}
```

`selectOne`은 조회 결과가 0건이면 `null`을 반환하고, 이 `null`이 `int`로 언박싱되면서 `NullPointerException`이 발생합니다. 매퍼 SQL은 로그인 아이디로만 조회합니다.

```sql
SELECT IFNULL(TIMESTAMPDIFF(day, CHG_PWD_LAST_PNTTM, sysdate()), 0)
  FROM COMTNGNRLMBER WHERE mber_id = #{id}
```

`IFNULL`은 조회된 행의 컬럼 값이 `null`인 경우만 `0`으로 막아 주고, 조회 결과 자체가 0건인 경우는 막지 못합니다. 세션은 살아 있는데 해당 계정 레코드가 존재하지 않으면(로그인 중인 사용자를 관리자가 삭제한 경우 등) `selectOne`이 `null`을 반환해 언박싱에서 예외가 납니다.

이 메서드는 인증된 사용자에 대해 두 경로에서 호출됩니다.

- `EgovComIndexController`(116행): 인덱스 화면 렌더링 시 `loginVO != null`이면 호출
- `EgovLoginController.noticeExpirePwd`(655행): 공통 화면 `EgovUnitContent.jsp`의 비밀번호 만료 안내에서 호출

두 호출부 모두 `loginVO != null`(세션 인증)만 확인하고 계정 존재 여부는 확인하지 않습니다. 삭제된 계정의 세션이 인덱스 화면에 진입하면 500 오류가 납니다.

## 변경 내용

`selectOne` 결과를 `Integer`로 받아 `null`이면 `0`을 반환하도록 가드를 추가했습니다.

```java
// AS-IS
return selectOne("LoginUsr.selectPassedDayChangePWD", vo);

// TO-BE
Integer passedDay = (Integer) selectOne("LoginUsr.selectPassedDayChangePWD", vo);
return passedDay == null ? 0 : passedDay;
```

행이 없을 때 `0`을 반환하는 것은 SQL의 `IFNULL(..., 0)`이 컬럼 `null`을 `0`으로 처리하는 것과 같은 기준입니다. 경과 일수 `0`은 만료 안내를 띄우지 않는 값이라 존재하지 않는 계정에 대해 안전합니다. DAO 한 곳을 고쳐 두 호출부 모두에 적용됩니다.

## 영향 범위

계정 레코드가 존재하는 정상 로그인은 기존과 동일하게 동작합니다. 조회 결과가 0건인 경우에만 예외 대신 `0`을 반환합니다.

## 테스트 방법

`selectOne`이 결과 0건에서 `null`을 반환하는 상황을 스텁으로 재현한 단위 테스트 `LoginDAOPassedDayTest`를 추가했습니다. POM이 surefire `skipTests=true`라 CI에서는 실행되지 않아, 로컬에서 skip을 풀어 이 테스트만 실행했습니다.

수정 전 `return (Integer) selectOne(...)`:

```
Tests run: 1, Failures: 0, Errors: 1
LoginDAOPassedDayTest.계정이_없으면_NPE_없이_0을_반환한다 » NullPointerException:
  Cannot invoke "java.lang.Integer.intValue()" because the return value of
  "egovframework.com.uat.uia.service.impl.LoginDAO.selectOne(String, Object)" is null
```

수정 후 `Integer passedDay = ...; return passedDay == null ? 0 : passedDay;`:

```
Tests run: 1, Failures: 0, Errors: 0
```
