### PR TITLE
fix: OAuth 프로필 응답에 선택 동의 필드가 없을 때 parseJson의 NPE 방지

### DIFF
--- a/src/main/java/egovframework/com/ext/oauth/service/OAuthLogin.java
+++ b/src/main/java/egovframework/com/ext/oauth/service/OAuthLogin.java
@@ -103,23 +103,23 @@ public class OAuthLogin {
 
 		if (oauthVO.getOrigin().equals("google")) {
 			user.setServiceName(OAuthConfig.GOOGLE_SERVICE_NAME);
-			user.setUserId(rootNode.get("sub").asText());
-			String uname = rootNode.get("name").asText();
+			user.setUserId(rootNode.path("sub").asText(""));
+			String uname = rootNode.path("name").asText("");
 			user.setUserName(uname);
 //			getEmails(user, rootNode);
 
 		} else if (oauthVO.getOrigin().equals("naver")) {
 			user.setServiceName(OAuthConfig.NAVER_SERVICE_NAME);
-			JsonNode resNode = rootNode.get("response");
-			user.setUserId(resNode.get("id").asText());
-			user.setNickName(resNode.get("nickname").asText());
-			user.setEmail(resNode.get("email").asText());
+			JsonNode resNode = rootNode.path("response");
+			user.setUserId(resNode.path("id").asText(""));
+			user.setNickName(resNode.path("nickname").asText(""));
+			user.setEmail(resNode.path("email").asText(""));
 
 		} else if (oauthVO.getOrigin().equals("kakao")) {
 			user.setServiceName(OAuthConfig.KAKAO_SERVICE_NAME);
-			JsonNode resNode = rootNode.get("properties");
-			user.setUserId(rootNode.get("id").asText());
-			user.setNickName(resNode.get("nickname").asText());
+			JsonNode resNode = rootNode.path("properties");
+			user.setUserId(rootNode.path("id").asText(""));
+			user.setNickName(resNode.path("nickname").asText(""));
 		}
 
 		return user;

--- a/src/main/java/egovframework/com/ext/oauth/service/OAuthLogin.java
+++ b/src/main/java/egovframework/com/ext/oauth/service/OAuthLogin.java
@@ -3,6 +3,7 @@ package egovframework.com.ext.oauth.service;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -120,6 +121,12 @@ public class OAuthLogin {
 			JsonNode resNode = rootNode.path("properties");
 			user.setUserId(rootNode.path("id").asText(""));
 			user.setNickName(resNode.path("nickname").asText(""));
+		}
+
+		// 사용자 식별자는 선택 동의 항목이 아니므로 누락 시 프로필 응답으로 취급하지 않는다.
+		// 이 메서드에는 제공자의 오류 응답도 전달되며, 기존에도 그 경우 예외가 콜백까지 전파됐다.
+		if (StringUtils.isEmpty(user.getUserId())) {
+			throw new IllegalStateException("OAuth 프로필 응답에 사용자 식별자가 없습니다. service=" + oauthVO.getOrigin());
 		}
 
 		return user;

--- a/src/test/java/egovframework/com/ext/oauth/service/OAuthLoginParseJsonTest.java
+++ b/src/test/java/egovframework/com/ext/oauth/service/OAuthLoginParseJsonTest.java
@@ -1,0 +1,70 @@
+package egovframework.com.ext.oauth.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@link OAuthLogin}의 private {@code parseJson(String)}이 OAuth 제공자 프로필 응답에서
+ * 선택 동의 항목이 빠졌을 때 발생하던 NPE를 검증한다.
+ *
+ * <p>네이버는 이메일 제공을, 카카오는 프로필(닉네임) 제공을 사용자가 선택적으로 거부할 수 있어
+ * 응답 JSON에서 해당 필드가 통째로 빠질 수 있다. 기존 구현은 {@code get("email")} 등의
+ * 반환값을 null 검사 없이 {@code asText()}로 역참조해
+ * {@code /auth/{oauthService}/callback} 콜백에서 500 오류가 발생했다.</p>
+ */
+class OAuthLoginParseJsonTest {
+
+	/** 리플렉션으로 private {@code parseJson}을 호출하고, 내부에서 던진 예외는 원인 그대로 다시 던진다. */
+	private OAuthUniversalUser invokeParseJson(String serviceName, String body) throws Throwable {
+		OAuthVO oauthVO = new OAuthVO(serviceName, "dummy-client-id", "dummy-secret",
+				"http://localhost/callback", "");
+		OAuthLogin oauthLogin = new OAuthLogin(oauthVO);
+
+		Method method = OAuthLogin.class.getDeclaredMethod("parseJson", String.class);
+		method.setAccessible(true);
+		try {
+			return (OAuthUniversalUser) method.invoke(oauthLogin, body);
+		} catch (InvocationTargetException e) {
+			throw e.getCause();
+		}
+	}
+
+	@Test
+	@DisplayName("네이버 이메일 미동의로 email 필드가 없어도 NPE 없이 파싱된다")
+	void naverWithoutEmail() throws Throwable {
+		String body = "{\"response\":{\"id\":\"nid-123\",\"nickname\":\"홍길동\"}}";
+
+		OAuthUniversalUser user = invokeParseJson("naver", body);
+
+		assertEquals("nid-123", user.getUserId());
+		assertEquals("홍길동", user.getNickName());
+		assertEquals("", user.getEmail(), "미동의로 빠진 email은 빈 문자열이어야 한다");
+	}
+
+	@Test
+	@DisplayName("카카오 프로필 미동의로 properties가 없어도 NPE 없이 파싱된다")
+	void kakaoWithoutProperties() throws Throwable {
+		String body = "{\"id\":98765}";
+
+		OAuthUniversalUser user = invokeParseJson("kakao", body);
+
+		assertEquals("98765", user.getUserId());
+		assertEquals("", user.getNickName(), "미동의로 빠진 nickname은 빈 문자열이어야 한다");
+	}
+
+	@Test
+	@DisplayName("구글 name 미제공 시에도 NPE 없이 파싱된다")
+	void googleWithoutName() throws Throwable {
+		String body = "{\"sub\":\"g-1\"}";
+
+		OAuthUniversalUser user = invokeParseJson("google", body);
+
+		assertEquals("g-1", user.getUserId());
+		assertEquals("", user.getUserName(), "미제공된 name은 빈 문자열이어야 한다");
+	}
+}

--- a/src/test/java/egovframework/com/ext/oauth/service/OAuthLoginParseJsonTest.java
+++ b/src/test/java/egovframework/com/ext/oauth/service/OAuthLoginParseJsonTest.java
@@ -1,6 +1,7 @@
 package egovframework.com.ext.oauth.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -16,6 +17,9 @@ import org.junit.jupiter.api.Test;
  * 응답 JSON에서 해당 필드가 통째로 빠질 수 있다. 기존 구현은 {@code get("email")} 등의
  * 반환값을 null 검사 없이 {@code asText()}로 역참조해
  * {@code /auth/{oauthService}/callback} 콜백에서 500 오류가 발생했다.</p>
+ *
+ * <p>반면 사용자 식별자는 선택 동의 항목이 아니다. {@code getUserProfile}은 제공자의 오류 응답도
+ * {@code parseJson}에 전달하므로, 식별자가 없는 응답이 사용자 객체로 반환되지 않는지도 함께 검증한다.</p>
  */
 class OAuthLoginParseJsonTest {
 
@@ -66,5 +70,32 @@ class OAuthLoginParseJsonTest {
 
 		assertEquals("g-1", user.getUserId());
 		assertEquals("", user.getUserName(), "미제공된 name은 빈 문자열이어야 한다");
+	}
+
+	@Test
+	@DisplayName("구글 오류 응답처럼 sub가 없으면 사용자 객체를 반환하지 않는다")
+	void googleWithoutUserId() {
+		String body = "{\"error\":\"invalid_token\",\"error_description\":\"Invalid Credentials\"}";
+
+		assertThrows(IllegalStateException.class, () -> invokeParseJson("google", body),
+				"식별자가 없는 응답은 프로필로 취급하지 않는다");
+	}
+
+	@Test
+	@DisplayName("네이버 오류 응답처럼 response.id가 없으면 사용자 객체를 반환하지 않는다")
+	void naverWithoutUserId() {
+		String body = "{\"resultcode\":\"024\",\"message\":\"Authentication failed\"}";
+
+		assertThrows(IllegalStateException.class, () -> invokeParseJson("naver", body),
+				"식별자가 없는 응답은 프로필로 취급하지 않는다");
+	}
+
+	@Test
+	@DisplayName("카카오 오류 응답처럼 id가 없으면 사용자 객체를 반환하지 않는다")
+	void kakaoWithoutUserId() {
+		String body = "{\"msg\":\"this access token does not exist\",\"code\":-401}";
+
+		assertThrows(IllegalStateException.class, () -> invokeParseJson("kakao", body),
+				"식별자가 없는 응답은 프로필로 취급하지 않는다");
 	}
 }


### PR DESCRIPTION
## 수정 사유

- [X] 버그수정
- [ ] 기능개선
- [ ] 신규기능

## 변경 이유

`OAuthLogin.parseJson(String)`은 OAuth 제공자의 프로필 응답 JSON에서 필드를 꺼낼 때 `JsonNode.get(필드)`의 반환값을 null 검사 없이 바로 `asText()`로 역참조합니다. 그런데 네이버는 이메일 제공을, 카카오는 프로필(닉네임) 제공을 사용자가 선택적으로 거부할 수 있어 응답에서 해당 필드나 상위 노드가 통째로 빠질 수 있습니다.

이 경우 `get()`이 `null`(또는 값이 JSON `null`이면 `NullNode`)을 돌려주고, 이어지는 `asText()`에서 `NullPointerException`이 발생합니다. `parseJson`은 `getUserProfile`을 거쳐 `EgovSignupController.oauthLoginCallback`(`/auth/{oauthService}/callback`)에서 호출되는데, 이 경로에는 예외 처리가 없어 이 NPE가 콜백까지 그대로 전파돼 OAuth 로그인 콜백이 실패합니다.

구체적으로 다음 세 지점이 취약합니다.

- 네이버: `response`에 `email`이 없으면 `resNode.get("email")`이 `null` → `asText()`에서 NPE
- 카카오: `properties`가 없으면 `resNode`가 `null` → `resNode.get("nickname")`에서 NPE
- 구글: `name` 미제공 시 `rootNode.get("name")`이 `null` → `asText()`에서 NPE

## 변경 내용

세 분기 모두 `get()` + `asText()` 조합을 Jackson이 누락/`null` 노드에도 안전한 `path()` + `asText(기본값)` 조합으로 바꿨습니다. `path()`는 노드가 없으면 `MissingNode`를 반환해 절대 `null`을 돌려주지 않고, `asText("")`는 누락 시 빈 문자열을 돌려줍니다. 같은 클래스의 주석 처리된 `getEmails`가 이미 `path()`를 쓰고 있어 파일 관례와도 일치합니다.

AS-IS

```java
} else if (oauthVO.getOrigin().equals("naver")) {
    user.setServiceName(OAuthConfig.NAVER_SERVICE_NAME);
    JsonNode resNode = rootNode.get("response");
    user.setUserId(resNode.get("id").asText());
    user.setNickName(resNode.get("nickname").asText());
    user.setEmail(resNode.get("email").asText());
```

TO-BE

```java
} else if (oauthVO.getOrigin().equals("naver")) {
    user.setServiceName(OAuthConfig.NAVER_SERVICE_NAME);
    JsonNode resNode = rootNode.path("response");
    user.setUserId(resNode.path("id").asText(""));
    user.setNickName(resNode.path("nickname").asText(""));
    user.setEmail(resNode.path("email").asText(""));
```

구글(`sub`/`name`)과 카카오(`properties`/`id`/`nickname`) 분기에도 같은 방식을 동일하게 적용했습니다.

다만 이 완화가 사용자 식별자에도 걸리면 식별자 없는 응답까지 사용자 객체로 반환됩니다. `getUserProfile`은 오류 응답도 `parseJson`에 넘기므로, 식별자가 비어 있으면 사용자 객체를 만들지 않도록 세 분기 뒤에 검사를 뒀습니다.

```java
if (StringUtils.isEmpty(user.getUserId())) {
    throw new IllegalStateException("OAuth 프로필 응답에 사용자 식별자가 없습니다. service=" + oauthVO.getOrigin());
}
```

오류 응답의 형식이나 HTTP 상태를 새로 보지는 않고 식별자 유무만 봅니다.

## 영향 범위

- `src/main/java/egovframework/com/ext/oauth/service/OAuthLogin.java`의 `parseJson` 한 메서드
- 필수 필드가 모두 존재하는 정상 응답의 결과는 그대로입니다(`path(...).asText("")`는 값이 있을 때 `get(...).asText()`와 동일한 문자열을 반환).
- 선택 동의 필드가 빠진 응답은 기존에 NPE로 콜백이 실패하던 것이 빈 문자열로 채워진 사용자 정보 반환으로 바뀝니다.
- 식별자가 없는 응답은 사용자 객체 없이 예외로 끝납니다. 변경 전에도 사용자 객체는 만들어지지 않았습니다.

## 테스트 방법

`parseJson`은 `String`을 인자로 받는 메서드라 필드가 빠진 JSON을 넣어 NPE를 재현하는 단위 테스트가 가능합니다. `src/test/java/egovframework/com/ext/oauth/service/OAuthLoginParseJsonTest.java`를 추가해 네이버 이메일 미동의, 카카오 프로필 미동의, 구글 `name` 미제공 세 경우와 세 제공자의 식별자 누락을 리플렉션으로 검증했습니다.

이 저장소는 surefire의 `skipTests`가 기본 `true`라 로컬에서 `pom.xml`을 임시로 `false`로 바꿔 실행했습니다(커밋에는 포함하지 않았습니다).

수정 전(RED): 세 케이스 모두 NPE로 실패했습니다.

```
mvn -B -Dtest=OAuthLoginParseJsonTest test   # (pom skipTests 임시 false 후)
[ERROR] Tests run: 3, Failures: 0, Errors: 3
 » NullPointer Cannot invoke "...JsonNode.asText()" because the return value of "...JsonNode.get(String)" is null   (naver email)
 » NullPointer Cannot invoke "...JsonNode.get(String)" because "resNode" is null                                    (kakao properties)
 » NullPointer Cannot invoke "...JsonNode.asText()" because the return value of "...JsonNode.get(String)" is null   (google name)
```

수정 후(GREEN):

```
mvn -B -Dtest=OAuthLoginParseJsonTest test   # (pom skipTests 임시 false 후)
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

