### PR TITLE
fix: 지식정보 답변 등록 시 첨부파일 저장 전에 지식전문가 권한을 먼저 검사하도록 순서 조정

### DIFF
--- a/src/main/java/egovframework/com/dam/spe/req/web/EgovRequestOfferController.java
+++ b/src/main/java/egovframework/com/dam/spe/req/web/EgovRequestOfferController.java
@@ -506,17 +506,6 @@ public class EgovRequestOfferController {
 			return "egovframework/com/dam/spe/req/EgovComDamRequestOfferRegist";
 		}
 
-		// 첨부파일 관련 첨부파일ID 생성
-		String atchFileId = "";
-
-		final List<MultipartFile> files = multiRequest.getFiles("file_1");
-
-		if (!files.isEmpty()) {
-			List<FileVO> fvoList = fileUtil.parseFileInf(files, "DSCH_", 0, "", "");
-			atchFileId = fileMngService.insertFileInfs(fvoList);
-			requestOfferVO.setAtchFileId(atchFileId);
-		}
-
 		// 아이디 설정
 		requestOfferVO.setFrstRegisterId(loginVO == null ? "" : EgovStringUtil.isNullToString(loginVO.getUniqId()));
 		requestOfferVO.setLastUpdusrId(loginVO == null ? "" : EgovStringUtil.isNullToString(loginVO.getUniqId()));
@@ -552,6 +541,17 @@ public class EgovRequestOfferController {
 		// 일반사용자일때
 		} else {
 			requestOfferVO.setEmplyrId(loginVO == null ? "" : EgovStringUtil.isNullToString(loginVO.getUniqId()));
+		}
+
+		// 첨부파일 관련 첨부파일ID 생성
+		String atchFileId = "";
+
+		final List<MultipartFile> files = multiRequest.getFiles("file_1");
+
+		if (!files.isEmpty()) {
+			List<FileVO> fvoList = fileUtil.parseFileInf(files, "DSCH_", 0, "", "");
+			atchFileId = fileMngService.insertFileInfs(fvoList);
+			requestOfferVO.setAtchFileId(atchFileId);
 		}
 
 		// 저장


### PR DESCRIPTION
## 수정 사유

- [X] 버그수정
- [ ] 기능개선
- [ ] 신규기능

## 변경 이유

`EgovRequestOfferController`의 지식정보 답변 등록 핸들러 `registRequestOfferActor.do`(`EgovRequestOfferRegistActor`)는 첨부파일을 먼저 저장한 뒤에 지식전문가 권한을 검사했습니다.

AS-IS 처리 순서는 다음과 같았습니다.

```java
// 첨부파일 관련 첨부파일ID 생성  (부수효과: COMTNFILE/COMTNFILEDETAIL INSERT + 물리 파일 기록)
if (!files.isEmpty()) {
    List<FileVO> fvoList = fileUtil.parseFileInf(files, "DSCH_", 0, "", "");
    atchFileId = fileMngService.insertFileInfs(fvoList);
    requestOfferVO.setAtchFileId(atchFileId);
}

// ... 아이디 설정 ...

// 지식전문가 답변일때
if (sCmd.equals("reply") && egovRequestOfferVOService.selectRequestOfferSpeCheck(hmParam)) {
    requestOfferVO.setSpeId(...);
// 지식전문가 아니고 reply 일때 (권한 없음)
} else if (sCmd.equals("reply")) {
    // ... 화면 값 재설정 후 등록 화면으로 되돌림 ...
    return "egovframework/com/dam/spe/req/EgovComDamRequestOfferRegist";
}

egovRequestOfferVOService.insertRequestOffer(requestOfferVO);
```

지식전문가가 아닌 사용자가 `cmd=reply`로 파일을 첨부해 제출하면 `else if (sCmd.equals("reply"))` 분기가 등록 화면으로 되돌리며 `insertRequestOffer`를 호출하지 않습니다. 그런데 이 시점에는 이미 `insertFileInfs`가 `COMTNFILE`/`COMTNFILEDETAIL` 레코드를 만들고 `parseFileInf`가 물리 파일을 기록한 상태입니다. `atchFileId`를 참조할 지식정보 레코드가 저장되지 않으므로, 저장된 파일은 어디에도 연결되지 않는 고아 첨부파일로 남습니다.

같은 메서드 안에서 `bindingResult.hasErrors()` 검증은 이미 첨부파일 저장 앞에 위치해 검증 실패 시 파일을 저장하지 않습니다. `reply` 권한 없음 분기만 첨부파일 저장 뒤에 놓여 이 규칙과 어긋나 있었습니다. 병합된 #1073(뉴스 등록 검증 실패 시 첨부파일 저장 방지)과 동일한 "부수효과 전 검증" 사례입니다.

## 변경 내용

동작은 그대로 두고 첨부파일 저장 블록을 지식전문가 권한 검사 분기 뒤, `insertRequestOffer` 호출 직전으로 이동했습니다. 권한 없음으로 되돌아가는 경로에서는 파일 저장에 도달하지 않습니다.

TO-BE 처리 순서는 다음과 같습니다.

```java
// 아이디 설정
requestOfferVO.setFrstRegisterId(...);
requestOfferVO.setLastUpdusrId(...);

// (지식전문가/지식사용자) 검사 및 설정
if (sCmd.equals("reply") && egovRequestOfferVOService.selectRequestOfferSpeCheck(hmParam)) {
    requestOfferVO.setSpeId(...);
} else if (sCmd.equals("reply")) {
    // 권한 없음: 파일 저장 전에 등록 화면으로 되돌림
    return "egovframework/com/dam/spe/req/EgovComDamRequestOfferRegist";
} else {
    requestOfferVO.setEmplyrId(...);
}

// 첨부파일 관련 첨부파일ID 생성  (검사를 통과한 경우에만 실행)
if (!files.isEmpty()) {
    List<FileVO> fvoList = fileUtil.parseFileInf(files, "DSCH_", 0, "", "");
    atchFileId = fileMngService.insertFileInfs(fvoList);
    requestOfferVO.setAtchFileId(atchFileId);
}

// 저장
egovRequestOfferVOService.insertRequestOffer(requestOfferVO);
```

블록 이동만 했고 조건식, 저장 로직, 파일 파싱 파라미터는 바꾸지 않았습니다.

## 영향 범위

- 대상: `EgovRequestOfferController.EgovRequestOfferRegistActor`(`/dam/spe/req/registRequestOfferActor.do`) 한 곳입니다.
- 지식전문가 답변(`reply` + 권한 있음)과 일반 사용자 등록은 기존과 동일하게 파일을 저장하고 레코드를 등록합니다. `atchFileId`, `frstRegisterId`, `lastUpdusrId`는 서로 독립된 필드라 블록 순서가 바뀌어도 `insertRequestOffer` 시점의 값은 동일합니다.
- 권한 없는 사용자의 `reply` 요청만 동작이 달라집니다. 기존에는 파일을 저장한 뒤 되돌렸고, 변경 후에는 파일을 저장하지 않고 되돌립니다. 화면 응답은 동일합니다.
- 같은 파일을 건드리는 열린 PR #1176은 상세/수정 경로의 NPE를 다루는 별개 메서드라 본 변경과 라인이 겹치지 않습니다.

## 테스트 방법

- [ ] JUnit 테스트
- [x] 수동 테스트

첨부 저장(`insertFileInfs`)은 독립 트랜잭션이라 `COMTNFILE`에 바로 커밋됩니다. 이 저장이 권한 검사보다 앞에 있으므로, 권한 없는 답변(`cmd=reply`, 비지식전문가)이 등록화면으로 되돌아가면 파일만 저장되고 참조 레코드(`COMTNDAMCALRES`)가 없는 고아 첨부가 남을 것으로 봤습니다. 아래 쿼리로 각 첨부가 참조되는지 확인했습니다.

```sql
SELECT f.ATCH_FILE_ID,
       (SELECT COUNT(*) FROM COMTNDAMCALRES r WHERE r.ATCH_FILE_ID = f.ATCH_FILE_ID) AS referenced
FROM COMTNFILE f;   -- referenced = 0 이면 참조되지 않는 고아
```

로컬 앱과 MySQL을 빈 상태에서 시작해, 일반사용자(비지식전문가)로 로그인한 뒤 정상 등록(`cmd=save`)과 권한 없는 답변(`cmd=reply`)을 각각 첨부와 함께 `registRequestOfferActor.do`에 제출하고 위 쿼리를 실행했습니다. (`COMTNDAMCALRES`/`COMTNFILE` 행 수)

수정 전:

```
정상 등록(cmd=save)        1 / 1
권한없는 답변(cmd=reply)    1 / 2      ← 파일만 +1

ATCH_FILE_ID          referenced
FILE_000000009000000  1               ← 정상 등록분
FILE_000000009000001  0               ← 권한없는 답변이 남긴 고아
```

수정 후 (첨부 저장을 권한 검사 뒤로 이동):

```
정상 등록(cmd=save)        1 / 1
권한없는 답변(cmd=reply)    1 / 1      ← 파일도 저장 안 됨

ATCH_FILE_ID          referenced
FILE_000000009000000  1               ← 정상 등록분만, 고아 없음
```
