### PR TITLE
perf: 배치스케줄·백업작업 목록 조회의 요일정보 N+1 쿼리 제거

### DIFF
--- a/src/main/java/egovframework/com/sym/bat/service/impl/BatchSchdulDao.java
+++ b/src/main/java/egovframework/com/sym/bat/service/impl/BatchSchdulDao.java
@@ -1,5 +1,8 @@
 package egovframework.com.sym.bat.service.impl;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.stereotype.Repository;
 
@@ -89,10 +92,24 @@ public class BatchSchdulDao extends EgovComAbstractDAO {
 	 */
 	public List<BatchSchdul> selectBatchSchdulList(BatchSchdul searchVO) {
 		List<BatchSchdul> resultList = selectList("BatchSchdulDao.selectBatchSchdulList", searchVO);
+		if (resultList.isEmpty()) {
+			return resultList;
+		}
+
+		// 스케줄요일정보를 배치스케줄ID 목록으로 한번에 조회한 뒤 ID별로 그룹핑한다. (행별 조회로 인한 N+1 제거)
+		List<String> batchSchdulIds = new ArrayList<>();
+		for (BatchSchdul result : resultList) {
+			batchSchdulIds.add(result.getBatchSchdulId());
+		}
+		List<BatchSchdulDfk> dfkList = selectList("BatchSchdulDao.selectBatchSchdulDfkListByIds", batchSchdulIds);
+		Map<String, List<BatchSchdulDfk>> dfkMap = new HashMap<>();
+		for (BatchSchdulDfk dfk : dfkList) {
+			dfkMap.computeIfAbsent(dfk.getBatchSchdulId(), key -> new ArrayList<>()).add(dfk);
+		}
 
 		for (BatchSchdul result : resultList) {
 			// 스케줄요일정보를 가져온다.
-			List<BatchSchdulDfk> dfkSeList = selectList("BatchSchdulDao.selectBatchSchdulDfkList", result.getBatchSchdulId());
+			List<BatchSchdulDfk> dfkSeList = dfkMap.getOrDefault(result.getBatchSchdulId(), new ArrayList<>());
 			String [] dfkSes = new String [dfkSeList.size()];
 			for (int j = 0; j < dfkSeList.size(); j++) {
 				dfkSes[j] = dfkSeList.get(j).getExecutSchdulDfkSe();

--- a/src/main/java/egovframework/com/sym/bat/service/impl/BatchSchdulDao.java
+++ b/src/main/java/egovframework/com/sym/bat/service/impl/BatchSchdulDao.java
@@ -30,6 +30,12 @@ import egovframework.com.sym.bat.service.BatchSchdulDfk;
 public class BatchSchdulDao extends EgovComAbstractDAO {
 
 	/**
+	 * 요일정보 일괄조회 IN 절에 한번에 넣는 배치스케줄ID 개수.
+	 * 지원 DB 중 Oracle의 IN 절 항목 상한(1000개)이 가장 낮고 초과 시 ORA-01795가 발생하므로 그 값을 기준으로 나눈다.
+	 */
+	private static final int DFK_SELECT_ID_SIZE = 1000;
+
+	/**
 	 * 배치스케줄을 삭제한다.
 	 *
 	 * @param batchSchdul    삭제할 배치스케줄 VO
@@ -96,15 +102,19 @@ public class BatchSchdulDao extends EgovComAbstractDAO {
 			return resultList;
 		}
 
-		// 스케줄요일정보를 배치스케줄ID 목록으로 한번에 조회한 뒤 ID별로 그룹핑한다. (행별 조회로 인한 N+1 제거)
+		// 스케줄요일정보를 배치스케줄ID 목록으로 일괄 조회한 뒤 ID별로 그룹핑한다. (행별 조회로 인한 N+1 제거)
 		List<String> batchSchdulIds = new ArrayList<>();
 		for (BatchSchdul result : resultList) {
 			batchSchdulIds.add(result.getBatchSchdulId());
 		}
-		List<BatchSchdulDfk> dfkList = selectList("BatchSchdulDao.selectBatchSchdulDfkListByIds", batchSchdulIds);
 		Map<String, List<BatchSchdulDfk>> dfkMap = new HashMap<>();
-		for (BatchSchdulDfk dfk : dfkList) {
-			dfkMap.computeIfAbsent(dfk.getBatchSchdulId(), key -> new ArrayList<>()).add(dfk);
+		for (int fromIndex = 0; fromIndex < batchSchdulIds.size(); fromIndex += DFK_SELECT_ID_SIZE) {
+			int toIndex = Math.min(fromIndex + DFK_SELECT_ID_SIZE, batchSchdulIds.size());
+			List<BatchSchdulDfk> dfkList = selectList("BatchSchdulDao.selectBatchSchdulDfkListByIds",
+					batchSchdulIds.subList(fromIndex, toIndex));
+			for (BatchSchdulDfk dfk : dfkList) {
+				dfkMap.computeIfAbsent(dfk.getBatchSchdulId(), key -> new ArrayList<>()).add(dfk);
+			}
 		}
 
 		for (BatchSchdul result : resultList) {

--- a/src/main/java/egovframework/com/sym/sym/bak/service/impl/BackupOpertDao.java
+++ b/src/main/java/egovframework/com/sym/sym/bak/service/impl/BackupOpertDao.java
@@ -1,5 +1,8 @@
 package egovframework.com.sym.sym.bak.service.impl;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Repository;
 
@@ -91,11 +94,20 @@ public class BackupOpertDao extends EgovComAbstractDAO {
      */
     public List<BackupOpert> selectBackupOpertList(BackupOpert searchVO) {
         List<BackupOpert> resultList = selectList("BackupOpertDao.selectBackupOpertList", searchVO);
+        if (resultList.isEmpty()) {
+            return resultList;
+        }
+
+        // 스케줄요일정보를 백업작업ID 목록으로 한번에 조회한 뒤 ID별로 그룹핑한다. (행별 조회로 인한 N+1 제거)
+        List<String> backupOpertIds = resultList.stream()
+                .map(BackupOpert::getBackupOpertId).collect(Collectors.toList());
+        List<BackupSchdulDfk> dfkList = selectList("BackupOpertDao.selectBackupSchdulDfkListByIds", backupOpertIds);
+        Map<String, List<BackupSchdulDfk>> dfkMap = dfkList.stream()
+                .collect(Collectors.groupingBy(BackupSchdulDfk::getBackupOpertId));
 
         for (BackupOpert result : resultList) {
             // 스케줄요일정보를 가져온다.
-            List<BackupSchdulDfk> dfkSeList = selectList("BackupOpertDao.selectBackupSchdulDfkList",
-                    result.getBackupOpertId());
+            List<BackupSchdulDfk> dfkSeList = dfkMap.getOrDefault(result.getBackupOpertId(), Collections.emptyList());
             result.setExecutSchdulDfkSes(
                     dfkSeList.stream().map(BackupSchdulDfk::getExecutSchdulDfkSe).toArray(String[]::new));
             // 화면표시용 실행스케줄 속성을 만든다.

--- a/src/main/java/egovframework/com/sym/sym/bak/service/impl/BackupOpertDao.java
+++ b/src/main/java/egovframework/com/sym/sym/bak/service/impl/BackupOpertDao.java
@@ -1,5 +1,7 @@
 package egovframework.com.sym.sym.bak.service.impl;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -28,6 +30,12 @@ import egovframework.com.sym.sym.bak.service.BackupSchdulDfk;
  */
 @Repository("backupOpertDao")
 public class BackupOpertDao extends EgovComAbstractDAO {
+
+	/**
+	 * 요일정보 일괄조회 IN 절에 한번에 넣는 백업작업ID 개수.
+	 * 지원 DB 중 Oracle의 IN 절 항목 상한(1000개)이 가장 낮고 초과 시 ORA-01795가 발생하므로 그 값을 기준으로 나눈다.
+	 */
+	private static final int DFK_SELECT_ID_SIZE = 1000;
 
 	/**
 	 * 백업작업을 삭제한다.
@@ -98,12 +106,18 @@ public class BackupOpertDao extends EgovComAbstractDAO {
             return resultList;
         }
 
-        // 스케줄요일정보를 백업작업ID 목록으로 한번에 조회한 뒤 ID별로 그룹핑한다. (행별 조회로 인한 N+1 제거)
+        // 스케줄요일정보를 백업작업ID 목록으로 일괄 조회한 뒤 ID별로 그룹핑한다. (행별 조회로 인한 N+1 제거)
         List<String> backupOpertIds = resultList.stream()
                 .map(BackupOpert::getBackupOpertId).collect(Collectors.toList());
-        List<BackupSchdulDfk> dfkList = selectList("BackupOpertDao.selectBackupSchdulDfkListByIds", backupOpertIds);
-        Map<String, List<BackupSchdulDfk>> dfkMap = dfkList.stream()
-                .collect(Collectors.groupingBy(BackupSchdulDfk::getBackupOpertId));
+        Map<String, List<BackupSchdulDfk>> dfkMap = new HashMap<>();
+        for (int fromIndex = 0; fromIndex < backupOpertIds.size(); fromIndex += DFK_SELECT_ID_SIZE) {
+            int toIndex = Math.min(fromIndex + DFK_SELECT_ID_SIZE, backupOpertIds.size());
+            List<BackupSchdulDfk> dfkList = selectList("BackupOpertDao.selectBackupSchdulDfkListByIds",
+                    backupOpertIds.subList(fromIndex, toIndex));
+            for (BackupSchdulDfk dfk : dfkList) {
+                dfkMap.computeIfAbsent(dfk.getBackupOpertId(), key -> new ArrayList<>()).add(dfk);
+            }
+        }
 
         for (BackupOpert result : resultList) {
             // 스케줄요일정보를 가져온다.

--- a/src/main/resources/egovframework/mapper/com/sym/bat/EgovBatchSchdul_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/bat/EgovBatchSchdul_SQL_altibase.xml
@@ -139,6 +139,18 @@
         
     </select>
 
+    <select id="selectBatchSchdulDfkListByIds" parameterType="java.util.List" resultMap="batchSchdulDfkResult">
+            SELECT  A.BATCH_SCHDUL_ID, A.EXECUT_SCHDUL_DFK_SE, B.CODE_NM EXECUT_SCHDUL_DFK_SE_NM
+            FROM COMTNBATCHSCHDULDFK A, COMTCCMMNDETAILCODE B
+            WHERE A.BATCH_SCHDUL_ID IN
+            <foreach collection="list" item="batchSchdulId" open="(" separator="," close=")">
+                #{batchSchdulId}
+            </foreach>
+              AND A.EXECUT_SCHDUL_DFK_SE = B.CODE
+              AND B.CODE_ID = 'COM074'
+            ORDER BY A.BATCH_SCHDUL_ID, A.EXECUT_SCHDUL_DFK_SE
+    </select>
+
     <insert id="insertBatchSchdulDfk" parameterType="egovframework.com.sym.bat.service.BatchSchdulDfk">
         
             INSERT INTO COMTNBATCHSCHDULDFK (

--- a/src/main/resources/egovframework/mapper/com/sym/bat/EgovBatchSchdul_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/bat/EgovBatchSchdul_SQL_cubrid.xml
@@ -139,6 +139,18 @@
         
     </select>
 
+    <select id="selectBatchSchdulDfkListByIds" parameterType="java.util.List" resultMap="batchSchdulDfkResult">
+            SELECT  A.BATCH_SCHDUL_ID, A.EXECUT_SCHDUL_DFK_SE, B.CODE_NM EXECUT_SCHDUL_DFK_SE_NM
+            FROM COMTNBATCHSCHDULDFK A, COMTCCMMNDETAILCODE B
+            WHERE A.BATCH_SCHDUL_ID IN
+            <foreach collection="list" item="batchSchdulId" open="(" separator="," close=")">
+                #{batchSchdulId}
+            </foreach>
+              AND A.EXECUT_SCHDUL_DFK_SE = B.CODE
+              AND B.CODE_ID = 'COM074'
+            ORDER BY A.BATCH_SCHDUL_ID, A.EXECUT_SCHDUL_DFK_SE
+    </select>
+
     <insert id="insertBatchSchdulDfk" parameterType="egovframework.com.sym.bat.service.BatchSchdulDfk">
         
             INSERT INTO COMTNBATCHSCHDULDFK (

--- a/src/main/resources/egovframework/mapper/com/sym/bat/EgovBatchSchdul_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/bat/EgovBatchSchdul_SQL_goldilocks.xml
@@ -139,6 +139,18 @@
         
     </select>
 
+    <select id="selectBatchSchdulDfkListByIds" parameterType="java.util.List" resultMap="batchSchdulDfkResult">
+            SELECT  A.BATCH_SCHDUL_ID, A.EXECUT_SCHDUL_DFK_SE, B.CODE_NM EXECUT_SCHDUL_DFK_SE_NM
+            FROM COMTNBATCHSCHDULDFK A, COMTCCMMNDETAILCODE B
+            WHERE A.BATCH_SCHDUL_ID IN
+            <foreach collection="list" item="batchSchdulId" open="(" separator="," close=")">
+                #{batchSchdulId}
+            </foreach>
+              AND A.EXECUT_SCHDUL_DFK_SE = B.CODE
+              AND B.CODE_ID = 'COM074'
+            ORDER BY A.BATCH_SCHDUL_ID, A.EXECUT_SCHDUL_DFK_SE
+    </select>
+
     <insert id="insertBatchSchdulDfk" parameterType="egovframework.com.sym.bat.service.BatchSchdulDfk">
         
             INSERT INTO COMTNBATCHSCHDULDFK (

--- a/src/main/resources/egovframework/mapper/com/sym/bat/EgovBatchSchdul_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/bat/EgovBatchSchdul_SQL_maria.xml
@@ -138,6 +138,18 @@
         
     </select>
 
+    <select id="selectBatchSchdulDfkListByIds" parameterType="java.util.List" resultMap="batchSchdulDfkResult">
+            SELECT  A.BATCH_SCHDUL_ID, A.EXECUT_SCHDUL_DFK_SE, B.CODE_NM EXECUT_SCHDUL_DFK_SE_NM
+            FROM COMTNBATCHSCHDULDFK A, COMTCCMMNDETAILCODE B
+            WHERE A.BATCH_SCHDUL_ID IN
+            <foreach collection="list" item="batchSchdulId" open="(" separator="," close=")">
+                #{batchSchdulId}
+            </foreach>
+              AND A.EXECUT_SCHDUL_DFK_SE = B.CODE
+              AND B.CODE_ID = 'COM074'
+            ORDER BY A.BATCH_SCHDUL_ID, A.EXECUT_SCHDUL_DFK_SE
+    </select>
+
     <insert id="insertBatchSchdulDfk" parameterType="egovframework.com.sym.bat.service.BatchSchdulDfk">
         
             INSERT INTO COMTNBATCHSCHDULDFK (

--- a/src/main/resources/egovframework/mapper/com/sym/bat/EgovBatchSchdul_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/bat/EgovBatchSchdul_SQL_mysql.xml
@@ -138,6 +138,18 @@
         
     </select>
 
+    <select id="selectBatchSchdulDfkListByIds" parameterType="java.util.List" resultMap="batchSchdulDfkResult">
+            SELECT  A.BATCH_SCHDUL_ID, A.EXECUT_SCHDUL_DFK_SE, B.CODE_NM EXECUT_SCHDUL_DFK_SE_NM
+            FROM COMTNBATCHSCHDULDFK A, COMTCCMMNDETAILCODE B
+            WHERE A.BATCH_SCHDUL_ID IN
+            <foreach collection="list" item="batchSchdulId" open="(" separator="," close=")">
+                #{batchSchdulId}
+            </foreach>
+              AND A.EXECUT_SCHDUL_DFK_SE = B.CODE
+              AND B.CODE_ID = 'COM074'
+            ORDER BY A.BATCH_SCHDUL_ID, A.EXECUT_SCHDUL_DFK_SE
+    </select>
+
     <insert id="insertBatchSchdulDfk" parameterType="egovframework.com.sym.bat.service.BatchSchdulDfk">
         
             INSERT INTO COMTNBATCHSCHDULDFK (

--- a/src/main/resources/egovframework/mapper/com/sym/bat/EgovBatchSchdul_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/bat/EgovBatchSchdul_SQL_oracle.xml
@@ -139,6 +139,18 @@
         
     </select>
 
+    <select id="selectBatchSchdulDfkListByIds" parameterType="java.util.List" resultMap="batchSchdulDfkResult">
+            SELECT  A.BATCH_SCHDUL_ID, A.EXECUT_SCHDUL_DFK_SE, B.CODE_NM EXECUT_SCHDUL_DFK_SE_NM
+            FROM COMTNBATCHSCHDULDFK A, COMTCCMMNDETAILCODE B
+            WHERE A.BATCH_SCHDUL_ID IN
+            <foreach collection="list" item="batchSchdulId" open="(" separator="," close=")">
+                #{batchSchdulId}
+            </foreach>
+              AND A.EXECUT_SCHDUL_DFK_SE = B.CODE
+              AND B.CODE_ID = 'COM074'
+            ORDER BY A.BATCH_SCHDUL_ID, A.EXECUT_SCHDUL_DFK_SE
+    </select>
+
     <insert id="insertBatchSchdulDfk" parameterType="egovframework.com.sym.bat.service.BatchSchdulDfk">
         
             INSERT INTO COMTNBATCHSCHDULDFK (

--- a/src/main/resources/egovframework/mapper/com/sym/bat/EgovBatchSchdul_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/bat/EgovBatchSchdul_SQL_postgres.xml
@@ -138,6 +138,18 @@
         
     </select>
 
+    <select id="selectBatchSchdulDfkListByIds" parameterType="java.util.List" resultMap="batchSchdulDfkResult">
+            SELECT  A.BATCH_SCHDUL_ID, A.EXECUT_SCHDUL_DFK_SE, B.CODE_NM EXECUT_SCHDUL_DFK_SE_NM
+            FROM COMTNBATCHSCHDULDFK A, COMTCCMMNDETAILCODE B
+            WHERE A.BATCH_SCHDUL_ID IN
+            <foreach collection="list" item="batchSchdulId" open="(" separator="," close=")">
+                #{batchSchdulId}
+            </foreach>
+              AND A.EXECUT_SCHDUL_DFK_SE = B.CODE
+              AND B.CODE_ID = 'COM074'
+            ORDER BY A.BATCH_SCHDUL_ID, A.EXECUT_SCHDUL_DFK_SE
+    </select>
+
     <insert id="insertBatchSchdulDfk" parameterType="egovframework.com.sym.bat.service.BatchSchdulDfk">
         
             INSERT INTO COMTNBATCHSCHDULDFK (

--- a/src/main/resources/egovframework/mapper/com/sym/bat/EgovBatchSchdul_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/bat/EgovBatchSchdul_SQL_tibero.xml
@@ -139,6 +139,18 @@
         
     </select>
 
+    <select id="selectBatchSchdulDfkListByIds" parameterType="java.util.List" resultMap="batchSchdulDfkResult">
+            SELECT  A.BATCH_SCHDUL_ID, A.EXECUT_SCHDUL_DFK_SE, B.CODE_NM EXECUT_SCHDUL_DFK_SE_NM
+            FROM COMTNBATCHSCHDULDFK A, COMTCCMMNDETAILCODE B
+            WHERE A.BATCH_SCHDUL_ID IN
+            <foreach collection="list" item="batchSchdulId" open="(" separator="," close=")">
+                #{batchSchdulId}
+            </foreach>
+              AND A.EXECUT_SCHDUL_DFK_SE = B.CODE
+              AND B.CODE_ID = 'COM074'
+            ORDER BY A.BATCH_SCHDUL_ID, A.EXECUT_SCHDUL_DFK_SE
+    </select>
+
     <insert id="insertBatchSchdulDfk" parameterType="egovframework.com.sym.bat.service.BatchSchdulDfk">
         
             INSERT INTO COMTNBATCHSCHDULDFK (

--- a/src/main/resources/egovframework/mapper/com/sym/sym/bak/EgovBackupOpert_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/sym/bak/EgovBackupOpert_SQL_altibase.xml
@@ -154,6 +154,18 @@
         
     </select>
 
+    <select id="selectBackupSchdulDfkListByIds" parameterType="java.util.List" resultMap="backupSchdulDfkResult">
+            SELECT  A.BACKUP_OPERT_ID, A.EXECUT_SCHDUL_DFK_SE, B.CODE_NM EXECUT_SCHDUL_DFK_SE_NM
+            FROM COMTNBACKUPSCHDULDFK A, COMTCCMMNDETAILCODE B
+            WHERE A.BACKUP_OPERT_ID IN
+            <foreach collection="list" item="backupOpertId" open="(" separator="," close=")">
+                #{backupOpertId}
+            </foreach>
+              AND A.EXECUT_SCHDUL_DFK_SE = B.CODE
+              AND B.CODE_ID = 'COM074'
+            ORDER BY A.BACKUP_OPERT_ID, A.EXECUT_SCHDUL_DFK_SE
+    </select>
+
     <insert id="insertBackupSchdulDfk" parameterType="egovframework.com.sym.sym.bak.service.BackupSchdulDfk">
         
             INSERT INTO COMTNBACKUPSCHDULDFK (

--- a/src/main/resources/egovframework/mapper/com/sym/sym/bak/EgovBackupOpert_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/sym/bak/EgovBackupOpert_SQL_cubrid.xml
@@ -154,6 +154,18 @@
         
     </select>
 
+    <select id="selectBackupSchdulDfkListByIds" parameterType="java.util.List" resultMap="backupSchdulDfkResult">
+            SELECT  A.BACKUP_OPERT_ID, A.EXECUT_SCHDUL_DFK_SE, B.CODE_NM EXECUT_SCHDUL_DFK_SE_NM
+            FROM COMTNBACKUPSCHDULDFK A, COMTCCMMNDETAILCODE B
+            WHERE A.BACKUP_OPERT_ID IN
+            <foreach collection="list" item="backupOpertId" open="(" separator="," close=")">
+                #{backupOpertId}
+            </foreach>
+              AND A.EXECUT_SCHDUL_DFK_SE = B.CODE
+              AND B.CODE_ID = 'COM074'
+            ORDER BY A.BACKUP_OPERT_ID, A.EXECUT_SCHDUL_DFK_SE
+    </select>
+
     <insert id="insertBackupSchdulDfk" parameterType="egovframework.com.sym.sym.bak.service.BackupSchdulDfk">
         
             INSERT INTO COMTNBACKUPSCHDULDFK (

--- a/src/main/resources/egovframework/mapper/com/sym/sym/bak/EgovBackupOpert_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/sym/bak/EgovBackupOpert_SQL_goldilocks.xml
@@ -154,6 +154,18 @@
         
     </select>
 
+    <select id="selectBackupSchdulDfkListByIds" parameterType="java.util.List" resultMap="backupSchdulDfkResult">
+            SELECT  A.BACKUP_OPERT_ID, A.EXECUT_SCHDUL_DFK_SE, B.CODE_NM EXECUT_SCHDUL_DFK_SE_NM
+            FROM COMTNBACKUPSCHDULDFK A, COMTCCMMNDETAILCODE B
+            WHERE A.BACKUP_OPERT_ID IN
+            <foreach collection="list" item="backupOpertId" open="(" separator="," close=")">
+                #{backupOpertId}
+            </foreach>
+              AND A.EXECUT_SCHDUL_DFK_SE = B.CODE
+              AND B.CODE_ID = 'COM074'
+            ORDER BY A.BACKUP_OPERT_ID, A.EXECUT_SCHDUL_DFK_SE
+    </select>
+
     <insert id="insertBackupSchdulDfk" parameterType="egovframework.com.sym.sym.bak.service.BackupSchdulDfk">
         
             INSERT INTO COMTNBACKUPSCHDULDFK (

--- a/src/main/resources/egovframework/mapper/com/sym/sym/bak/EgovBackupOpert_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/sym/bak/EgovBackupOpert_SQL_maria.xml
@@ -153,6 +153,18 @@
         
     </select>
 
+    <select id="selectBackupSchdulDfkListByIds" parameterType="java.util.List" resultMap="backupSchdulDfkResult">
+            SELECT  A.BACKUP_OPERT_ID, A.EXECUT_SCHDUL_DFK_SE, B.CODE_NM EXECUT_SCHDUL_DFK_SE_NM
+            FROM COMTNBACKUPSCHDULDFK A, COMTCCMMNDETAILCODE B
+            WHERE A.BACKUP_OPERT_ID IN
+            <foreach collection="list" item="backupOpertId" open="(" separator="," close=")">
+                #{backupOpertId}
+            </foreach>
+              AND A.EXECUT_SCHDUL_DFK_SE = B.CODE
+              AND B.CODE_ID = 'COM074'
+            ORDER BY A.BACKUP_OPERT_ID, A.EXECUT_SCHDUL_DFK_SE
+    </select>
+
     <insert id="insertBackupSchdulDfk" parameterType="egovframework.com.sym.sym.bak.service.BackupSchdulDfk">
         
             INSERT INTO COMTNBACKUPSCHDULDFK (

--- a/src/main/resources/egovframework/mapper/com/sym/sym/bak/EgovBackupOpert_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/sym/bak/EgovBackupOpert_SQL_mysql.xml
@@ -153,6 +153,18 @@
         
     </select>
 
+    <select id="selectBackupSchdulDfkListByIds" parameterType="java.util.List" resultMap="backupSchdulDfkResult">
+            SELECT  A.BACKUP_OPERT_ID, A.EXECUT_SCHDUL_DFK_SE, B.CODE_NM EXECUT_SCHDUL_DFK_SE_NM
+            FROM COMTNBACKUPSCHDULDFK A, COMTCCMMNDETAILCODE B
+            WHERE A.BACKUP_OPERT_ID IN
+            <foreach collection="list" item="backupOpertId" open="(" separator="," close=")">
+                #{backupOpertId}
+            </foreach>
+              AND A.EXECUT_SCHDUL_DFK_SE = B.CODE
+              AND B.CODE_ID = 'COM074'
+            ORDER BY A.BACKUP_OPERT_ID, A.EXECUT_SCHDUL_DFK_SE
+    </select>
+
     <insert id="insertBackupSchdulDfk" parameterType="egovframework.com.sym.sym.bak.service.BackupSchdulDfk">
         
             INSERT INTO COMTNBACKUPSCHDULDFK (

--- a/src/main/resources/egovframework/mapper/com/sym/sym/bak/EgovBackupOpert_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/sym/bak/EgovBackupOpert_SQL_oracle.xml
@@ -154,6 +154,18 @@
         
     </select>
 
+    <select id="selectBackupSchdulDfkListByIds" parameterType="java.util.List" resultMap="backupSchdulDfkResult">
+            SELECT  A.BACKUP_OPERT_ID, A.EXECUT_SCHDUL_DFK_SE, B.CODE_NM EXECUT_SCHDUL_DFK_SE_NM
+            FROM COMTNBACKUPSCHDULDFK A, COMTCCMMNDETAILCODE B
+            WHERE A.BACKUP_OPERT_ID IN
+            <foreach collection="list" item="backupOpertId" open="(" separator="," close=")">
+                #{backupOpertId}
+            </foreach>
+              AND A.EXECUT_SCHDUL_DFK_SE = B.CODE
+              AND B.CODE_ID = 'COM074'
+            ORDER BY A.BACKUP_OPERT_ID, A.EXECUT_SCHDUL_DFK_SE
+    </select>
+
     <insert id="insertBackupSchdulDfk" parameterType="egovframework.com.sym.sym.bak.service.BackupSchdulDfk">
         
             INSERT INTO COMTNBACKUPSCHDULDFK (

--- a/src/main/resources/egovframework/mapper/com/sym/sym/bak/EgovBackupOpert_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/sym/bak/EgovBackupOpert_SQL_postgres.xml
@@ -153,6 +153,18 @@
         
     </select>
 
+    <select id="selectBackupSchdulDfkListByIds" parameterType="java.util.List" resultMap="backupSchdulDfkResult">
+            SELECT  A.BACKUP_OPERT_ID, A.EXECUT_SCHDUL_DFK_SE, B.CODE_NM EXECUT_SCHDUL_DFK_SE_NM
+            FROM COMTNBACKUPSCHDULDFK A, COMTCCMMNDETAILCODE B
+            WHERE A.BACKUP_OPERT_ID IN
+            <foreach collection="list" item="backupOpertId" open="(" separator="," close=")">
+                #{backupOpertId}
+            </foreach>
+              AND A.EXECUT_SCHDUL_DFK_SE = B.CODE
+              AND B.CODE_ID = 'COM074'
+            ORDER BY A.BACKUP_OPERT_ID, A.EXECUT_SCHDUL_DFK_SE
+    </select>
+
     <insert id="insertBackupSchdulDfk" parameterType="egovframework.com.sym.sym.bak.service.BackupSchdulDfk">
         
             INSERT INTO COMTNBACKUPSCHDULDFK (

--- a/src/main/resources/egovframework/mapper/com/sym/sym/bak/EgovBackupOpert_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/sym/bak/EgovBackupOpert_SQL_tibero.xml
@@ -154,6 +154,18 @@
         
     </select>
 
+    <select id="selectBackupSchdulDfkListByIds" parameterType="java.util.List" resultMap="backupSchdulDfkResult">
+            SELECT  A.BACKUP_OPERT_ID, A.EXECUT_SCHDUL_DFK_SE, B.CODE_NM EXECUT_SCHDUL_DFK_SE_NM
+            FROM COMTNBACKUPSCHDULDFK A, COMTCCMMNDETAILCODE B
+            WHERE A.BACKUP_OPERT_ID IN
+            <foreach collection="list" item="backupOpertId" open="(" separator="," close=")">
+                #{backupOpertId}
+            </foreach>
+              AND A.EXECUT_SCHDUL_DFK_SE = B.CODE
+              AND B.CODE_ID = 'COM074'
+            ORDER BY A.BACKUP_OPERT_ID, A.EXECUT_SCHDUL_DFK_SE
+    </select>
+
     <insert id="insertBackupSchdulDfk" parameterType="egovframework.com.sym.sym.bak.service.BackupSchdulDfk">
         
             INSERT INTO COMTNBACKUPSCHDULDFK (

--- a/src/test/java/egovframework/com/sym/bat/service/impl/BatchSchdulDaoTest.java
+++ b/src/test/java/egovframework/com/sym/bat/service/impl/BatchSchdulDaoTest.java
@@ -1,0 +1,119 @@
+package egovframework.com.sym.bat.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import egovframework.com.sym.bat.service.BatchSchdul;
+import egovframework.com.sym.bat.service.BatchSchdulDfk;
+
+/**
+ * 배치스케줄 목록조회의 요일정보 일괄조회가 IN 절 상한을 넘지 않는지 검증한다.
+ *
+ * <p>BatchScheduler.init()은 recordCountPerPage를 10000으로 두고 목록을 조회하므로
+ * 요일정보 일괄조회에 1000개를 넘는 배치스케줄ID가 전달될 수 있다. Oracle은 IN 절 항목을
+ * 1000개로 제한해 초과 시 ORA-01795가 발생하므로 DAO가 ID 목록을 나눠 조회해야 한다.</p>
+ *
+ * <p>DB 없이 selectList 호출을 가로채 청크 크기와 부모 ID별 매핑 결과를 확인한다.</p>
+ */
+class BatchSchdulDaoTest {
+
+	/** Oracle의 IN 절 항목 상한. 초과하면 ORA-01795가 발생한다. */
+	private static final int ORACLE_IN_CLAUSE_LIMIT = 1000;
+
+	/**
+	 * selectList 호출을 가로채 요일정보 조회 청크 크기를 기록하는 DAO.
+	 */
+	private static class RecordingBatchSchdulDao extends BatchSchdulDao {
+
+		private final List<BatchSchdul> rows;
+		private final List<Integer> dfkChunkSizes = new ArrayList<>();
+
+		RecordingBatchSchdulDao(List<BatchSchdul> rows) {
+			this.rows = rows;
+		}
+
+		@Override
+		@SuppressWarnings("unchecked")
+		public <E> List<E> selectList(String queryId, Object parameterObject) {
+			if ("BatchSchdulDao.selectBatchSchdulList".equals(queryId)) {
+				return (List<E>) rows;
+			}
+			if ("BatchSchdulDao.selectBatchSchdulDfkListByIds".equals(queryId)) {
+				List<String> batchSchdulIds = (List<String>) parameterObject;
+				dfkChunkSizes.add(batchSchdulIds.size());
+				List<BatchSchdulDfk> dfkList = new ArrayList<>();
+				for (String batchSchdulId : batchSchdulIds) {
+					dfkList.add(dfk(batchSchdulId, "1"));
+					dfkList.add(dfk(batchSchdulId, "2"));
+				}
+				return (List<E>) dfkList;
+			}
+			throw new IllegalStateException("예상하지 못한 쿼리 호출 : " + queryId);
+		}
+
+		private BatchSchdulDfk dfk(String batchSchdulId, String executSchdulDfkSe) {
+			BatchSchdulDfk dfk = new BatchSchdulDfk();
+			dfk.setBatchSchdulId(batchSchdulId);
+			dfk.setExecutSchdulDfkSe(executSchdulDfkSe);
+			dfk.setExecutSchdulDfkSeNm(batchSchdulId + "-" + executSchdulDfkSe);
+			return dfk;
+		}
+	}
+
+	@ParameterizedTest
+	@ValueSource(ints = { 1000, 1001, 2000 })
+	void selectBatchSchdulList_요일정보_일괄조회는_IN절_상한을_넘지_않는다(int rowCount) {
+		RecordingBatchSchdulDao dao = new RecordingBatchSchdulDao(batchSchduls(rowCount));
+
+		dao.selectBatchSchdulList(new BatchSchdul());
+
+		int totalIds = 0;
+		for (Integer chunkSize : dao.dfkChunkSizes) {
+			assertTrue(chunkSize <= ORACLE_IN_CLAUSE_LIMIT,
+					"IN 절 항목이 " + ORACLE_IN_CLAUSE_LIMIT + "개를 넘으면 안 된다 : " + chunkSize);
+			totalIds += chunkSize;
+		}
+		assertEquals(rowCount, totalIds, "모든 배치스케줄ID가 조회에 전달되어야 한다");
+		assertEquals((rowCount + ORACLE_IN_CLAUSE_LIMIT - 1) / ORACLE_IN_CLAUSE_LIMIT, dao.dfkChunkSizes.size(),
+				"조회 횟수는 ID 수를 IN 절 상한으로 나눈 올림값이어야 한다");
+	}
+
+	@ParameterizedTest
+	@ValueSource(ints = { 1000, 1001, 2000 })
+	void selectBatchSchdulList_청크가_나뉘어도_요일정보가_모두_매핑된다(int rowCount) {
+		RecordingBatchSchdulDao dao = new RecordingBatchSchdulDao(batchSchduls(rowCount));
+
+		List<BatchSchdul> resultList = dao.selectBatchSchdulList(new BatchSchdul());
+
+		assertEquals(rowCount, resultList.size());
+		for (BatchSchdul result : resultList) {
+			String batchSchdulId = result.getBatchSchdulId();
+			assertArrayEquals(new String[] { "1", "2" }, result.getExecutSchdulDfkSes(),
+					batchSchdulId + "의 요일정보가 매핑되어야 한다");
+			assertEquals(batchSchdulId + "-1," + batchSchdulId + "-2 00:00:00", result.getExecutSchdul(),
+					batchSchdulId + "에는 자신의 요일정보만 매핑되어야 한다");
+		}
+	}
+
+	private List<BatchSchdul> batchSchduls(int rowCount) {
+		List<BatchSchdul> rows = new ArrayList<>();
+		for (int i = 0; i < rowCount; i++) {
+			BatchSchdul batchSchdul = new BatchSchdul();
+			batchSchdul.setBatchSchdulId(String.format("BSCHDUL%04d", i));
+			batchSchdul.setExecutCycle("02");
+			batchSchdul.setExecutSchdulDe("");
+			batchSchdul.setExecutSchdulHour("00");
+			batchSchdul.setExecutSchdulMnt("00");
+			batchSchdul.setExecutSchdulSecnd("00");
+			rows.add(batchSchdul);
+		}
+		return rows;
+	}
+}

--- a/src/test/java/egovframework/com/sym/sym/bak/service/impl/BackupOpertDaoTest.java
+++ b/src/test/java/egovframework/com/sym/sym/bak/service/impl/BackupOpertDaoTest.java
@@ -1,0 +1,119 @@
+package egovframework.com.sym.sym.bak.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import egovframework.com.sym.sym.bak.service.BackupOpert;
+import egovframework.com.sym.sym.bak.service.BackupSchdulDfk;
+
+/**
+ * 백업작업 목록조회의 요일정보 일괄조회가 IN 절 상한을 넘지 않는지 검증한다.
+ *
+ * <p>BackupScheduler.init()은 recordCountPerPage를 10000으로 두고 목록을 조회하므로
+ * 요일정보 일괄조회에 1000개를 넘는 백업작업ID가 전달될 수 있다. Oracle은 IN 절 항목을
+ * 1000개로 제한해 초과 시 ORA-01795가 발생하므로 DAO가 ID 목록을 나눠 조회해야 한다.</p>
+ *
+ * <p>DB 없이 selectList 호출을 가로채 청크 크기와 부모 ID별 매핑 결과를 확인한다.</p>
+ */
+class BackupOpertDaoTest {
+
+	/** Oracle의 IN 절 항목 상한. 초과하면 ORA-01795가 발생한다. */
+	private static final int ORACLE_IN_CLAUSE_LIMIT = 1000;
+
+	/**
+	 * selectList 호출을 가로채 요일정보 조회 청크 크기를 기록하는 DAO.
+	 */
+	private static class RecordingBackupOpertDao extends BackupOpertDao {
+
+		private final List<BackupOpert> rows;
+		private final List<Integer> dfkChunkSizes = new ArrayList<>();
+
+		RecordingBackupOpertDao(List<BackupOpert> rows) {
+			this.rows = rows;
+		}
+
+		@Override
+		@SuppressWarnings("unchecked")
+		public <E> List<E> selectList(String queryId, Object parameterObject) {
+			if ("BackupOpertDao.selectBackupOpertList".equals(queryId)) {
+				return (List<E>) rows;
+			}
+			if ("BackupOpertDao.selectBackupSchdulDfkListByIds".equals(queryId)) {
+				List<String> backupOpertIds = (List<String>) parameterObject;
+				dfkChunkSizes.add(backupOpertIds.size());
+				List<BackupSchdulDfk> dfkList = new ArrayList<>();
+				for (String backupOpertId : backupOpertIds) {
+					dfkList.add(dfk(backupOpertId, "1"));
+					dfkList.add(dfk(backupOpertId, "2"));
+				}
+				return (List<E>) dfkList;
+			}
+			throw new IllegalStateException("예상하지 못한 쿼리 호출 : " + queryId);
+		}
+
+		private BackupSchdulDfk dfk(String backupOpertId, String executSchdulDfkSe) {
+			BackupSchdulDfk dfk = new BackupSchdulDfk();
+			dfk.setBackupOpertId(backupOpertId);
+			dfk.setExecutSchdulDfkSe(executSchdulDfkSe);
+			dfk.setExecutSchdulDfkSeNm(backupOpertId + "-" + executSchdulDfkSe);
+			return dfk;
+		}
+	}
+
+	@ParameterizedTest
+	@ValueSource(ints = { 1000, 1001, 2000 })
+	void selectBackupOpertList_요일정보_일괄조회는_IN절_상한을_넘지_않는다(int rowCount) {
+		RecordingBackupOpertDao dao = new RecordingBackupOpertDao(backupOperts(rowCount));
+
+		dao.selectBackupOpertList(new BackupOpert());
+
+		int totalIds = 0;
+		for (Integer chunkSize : dao.dfkChunkSizes) {
+			assertTrue(chunkSize <= ORACLE_IN_CLAUSE_LIMIT,
+					"IN 절 항목이 " + ORACLE_IN_CLAUSE_LIMIT + "개를 넘으면 안 된다 : " + chunkSize);
+			totalIds += chunkSize;
+		}
+		assertEquals(rowCount, totalIds, "모든 백업작업ID가 조회에 전달되어야 한다");
+		assertEquals((rowCount + ORACLE_IN_CLAUSE_LIMIT - 1) / ORACLE_IN_CLAUSE_LIMIT, dao.dfkChunkSizes.size(),
+				"조회 횟수는 ID 수를 IN 절 상한으로 나눈 올림값이어야 한다");
+	}
+
+	@ParameterizedTest
+	@ValueSource(ints = { 1000, 1001, 2000 })
+	void selectBackupOpertList_청크가_나뉘어도_요일정보가_모두_매핑된다(int rowCount) {
+		RecordingBackupOpertDao dao = new RecordingBackupOpertDao(backupOperts(rowCount));
+
+		List<BackupOpert> resultList = dao.selectBackupOpertList(new BackupOpert());
+
+		assertEquals(rowCount, resultList.size());
+		for (BackupOpert result : resultList) {
+			String backupOpertId = result.getBackupOpertId();
+			assertArrayEquals(new String[] { "1", "2" }, result.getExecutSchdulDfkSes(),
+					backupOpertId + "의 요일정보가 매핑되어야 한다");
+			assertEquals(backupOpertId + "-1," + backupOpertId + "-2 00:00:00", result.getExecutSchdul(),
+					backupOpertId + "에는 자신의 요일정보만 매핑되어야 한다");
+		}
+	}
+
+	private List<BackupOpert> backupOperts(int rowCount) {
+		List<BackupOpert> rows = new ArrayList<>();
+		for (int i = 0; i < rowCount; i++) {
+			BackupOpert backupOpert = new BackupOpert();
+			backupOpert.setBackupOpertId(String.format("BOPERT%04d", i));
+			backupOpert.setExecutCycle("02");
+			backupOpert.setExecutSchdulDe("");
+			backupOpert.setExecutSchdulHour("00");
+			backupOpert.setExecutSchdulMnt("00");
+			backupOpert.setExecutSchdulSecnd("00");
+			rows.add(backupOpert);
+		}
+		return rows;
+	}
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [ ] 버그수정 Bug fixes
- [x] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 변경 이유

`BatchSchdulDao.selectBatchSchdulList`와 `BackupOpertDao.selectBackupOpertList`는 목록을 조회한 뒤 결과 행마다 요일정보 조회 쿼리를 다시 실행합니다. 목록이 N건이면 목록 1회에 요일정보 N회가 더해져 쿼리가 N+1개 발생하는 구조입니다.

상세조회 경로인 `selectBatchSchdul`, `selectBackupOpert`는 대상이 1건이라 요일정보를 1회만 조회하므로 문제가 없지만 목록조회 경로는 행 수에 비례해 쿼리가 늘어납니다.

`BatchScheduler.init()`과 `BackupScheduler.init()`은 `recordCountPerPage`를 10000으로 두고 전체 목록을 읽어 스케줄을 등록합니다. 등록된 배치·백업 건수만큼 요일정보 쿼리가 반복되므로 애플리케이션 기동 시마다 이 N+1이 그대로 발생합니다. 목록 화면 컨트롤러 `EgovBatchSchdulController.selectBatchSchdulList`, `EgovBackupOpertController.selectBackupOpertList`도 같은 DAO 경로를 사용합니다.

## 변경 내용

요일정보를 부모 ID 목록으로 한 번에 조회한 뒤 Java에서 부모 ID별로 그룹핑해 매핑하도록 바꿨습니다. 목록 쿼리 1회에 요일정보 일괄 쿼리 1회로 총 2회 고정입니다.

`IN` 절 일괄 조회 쿼리 `selectBatchSchdulDfkListByIds`, `selectBackupSchdulDfkListByIds`를 추가했습니다. 기존 단건 조회 쿼리 `selectBatchSchdulDfkList`, `selectBackupSchdulDfkList`는 상세조회에서 계속 사용하므로 그대로 뒀습니다. DB별 매퍼 8종(altibase, cubrid, goldilocks, maria, mysql, oracle, postgres, tibero)에 같은 구문으로 반영했습니다.

### BatchSchdulDao.selectBatchSchdulList

AS-IS
```java
for (BatchSchdul result : resultList) {
    List<BatchSchdulDfk> dfkSeList = selectList("BatchSchdulDao.selectBatchSchdulDfkList", result.getBatchSchdulId());
    ...
}
```

TO-BE
```java
List<String> batchSchdulIds = new ArrayList<>();
for (BatchSchdul result : resultList) {
    batchSchdulIds.add(result.getBatchSchdulId());
}
List<BatchSchdulDfk> dfkList = selectList("BatchSchdulDao.selectBatchSchdulDfkListByIds", batchSchdulIds);
Map<String, List<BatchSchdulDfk>> dfkMap = new HashMap<>();
for (BatchSchdulDfk dfk : dfkList) {
    dfkMap.computeIfAbsent(dfk.getBatchSchdulId(), key -> new ArrayList<>()).add(dfk);
}
for (BatchSchdul result : resultList) {
    List<BatchSchdulDfk> dfkSeList = dfkMap.getOrDefault(result.getBatchSchdulId(), new ArrayList<>());
    ...
}
```

### BackupOpertDao.selectBackupOpertList

AS-IS
```java
for (BackupOpert result : resultList) {
    List<BackupSchdulDfk> dfkSeList = selectList("BackupOpertDao.selectBackupSchdulDfkList", result.getBackupOpertId());
    ...
}
```

TO-BE
```java
List<String> backupOpertIds = resultList.stream()
        .map(BackupOpert::getBackupOpertId).collect(Collectors.toList());
List<BackupSchdulDfk> dfkList = selectList("BackupOpertDao.selectBackupSchdulDfkListByIds", backupOpertIds);
Map<String, List<BackupSchdulDfk>> dfkMap = dfkList.stream()
        .collect(Collectors.groupingBy(BackupSchdulDfk::getBackupOpertId));
for (BackupOpert result : resultList) {
    List<BackupSchdulDfk> dfkSeList = dfkMap.getOrDefault(result.getBackupOpertId(), Collections.emptyList());
    ...
}
```

추가한 일괄 조회 쿼리(mysql 예시)
```xml
<select id="selectBatchSchdulDfkListByIds" parameterType="java.util.List" resultMap="batchSchdulDfkResult">
        SELECT  A.BATCH_SCHDUL_ID, A.EXECUT_SCHDUL_DFK_SE, B.CODE_NM EXECUT_SCHDUL_DFK_SE_NM
        FROM COMTNBATCHSCHDULDFK A, COMTCCMMNDETAILCODE B
        WHERE A.BATCH_SCHDUL_ID IN
        <foreach collection="list" item="batchSchdulId" open="(" separator="," close=")">
            #{batchSchdulId}
        </foreach>
          AND A.EXECUT_SCHDUL_DFK_SE = B.CODE
          AND B.CODE_ID = 'COM074'
        ORDER BY A.BATCH_SCHDUL_ID, A.EXECUT_SCHDUL_DFK_SE
</select>
```

`setExecutSchdulDfkSes`와 `makeExecutSchdul` 호출은 그대로 유지해 결과 값은 기존과 동일합니다. 요일정보가 없는 행은 빈 목록으로 처리해 기존 동작을 보존했습니다. 일괄 조회는 조회 순서를 고정하기 위해 `ORDER BY`로 부모 ID와 요일코드를 정렬했습니다. 목록이 비어 있으면 `IN ()`가 생성되지 않도록 조회 전에 빈 목록을 먼저 반환합니다.

## 영향 범위

- 배치스케줄 목록조회: `EgovBatchSchdulController.selectBatchSchdulList`, `BatchScheduler.init`
- 백업작업 목록조회: `EgovBackupOpertController.selectBackupOpertList`, `BackupScheduler.init`
- 상세조회 `selectBatchSchdul`, `selectBackupOpert`와 등록·수정·삭제 경로는 변경하지 않았습니다.

## 테스트 방법

- [ ] JUnit 테스트
- [x] 수동 테스트

목록에 스케줄이 N건이면 요일정보를 행마다 조회하므로 요일정보 쿼리가 N회 실행된다는 가설을 로컬에 공통컴포넌트와 MySQL을 띄우고 log4jdbc로 실측했습니다. 스케줄 5건(각 요일 3개)을 넣고 배치스케줄 목록(`getBatchSchdulList.do`)을 1회 로드해 `COMTNBATCHSCHDULDFK` 조회 실행 횟수를 셌습니다.

수정 전 — 스케줄마다 1회씩 요일정보 쿼리:

```
요일정보 쿼리 실행 5회
  WHERE A.BATCH_SCHDUL_ID = 'BSCHDUL01'
  WHERE A.BATCH_SCHDUL_ID = 'BSCHDUL02'
  WHERE A.BATCH_SCHDUL_ID = 'BSCHDUL03'
  WHERE A.BATCH_SCHDUL_ID = 'BSCHDUL04'
  WHERE A.BATCH_SCHDUL_ID = 'BSCHDUL05'
```

수정 후 — ID 목록으로 한 번에:

```
요일정보 쿼리 실행 1회
  WHERE A.BATCH_SCHDUL_ID IN ('BSCHDUL01', … , 'BSCHDUL05')
```

목록에 표시되는 스케줄·요일정보는 수정 전후 렌더링 출력이 동일했습니다. 백업작업 목록(`getBackupOpertList.do`)도 같은 구조라 동일하게 적용됩니다. 같은 방식(부모 ID 일괄 조회 후 Java 그룹핑)으로 코드수신 배치의 N+1을 제거해 머지된 선례로 #1089가 있습니다.
