### PR TITLE
fix: 기념일 D-day 계산 fallback 경로 월 오프셋·자릿수 정정

### DIFF
--- a/src/main/java/egovframework/com/uss/ion/ans/service/impl/EgovAnnvrsryManageServiceImpl.java
+++ b/src/main/java/egovframework/com/uss/ion/ans/service/impl/EgovAnnvrsryManageServiceImpl.java
@@ -46,6 +46,7 @@ import jakarta.annotation.Resource;
  *   2018.11.30  최두영          selectAnnvrsryManageBnde에서 annvrsryManageVO의 null처리 추가
  *   2022.11.11  김혜준          시큐어코딩 처리
  *   2025.08.02  이백행          2025년 컨트리뷰션 PMD로 소프트웨어 보안약점 진단하고 제거하기-LocalVariableNamingConventions(final이 아닌 변수는 밑줄을 포함할 수 없음)
+ *   2026.07.21  z3rotig4r      getDateCount D-day fallback 경로 월 오프셋·자릿수 정정(0-based 월·미패딩으로 인한 SIOOBE/월 오류 제거)
  *
  *      </pre>
  */
@@ -204,9 +205,11 @@ public class EgovAnnvrsryManageServiceImpl extends EgovAbstractServiceImpl imple
 		// 매년반복일 경우
 		if ("1".equals(annvrsryManageVO.getReptitSe())) {
 			sAnnvrsryDe = Integer.toString(today.get(Calendar.YEAR))
-					+ (sAnnvrsryDe == null || sAnnvrsryDe.length() < 8 ? today.get(Calendar.MONTH)
+					+ (sAnnvrsryDe == null || sAnnvrsryDe.length() < 8
+							? String.format("%02d", today.get(Calendar.MONTH) + 1)
 							: sAnnvrsryDe.substring(4, 6))
-					+ (sAnnvrsryDe == null || sAnnvrsryDe.length() < 8 ? today.get(Calendar.DATE)
+					+ (sAnnvrsryDe == null || sAnnvrsryDe.length() < 8
+							? String.format("%02d", today.get(Calendar.DATE))
 							: sAnnvrsryDe.substring(6, 8));
 		}
 
@@ -219,7 +222,7 @@ public class EgovAnnvrsryManageServiceImpl extends EgovAbstractServiceImpl imple
 			targetDate.set(Integer.parseInt(sAnnvrsryDe.substring(0, 4)),
 					Integer.parseInt(sAnnvrsryDe.substring(4, 6)) - 1, Integer.parseInt(sAnnvrsryDe.substring(6, 8)));
 		} else {
-			targetDate.set(today.get(Calendar.YEAR), today.get(Calendar.MONTH) + 1, today.get(Calendar.DATE));
+			targetDate.set(today.get(Calendar.YEAR), today.get(Calendar.MONTH), today.get(Calendar.DATE));
 		}
 
 		long resultTime = targetDate.getTime().getTime() - today.getTime().getTime(); // 차이 구하기

--- a/src/test/java/egovframework/com/uss/ion/ans/service/impl/EgovAnnvrsryManageServiceImplTest.java
+++ b/src/test/java/egovframework/com/uss/ion/ans/service/impl/EgovAnnvrsryManageServiceImplTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright The eGovFrame Open Community (http://open.egovframe.go.kr)).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package egovframework.com.uss.ion.ans.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.Test;
+
+import egovframework.com.uss.ion.ans.service.AnnvrsryManageVO;
+
+/**
+ * {@link EgovAnnvrsryManageServiceImpl#getDateCount}의 D-day 계산 fallback 경로가
+ * 월 오프셋·자릿수 오류로 StringIndexOutOfBoundsException 또는 잘못된 D-day를
+ * 내지 않는지 검증한다.
+ */
+class EgovAnnvrsryManageServiceImplTest {
+
+    private static long callGetDateCount(AnnvrsryManageVO vo) throws Exception {
+        EgovAnnvrsryManageServiceImpl service = new EgovAnnvrsryManageServiceImpl();
+        Method m = EgovAnnvrsryManageServiceImpl.class.getDeclaredMethod("getDateCount", AnnvrsryManageVO.class);
+        m.setAccessible(true);
+        return (long) m.invoke(service, vo);
+    }
+
+    @Test
+    void getDateCount_yearlyRepeatWithoutStoredDate_usesTodayWithoutException() {
+        // 매년반복이고 저장된 날짜가 없으면 오늘 날짜(월/일)로 조립한다.
+        // 수정 전에는 0-based 월·미패딩으로 "2026621"(7자) 같은 문자열이 만들어져
+        // substring(6,8)에서 StringIndexOutOfBoundsException이 발생했다.
+        AnnvrsryManageVO vo = new AnnvrsryManageVO();
+        vo.setReptitSe("1");
+        vo.setAnnvrsryDe(null);
+
+        long dday = assertDoesNotThrow(() -> callGetDateCount(vo),
+                "저장 날짜가 없는 매년반복 기념일은 예외 없이 계산되어야 한다");
+        assertEquals(0L, dday, "오늘 날짜로 조립되므로 D-day는 0이어야 한다");
+    }
+
+    @Test
+    void getDateCount_emptyDateFallback_usesTodayMonth() throws Exception {
+        // 반복이 아니고 날짜가 비어 있으면 오늘 날짜로 대상일을 설정한다.
+        // 수정 전에는 Calendar.set의 month에 +1이 잘못 붙어 한 달 뒤로 설정되었다.
+        AnnvrsryManageVO vo = new AnnvrsryManageVO();
+        vo.setReptitSe("0");
+        vo.setAnnvrsryDe("");
+
+        assertEquals(0L, callGetDateCount(vo), "오늘로 설정되므로 D-day는 0이어야 한다(월 +1 오류 없음)");
+    }
+
+    @Test
+    void getDateCount_storedEightDigitDate_unaffected() throws Exception {
+        // 정상 8자리 저장 날짜 경로는 기존 동작을 유지한다(오늘이면 D-day 0).
+        java.util.Calendar today = java.util.Calendar.getInstance();
+        String todayStr = String.format("%04d%02d%02d",
+                today.get(java.util.Calendar.YEAR),
+                today.get(java.util.Calendar.MONTH) + 1,
+                today.get(java.util.Calendar.DATE));
+
+        AnnvrsryManageVO vo = new AnnvrsryManageVO();
+        vo.setReptitSe("1");
+        vo.setAnnvrsryDe(todayStr);
+
+        assertEquals(0L, callGetDateCount(vo), "오늘 날짜(8자리) 기념일의 D-day는 0이어야 한다");
+    }
+}


### PR DESCRIPTION
## 문제

`getDateCount`는 "다가오는 기념일" D-day를 계산합니다. 저장된 날짜가 있는 정상 경로는 `substring(4, 6) - 1`(1-based → 0-based)과 `substring(6, 8)`로 파싱하는데, fallback 경로가 이 형식과 일치하지 않습니다.

1. **매년반복이고 저장 날짜가 8자리 미만일 때**, 월을 `today.get(Calendar.MONTH)`(0-based, 미패딩)로 조립합니다. 한 자리 월/일이면 `"2026" + "6" + "5" = "202665"`(6자)가 되어 `substring(6, 8)`에서 `StringIndexOutOfBoundsException`이 발생하고, 두 자리여도 0-based 월이라 D-day가 한 달 어긋납니다.
2. **날짜가 비어 있을 때** fallback은 `Calendar.set(year, today.get(Calendar.MONTH) + 1, date)`로 month에 `+1`을 더합니다. `Calendar.set`의 month는 0-based이고 `today.get(Calendar.MONTH)`도 이미 0-based이므로, `+1`은 한 달 뒤로 잘못 설정합니다(정상 경로는 `-1`로 0-based 변환).

## 수정

- fallback의 월/일을 `String.format("%02d", ...)`로 1-based·2자리로 조립해 정상 경로의 파싱 형식과 맞췄습니다.
- 빈 날짜 fallback의 `Calendar.set`에서 잘못된 `+ 1`을 제거했습니다.

정상 8자리 저장 날짜 경로는 그대로입니다.

## 검증

fallback 두 경로가 예외 없이 오늘 기준 D-day 0을 반환하는지, 정상 8자리 경로가 유지되는지 검증하는 단위 테스트를 추가했습니다(수정 전에는 `StringIndexOutOfBoundsException`과 한 달 어긋난 D-day 재현).