### PR TITLE
fix: 설문 템플릿 등록 검증 실패 재표시 시 파일 업로드 허용 확장자 목록 유실 방지

### DIFF
--- a/src/main/java/egovframework/com/uss/olp/qtm/web/EgovQustnrTmplatManageController.java
+++ b/src/main/java/egovframework/com/uss/olp/qtm/web/EgovQustnrTmplatManageController.java
@@ -478,7 +478,8 @@ public class EgovQustnrTmplatManageController {
 		final MultipartHttpServletRequest multiRequest,
 		@ModelAttribute("searchVO") ComDefaultVO searchVO,
 		@Valid QustnrTmplatManageVO qustnrTmplatManageVO,BindingResult bindingResult,
-		RedirectAttributes redirectAttributes)
+		RedirectAttributes redirectAttributes,
+		ModelMap model)
 		throws Exception {
 		// 0. Spring Security 사용자권한 처리
 		Boolean isAuthenticated = EgovUserDetailsHelper.isAuthenticated();
@@ -489,6 +490,11 @@ public class EgovQustnrTmplatManageController {
 		// 유효성 검증, 실패시 포워딩
 				if(bindingResult.hasErrors()) {
 					System.out.println("####파라미터검증에러"+ bindingResult.getAllErrors());//확인용 로그
+					String whiteListFileUploadExtensions = EgovProperties.getProperty("Globals.fileUpload.Extensions");
+					String fileUploadMaxSize = EgovProperties.getProperty("Globals.fileUpload.maxSize");
+
+					model.addAttribute("fileUploadExtensions", whiteListFileUploadExtensions);
+					model.addAttribute("fileUploadMaxSize", fileUploadMaxSize);
 					return "egovframework/com/uss/olp/qtm/EgovQustnrTmplatManageRegist";
 				}
 				
@@ -518,6 +524,11 @@ public class EgovQustnrTmplatManageController {
 								"qestnrTmplatImage",
 								"file.invalid",
 								"유효한 이미지 파일이 아닙니다.");
+						String whiteListFileUploadExtensions = EgovProperties.getProperty("Globals.fileUpload.Extensions");
+						String fileUploadMaxSize = EgovProperties.getProperty("Globals.fileUpload.maxSize");
+
+						model.addAttribute("fileUploadExtensions", whiteListFileUploadExtensions);
+						model.addAttribute("fileUploadMaxSize", fileUploadMaxSize);
 						return "egovframework/com/uss/olp/qtm/EgovQustnrTmplatManageRegist";
 					}
 					qustnrTmplatManageVO.setQestnrTmplatImagepathnm(fileBytes);
@@ -531,6 +542,11 @@ public class EgovQustnrTmplatManageController {
 					"qestnrTmplatImage",
 					"file.empty",// 메세지 파일에 해당 태그는 없지만 채워놓음
 					"템플릿 이미지를 선택해주세요.");
+			String whiteListFileUploadExtensions = EgovProperties.getProperty("Globals.fileUpload.Extensions");
+			String fileUploadMaxSize = EgovProperties.getProperty("Globals.fileUpload.maxSize");
+
+			model.addAttribute("fileUploadExtensions", whiteListFileUploadExtensions);
+			model.addAttribute("fileUploadMaxSize", fileUploadMaxSize);
 			return "egovframework/com/uss/olp/qtm/EgovQustnrTmplatManageRegist";
 		}
 		

--- a/src/main/java/egovframework/com/uss/olp/qtm/web/EgovQustnrTmplatManageController.java
+++ b/src/main/java/egovframework/com/uss/olp/qtm/web/EgovQustnrTmplatManageController.java
@@ -478,7 +478,8 @@ public class EgovQustnrTmplatManageController {
 		final MultipartHttpServletRequest multiRequest,
 		@ModelAttribute("searchVO") ComDefaultVO searchVO,
 		@Valid QustnrTmplatManageVO qustnrTmplatManageVO,BindingResult bindingResult,
-		RedirectAttributes redirectAttributes)
+		RedirectAttributes redirectAttributes,
+		ModelMap model)
 		throws Exception {
 		// 0. Spring Security 사용자권한 처리
 		Boolean isAuthenticated = EgovUserDetailsHelper.isAuthenticated();
@@ -489,6 +490,11 @@ public class EgovQustnrTmplatManageController {
 		// 유효성 검증, 실패시 포워딩
 				if(bindingResult.hasErrors()) {
 					LOGGER.debug("파라미터 검증 에러: {}", bindingResult.getAllErrors());
+					String whiteListFileUploadExtensions = EgovProperties.getProperty("Globals.fileUpload.Extensions");
+					String fileUploadMaxSize = EgovProperties.getProperty("Globals.fileUpload.maxSize");
+
+					model.addAttribute("fileUploadExtensions", whiteListFileUploadExtensions);
+					model.addAttribute("fileUploadMaxSize", fileUploadMaxSize);
 					return "egovframework/com/uss/olp/qtm/EgovQustnrTmplatManageRegist";
 				}
 				
@@ -518,6 +524,11 @@ public class EgovQustnrTmplatManageController {
 								"qestnrTmplatImage",
 								"file.invalid",
 								"유효한 이미지 파일이 아닙니다.");
+						String whiteListFileUploadExtensions = EgovProperties.getProperty("Globals.fileUpload.Extensions");
+						String fileUploadMaxSize = EgovProperties.getProperty("Globals.fileUpload.maxSize");
+
+						model.addAttribute("fileUploadExtensions", whiteListFileUploadExtensions);
+						model.addAttribute("fileUploadMaxSize", fileUploadMaxSize);
 						return "egovframework/com/uss/olp/qtm/EgovQustnrTmplatManageRegist";
 					}
 					qustnrTmplatManageVO.setQestnrTmplatImagepathnm(fileBytes);
@@ -531,6 +542,11 @@ public class EgovQustnrTmplatManageController {
 					"qestnrTmplatImage",
 					"file.empty",// 메세지 파일에 해당 태그는 없지만 채워놓음
 					"템플릿 이미지를 선택해주세요.");
+			String whiteListFileUploadExtensions = EgovProperties.getProperty("Globals.fileUpload.Extensions");
+			String fileUploadMaxSize = EgovProperties.getProperty("Globals.fileUpload.maxSize");
+
+			model.addAttribute("fileUploadExtensions", whiteListFileUploadExtensions);
+			model.addAttribute("fileUploadMaxSize", fileUploadMaxSize);
 			return "egovframework/com/uss/olp/qtm/EgovQustnrTmplatManageRegist";
 		}
 		

--- a/src/test/java/egovframework/com/uss/olp/qtm/web/EgovQustnrTmplatManageControllerRegistRestoreTest.java
+++ b/src/test/java/egovframework/com/uss/olp/qtm/web/EgovQustnrTmplatManageControllerRegistRestoreTest.java
@@ -1,0 +1,124 @@
+package egovframework.com.uss.olp.qtm.web;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.Collections;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.ui.ExtendedModelMap;
+import org.springframework.ui.Model;
+import org.springframework.ui.ModelMap;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.multipart.MultipartHttpServletRequest;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+import org.springframework.web.servlet.mvc.support.RedirectAttributesModelMap;
+
+import egovframework.com.cmm.ComDefaultVO;
+import egovframework.com.cmm.LoginVO;
+import egovframework.com.cmm.service.EgovUserDetailsService;
+import egovframework.com.cmm.util.EgovUserDetailsHelper;
+import egovframework.com.uss.olp.qtm.service.QustnrTmplatManageVO;
+
+/**
+ * 설문 템플릿 등록 저장 핸들러({@code qustnrTmplatManageRegistActor})의 검증 실패 재표시 경로가
+ * 파일 업로드 허용 확장자·최대 크기({@code fileUploadExtensions}·{@code fileUploadMaxSize})를
+ * {@code model}에 담는지 검증한다.
+ *
+ * <p>수정 전에는 검증 실패 반환 지점이 두 값을 복원하지 않아 재표시 JSP의
+ * {@code checkExtensions("qestnrTmplatImage", "")} 허용 목록이 비고, 빈 허용 목록은 모든 확장자를
+ * 거부해 정상 이미지도 첨부할 수 없었다.</p>
+ *
+ * <p>수정 전후로 메서드 시그니처가 달라(수정 후 {@code ModelMap} 파라미터 추가) 리플렉션으로 호출한다.</p>
+ */
+class EgovQustnrTmplatManageControllerRegistRestoreTest {
+
+	private final InvocationHandler authStub = (proxy, method, args) -> {
+		switch (method.getName()) {
+		case "isAuthenticated":
+			return Boolean.TRUE;
+		case "getAuthenticatedUser":
+			LoginVO loginVO = new LoginVO();
+			loginVO.setUniqId("USRCNFRM_TEST");
+			return loginVO;
+		case "getAuthorities":
+			return Collections.emptyList();
+		default:
+			return null;
+		}
+	};
+
+	@BeforeEach
+	void setUpStaticAuth() {
+		EgovUserDetailsService auth = (EgovUserDetailsService) Proxy.newProxyInstance(
+				getClass().getClassLoader(), new Class[] { EgovUserDetailsService.class }, authStub);
+		ReflectionTestUtils.setField(EgovUserDetailsHelper.class, "egovUserDetailsService", auth);
+	}
+
+	@AfterEach
+	void tearDownStaticAuth() {
+		ReflectionTestUtils.setField(EgovUserDetailsHelper.class, "egovUserDetailsService", null);
+	}
+
+	private Method findRegistActor() {
+		for (Method m : EgovQustnrTmplatManageController.class.getDeclaredMethods()) {
+			if (m.getName().equals("qustnrTmplatManageRegistActor")) {
+				return m;
+			}
+		}
+		throw new IllegalStateException("qustnrTmplatManageRegistActor 메서드를 찾을 수 없다");
+	}
+
+	@Test
+	@DisplayName("설문 템플릿 등록 검증 실패 시 파일 업로드 제약값을 model에 담는다")
+	void registActorRestoresFileUploadLimits() throws Throwable {
+		EgovQustnrTmplatManageController controller = new EgovQustnrTmplatManageController();
+		Method method = findRegistActor();
+		ExtendedModelMap model = new ExtendedModelMap();
+		boolean hasModelParam = false;
+		Class<?>[] types = method.getParameterTypes();
+		Object[] args = new Object[types.length];
+		for (int i = 0; i < types.length; i++) {
+			if (MultipartHttpServletRequest.class.isAssignableFrom(types[i])) {
+				args[i] = null;
+			} else if (QustnrTmplatManageVO.class.isAssignableFrom(types[i])) {
+				args[i] = new QustnrTmplatManageVO();
+			} else if (ComDefaultVO.class.isAssignableFrom(types[i])) {
+				args[i] = new ComDefaultVO();
+			} else if (BindingResult.class.isAssignableFrom(types[i])) {
+				BindingResult bindingResult = new BeanPropertyBindingResult(new QustnrTmplatManageVO(),
+						"qustnrTmplatManageVO");
+				bindingResult.reject("validation.error");
+				args[i] = bindingResult;
+			} else if (RedirectAttributes.class.isAssignableFrom(types[i])) {
+				args[i] = new RedirectAttributesModelMap();
+			} else if (Model.class.isAssignableFrom(types[i]) || ModelMap.class.isAssignableFrom(types[i])) {
+				args[i] = model;
+				hasModelParam = true;
+			} else {
+				args[i] = null;
+			}
+		}
+		if (!hasModelParam) {
+			fail("검증 실패 재표시에 파일 업로드 제약값을 담을 Model 파라미터가 없다");
+		}
+		try {
+			method.invoke(controller, args);
+		} catch (InvocationTargetException e) {
+			throw e.getCause();
+		}
+
+		assertTrue(model.containsAttribute("fileUploadExtensions"),
+				"검증 실패 재표시 시 fileUploadExtensions가 model에 있어야 확장자 허용 목록이 비지 않는다");
+		assertTrue(model.containsAttribute("fileUploadMaxSize"), "fileUploadMaxSize도 담겨야 한다");
+	}
+}


### PR DESCRIPTION
## 수정 사유

- [x] 버그수정
- [ ] 기능개선
- [ ] 리팩터링

## 변경 이유

설문 템플릿 등록 처리(`qustnrTmplatManageRegistActor`)에는 검증 실패로 등록 폼을 다시 반환하는 지점이 세 곳 있습니다.

- `bindingResult.hasErrors()`인 경우
- 서버측 이미지 검증(매직바이트) 실패로 `rejectValue` 후 반환하는 경우
- 첨부 이미지가 없어 `rejectValue` 후 반환하는 경우

정상 표시 경로(`qustnrTmplatManageRegist`)와 수정 처리(`qustnrTmplatManageModifyActor`)는 파일 업로드 허용 확장자·최대 크기(`fileUploadExtensions`·`fileUploadMaxSize`)를 `model`에 담는데, 등록 처리의 세 반환 지점은 이를 다시 담지 않습니다.

재표시된 `EgovQustnrTmplatManageRegist.jsp`는 파일 선택 시 다음으로 확장자를 검사합니다.

```js
const isAllowed = EgovMultiFilesChecker.checkExtensions("qestnrTmplatImage", "<c:out value='${fileUploadExtensions}'/>");
```

`${fileUploadExtensions}`가 비면 허용 목록이 빈 문자열이 되고 빈 허용 목록은 모든 확장자를 거부합니다. 사용자는 검증 오류를 고치려 정상적인 이미지 파일을 다시 선택해도 "허용되지 않는 확장자" 경고를 받아 템플릿 등록을 마칠 수 없습니다.

이 재표시는 일반 사용자가 자연히 도달합니다. 서버측 이미지 검증(`isValidImageBytes`, 매직바이트·디코딩)은 클라이언트에 대응 검사가 없고 파일 업로드 화이트리스트(`Globals.fileUpload.Extensions`)에는 `.xls`·`.xlsx`처럼 이미지가 아닌 확장자가 포함돼 있어 사용자가 이런 파일이나 손상된 이미지를 고르면 클라이언트 확장자 검사는 통과하고 서버 이미지 검증에서 실패합니다. 그 순간 세 반환 지점 중 하나에 도달하고 이후에는 허용 목록이 비어 정상 이미지조차 다시 첨부할 수 없습니다.

## 변경 내용

수정 처리(`qustnrTmplatManageModifyActor`)와 동일하게, 등록 처리의 세 반환 지점에서도 파일 업로드 제약값을 `model`에 담도록 바로잡습니다.

AS-IS (세 반환 지점)
```java
if (bindingResult.hasErrors()) {
    ...
    return "egovframework/com/uss/olp/qtm/EgovQustnrTmplatManageRegist";
}
```

TO-BE
```java
if (bindingResult.hasErrors()) {
    ...
    String whiteListFileUploadExtensions = EgovProperties.getProperty("Globals.fileUpload.Extensions");
    String fileUploadMaxSize = EgovProperties.getProperty("Globals.fileUpload.maxSize");

    model.addAttribute("fileUploadExtensions", whiteListFileUploadExtensions);
    model.addAttribute("fileUploadMaxSize", fileUploadMaxSize);
    return "egovframework/com/uss/olp/qtm/EgovQustnrTmplatManageRegist";
}
```

핸들러에 `ModelMap model` 파라미터를 추가했습니다(수정 처리와 동일한 시그니처).

## 영향 범위

- `EgovQustnrTmplatManageController`의 등록 처리 검증 실패 재표시 경로. 정상 등록 흐름과 수정 처리는 그대로입니다.

## 테스트 방법

`EgovQustnrTmplatManageControllerRegistRestoreTest`를 추가했습니다. 등록 저장 핸들러를 검증 실패 상태로 호출해 파일 업로드 제약값이 `model`에 담기는지 확인합니다. 정적 인증은 스텁으로 대체하고 수정 전후로 시그니처가 달라(수정 후 `ModelMap` 파라미터 추가) 리플렉션으로 호출합니다.

프로젝트 `pom.xml`이 `skipTests`를 기본값 true로 두므로 아래처럼 해제하고 실행합니다.

```
mvn -Dtest=EgovQustnrTmplatManageControllerRegistRestoreTest test
```

수정 전에는 제약값을 담을 `model` 파라미터가 없어 검증이 실패합니다.

```
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.139 s <<< FAILURE! -- in egovframework.com.uss.olp.qtm.web.EgovQustnrTmplatManageControllerRegistRestoreTest
[ERROR]   EgovQustnrTmplatManageControllerRegistRestoreTest.registActorRestoresFileUploadLimits:112 검증 실패 재표시에 파일 업로드 제약값을 담을 Model 파라미터가 없다
```

수정 후에는 검증이 통과합니다.

```
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.144 s -- in egovframework.com.uss.olp.qtm.web.EgovQustnrTmplatManageControllerRegistRestoreTest
```

아래는 실제 화면 동작을 확인한 기록입니다. 미수정과 수정본을 같은 DB에 다른 포트로 띄우고 필수값을 비운 채 등록을 요청해 검증 실패를 유발한 뒤 재표시된 HTML의 확장자 검사 스크립트를 확인했습니다.

미수정(RED)
```
checkExtensions("qestnrTmplatImage", "")        ← 허용 목록 빈 문자열(모든 파일 거부)
```

수정본(GREEN)
```
checkExtensions("qestnrTmplatImage", ".gif,.jpg,.jpeg,.png,.xls,.xlsx")
```

미수정은 재표시 화면에서 허용 목록이 비어 정상 이미지도 거부됩니다. 수정본은 허용 목록이 복원되어 파일을 첨부할 수 있습니다.
