### PR TITLE
fix: 도움말 등록·수정 검증 실패 시 구분코드 목록 복원 및 수정 폼 바인딩명 정정

### DIFF
--- a/src/main/java/egovframework/com/uss/olh/hpc/web/EgovHpcmController.java
+++ b/src/main/java/egovframework/com/uss/olh/hpc/web/EgovHpcmController.java
@@ -131,17 +131,25 @@ public class EgovHpcmController {
 	@PostMapping("/uss/olh/hpc/insertHpcmView.do")
 	public String insertHpcmView(@ModelAttribute("searchVO") HpcmVO searchVO, Model model) throws Exception {
 
-		// 공통코드를 가져오기 위한 Vo
-		ComDefaultCodeVO vo = new ComDefaultCodeVO();
-		vo.setCodeId("COM021");
-
-		List<CmmnDetailCode> hpcmSeCode = cmmUseService.selectCmmCodeDetail(vo);
-		model.addAttribute("hpcmSeCode", hpcmSeCode);
+		model.addAttribute("hpcmSeCode", selectHpcmSeCodeList());
 
 		model.addAttribute("hpcmVO", new HpcmVO());
 
 		return "egovframework/com/uss/olh/hpc/EgovHpcmRegist";
 
+	}
+
+	/**
+	 * 도움말구분 공통코드(COM021) 목록을 조회한다.
+	 *
+	 * @return 도움말구분 공통코드 목록
+	 * @throws Exception
+	 */
+	private List<CmmnDetailCode> selectHpcmSeCodeList() throws Exception {
+		ComDefaultCodeVO vo = new ComDefaultCodeVO();
+		vo.setCodeId("COM021");
+
+		return cmmUseService.selectCmmCodeDetail(vo);
 	}
 
 	/**
@@ -155,9 +163,10 @@ public class EgovHpcmController {
 	 */
 	@PostMapping("/uss/olh/hpc/insertHpcm.do")
 	public String insertHpcmCn(@ModelAttribute("searchVO") HpcmVO searchVO, @Valid @ModelAttribute("hpcmVO") HpcmVO hpcmVO,
-			BindingResult bindingResult) throws Exception {
+			BindingResult bindingResult, Model model) throws Exception {
 
 		if (bindingResult.hasErrors()) {
+			model.addAttribute("hpcmSeCode", selectHpcmSeCodeList());
 			return "egovframework/com/uss/olh/hpc/EgovHpcmRegist";
 		}
 
@@ -187,12 +196,7 @@ public class EgovHpcmController {
 	public String updateHpcmView(@RequestParam("hpcmId") String hpcmId, @ModelAttribute("searchVO") HpcmVO searchVO,
 			ModelMap model) throws Exception {
 
-		// 공통코드를 가져오기 위한 Vo
-		ComDefaultCodeVO vo = new ComDefaultCodeVO();
-		vo.setCodeId("COM021");
-
-		List<CmmnDetailCode> hpcmSeCode = cmmUseService.selectCmmCodeDetail(vo);
-		model.addAttribute("hpcmSeCode", hpcmSeCode);
+		model.addAttribute("hpcmSeCode", selectHpcmSeCodeList());
 
 		HpcmVO hpcmVO = new HpcmVO();
 		hpcmVO.setHpcmId(hpcmId);
@@ -212,10 +216,11 @@ public class EgovHpcmController {
 	 * @throws Exception
 	 */
 	@PostMapping("/uss/olh/hpc/updateHpcm.do")
-	public String updateHpcm(@ModelAttribute("searchVO") HpcmVO searchVO, @Valid @ModelAttribute("hpcmManageVO") HpcmVO hpcmVO,
-			BindingResult bindingResult) throws Exception {
+	public String updateHpcm(@ModelAttribute("searchVO") HpcmVO searchVO, @Valid @ModelAttribute("hpcmVO") HpcmVO hpcmVO,
+			BindingResult bindingResult, Model model) throws Exception {
 
 		if (bindingResult.hasErrors()) {
+			model.addAttribute("hpcmSeCode", selectHpcmSeCodeList());
 			return "egovframework/com/uss/olh/hpc/EgovHpcmUpdt";
 		}
 

--- a/src/test/java/egovframework/com/uss/olh/hpc/web/EgovHpcmControllerValidationRestoreTest.java
+++ b/src/test/java/egovframework/com/uss/olh/hpc/web/EgovHpcmControllerValidationRestoreTest.java
@@ -1,0 +1,128 @@
+package egovframework.com.uss.olh.hpc.web;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.lang.reflect.Proxy;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.ui.ExtendedModelMap;
+import org.springframework.ui.Model;
+import org.springframework.ui.ModelMap;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.ModelAttribute;
+
+import egovframework.com.cmm.service.EgovCmmUseService;
+import egovframework.com.uss.olh.hpc.service.HpcmVO;
+
+/**
+ * 도움말 수정({@link EgovHpcmController#updateHpcm})·등록({@code insertHpcmCn})의 검증 실패 분기를 검증한다.
+ *
+ * <p>수정 폼 JSP는 {@code <form:form modelAttribute="hpcmVO">}로 바인딩하고 도움말구분
+ * 드롭다운을 {@code ${hpcmSeCode}}로 채운다. 수정 대상 메서드가 다른 이름으로 바인딩하면
+ * 검증 실패 재표시 때 {@code hpcmVO}가 model에 없어 form 태그가
+ * {@code IllegalStateException}을 던지고(500), {@code hpcmSeCode}를 복원하지 않으면
+ * 필수 드롭다운이 빈 채로 렌더된다.</p>
+ *
+ * <p>수정 전 코드에서는 수정 처리의 바인딩명이 {@code hpcmManageVO}이고 두 분기 모두
+ * {@code hpcmSeCode}를 복원하지 않아 세 검증이 모두 실패한다.</p>
+ *
+ * <p>수정 전후로 메서드 시그니처가 달라 리플렉션으로 호출한다.</p>
+ */
+class EgovHpcmControllerValidationRestoreTest {
+
+	private final InvocationHandler emptyStub = (proxy, method, args) ->
+			List.class.isAssignableFrom(method.getReturnType()) ? Collections.emptyList() : null;
+
+	private EgovHpcmController newControllerWithStubs() {
+		EgovHpcmController controller = new EgovHpcmController();
+		ReflectionTestUtils.setField(controller, "cmmUseService",
+				Proxy.newProxyInstance(getClass().getClassLoader(),
+						new Class[] { EgovCmmUseService.class }, emptyStub));
+		return controller;
+	}
+
+	private Method findMethod(String name) {
+		for (Method m : EgovHpcmController.class.getDeclaredMethods()) {
+			if (m.getName().equals(name)) {
+				return m;
+			}
+		}
+		throw new IllegalStateException(name + " 메서드를 찾을 수 없다");
+	}
+
+	/** 파라미터 타입에 맞춰 인자를 만들어 호출하고, JSP가 읽을 model을 돌려준다. */
+	private ModelMap invokeWithValidationError(Method method, EgovHpcmController controller) throws Throwable {
+		ExtendedModelMap model = new ExtendedModelMap();
+		boolean hasModelParam = false;
+		Object[] args = new Object[method.getParameterCount()];
+		Class<?>[] types = method.getParameterTypes();
+		for (int i = 0; i < types.length; i++) {
+			if (HpcmVO.class.isAssignableFrom(types[i])) {
+				args[i] = new HpcmVO();
+			} else if (BindingResult.class.isAssignableFrom(types[i])) {
+				BindingResult bindingResult = new BeanPropertyBindingResult(new HpcmVO(), "hpcmVO");
+				bindingResult.reject("validation.error");
+				args[i] = bindingResult;
+			} else if (types[i].isAssignableFrom(ExtendedModelMap.class)
+					|| Model.class.isAssignableFrom(types[i]) || ModelMap.class.isAssignableFrom(types[i])) {
+				args[i] = model;
+				hasModelParam = true;
+			} else {
+				args[i] = null;
+			}
+		}
+		if (!hasModelParam) {
+			fail("검증 실패 분기에서 참조데이터를 복원할 Model 파라미터가 없다");
+		}
+		try {
+			method.invoke(controller, args);
+		} catch (InvocationTargetException e) {
+			throw e.getCause();
+		}
+		return model;
+	}
+
+	@Test
+	@DisplayName("수정 처리의 폼 바인딩명이 JSP form:form의 modelAttribute(hpcmVO)와 일치한다")
+	void updateHpcmBindsUnderTheNameTheJspExpects() {
+		Method updateHpcm = findMethod("updateHpcm");
+		String boundName = null;
+		for (Parameter p : updateHpcm.getParameters()) {
+			ModelAttribute ann = p.getAnnotation(ModelAttribute.class);
+			if (ann != null && !"searchVO".equals(ann.value())) {
+				boundName = ann.value();
+			}
+		}
+		assertNotNull(boundName, "수정 대상 VO의 @ModelAttribute 바인딩명을 찾을 수 없다");
+		assertEquals("hpcmVO", boundName,
+				"EgovHpcmUpdt.jsp의 <form:form modelAttribute=\"hpcmVO\">와 일치해야 검증 실패 재표시가 500이 되지 않는다");
+	}
+
+	@Test
+	@DisplayName("도움말 수정 검증 실패 시 도움말구분 드롭다운 목록(hpcmSeCode)을 복원한다")
+	void updateHpcmRestoresCodeListOnValidationError() throws Throwable {
+		ModelMap model = invokeWithValidationError(findMethod("updateHpcm"), newControllerWithStubs());
+		assertTrue(model.containsAttribute("hpcmSeCode"),
+				"검증 실패 재표시 시 hpcmSeCode가 model에 있어야 드롭다운이 비지 않는다");
+	}
+
+	@Test
+	@DisplayName("도움말 등록 검증 실패 시 도움말구분 드롭다운 목록(hpcmSeCode)을 복원한다")
+	void insertHpcmRestoresCodeListOnValidationError() throws Throwable {
+		ModelMap model = invokeWithValidationError(findMethod("insertHpcmCn"), newControllerWithStubs());
+		assertTrue(model.containsAttribute("hpcmSeCode"),
+				"검증 실패 재표시 시 hpcmSeCode가 model에 있어야 드롭다운이 비지 않는다");
+	}
+}


### PR DESCRIPTION
## 수정 사유

- [x] 버그 수정 (Bug fix)
- [ ] 기능 개선 (Enhancement)
- [ ] 신규 기능 (New feature)
- [ ] 리팩터링 (Refactoring)

## 변경 이유

도움말(`EgovHpcmController`) 등록·수정 화면에서 서버측 검증(`@Valid`)에 실패해 폼을 다시 보여줄 때 두 가지 문제가 있었습니다.

1. 수정 화면 500 오류
   수정 뷰 핸들러 `updateHpcmView`는 대상 객체를 `hpcmVO`라는 이름으로 model에 담고, `EgovHpcmUpdt.jsp`의 `<form:form modelAttribute="hpcmVO">`도 같은 이름에 바인딩합니다. 그런데 저장 핸들러 `updateHpcm`은 커맨드 객체를 `@ModelAttribute("hpcmManageVO")`로 받아 검증 실패로 `EgovHpcmUpdt`를 다시 반환하면 model에는 `hpcmManageVO`만 있고 `hpcmVO`가 없습니다. `form:form`이 `hpcmVO`의 대상 객체나 `BindingResult`를 찾지 못해 `IllegalStateException: Neither BindingResult nor plain target object for bean name 'hpcmVO' available as request attribute`가 발생하고 HTTP 500으로 이어집니다. 이 클래스에는 `@SessionAttributes`나 `@ModelAttribute` 사전 등록 메서드가 없어 `hpcmVO`가 다른 경로로 채워지지도 않습니다. 형제 핸들러인 등록 저장 `insertHpcmCn`은 이미 JSP와 일치하는 `@ModelAttribute("hpcmVO")`를 쓰고 있어 수정 경로만 이름이 어긋나 있었습니다.

2. 검증 실패 시 도움말구분 셀렉트박스가 빈 채로 렌더링
   뷰 핸들러 `insertHpcmView`·`updateHpcmView`는 도움말구분 공통코드(코드 `COM021`)를 조회해 `hpcmSeCode`로 담고, JSP는 `<form:options items="${hpcmSeCode}">`로 그립니다. 저장 핸들러의 `bindingResult.hasErrors()` 분기는 같은 JSP를 반환하면서 `hpcmSeCode`를 다시 담지 않아 검증 실패 후 화면에서는 `${hpcmSeCode}`가 비어 `--선택하세요--`만 남고 구분 목록이 사라집니다.

## 변경 내용

파일: `src/main/java/egovframework/com/uss/olh/hpc/web/EgovHpcmController.java`

### 1. `updateHpcm` 바인딩명을 JSP와 일치시켜 500 제거

AS-IS
```java
public String updateHpcm(@ModelAttribute("searchVO") HpcmVO searchVO, @Valid @ModelAttribute("hpcmManageVO") HpcmVO hpcmVO,
        BindingResult bindingResult) throws Exception {
```

TO-BE
```java
public String updateHpcm(@ModelAttribute("searchVO") HpcmVO searchVO, @Valid @ModelAttribute("hpcmVO") HpcmVO hpcmVO,
        BindingResult bindingResult, Model model) throws Exception {
```

### 2. 검증 실패 분기에서 도움말구분 코드 목록 복원

뷰 핸들러 두 곳에 중복돼 있던 `COM021` 조회 로직을 헬퍼 `selectHpcmSeCodeList()`로 추출하고, 등록·수정 저장 핸들러의 `hasErrors()` 분기에서도 호출해 `hpcmSeCode`를 다시 담습니다.

AS-IS (등록·수정 공통, 검증 실패 분기)
```java
if (bindingResult.hasErrors()) {
    return "egovframework/com/uss/olh/hpc/EgovHpcmRegist"; // 수정은 EgovHpcmUpdt
}
```

TO-BE
```java
if (bindingResult.hasErrors()) {
    model.addAttribute("hpcmSeCode", selectHpcmSeCodeList());
    return "egovframework/com/uss/olh/hpc/EgovHpcmRegist"; // 수정은 EgovHpcmUpdt
}
```

추출한 헬퍼
```java
private List<CmmnDetailCode> selectHpcmSeCodeList() throws Exception {
    ComDefaultCodeVO vo = new ComDefaultCodeVO();
    vo.setCodeId("COM021");

    return cmmUseService.selectCmmCodeDetail(vo);
}
```

뷰 핸들러 `insertHpcmView`·`updateHpcmView`의 동작은 그대로 두고, 조회 방식만 헬퍼 호출로 바꿨습니다.

## 영향 범위

- 도움말 등록(`/uss/olh/hpc/insertHpcm.do`)과 수정(`/uss/olh/hpc/updateHpcm.do`)의 검증 실패 재표시 경로에만 영향을 줍니다.
- 정상 저장 흐름(`forward:/uss/olh/hpc/selectHpcmList.do`)과 목록·상세·삭제 핸들러는 변경이 없습니다.
- 앞서 머지된 #1068(공통상세코드 목록 복원)·#1069(롤타입 목록 복원)와 같은 성격의 결함이며 대상 파일과 화면이 달라 중복이 아닙니다.

## 테스트 방법

- [x] JUnit 테스트
- [x] 수동 테스트

`EgovHpcmControllerValidationRestoreTest`를 추가했습니다. 수정·등록 저장 핸들러를 검증 실패 상태(`BindingResult`에 오류가 있는 상태)로 호출해 재표시 model에 `hpcmSeCode`가 복원되는지, 그리고 수정 저장 핸들러의 커맨드 객체 바인딩명이 JSP `<form:form modelAttribute="hpcmVO">`와 일치하는지 확인합니다. 공통코드 조회는 동적 프록시 스텁으로 대체해 DB 없이 실행됩니다.

프로젝트 `pom.xml`이 `skipTests`를 기본값 true로 두므로 아래처럼 해제하고 실행합니다.

```
mvn -Dtest=EgovHpcmControllerValidationRestoreTest test
```

수정 전에는 바인딩명 불일치와 목록 미복원으로 세 검증이 모두 실패합니다.

```
[ERROR] Tests run: 3, Failures: 3, Errors: 0, Skipped: 0, Time elapsed: 0.155 s <<< FAILURE! -- in egovframework.com.uss.olh.hpc.web.EgovHpcmControllerValidationRestoreTest
[ERROR]   EgovHpcmControllerValidationRestoreTest.updateHpcmBindsUnderTheNameTheJspExpects:109 EgovHpcmUpdt.jsp의 <form:form modelAttribute="hpcmVO">와 일치해야 검증 실패 재표시가 500이 되지 않는다 ==> expected: <hpcmVO> but was: <hpcmManageVO>
[ERROR]   EgovHpcmControllerValidationRestoreTest.updateHpcmRestoresCodeListOnValidationError:116->invokeWithValidationError:87 검증 실패 분기에서 참조데이터를 복원할 Model 파라미터가 없다
[ERROR]   EgovHpcmControllerValidationRestoreTest.insertHpcmRestoresCodeListOnValidationError:124->invokeWithValidationError:87 검증 실패 분기에서 참조데이터를 복원할 Model 파라미터가 없다
```

수정 후에는 세 검증이 통과합니다.

```
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.167 s -- in egovframework.com.uss.olh.hpc.web.EgovHpcmControllerValidationRestoreTest
```

수동으로는 로컬에 공통컴포넌트와 MySQL을 띄우고 E2E로 확인했습니다. 도움말 하나를 등록한 뒤 그 수정 폼에서 `@Size(max=1000)`을 넘는 `hpcmDf`(1001자)를 보내 검증을 실패시키고 응답과 로그를 봤습니다.

수정 전:

```
$ curl … /uss/olh/hpc/updateHpcm.do   (hpcmDf 1001자)
HTTP 500
로그: java.lang.IllegalStateException: Neither BindingResult nor plain target object
      for bean name 'hpcmVO' available as request attribute   (EgovHpcmUpdt_jsp)
```

수정 후:

```
$ curl … /uss/olh/hpc/updateHpcm.do   (hpcmDf 1001자)
HTTP 200   — 수정 폼이 다시 뜨고, 도움말구분 셀렉트박스(COM021)도 채워짐
```
