### PR TITLE
fix: 설문 응답 등록·수정 검증 실패 재표시 시 참조데이터 복원

### DIFF
--- a/src/main/java/egovframework/com/uss/olp/qri/web/EgovQustnrRespondInfoController.java
+++ b/src/main/java/egovframework/com/uss/olp/qri/web/EgovQustnrRespondInfoController.java
@@ -712,6 +712,8 @@ public class EgovQustnrRespondInfoController {
 
 		if (sCmd.equals("save")) {
 			if (bindingResult.hasErrors()) {
+				List<EgovMap> resultList = egovQustnrRespondInfoService.selectQustnrRespondInfoDetail(qustnrRespondInfoVO);
+				model.addAttribute("resultList", resultList);
 				return sLocationUrl;
 			}
 

--- a/src/main/java/egovframework/com/uss/olp/qri/web/EgovQustnrRespondInfoController.java
+++ b/src/main/java/egovframework/com/uss/olp/qri/web/EgovQustnrRespondInfoController.java
@@ -382,6 +382,34 @@ public class EgovQustnrRespondInfoController {
 		if (bindingResult.hasErrors()) {
 			LOGGER.info("####EgovQustnrRespondInfoManageRegist 유효성검증 ERROR");
 			model.addAttribute("searchVO", searchVO);
+
+			// 검증 실패로 폼을 다시 표시할 때도 정상 표시 경로와 동일하게 참조데이터를 재적재한다.
+			// (누락 시 문항 영역이 빈 templateUrl로 에러 페이지 대체 + hidden qestnrTmplatId/qestnrId 유실)
+			if (loginVO.getUniqId() != null) {
+				commandMap.put("uniqId", loginVO.getUniqId());
+				// 사용자정보
+				model.addAttribute("Emplyrinfo",
+						egovQustnrRespondInfoService.selectQustnrRespondInfoManageEmplyrinfo(commandMap));
+			}
+			// 설문템플릿정보
+			model.addAttribute("QustnrTmplatManage",
+					egovQustnrRespondInfoService.selectQustnrTmplatManage(commandMap));
+			// 설문정보
+			model.addAttribute("Comtnqestnrinfo",
+					egovQustnrRespondInfoService.selectQustnrRespondInfoManageComtnqestnrinfo(commandMap));
+			// 문항정보
+			model.addAttribute("Comtnqustnrqesitm",
+					egovQustnrRespondInfoService.selectQustnrRespondInfoManageComtnqustnrqesitm(commandMap));
+			// 항목정보
+			model.addAttribute("Comtnqustnriem",
+					egovQustnrRespondInfoService.selectQustnrRespondInfoManageComtnqustnriem(commandMap));
+			// 설문템플릿ID 설정
+			model.addAttribute("qestnrTmplatId",
+					commandMap.get("qestnrTmplatId") == null ? "" : (String) commandMap.get("qestnrTmplatId"));
+			// 설문지정보ID 설정
+			model.addAttribute("qestnrId",
+					commandMap.get("qestnrId") == null ? "" : (String) commandMap.get("qestnrId"));
+
 			return "egovframework/com/uss/olp/qnn/EgovQustnrRespondInfoManageRegist";
 		}
 

--- a/src/test/java/egovframework/com/uss/olp/qri/web/EgovQustnrRespondInfoControllerModifyRestoreTest.java
+++ b/src/test/java/egovframework/com/uss/olp/qri/web/EgovQustnrRespondInfoControllerModifyRestoreTest.java
@@ -1,0 +1,93 @@
+package egovframework.com.uss.olp.qri.web;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Proxy;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.ui.ModelMap;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.servlet.mvc.support.RedirectAttributesModelMap;
+
+import egovframework.com.cmm.ComDefaultVO;
+import egovframework.com.cmm.LoginVO;
+import egovframework.com.cmm.service.EgovUserDetailsService;
+import egovframework.com.cmm.util.EgovUserDetailsHelper;
+import egovframework.com.uss.olp.qri.service.EgovQustnrRespondInfoService;
+import egovframework.com.uss.olp.qri.service.QustnrRespondInfoVO;
+
+/**
+ * 설문 응답 수정 처리({@link EgovQustnrRespondInfoController#qustnrRespondInfoModify})의 검증 실패 분기가,
+ * 재표시 화면이 참조하는 {@code resultList}를 model에 복원하는지 검증한다.
+ *
+ * <p>검증 실패 분기가 {@code resultList}를 복원하지 않으면 재표시 화면의 hidden 식별자가 비어,
+ * 사용자가 오류를 고쳐 재제출할 때 빈 식별자로 갱신이 이뤄져 수정이 유실된다.
+ * 수정 전 코드에서는 {@code resultList}가 담기지 않아 검증이 실패한다.</p>
+ */
+class EgovQustnrRespondInfoControllerModifyRestoreTest {
+
+	private final InvocationHandler authStub = (proxy, method, args) -> {
+		switch (method.getName()) {
+		case "isAuthenticated":
+			return Boolean.TRUE;
+		case "getAuthenticatedUser":
+			LoginVO loginVO = new LoginVO();
+			loginVO.setUniqId("USRCNFRM_TEST");
+			return loginVO;
+		case "getAuthorities":
+			return List.of("ROLE_ADMIN");
+		default:
+			return null;
+		}
+	};
+
+	private final InvocationHandler emptyStub = (proxy, method, args) ->
+			List.class.isAssignableFrom(method.getReturnType()) ? Collections.emptyList() : null;
+
+	@BeforeEach
+	void setUpStaticAuth() {
+		EgovUserDetailsService auth = (EgovUserDetailsService) Proxy.newProxyInstance(
+				getClass().getClassLoader(), new Class[] { EgovUserDetailsService.class }, authStub);
+		ReflectionTestUtils.setField(EgovUserDetailsHelper.class, "egovUserDetailsService", auth);
+	}
+
+	@AfterEach
+	void tearDownStaticAuth() {
+		ReflectionTestUtils.setField(EgovUserDetailsHelper.class, "egovUserDetailsService", null);
+	}
+
+	@Test
+	@DisplayName("설문 응답 수정 검증 실패 시 재표시가 참조하는 resultList를 복원한다")
+	void modifyRestoresResultListOnValidationError() throws Exception {
+		EgovQustnrRespondInfoController controller = new EgovQustnrRespondInfoController();
+		ReflectionTestUtils.setField(controller, "egovQustnrRespondInfoService",
+				Proxy.newProxyInstance(getClass().getClassLoader(),
+						new Class[] { EgovQustnrRespondInfoService.class }, emptyStub));
+
+		QustnrRespondInfoVO qustnrRespondInfoVO = new QustnrRespondInfoVO();
+		BindingResult bindingResult = new BeanPropertyBindingResult(qustnrRespondInfoVO, "qustnrRespondInfoVO");
+		bindingResult.reject("validation.error");
+
+		Map<String, Object> commandMap = new HashMap<>();
+		commandMap.put("cmd", "save");
+		ModelMap model = new ModelMap();
+
+		String view = controller.qustnrRespondInfoModify(new ComDefaultVO(), commandMap, null,
+				qustnrRespondInfoVO, bindingResult, new RedirectAttributesModelMap(), model);
+
+		assertEquals("egovframework/com/uss/olp/qri/EgovQustnrRespondInfoModify", view);
+		assertTrue(model.containsAttribute("resultList"),
+				"검증 실패 재표시 시 resultList가 model에 있어야 재제출 대상 식별자가 보존된다");
+	}
+}

--- a/src/test/java/egovframework/com/uss/olp/qri/web/EgovQustnrRespondInfoControllerValidationRestoreTest.java
+++ b/src/test/java/egovframework/com/uss/olp/qri/web/EgovQustnrRespondInfoControllerValidationRestoreTest.java
@@ -1,0 +1,118 @@
+package egovframework.com.uss.olp.qri.web;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Proxy;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.ui.ModelMap;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.servlet.mvc.support.RedirectAttributesModelMap;
+
+import egovframework.com.cmm.ComDefaultVO;
+import egovframework.com.cmm.LoginVO;
+import egovframework.com.cmm.service.EgovCmmUseService;
+import egovframework.com.cmm.service.EgovUserDetailsService;
+import egovframework.com.cmm.util.EgovUserDetailsHelper;
+import egovframework.com.uss.olp.qri.service.EgovQustnrRespondInfoService;
+
+/**
+ * 설문 응답 등록({@link EgovQustnrRespondInfoController#egovQustnrRespondInfoManageRegist})의
+ * 검증 실패 분기가, 정상 표시 경로처럼 재표시 JSP가 참조하는 참조데이터
+ * (설문템플릿·설문정보·문항·항목 목록과 hidden {@code qestnrTmplatId}/{@code qestnrId})를
+ * model에 복원하는지 검증한다.
+ *
+ * <p>재표시 JSP는 {@code QustnrTmplatManage[0].qestnrTmplatCours}로 문항 영역
+ * {@code <c:import>}의 templateUrl을 만들고, hidden 식별자 두 개로 재제출을 구성한다.
+ * 검증 실패 분기가 이를 복원하지 않으면 재표시 화면이 에러 페이지로 대체되고
+ * 재제출이 빈 식별자로 저장을 시도해 응답이 사라진다.</p>
+ *
+ * <p>수정 전 코드에서는 {@code searchVO}만 담겨 모든 검증이 실패한다.</p>
+ */
+class EgovQustnrRespondInfoControllerValidationRestoreTest {
+
+	/** 조회 메서드 반환 타입에 맞춰 빈 값을 돌려주는 스텁. */
+	private final InvocationHandler emptyStub = (proxy, method, args) -> {
+		Class<?> rt = method.getReturnType();
+		if (List.class.isAssignableFrom(rt)) {
+			return Collections.emptyList();
+		}
+		if (Map.class.isAssignableFrom(rt)) {
+			return Collections.emptyMap();
+		}
+		return null;
+	};
+
+	/** 로그인 상태 스텁 — 인증 통과 후 검증 실패 분기에 도달하게 한다. */
+	private final InvocationHandler authStub = (proxy, method, args) -> {
+		switch (method.getName()) {
+		case "isAuthenticated":
+			return Boolean.TRUE;
+		case "getAuthenticatedUser":
+			LoginVO loginVO = new LoginVO();
+			loginVO.setUniqId("USRCNFRM_TEST");
+			return loginVO;
+		case "getAuthorities":
+			return Collections.emptyList();
+		default:
+			return null;
+		}
+	};
+
+	@BeforeEach
+	void setUpStaticAuth() {
+		EgovUserDetailsService auth = (EgovUserDetailsService) Proxy.newProxyInstance(
+				getClass().getClassLoader(), new Class[] { EgovUserDetailsService.class }, authStub);
+		ReflectionTestUtils.setField(EgovUserDetailsHelper.class, "egovUserDetailsService", auth);
+	}
+
+	@AfterEach
+	void tearDownStaticAuth() {
+		ReflectionTestUtils.setField(EgovUserDetailsHelper.class, "egovUserDetailsService", null);
+	}
+
+	@Test
+	@DisplayName("설문 응답 등록 검증 실패 시 재표시 폼이 참조하는 참조데이터를 복원한다")
+	void registRestoresReferenceDataOnValidationError() throws Exception {
+		EgovQustnrRespondInfoController controller = new EgovQustnrRespondInfoController();
+		ClassLoader cl = getClass().getClassLoader();
+		ReflectionTestUtils.setField(controller, "egovQustnrRespondInfoService",
+				Proxy.newProxyInstance(cl, new Class[] { EgovQustnrRespondInfoService.class }, emptyStub));
+		ReflectionTestUtils.setField(controller, "cmmUseService",
+				Proxy.newProxyInstance(cl, new Class[] { EgovCmmUseService.class }, emptyStub));
+
+		ComDefaultVO searchVO = new ComDefaultVO();
+		BindingResult bindingResult = new BeanPropertyBindingResult(searchVO, "searchVO");
+		bindingResult.reject("required", "문항 입력 없음");
+
+		Map<String, Object> commandMap = new HashMap<>();
+		commandMap.put("cmd", "save");
+		commandMap.put("qestnrTmplatId", "TMPLAT_TEST01");
+		commandMap.put("qestnrId", "QESTNR_TEST01");
+
+		ModelMap model = new ModelMap();
+
+		String view = controller.egovQustnrRespondInfoManageRegist(searchVO, bindingResult, commandMap,
+				null, new RedirectAttributesModelMap(), model);
+
+		assertEquals("egovframework/com/uss/olp/qnn/EgovQustnrRespondInfoManageRegist", view);
+		assertTrue(model.containsAttribute("QustnrTmplatManage"),
+				"재표시 JSP의 문항 영역 templateUrl 원천인 QustnrTmplatManage가 복원되어야 한다");
+		assertTrue(model.containsAttribute("Comtnqestnrinfo"), "설문정보가 복원되어야 한다");
+		assertTrue(model.containsAttribute("Comtnqustnrqesitm"), "문항정보가 복원되어야 한다");
+		assertTrue(model.containsAttribute("Comtnqustnriem"), "항목정보가 복원되어야 한다");
+		assertEquals("TMPLAT_TEST01", model.get("qestnrTmplatId"), "hidden 설문템플릿ID가 유지되어야 한다");
+		assertEquals("QESTNR_TEST01", model.get("qestnrId"), "hidden 설문ID가 유지되어야 한다");
+	}
+}


### PR DESCRIPTION
## 수정 사유

- [x] 버그수정
- [ ] 기능개선
- [ ] 리팩터링

## 변경 이유

`EgovQustnrRespondInfoController`의 응답 등록과 응답 수정은 둘 다 검증에 실패하면 폼을 다시 반환하는데, 정상 표시 경로가 담는 참조데이터를 검증 실패 경로에서는 다시 담지 않습니다. 같은 파일의 같은 유형이라 한 번에 정리합니다.

앞서 병합된 검증 실패 재표시 시 참조데이터 복원(#1068, #1069)과 동일한 유형입니다.

### 1) 응답 등록 — `egovQustnrRespondInfoManageRegist`

문항 미응답을 `bindingResult.reject(...)`로 잡습니다. 그런데 재표시할 때 `searchVO`만 담습니다.

```java
if (bindingResult.hasErrors()) {
    model.addAttribute("searchVO", searchVO);
    return "egovframework/com/uss/olp/qnn/EgovQustnrRespondInfoManageRegist";
}
```

정상 표시 경로는 `QustnrTmplatManage`, `Comtnqestnrinfo`, `Comtnqustnrqesitm`, `Comtnqustnriem`, `Emplyrinfo`, `qestnrTmplatId`, `qestnrId`를 model에 담습니다. 재표시 JSP는 이 값들을 그대로 사용하므로 두 가지 문제가 생깁니다.

- `${QustnrTmplatManage[0].qestnrTmplatCours}`가 비어 설문 템플릿을 불러오는 `<c:import>`에 빈 `templateUrl`이 전달되고 화이트리스트 불일치로 오류 뷰가 반환되어 재표시 화면 전체가 실패합니다.
- hidden `qestnrTmplatId`/`qestnrId`가 빈 값이 되어 사용자가 답을 고쳐 재제출하면 빈 식별자로 `COMTNQUSTNRRSPNSRESULT` 등록이 시도되고 외래키 제약 위반으로 응답이 저장되지 않습니다.

### 2) 응답 수정(관리자) — `qustnrRespondInfoModify`

응답자명 누락이나 답변 길이 초과를 검증합니다(`QustnrRespondInfoVO`의 `@EgovNullCheck respondNm`, `respondAnswerCn`/`etcAnswerCn`의 `@Size(max=1000)`).

```java
if (sCmd.equals("save")) {
    if (bindingResult.hasErrors()) {
        return sLocationUrl;
    }
    ...
} else {
    List<EgovMap> resultList = egovQustnrRespondInfoService.selectQustnrRespondInfoDetail(qustnrRespondInfoVO);
    model.addAttribute("resultList", resultList);
}
```

정상 표시 경로(else)는 `resultList`를 담지만 검증 실패 경로는 아무것도 담지 않습니다. `EgovQustnrRespondInfoModify.jsp`는 hidden 필드 `qestnrId`/`qestnrTmplatId`/`qestnrQesitmId`/`qustnrIemId`/`qestnrQesrspnsId`를 모두 `resultList[0]`에서 읽습니다.

```jsp
<input name="qestnrId" id="qestnrId" type="hidden" value="${resultList[0].qestnrId}">
<input name="qestnrTmplatId" id="qestnrTmplatId" type="hidden" value="${resultList[0].qestnrTmplatId}">
...
<input name="qestnrQesrspnsId" type="hidden" value="${resultList[0].qestnrQesrspnsId}">
```

재표시에서 `resultList`가 비어 이 hidden 필드는 전부 빈 문자열로 렌더링됩니다. 이 화면에서 respondNm을 채워 재제출하면 PK 역할을 하는 `qestnrQesrspnsId`도 빈 문자열로 함께 제출됩니다. 이번에는 검증을 통과해 `updateQustnrRespondInfo`가 실행되고 매퍼는 이 값을 WHERE 조건으로 씁니다.

```xml
UPDATE COMTNQUSTNRRSPNSRESULT
SET QUSTNR_IEM_ID=#{qustnrIemId}, RESPOND_ANSWER_CN=#{respondAnswerCn}, ...
WHERE QUSTNR_RSPNS_RESULT_ID = #{qestnrQesrspnsId}
```

`QUSTNR_RSPNS_RESULT_ID`가 빈 문자열인 행은 존재하지 않으므로 UPDATE는 0건 처리로 끝나고 예외도 나지 않습니다. 화면은 그대로 목록으로 리다이렉트되어 사용자는 정정이 저장된 것으로 알지만 실제로는 원래 응답이 그대로 남고 정정 내용은 조용히 유실됩니다. 등록 경로가 `<c:import>`로 즉시 오류 화면을 반환하는 것과 달리 이 경로는 화면이 정상처럼 보이면서 저장만 실패한다는 점이 다릅니다.

## 변경 내용

두 경로 모두 정상 표시 경로가 담는 참조데이터를 검증 실패 경로에도 동일하게 담도록 했습니다.

### 1) 응답 등록

AS-IS
```java
if (bindingResult.hasErrors()) {
    model.addAttribute("searchVO", searchVO);
    return "egovframework/com/uss/olp/qnn/EgovQustnrRespondInfoManageRegist";
}
```

TO-BE
```java
if (bindingResult.hasErrors()) {
    model.addAttribute("searchVO", searchVO);

    if (loginVO.getUniqId() != null) {
        commandMap.put("uniqId", loginVO.getUniqId());
        model.addAttribute("Emplyrinfo", egovQustnrRespondInfoService.selectQustnrRespondInfoManageEmplyrinfo(commandMap));
    }
    model.addAttribute("QustnrTmplatManage", egovQustnrRespondInfoService.selectQustnrTmplatManage(commandMap));
    model.addAttribute("Comtnqestnrinfo", egovQustnrRespondInfoService.selectQustnrRespondInfoManageComtnqestnrinfo(commandMap));
    model.addAttribute("Comtnqustnrqesitm", egovQustnrRespondInfoService.selectQustnrRespondInfoManageComtnqustnrqesitm(commandMap));
    model.addAttribute("Comtnqustnriem", egovQustnrRespondInfoService.selectQustnrRespondInfoManageComtnqustnriem(commandMap));
    model.addAttribute("qestnrTmplatId", commandMap.get("qestnrTmplatId") == null ? "" : (String) commandMap.get("qestnrTmplatId"));
    model.addAttribute("qestnrId", commandMap.get("qestnrId") == null ? "" : (String) commandMap.get("qestnrId"));

    return "egovframework/com/uss/olp/qnn/EgovQustnrRespondInfoManageRegist";
}
```

`comCode014`/`comCode034`는 `hasErrors` 검사 이전에 이미 담기므로 제외했습니다.

### 2) 응답 수정

AS-IS
```java
if (sCmd.equals("save")) {
    if (bindingResult.hasErrors()) {
        return sLocationUrl;
    }
```

TO-BE
```java
if (sCmd.equals("save")) {
    if (bindingResult.hasErrors()) {
        List<EgovMap> resultList = egovQustnrRespondInfoService.selectQustnrRespondInfoDetail(qustnrRespondInfoVO);
        model.addAttribute("resultList", resultList);
        return sLocationUrl;
    }
```

이 메서드의 정상 표시 경로는 `resultList` 외 다른 참조데이터를 담지 않으므로 복원 대상도 이 한 줄입니다. `selectQustnrRespondInfoDetail`은 `qestnrQesrspnsId`만 조회 키로 쓰는데 이 값은 검증 실패 시에도 폼에서 정상적으로 바인딩되어 `qustnrRespondInfoVO`에 남아 있으므로 재조회에 문제가 없습니다.

## 영향 범위

- `EgovQustnrRespondInfoController.java`의 검증 실패 분기 두 곳(응답 등록·응답 수정). 두 메서드는 서로 독립적입니다.
- 정상 표시 경로와 저장 성공 경로는 그대로입니다. 재조회 쿼리·저장 쿼리·JSP는 변경하지 않았습니다.

## 테스트 방법

두 경로 각각에 단위 테스트를 추가했습니다.

- `EgovQustnrRespondInfoControllerValidationRestoreTest` — 응답 등록 핸들러를 검증 실패 상태로 호출해 재표시 JSP가 참조하는 참조데이터(`QustnrTmplatManage`·설문/문항/항목 목록)와 hidden 식별자(`qestnrTmplatId`/`qestnrId`)가 model에 복원되는지 확인합니다.
- `EgovQustnrRespondInfoControllerModifyRestoreTest` — 수정 처리를 검증 실패 상태로 호출해 재표시가 참조하는 `resultList`가 model에 담기는지 확인합니다.

서비스와 인증은 동적 프록시 스텁으로 대체해 DB 없이 실행됩니다. 프로젝트 `pom.xml`이 `skipTests`를 기본값 true로 두므로 아래처럼 해제하고 실행합니다.

```
mvn -Dtest='EgovQustnrRespondInfoControllerValidationRestoreTest,EgovQustnrRespondInfoControllerModifyRestoreTest' test
```

수정 전에는 두 경로 모두 참조데이터가 복원되지 않아 검증이 실패합니다.

```
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.176 s <<< FAILURE! -- in egovframework.com.uss.olp.qri.web.EgovQustnrRespondInfoControllerValidationRestoreTest
[ERROR]   EgovQustnrRespondInfoControllerValidationRestoreTest.registRestoresReferenceDataOnValidationError:110 재표시 JSP의 문항 영역 templateUrl 원천인 QustnrTmplatManage가 복원되어야 한다 ==> expected: <true> but was: <false>
```

```
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0 <<< FAILURE! -- in egovframework.com.uss.olp.qri.web.EgovQustnrRespondInfoControllerModifyRestoreTest
[ERROR]   EgovQustnrRespondInfoControllerModifyRestoreTest.modifyRestoresResultListOnValidationError 검증 실패 재표시 시 resultList가 model에 있어야 재제출 대상 식별자가 보존된다 ==> expected: <true> but was: <false>
```

수정 후에는 둘 다 통과합니다.

```
[INFO] Running egovframework.com.uss.olp.qri.web.EgovQustnrRespondInfoControllerModifyRestoreTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.136 s -- in egovframework.com.uss.olp.qri.web.EgovQustnrRespondInfoControllerModifyRestoreTest
[INFO] Running egovframework.com.uss.olp.qri.web.EgovQustnrRespondInfoControllerValidationRestoreTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s -- in egovframework.com.uss.olp.qri.web.EgovQustnrRespondInfoControllerValidationRestoreTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

아래는 응답 등록 경로를 실제 화면으로 확인한 E2E 기록입니다. MySQL 8 + 톰캣 샌드박스에 설문 1건(템플릿·설문정보·주관식 문항 1개)을 심고 `USER`로 로그인한 뒤,

1. 주관식 문항을 빈 값으로 제출해 검증 실패를 유발하고 재표시된 HTML을 관찰합니다(설문 제목 노출 여부, hidden 식별자 값).
2. 재표시 화면의 hidden 값을 그대로 써서 답을 채워 재제출하고 `COMTNQUSTNRRSPNSRESULT` 행 수를 확인합니다.

미수정(RED)과 수정본(GREEN)을 같은 DB에 다른 포트로 띄워 실행했습니다.

미수정(RED)
```
① 검증 실패 재표시: 설문제목 노출 0회, 응답 본문 1101바이트(시스템 에러 페이지)
   톰캣 로그: jakarta.servlet.ServletException: JSP file [/WEB-INF/jsp/egovframework/com/cmm/egovError.jsp] not found
             ... EgovQustnrRespondInfoManageRegist_jsp._jspx_meth_c_005fimport_005f0   (<c:import> 지점)
② 정정 재제출(재표시의 빈 hidden 사용): COMTNQUSTNRRSPNSRESULT 0 → 0 (외래키 위반, 응답 유실)
```

수정본(GREEN)
```
① 검증 실패 재표시: 설문제목 노출 1회, 응답 본문 10419바이트(정상 설문 폼)
   hidden qestnrTmplatId=TMPLAT_SANDBOX01  qestnrId=QESTNR_SANDBOX01
② 정정 재제출: COMTNQUSTNRRSPNSRESULT 0 → 1 (정상 저장)
```

미수정은 검증 실패 재표시가 시스템 에러 페이지가 되어 사용자가 자신의 답을 고칠 화면을 받지 못하고 재제출한 응답도 외래키 위반으로 유실됩니다. 수정본은 설문 폼이 정상 표시되고 식별자가 유지되어 재제출이 저장됩니다.
