### PR TITLE
상담 수정 검증 실패 시 참조데이터 복원 (수정 대상 식별자 유실 방지)

### DIFF
--- a/src/main/java/egovframework/com/uss/olp/cns/web/EgovCnsltManageController.java
+++ b/src/main/java/egovframework/com/uss/olp/cns/web/EgovCnsltManageController.java
@@ -441,6 +441,8 @@ public class EgovCnsltManageController {
 
 		if (bindingResult.hasErrors()) {
 
+			// 검증 실패로 수정 폼을 다시 표시할 때 JSP가 참조하는 result(대상 식별자·첨부 등)를 표시 경로와 동일하게 복원한다.
+			model.addAttribute("result", cnsltManageService.selectCnsltListDetail(cnsltManageVO));
 			return "egovframework/com/uss/olp/cns/EgovCnsltDtlsUpdt";
 
 		}
@@ -635,6 +637,8 @@ public class EgovCnsltManageController {
 
 			List<CmmnDetailCode> resultList = cmmUseService.selectCmmCodeDetail(vo);
 			model.addAttribute("resultList", resultList);
+			// 검증 실패로 답변 수정 폼을 다시 표시할 때 JSP가 참조하는 result(대상 식별자 등)를 표시 경로와 동일하게 복원한다.
+			model.addAttribute("result", cnsltManageService.selectCnsltListDetail(cnsltManageVO));
 			return "egovframework/com/uss/olp/cns/EgovCnsltDtlsAnswerUpdt";
 
 		}

--- a/src/test/java/egovframework/com/uss/olp/cns/web/EgovCnsltManageControllerValidationRestoreTest.java
+++ b/src/test/java/egovframework/com/uss/olp/cns/web/EgovCnsltManageControllerValidationRestoreTest.java
@@ -1,0 +1,98 @@
+package egovframework.com.uss.olp.cns.web;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Proxy;
+import java.util.Collections;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.ui.ExtendedModelMap;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.BindingResult;
+
+import egovframework.com.cmm.service.EgovCmmUseService;
+import egovframework.com.uss.olp.cns.service.CnsltManageDefaultVO;
+import egovframework.com.uss.olp.cns.service.CnsltManageVO;
+import egovframework.com.uss.olp.cns.service.EgovCnsltManageService;
+
+/**
+ * 상담 수정({@link EgovCnsltManageController#updateCnsltDtls})과 답변 수정
+ * ({@code updateCnsltDtlsAnswer})의 검증 실패 분기가, 정상 표시 경로처럼 재표시 JSP가 참조하는
+ * {@code result}(수정 대상 식별자 포함)를 model에 복원하는지 검증한다.
+ *
+ * <p>재표시 JSP는 hidden {@code cnsltId}와 onSubmit 스크립트 인자를 모두 {@code ${result.cnsltId}}에서
+ * 읽는다. 검증 실패 분기가 {@code result}를 복원하지 않으면 식별자가 비어, 사용자가 오류를 고쳐
+ * 재제출할 때 빈 식별자로 {@code WHERE CNSLT_ID=''} 갱신이 실행되어 수정이 조용히 사라진다.</p>
+ *
+ * <p>수정 전 코드에서는 {@code result}가 담기지 않아 두 테스트가 모두 실패한다.</p>
+ */
+class EgovCnsltManageControllerValidationRestoreTest {
+
+	/** selectCnsltListDetail은 요청 식별자를 그대로 되돌려주고, selectCmmCodeDetail은 빈 목록을 돌려주는 스텁. */
+	private final InvocationHandler stub = (proxy, method, args) -> {
+		switch (method.getName()) {
+		case "selectCnsltListDetail":
+			CnsltManageVO vo = new CnsltManageVO();
+			vo.setCnsltId(((CnsltManageVO) args[0]).getCnsltId());
+			return vo;
+		case "selectCmmCodeDetail":
+			return Collections.emptyList();
+		default:
+			return null;
+		}
+	};
+
+	private EgovCnsltManageController newControllerWithStubs() {
+		EgovCnsltManageController controller = new EgovCnsltManageController();
+		ClassLoader cl = getClass().getClassLoader();
+		EgovCnsltManageService cnsltSvc = (EgovCnsltManageService) Proxy.newProxyInstance(cl,
+				new Class[] { EgovCnsltManageService.class }, stub);
+		EgovCmmUseService cmmSvc = (EgovCmmUseService) Proxy.newProxyInstance(cl,
+				new Class[] { EgovCmmUseService.class }, stub);
+		ReflectionTestUtils.setField(controller, "cnsltManageService", cnsltSvc);
+		ReflectionTestUtils.setField(controller, "cmmUseService", cmmSvc);
+		return controller;
+	}
+
+	private BindingResult failingBindingResult(CnsltManageVO target) {
+		BindingResult bindingResult = new BeanPropertyBindingResult(target, "cnsltManageVO");
+		bindingResult.reject("validation.error");
+		return bindingResult;
+	}
+
+	@Test
+	@DisplayName("상담 수정 검증 실패 시 재표시 폼이 참조하는 result(대상 식별자)를 복원한다")
+	void updateCnsltDtls_restoresResultOnValidationError() throws Exception {
+		EgovCnsltManageController controller = newControllerWithStubs();
+		CnsltManageVO submitted = new CnsltManageVO();
+		submitted.setCnsltId("CNSLT_X");
+		ExtendedModelMap model = new ExtendedModelMap();
+
+		String view = controller.updateCnsltDtls("N", null, new CnsltManageDefaultVO(), submitted,
+				failingBindingResult(submitted), model);
+
+		assertEquals("egovframework/com/uss/olp/cns/EgovCnsltDtlsUpdt", view);
+		assertNotNull(model.get("result"), "검증 실패 재표시 시 result가 model에 있어야 cnsltId가 보존된다");
+		assertEquals("CNSLT_X", ((CnsltManageVO) model.get("result")).getCnsltId());
+	}
+
+	@Test
+	@DisplayName("답변 수정 검증 실패 시 재표시 폼이 참조하는 result(대상 식별자)를 복원한다")
+	void updateCnsltDtlsAnswer_restoresResultOnValidationError() throws Exception {
+		EgovCnsltManageController controller = newControllerWithStubs();
+		CnsltManageVO submitted = new CnsltManageVO();
+		submitted.setCnsltId("CNSLT_Y");
+		ExtendedModelMap model = new ExtendedModelMap();
+
+		String view = controller.updateCnsltDtlsAnswer(submitted, failingBindingResult(submitted),
+				new CnsltManageDefaultVO(), model);
+
+		assertEquals("egovframework/com/uss/olp/cns/EgovCnsltDtlsAnswerUpdt", view);
+		assertNotNull(model.get("result"), "검증 실패 재표시 시 result가 model에 있어야 cnsltId가 보존된다");
+		assertEquals("CNSLT_Y", ((CnsltManageVO) model.get("result")).getCnsltId());
+	}
+}


### PR DESCRIPTION
## 수정 사유

- [x] 버그수정
- [ ] 기능개선
- [ ] 리팩터링

## 변경 이유

상담 수정(`EgovCnsltManageController.updateCnsltDtls`)과 답변 수정(`updateCnsltDtlsAnswer`)은 검증에 실패하면 수정 폼을 다시 보여줍니다. 그런데 정상 표시 경로가 담는 `result`를 검증 실패 경로에서는 다시 담지 않습니다.

```java
if (bindingResult.hasErrors()) {
    return "egovframework/com/uss/olp/cns/EgovCnsltDtlsUpdt";
}
```

정상 표시 경로(`updateCnsltDtlsView`)는 `result`를 model에 담고 재표시 JSP는 수정 대상 식별자를 이 `result`에서 읽습니다.

```jsp
<form:form ... onSubmit="fn_egov_updt_cnsltdtls(document.forms[0],'${result.cnsltId}'); return false;">
<input name="cnsltId" type="hidden" value="<c:out value='${result.cnsltId}'/>">
```

검증 실패 경로에서 `result`가 없으면 `${result.cnsltId}`가 빈 값이 되어 hidden 필드와 onSubmit 스크립트 인자가 모두 비워집니다. 스크립트는 `form.cnsltId.value`를 이 빈 값으로 덮어쓰므로 사용자가 오류를 고쳐 다시 저장하면 빈 식별자로 `UPDATE COMTNCNSLTLIST ... WHERE CNSLT_ID=''`가 실행됩니다. 아무 행도 갱신되지 않지만 화면은 정상처럼 목록으로 이동해 사용자의 수정이 오류 표시 없이 사라집니다.

앞서 병합된 검증 실패 재표시 시 참조데이터 복원(#1068, #1069)과 같은 유형입니다.

## 변경 내용

정상 표시 경로와 동일하게 검증 실패 경로에서도 서비스 재조회로 `result`를 복원합니다.

AS-IS
```java
if (bindingResult.hasErrors()) {
    return "egovframework/com/uss/olp/cns/EgovCnsltDtlsUpdt";
}
```

TO-BE
```java
if (bindingResult.hasErrors()) {
    model.addAttribute("result", cnsltManageService.selectCnsltListDetail(cnsltManageVO));
    return "egovframework/com/uss/olp/cns/EgovCnsltDtlsUpdt";
}
```

답변 수정(`updateCnsltDtlsAnswer`)의 검증 실패 경로에도 같은 복원을 추가했습니다.

## 영향 범위

- `EgovCnsltManageController`의 검증 실패 분기 두 곳(상담 수정·답변 수정). 정상 표시 경로와 저장 경로는 그대로입니다.

## 테스트 방법

`EgovCnsltManageControllerValidationRestoreTest`를 추가했습니다. 상담 수정·답변 수정 메서드를 검증 실패 상태(`BindingResult`에 오류가 있는 상태)로 직접 호출하고 재표시 JSP가 참조하는 `result`가 model에 복원되어 그 `cnsltId`가 유지되는지 확인합니다. 서비스 의존성은 동적 프록시 스텁으로 대체해 DB 없이 실행됩니다.

프로젝트 `pom.xml`이 `skipTests`를 기본값 true로 두므로 아래처럼 해제하고 실행합니다.

```
mvn -Dtest=EgovCnsltManageControllerValidationRestoreTest test
```

수정 전에는 `result`가 복원되지 않아 두 검증이 실패합니다.

```
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running egovframework.com.uss.olp.cns.web.EgovCnsltManageControllerValidationRestoreTest
[ERROR] Tests run: 2, Failures: 2, Errors: 0, Skipped: 0, Time elapsed: 0.141 s <<< FAILURE! -- in egovframework.com.uss.olp.cns.web.EgovCnsltManageControllerValidationRestoreTest
[ERROR]   EgovCnsltManageControllerValidationRestoreTest.updateCnsltDtls_restoresResultOnValidationError:79 검증 실패 재표시 시 result가 model에 있어야 cnsltId가 보존된다 ==> expected: not <null>
[ERROR]   EgovCnsltManageControllerValidationRestoreTest.updateCnsltDtlsAnswer_restoresResultOnValidationError:95 검증 실패 재표시 시 result가 model에 있어야 cnsltId가 보존된다 ==> expected: not <null>
```

수정 후에는 두 검증이 통과합니다.

```
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running egovframework.com.uss.olp.cns.web.EgovCnsltManageControllerValidationRestoreTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.148 s -- in egovframework.com.uss.olp.cns.web.EgovCnsltManageControllerValidationRestoreTest
```

동작으로 보면 수정 전에는 검증 실패 후 정정 재제출이 빈 식별자로 `WHERE CNSLT_ID=''` 갱신을 실행해 아무 행도 바뀌지 않고 수정이 사라집니다. 수정 후에는 식별자가 유지되어 정상 저장됩니다.
