### PR TITLE
fix: 지식정보 상세·수정 조회 시 존재하지 않는 knoId의 selectOne null 역참조 NPE 방지

### DIFF
--- a/src/main/java/egovframework/com/dam/spe/req/web/EgovRequestOfferController.java
+++ b/src/main/java/egovframework/com/dam/spe/req/web/EgovRequestOfferController.java
@@ -209,6 +209,9 @@ public class EgovRequestOfferController {
 		if (!sCmd.equals("del")) {
 			// 상세정보 불러오기
 			RequestOfferVO requestOfferVOs = egovRequestOfferVOService.selectRequestOfferDetail(requestOfferVO);
+			if (requestOfferVOs == null) {
+				return "forward:/dam/spe/req/listRequestOffer.do";
+			}
 			model.addAttribute("requestOfferVO", requestOfferVOs);
 
 			// 조직유형 불러오기
@@ -271,6 +274,9 @@ public class EgovRequestOfferController {
 
 		// 수정정보 불러오기
 		RequestOfferVO requestOfferVOs = egovRequestOfferVOService.selectRequestOfferDetail(requestOfferVO);
+		if (requestOfferVOs == null) {
+			return "forward:/dam/spe/req/listRequestOffer.do";
+		}
 		model.addAttribute("requestOfferVO", requestOfferVOs);
 
 		// 조직유형 불러오기


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 변경 이유

지식정보제공 상세(`EgovRequestOfferDetail`, `/dam/spe/req/detailRequestOffer.do`)와 수정(`EgovRequestOfferModify`, `/dam/spe/req/updtRequestOffer.do`)은 `selectRequestOfferDetail`로 조회한 결과를 null 확인 없이 `getOrgnztId()`로 역참조합니다.

```java
RequestOfferVO requestOfferVOs = egovRequestOfferVOService.selectRequestOfferDetail(requestOfferVO);
model.addAttribute("requestOfferVO", requestOfferVOs);
...
searchMatVO.setSearchKeyword(requestOfferVOs.getOrgnztId());   // requestOfferVOs가 null이면 NPE
```

`selectRequestOfferDetail`은 DAO에서 `selectOne`으로 조회하며, 매칭되는 knoId가 없으면 `null`을 반환합니다.

```java
public RequestOfferVO selectRequestOfferDetail(RequestOfferVO requestOfferVO) {
    return (RequestOfferVO) selectOne("RequestOffer.selectRequestOfferDetail", requestOfferVO);
}
```

두 핸들러는 `knoId`를 요청에서 그대로 받습니다. 같은 컨트롤러가 삭제 기능(`cmd=del`)을 제공하므로, 목록에서 항목이 삭제된 뒤 남아 있는 링크로 상세나 수정을 열면 조회 결과가 `null`이 되어 `getOrgnztId()`에서 `NullPointerException`이 발생하고 화면이 500으로 실패합니다.

## 변경 내용

두 핸들러 모두 조회 결과가 `null`이면 목록으로 돌려보내도록 가드를 추가했습니다.

```java
RequestOfferVO requestOfferVOs = egovRequestOfferVOService.selectRequestOfferDetail(requestOfferVO);
if (requestOfferVOs == null) {
    return "forward:/dam/spe/req/listRequestOffer.do";
}
model.addAttribute("requestOfferVO", requestOfferVOs);
```

돌려보내는 방식은 같은 컨트롤러가 삭제 처리 후 목록으로 복귀할 때 쓰는 `forward:/dam/spe/req/listRequestOffer.do`와 동일하게 맞췄습니다(현재 코드의 205행, 387행, 560행과 같은 방식).

## 영향 범위

존재하는 knoId로 여는 정상 상세·수정은 기존과 동일하게 동작합니다. 조회 결과가 없을 때만 예외 대신 목록으로 이동합니다.

## 테스트 방법

로컬에 공통컴포넌트와 MySQL을 띄우고 일반사용자로 로그인한 뒤, 존재하지 않는 `knoId`로 `detailRequestOffer.do`를 요청했습니다.

```
없는 knoId 요청 →
  수정 전   시스템 에러 화면        (전역 예외 뷰가 대신 뜸)
  수정 후   지식정보 목록 화면      (listRequestOffer 로 정상 이동)
```

원인: `selectRequestOfferDetail`은 `selectOne` 기반이라 없는 `knoId`에서 `null`을 반환합니다. 수정 전에는 그 `null`을 곧바로 `requestOfferVOs.getOrgnztId()`로 역참조해 `NullPointerException`이 났습니다. 전역 예외 리졸버(`SimpleMappingExceptionResolver`)가 스택을 남기지 않아 로그엔 예외가 안 찍히지만, 직전 `selectMapTeamList`는 실행되고 다음 `selectMapMaterialList`는 호출되지 않은 gap으로 그 역참조 지점을 특정했습니다.

수정: 조회 결과가 `null`이면 목록으로 forward하는 가드를 추가해, 같은 요청이 에러 대신 지식정보 목록으로 이동합니다. `updtRequestOffer.do`도 같은 역참조 구조라 동일하게 처리했습니다.
