### PR TITLE
fix: 간부상태 등록·수정 검증 실패 재표시 시 간부상태 공통코드 목록 유실 방지

### DIFF
--- a/src/main/java/egovframework/com/cop/smt/lsm/web/EgovLeaderSchdulController.java
+++ b/src/main/java/egovframework/com/cop/smt/lsm/web/EgovLeaderSchdulController.java
@@ -865,8 +865,11 @@ public class EgovLeaderSchdulController {
 		Boolean isAuthenticated = EgovUserDetailsHelper.isAuthenticated();
 
 		if (bindingResult.hasErrors()) {
-			//LeaderSttus result = leaderSchdulService.selectLeaderSttus(leaderSttusVO);
-		    //model.addAttribute("leaderSttus", result);
+			// 검증 실패로 수정 화면을 다시 표시할 때 표시 경로(modifyLeaderSttus)와 동일하게 간부상태 공통코드 목록을 복원한다.
+			ComDefaultCodeVO voComCode = new ComDefaultCodeVO();
+			voComCode.setCodeId("COM061");
+			List<CmmnDetailCode> listComCode = cmmUseService.selectCmmCodeDetail(voComCode);
+			model.addAttribute("leaderSttus", listComCode);
 		    return "egovframework/com/cop/smt/lsm/EgovLeaderSttusUpdt";
 		}
 
@@ -901,6 +904,11 @@ public class EgovLeaderSchdulController {
 
 		//서버  validate 체크
 		if(bindingResult.hasErrors()){
+			// 검증 실패로 등록 화면을 다시 표시할 때 표시 경로(addLeaderSttus)와 동일하게 간부상태 공통코드 목록을 복원한다.
+			ComDefaultCodeVO voComCode = new ComDefaultCodeVO();
+			voComCode.setCodeId("COM061");
+			List<CmmnDetailCode> listComCode = cmmUseService.selectCmmCodeDetail(voComCode);
+			model.addAttribute("leaderSttus", listComCode);
 			return sLocationUrl;
 		}
 

--- a/src/test/java/egovframework/com/cop/smt/lsm/web/EgovLeaderSchdulControllerLeaderSttusRestoreTest.java
+++ b/src/test/java/egovframework/com/cop/smt/lsm/web/EgovLeaderSchdulControllerLeaderSttusRestoreTest.java
@@ -1,0 +1,106 @@
+package egovframework.com.cop.smt.lsm.web;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Proxy;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.ui.ModelMap;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.BindingResult;
+
+import egovframework.com.cmm.LoginVO;
+import egovframework.com.cmm.service.EgovCmmUseService;
+import egovframework.com.cmm.service.EgovUserDetailsService;
+import egovframework.com.cmm.util.EgovUserDetailsHelper;
+import egovframework.com.cop.smt.lsm.service.LeaderSttusVO;
+
+/**
+ * 간부상태 등록 처리({@link EgovLeaderSchdulController#insertLeaderSttus})의 검증 실패 분기가,
+ * 표시 경로({@code addLeaderSttus})처럼 간부상태 공통코드 목록({@code leaderSttus}, 코드 COM061)을
+ * model에 복원하는지 검증한다.
+ *
+ * <p>재표시 JSP는 필수 항목인 간부상태를 {@code <form:options items="${leaderSttus}">}로 그린다.
+ * 검증 실패 분기가 목록을 복원하지 않으면 필수 셀렉트박스가 옵션 없이 렌더되어 사용자가 값을 고를 수 없다.
+ * 수정 전 코드에서는 {@code leaderSttus}가 담기지 않아 검증이 실패한다.</p>
+ */
+class EgovLeaderSchdulControllerLeaderSttusRestoreTest {
+
+	private final InvocationHandler authStub = (proxy, method, args) -> {
+		switch (method.getName()) {
+		case "isAuthenticated":
+			return Boolean.TRUE;
+		case "getAuthenticatedUser":
+			LoginVO loginVO = new LoginVO();
+			loginVO.setUniqId("USRCNFRM_TEST");
+			return loginVO;
+		case "getAuthorities":
+			return List.of("ROLE_ADMIN");
+		default:
+			return null;
+		}
+	};
+
+	private final InvocationHandler emptyStub = (proxy, method, args) ->
+			List.class.isAssignableFrom(method.getReturnType()) ? Collections.emptyList() : null;
+
+	@BeforeEach
+	void setUpStaticAuth() {
+		EgovUserDetailsService auth = (EgovUserDetailsService) Proxy.newProxyInstance(
+				getClass().getClassLoader(), new Class[] { EgovUserDetailsService.class }, authStub);
+		ReflectionTestUtils.setField(EgovUserDetailsHelper.class, "egovUserDetailsService", auth);
+	}
+
+	@AfterEach
+	void tearDownStaticAuth() {
+		ReflectionTestUtils.setField(EgovUserDetailsHelper.class, "egovUserDetailsService", null);
+	}
+
+	@Test
+	@DisplayName("간부상태 등록 검증 실패 시 간부상태 공통코드 목록(leaderSttus)을 복원한다")
+	void insertLeaderSttusRestoresCodeListOnValidationError() throws Exception {
+		EgovLeaderSchdulController controller = new EgovLeaderSchdulController();
+		ReflectionTestUtils.setField(controller, "cmmUseService",
+				Proxy.newProxyInstance(getClass().getClassLoader(),
+						new Class[] { EgovCmmUseService.class }, emptyStub));
+
+		LeaderSttusVO leaderSttusVO = new LeaderSttusVO();
+		BindingResult bindingResult = new BeanPropertyBindingResult(leaderSttusVO, "leaderSttusVO");
+		bindingResult.reject("validation.error");
+		ModelMap model = new ModelMap();
+
+		String view = controller.insertLeaderSttus(leaderSttusVO, bindingResult, model);
+
+		assertEquals("egovframework/com/cop/smt/lsm/EgovLeaderSttusRegist", view);
+		assertTrue(model.containsAttribute("leaderSttus"),
+				"검증 실패 재표시 시 leaderSttus가 model에 있어야 필수 셀렉트박스가 비지 않는다");
+	}
+
+	@Test
+	@DisplayName("간부상태 수정 검증 실패 시 간부상태 공통코드 목록(leaderSttus)을 복원한다")
+	void updateLeaderSttusRestoresCodeListOnValidationError() throws Exception {
+		EgovLeaderSchdulController controller = new EgovLeaderSchdulController();
+		ReflectionTestUtils.setField(controller, "cmmUseService",
+				Proxy.newProxyInstance(getClass().getClassLoader(),
+						new Class[] { EgovCmmUseService.class }, emptyStub));
+
+		LeaderSttusVO leaderSttusVO = new LeaderSttusVO();
+		BindingResult bindingResult = new BeanPropertyBindingResult(leaderSttusVO, "leaderSttusVO");
+		bindingResult.reject("validation.error");
+		ModelMap model = new ModelMap();
+
+		String view = controller.updateLeaderSttus(leaderSttusVO, bindingResult, model);
+
+		assertEquals("egovframework/com/cop/smt/lsm/EgovLeaderSttusUpdt", view);
+		assertTrue(model.containsAttribute("leaderSttus"),
+				"검증 실패 재표시 시 leaderSttus가 model에 있어야 필수 셀렉트박스가 비지 않는다");
+	}
+}


### PR DESCRIPTION
## 수정 사유

- [x] 버그수정
- [ ] 기능개선
- [ ] 리팩터링

## 변경 이유

간부상태 등록 처리(`insertLeaderSttus`)와 수정 처리(`updateLeaderSttus`)는 검증에 실패하면 등록·수정 화면을 다시 반환합니다. 그런데 표시 경로(`addLeaderSttus`·`modifyLeaderSttus`)가 담는 간부상태 공통코드 목록(`leaderSttus`, 코드 `COM061`)을 다시 담지 않습니다.

```java
// insertLeaderSttus
if (bindingResult.hasErrors()) {
    return sLocationUrl; // "egovframework/com/cop/smt/lsm/EgovLeaderSttusRegist"
}

// updateLeaderSttus (복원 코드가 주석 처리돼 있고, 형까지 어긋나 실효가 없습니다)
if (bindingResult.hasErrors()) {
    //LeaderSttus result = leaderSchdulService.selectLeaderSttus(leaderSttusVO);
    //model.addAttribute("leaderSttus", result);
    return "egovframework/com/cop/smt/lsm/EgovLeaderSttusUpdt";
}
```

재표시된 `EgovLeaderSttusRegist.jsp`·`EgovLeaderSttusUpdt.jsp`는 필수 항목인 간부상태를 셀렉트박스로 그립니다.

```jsp
<form:select path="leaderSttus" title="간부상태">
    <form:options items="${leaderSttus}" itemValue="code" itemLabel="codeNm"/>
</form:select>
```

`${leaderSttus}`가 비면 옵션이 하나도 없는 빈 셀렉트박스가 렌더됩니다. 필수 항목인데도 사용자가 값을 다시 고를 수 없어 다른 필드의 오류를 고쳐도 등록·수정을 마칠 수 없습니다. 참고로 수정 처리의 복원 코드는 주석 처리된 데다 단일 객체를 `List` 자리에 담아 되살려도 동작하지 않았습니다.

## 변경 내용

표시 경로와 동일하게 두 검증 실패 분기에서 `COM061` 목록을 조회해 `leaderSttus`로 담도록 바로잡습니다.

TO-BE (등록·수정 공통)
```java
if (bindingResult.hasErrors()) {
    ComDefaultCodeVO voComCode = new ComDefaultCodeVO();
    voComCode.setCodeId("COM061");
    List<CmmnDetailCode> listComCode = cmmUseService.selectCmmCodeDetail(voComCode);
    model.addAttribute("leaderSttus", listComCode);
    return sLocationUrl; // 수정은 EgovLeaderSttusUpdt
}
```

## 영향 범위

- `EgovLeaderSchdulController`의 간부상태 등록·수정 검증 실패 재표시 경로 두 곳. 정상 등록·수정 흐름과 표시 경로는 그대로입니다.

## 테스트 방법

`EgovLeaderSchdulControllerLeaderSttusRestoreTest`를 추가했습니다. 등록·수정 처리를 검증 실패 상태로 호출해 간부상태 공통코드 목록(`leaderSttus`)이 `model`에 담기는지 확인합니다. 정적 인증과 공통코드 조회는 스텁으로 대체해 DB 없이 실행됩니다.

프로젝트 `pom.xml`이 `skipTests`를 기본값 true로 두므로 아래처럼 해제하고 실행합니다.

```
mvn -Dtest=EgovLeaderSchdulControllerLeaderSttusRestoreTest test
```

수정 전에는 등록·수정 두 분기 모두 `leaderSttus`를 복원하지 않아 두 검증이 실패합니다.

```
[ERROR] Tests run: 2, Failures: 2, Errors: 0, Skipped: 0 <<< FAILURE! -- in egovframework.com.cop.smt.lsm.web.EgovLeaderSchdulControllerLeaderSttusRestoreTest
[ERROR]   EgovLeaderSchdulControllerLeaderSttusRestoreTest.insertLeaderSttusRestoresCodeListOnValidationError 검증 실패 재표시 시 leaderSttus가 model에 있어야 필수 셀렉트박스가 비지 않는다 ==> expected: <true> but was: <false>
[ERROR]   EgovLeaderSchdulControllerLeaderSttusRestoreTest.updateLeaderSttusRestoresCodeListOnValidationError 검증 실패 재표시 시 leaderSttus가 model에 있어야 필수 셀렉트박스가 비지 않는다 ==> expected: <true> but was: <false>
```

수정 후에는 두 검증이 통과합니다.

```
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.149 s -- in egovframework.com.cop.smt.lsm.web.EgovLeaderSchdulControllerLeaderSttusRestoreTest
```

아래는 실제 화면 동작을 확인한 기록입니다. 미수정과 수정본을 같은 DB에 다른 포트로 띄우고 다른 필수값을 비운 채 등록을 요청해 검증 실패를 유발한 뒤 재표시된 간부상태 셀렉트박스의 옵션 수를 확인했습니다. 미수정은 옵션 5개에서 0개로, 수정본은 5개로 유지됐습니다.
