### PR TITLE
fix: 일지관리·FAQ 등록·수정 검증 실패 재표시 시 파일 업로드 제약값 유실 방지

### DIFF
--- a/src/main/java/egovframework/com/cop/smt/dsm/web/EgovDiaryManageController.java
+++ b/src/main/java/egovframework/com/cop/smt/dsm/web/EgovDiaryManageController.java
@@ -254,7 +254,7 @@ public class EgovDiaryManageController {
 	public String diaryManageModifyActor(final MultipartHttpServletRequest multiRequest,
 			@ModelAttribute("searchVO") ComDefaultVO searchVO, @RequestParam Map<?, ?> commandMap,
 			@Valid @ModelAttribute("diaryManageVO") DiaryManageVO diaryManageVO, BindingResult bindingResult, 
-			RedirectAttributes redirectAttributes)
+			RedirectAttributes redirectAttributes, ModelMap model)
 			throws Exception {
 
 		// 0. Spring Security 사용자권한 처리
@@ -279,8 +279,8 @@ public class EgovDiaryManageController {
 		String whiteListFileUploadExtensions = EgovProperties.getProperty("Globals.fileUpload.Extensions");
 		String fileUploadMaxSize = EgovProperties.getProperty("Globals.fileUpload.maxSize");
 
-		redirectAttributes.addAttribute("fileUploadExtensions", whiteListFileUploadExtensions);
-		redirectAttributes.addAttribute("fileUploadMaxSize", fileUploadMaxSize);
+		model.addAttribute("fileUploadExtensions", whiteListFileUploadExtensions);
+		model.addAttribute("fileUploadMaxSize", fileUploadMaxSize);
 
 		String sLocationUrl = "egovframework/com/cop/smt/dsm/EgovDiaryManageModify";
 
@@ -389,7 +389,7 @@ public class EgovDiaryManageController {
 	public String diaryManageRegistActor(final MultipartHttpServletRequest multiRequest,
 			@ModelAttribute("searchVO") ComDefaultVO searchVO, @RequestParam Map<?, ?> commandMap,
 			@Valid @ModelAttribute("diaryManageVO") DiaryManageVO diaryManageVO, BindingResult bindingResult, 
-			RedirectAttributes redirectAttributes)
+			RedirectAttributes redirectAttributes, ModelMap model)
 			throws Exception {
 
 		// 0. Spring Security 사용자권한 처리
@@ -406,8 +406,8 @@ public class EgovDiaryManageController {
 		String whiteListFileUploadExtensions = EgovProperties.getProperty("Globals.fileUpload.Extensions");
 		String fileUploadMaxSize = EgovProperties.getProperty("Globals.fileUpload.maxSize");
 
-		redirectAttributes.addAttribute("fileUploadExtensions", whiteListFileUploadExtensions);
-		redirectAttributes.addAttribute("fileUploadMaxSize", fileUploadMaxSize);
+		model.addAttribute("fileUploadExtensions", whiteListFileUploadExtensions);
+		model.addAttribute("fileUploadMaxSize", fileUploadMaxSize);
 
 		String sLocationUrl = "egovframework/com/cop/smt/dsm/EgovDiaryManageRegist";
 

--- a/src/main/java/egovframework/com/uss/olh/faq/web/EgovFaqController.java
+++ b/src/main/java/egovframework/com/uss/olh/faq/web/EgovFaqController.java
@@ -168,9 +168,12 @@ public class EgovFaqController {
 	@PostMapping("/uss/olh/faq/insertFaq.do")
 	public String insertFaqCn(final MultipartHttpServletRequest multiRequest, // 첨부파일을 위한...
 			@ModelAttribute("searchVO") FaqVO searchVO, @Valid @ModelAttribute("faqVO") FaqVO faqVO,
-			BindingResult bindingResult) throws Exception {
+			BindingResult bindingResult, ModelMap model) throws Exception {
 
 		if (bindingResult.hasErrors()) {
+			// 파일업로드 제한 - 재표시 JSP 가 자바스크립트 인자로 그대로 출력한다
+			model.addAttribute("fileUploadExtensions", Globals.FILE_UP_EXTS);
+			model.addAttribute("fileUploadMaxSize", Globals.FILE_UP_MAX_SIZE);
 			return "egovframework/com/uss/olh/faq/EgovFaqRegist";
 		}
 
@@ -253,6 +256,9 @@ public class EgovFaqController {
 			BindingResult bindingResult, ModelMap model) throws Exception {
 
 		if (bindingResult.hasErrors()) {
+			// 파일업로드 제한 - 재표시 JSP 가 자바스크립트 인자로 그대로 출력한다
+			model.addAttribute("fileUploadExtensions", Globals.FILE_UP_EXTS);
+			model.addAttribute("fileUploadMaxSize", Globals.FILE_UP_MAX_SIZE);
 			return "egovframework/com/uss/olh/faq/EgovFaqUpdt";
 		}
 

--- a/src/test/java/egovframework/com/cop/smt/dsm/web/EgovDiaryManageControllerFileUploadRestoreTest.java
+++ b/src/test/java/egovframework/com/cop/smt/dsm/web/EgovDiaryManageControllerFileUploadRestoreTest.java
@@ -1,0 +1,143 @@
+package egovframework.com.cop.smt.dsm.web;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.ui.ExtendedModelMap;
+import org.springframework.ui.Model;
+import org.springframework.ui.ModelMap;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.multipart.MultipartHttpServletRequest;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+import org.springframework.web.servlet.mvc.support.RedirectAttributesModelMap;
+
+import egovframework.com.cmm.ComDefaultVO;
+import egovframework.com.cmm.LoginVO;
+import egovframework.com.cmm.service.EgovUserDetailsService;
+import egovframework.com.cmm.util.EgovUserDetailsHelper;
+import egovframework.com.cop.smt.dsm.service.DiaryManageVO;
+
+/**
+ * 일지관리 등록·수정 저장 핸들러({@code diaryManageRegistActor}·{@code diaryManageModifyActor})의
+ * 검증 실패 재표시 경로가 파일 업로드 제약값({@code fileUploadExtensions}·{@code fileUploadMaxSize})을
+ * {@code model}에 담는지 검증한다.
+ *
+ * <p>두 핸들러는 forward 뷰를 반환하는데, 수정 전에는 두 값을 {@code RedirectAttributes}에 담아
+ * forward 뷰에 병합되지 않았다. 그 결과 재표시 JSP의 {@code checkFileSize("egovComFileUploader", )}가
+ * 인자 없는 자바스크립트로 렌더되어 스크립트 블록 전체가 문법 오류로 죽고 저장 함수가 사라진다.</p>
+ *
+ * <p>수정 전후로 메서드 시그니처가 달라(수정 후 {@code ModelMap} 파라미터 추가) 리플렉션으로 호출한다.</p>
+ */
+class EgovDiaryManageControllerFileUploadRestoreTest {
+
+	private final InvocationHandler authStub = (proxy, method, args) -> {
+		switch (method.getName()) {
+		case "isAuthenticated":
+			return Boolean.TRUE;
+		case "getAuthenticatedUser":
+			LoginVO loginVO = new LoginVO();
+			loginVO.setUniqId("USRCNFRM_TEST");
+			return loginVO;
+		case "getAuthorities":
+			return Collections.emptyList();
+		default:
+			return null;
+		}
+	};
+
+	@BeforeEach
+	void setUpStaticAuth() {
+		EgovUserDetailsService auth = (EgovUserDetailsService) Proxy.newProxyInstance(
+				getClass().getClassLoader(), new Class[] { EgovUserDetailsService.class }, authStub);
+		ReflectionTestUtils.setField(EgovUserDetailsHelper.class, "egovUserDetailsService", auth);
+	}
+
+	@AfterEach
+	void tearDownStaticAuth() {
+		ReflectionTestUtils.setField(EgovUserDetailsHelper.class, "egovUserDetailsService", null);
+	}
+
+	private Method findMethod(String name) {
+		for (Method m : EgovDiaryManageController.class.getDeclaredMethods()) {
+			if (m.getName().equals(name)) {
+				return m;
+			}
+		}
+		throw new IllegalStateException(name + " 메서드를 찾을 수 없다");
+	}
+
+	private ModelMap invokeWithValidationError(String methodName) throws Throwable {
+		EgovDiaryManageController controller = new EgovDiaryManageController();
+		Method method = findMethod(methodName);
+		ExtendedModelMap model = new ExtendedModelMap();
+		boolean hasModelParam = false;
+		Class<?>[] types = method.getParameterTypes();
+		Object[] args = new Object[types.length];
+		for (int i = 0; i < types.length; i++) {
+			if (MultipartHttpServletRequest.class.isAssignableFrom(types[i])) {
+				args[i] = null;
+			} else if (Map.class.isAssignableFrom(types[i]) && !Model.class.isAssignableFrom(types[i])
+					&& !ModelMap.class.isAssignableFrom(types[i])) {
+				Map<String, Object> commandMap = new HashMap<>();
+				commandMap.put("cmd", "save");
+				args[i] = commandMap;
+			} else if (DiaryManageVO.class.isAssignableFrom(types[i])) {
+				args[i] = new DiaryManageVO();
+			} else if (ComDefaultVO.class.isAssignableFrom(types[i])) {
+				args[i] = new ComDefaultVO();
+			} else if (BindingResult.class.isAssignableFrom(types[i])) {
+				BindingResult bindingResult = new BeanPropertyBindingResult(new DiaryManageVO(), "diaryManageVO");
+				bindingResult.reject("validation.error");
+				args[i] = bindingResult;
+			} else if (RedirectAttributes.class.isAssignableFrom(types[i])) {
+				args[i] = new RedirectAttributesModelMap();
+			} else if (Model.class.isAssignableFrom(types[i]) || ModelMap.class.isAssignableFrom(types[i])) {
+				args[i] = model;
+				hasModelParam = true;
+			} else {
+				args[i] = null;
+			}
+		}
+		if (!hasModelParam) {
+			fail("검증 실패 재표시에 파일 업로드 제약값을 담을 Model 파라미터가 없다");
+		}
+		try {
+			method.invoke(controller, args);
+		} catch (InvocationTargetException e) {
+			throw e.getCause();
+		}
+		return model;
+	}
+
+	@Test
+	@DisplayName("일지 등록 검증 실패 시 파일 업로드 제약값을 model에 담는다")
+	void registActorRestoresFileUploadLimits() throws Throwable {
+		ModelMap model = invokeWithValidationError("diaryManageRegistActor");
+		assertTrue(model.containsAttribute("fileUploadMaxSize"),
+				"검증 실패 재표시 시 fileUploadMaxSize가 model에 있어야 checkFileSize 인자가 비지 않는다");
+		assertTrue(model.containsAttribute("fileUploadExtensions"), "fileUploadExtensions도 담겨야 한다");
+	}
+
+	@Test
+	@DisplayName("일지 수정 검증 실패 시 파일 업로드 제약값을 model에 담는다")
+	void modifyActorRestoresFileUploadLimits() throws Throwable {
+		ModelMap model = invokeWithValidationError("diaryManageModifyActor");
+		assertTrue(model.containsAttribute("fileUploadMaxSize"), "fileUploadMaxSize가 담겨야 한다");
+		assertTrue(model.containsAttribute("fileUploadExtensions"), "fileUploadExtensions가 담겨야 한다");
+	}
+}

--- a/src/test/java/egovframework/com/uss/olh/faq/web/EgovFaqControllerFileUploadRestoreTest.java
+++ b/src/test/java/egovframework/com/uss/olh/faq/web/EgovFaqControllerFileUploadRestoreTest.java
@@ -1,0 +1,91 @@
+package egovframework.com.uss.olh.faq.web;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.ui.ExtendedModelMap;
+import org.springframework.ui.Model;
+import org.springframework.ui.ModelMap;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.multipart.MultipartHttpServletRequest;
+
+import egovframework.com.uss.olh.faq.service.FaqVO;
+
+/**
+ * FAQ 등록·수정 저장 핸들러({@code insertFaqCn}·{@code updateFaqCn})의 검증 실패 재표시 경로가
+ * 파일 업로드 제약값({@code fileUploadExtensions}·{@code fileUploadMaxSize})을 model 에 담는지 검증한다.
+ *
+ * <p>재표시 JSP 는 이 값을 자바스크립트 인자로 그대로 출력한다. 값이 없으면
+ * {@code checkFileSize("egovComFileUploader", )} 가 되어 스크립트 블록 전체가 문법 오류로 죽고
+ * 저장 함수가 사라진다.</p>
+ *
+ * <p>수정 전후로 {@code insertFaqCn} 의 시그니처가 달라 리플렉션으로 호출한다.</p>
+ */
+class EgovFaqControllerFileUploadRestoreTest {
+
+	private Method findMethod(String name) {
+		for (Method m : EgovFaqController.class.getDeclaredMethods()) {
+			if (m.getName().equals(name)) {
+				return m;
+			}
+		}
+		throw new IllegalStateException(name + " 메서드를 찾을 수 없다");
+	}
+
+	private ModelMap invokeWithValidationError(String methodName) throws Throwable {
+		EgovFaqController controller = new EgovFaqController();
+		Method method = findMethod(methodName);
+		ExtendedModelMap model = new ExtendedModelMap();
+		boolean hasModelParam = false;
+		Class<?>[] types = method.getParameterTypes();
+		Object[] args = new Object[types.length];
+		for (int i = 0; i < types.length; i++) {
+			if (MultipartHttpServletRequest.class.isAssignableFrom(types[i])) {
+				args[i] = null;
+			} else if (FaqVO.class.isAssignableFrom(types[i])) {
+				args[i] = new FaqVO();
+			} else if (BindingResult.class.isAssignableFrom(types[i])) {
+				BindingResult bindingResult = new BeanPropertyBindingResult(new FaqVO(), "faqVO");
+				bindingResult.reject("validation.error");
+				args[i] = bindingResult;
+			} else if (Model.class.isAssignableFrom(types[i]) || ModelMap.class.isAssignableFrom(types[i])) {
+				args[i] = model;
+				hasModelParam = true;
+			} else {
+				args[i] = null;
+			}
+		}
+		if (!hasModelParam) {
+			fail("검증 실패 재표시에 파일 업로드 제약값을 담을 Model 파라미터가 없다");
+		}
+		try {
+			method.invoke(controller, args);
+		} catch (InvocationTargetException e) {
+			throw e.getCause();
+		}
+		return model;
+	}
+
+	@Test
+	@DisplayName("FAQ 등록 검증 실패 시 파일 업로드 제약값을 model에 담는다")
+	void insertFaqCnRestoresFileUploadLimits() throws Throwable {
+		ModelMap model = invokeWithValidationError("insertFaqCn");
+		assertTrue(model.containsAttribute("fileUploadMaxSize"),
+				"검증 실패 재표시 시 fileUploadMaxSize가 model에 있어야 checkFileSize 인자가 비지 않는다");
+		assertTrue(model.containsAttribute("fileUploadExtensions"), "fileUploadExtensions도 담겨야 한다");
+	}
+
+	@Test
+	@DisplayName("FAQ 수정 검증 실패 시 파일 업로드 제약값을 model에 담는다")
+	void updateFaqCnRestoresFileUploadLimits() throws Throwable {
+		ModelMap model = invokeWithValidationError("updateFaqCn");
+		assertTrue(model.containsAttribute("fileUploadMaxSize"), "fileUploadMaxSize가 담겨야 한다");
+		assertTrue(model.containsAttribute("fileUploadExtensions"), "fileUploadExtensions가 담겨야 한다");
+	}
+}


### PR DESCRIPTION
## 수정 사유

- [x] 버그수정
- [ ] 기능개선
- [ ] 리팩터링

## 변경 이유

일지관리 등록(`diaryManageRegistActor`)과 수정(`diaryManageModifyActor`)은 파일 업로드 제약값(`fileUploadExtensions`·`fileUploadMaxSize`)을 `RedirectAttributes`에 담습니다. 그런데 검증에 실패하면 목록으로 리다이렉트하지 않고 등록·수정 폼을 forward로 반환합니다.

```java
redirectAttributes.addAttribute("fileUploadExtensions", whiteListFileUploadExtensions);
redirectAttributes.addAttribute("fileUploadMaxSize", fileUploadMaxSize);
...
if (bindingResult.hasErrors()) {
    return sLocationUrl; // "egovframework/com/cop/smt/dsm/EgovDiaryManageRegist" (forward)
}
```

`RedirectAttributes`는 리다이렉트에서만 모델로 병합되므로 forward 뷰에는 전달되지 않습니다. 재표시된 JSP에서 `${fileUploadMaxSize}`가 비어 인라인 스크립트가 다음처럼 렌더됩니다.

```js
var resultSize = EgovMultiFilesChecker.checkFileSize("egovComFileUploader", ); // 인자 누락
```

빈 인자로 인한 자바스크립트 문법 오류로 해당 `<script>` 블록 전체가 파싱되지 않아 `fn_egov_save_DiaryManage`·`fn_egov_list_DiaryManage`가 정의되지 않습니다. 사용자는 검증 오류를 고쳐도 저장 버튼이 동작하지 않아 등록·수정을 마칠 수 없습니다.

표시 경로(`diaryManageRegist`)와 형제 컨트롤러(`EgovMemoReprtController`)는 같은 값을 `model`에 담고 있어 두 저장 핸들러만 잘못된 대상(`RedirectAttributes`)을 쓰고 있었습니다.

이 재표시는 서버측 검증(`@Valid`)이 실패할 때 나타납니다. 이 폼의 클라이언트 검증(`validateDiaryManageVO`)은 서버 제약을 필드별로 그대로 반영하므로 정상적인 브라우저에서 폼을 채워 저장할 때보다는 클라이언트 검증을 거치지 않는 요청 — 스크립트 비활성, 개발자도구·프록시를 통한 직접 POST, 비브라우저 클라이언트 등 — 에서 서버 검증 실패에 도달합니다. 클라이언트 검사는 신뢰 경계가 아니라 보조 UX이므로 서버는 이런 요청도 처리하며 그때 재표시 화면의 스크립트가 깨져 저장이 막힙니다.

## 변경 내용

두 저장 핸들러의 파일 업로드 제약값을 표시 경로·형제 컨트롤러와 동일하게 `model`에 담도록 바로잡습니다. 검증 실패 시 forward되는 뷰에 두 값이 정상 전달됩니다.

AS-IS
```java
redirectAttributes.addAttribute("fileUploadExtensions", whiteListFileUploadExtensions);
redirectAttributes.addAttribute("fileUploadMaxSize", fileUploadMaxSize);
```

TO-BE
```java
model.addAttribute("fileUploadExtensions", whiteListFileUploadExtensions);
model.addAttribute("fileUploadMaxSize", fileUploadMaxSize);
```

로그인 실패 시 리다이렉트에 쓰는 `redirectAttributes.addAttribute("message", ...)`는 리다이렉트 경로이므로 그대로 두었습니다.

## 영향 범위

- `EgovDiaryManageController`의 등록·수정 저장 핸들러 두 곳. 정상 저장 흐름(목록 리다이렉트)과 표시 경로는 그대로입니다.

## 테스트 방법

`EgovDiaryManageControllerFileUploadRestoreTest`를 추가했습니다. 등록·수정 저장 핸들러를 검증 실패 상태로 호출해 파일 업로드 제약값(`fileUploadExtensions`·`fileUploadMaxSize`)이 `model`에 담기는지 확인합니다. 정적 인증은 스텁으로 대체하고 수정 전후로 시그니처가 달라(수정 후 `ModelMap` 파라미터 추가) 리플렉션으로 호출합니다.

프로젝트 `pom.xml`이 `skipTests`를 기본값 true로 두므로 아래처럼 해제하고 실행합니다.

```
mvn -Dtest=EgovDiaryManageControllerFileUploadRestoreTest test
```

수정 전에는 두 값을 담을 `model` 파라미터가 없어 두 검증이 실패합니다.

```
[ERROR] Tests run: 2, Failures: 2, Errors: 0, Skipped: 0, Time elapsed: 0.131 s <<< FAILURE! -- in egovframework.com.cop.smt.dsm.web.EgovDiaryManageControllerFileUploadRestoreTest
[ERROR]   EgovDiaryManageControllerFileUploadRestoreTest.modifyActorRestoresFileUploadLimits:139->invokeWithValidationError:117 검증 실패 재표시에 파일 업로드 제약값을 담을 Model 파라미터가 없다
[ERROR]   EgovDiaryManageControllerFileUploadRestoreTest.registActorRestoresFileUploadLimits:130->invokeWithValidationError:117 검증 실패 재표시에 파일 업로드 제약값을 담을 Model 파라미터가 없다
```

수정 후에는 두 검증이 통과합니다.

```
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.144 s -- in egovframework.com.cop.smt.dsm.web.EgovDiaryManageControllerFileUploadRestoreTest
```

아래는 실제 화면 동작을 확인한 기록입니다. 미수정과 수정본을 같은 DB에 다른 포트로 띄우고 필수값을 비운 채 저장을 요청해 검증 실패를 유발한 뒤 재표시된 HTML의 스크립트를 확인했습니다.

미수정(RED)
```
checkFileSize("egovComFileUploader", )        ← 인자 없음(문법 오류)
```

수정본(GREEN)
```
checkFileSize("egovComFileUploader", 104857600)
checkExtensions("egovComFileUploader", ".gif,.jpg,.jpeg,.png,.xls,.xlsx")
```

미수정은 재표시 화면의 스크립트가 문법 오류로 저장 함수를 잃어 사용자가 오류를 고쳐도 저장할 수 없습니다. 수정본은 제약값이 정상 렌더되어 저장이 동작합니다.


---

## FAQ 등록·수정 추가 (2026-08-19)

같은 결함이 FAQ 등록·수정에도 있어 이 PR에 함께 담았습니다. 별건으로 내면 수정이 세 갈래로 흩어져 리뷰가 어려워집니다.

`insertFaqView`(`:142`)와 `updateFaqView`(`:216`)는 두 제약값을 `model`에 담는데, 같은 JSP를 다시 그리는 `insertFaqCn`(`:169`)과 `updateFaqCn`(`:251`)은 담지 않습니다. `updateFaqCn`은 `ModelMap`을 받아두고도 한 번도 쓰지 않습니다.

`EgovFaqRegist.jsp:60`과 `EgovFaqUpdt.jsp:60`이 그 값을 자바스크립트 인자로 그대로 출력합니다.

```jsp
var resultSize = EgovMultiFilesChecker.checkFileSize("egovComFileUploader", <c:out value='${fileUploadMaxSize}'/>);
```

일지관리와 같은 형태로 두 재표시 경로에 복원을 넣었고 `insertFaqCn`에는 담을 대상이 없어 `ModelMap` 파라미터를 추가했습니다.

### FAQ 테스트

`EgovFaqControllerFileUploadRestoreTest` 2건을 새로 넣었습니다. 일지관리 테스트와 같은 구조이며 수정 전후로 `insertFaqCn`의 시그니처가 달라 리플렉션으로 호출합니다.

수정 전(RED)

```
[ERROR] Tests run: 2, Failures: 2, Errors: 0, Skipped: 0, Time elapsed: 0.018 s <<< FAILURE! -- in egovframework.com.uss.olh.faq.web.EgovFaqControllerFileUploadRestoreTest
[ERROR]   EgovFaqControllerFileUploadRestoreTest.insertFaqCnRestoresFileUploadLimits:78->invokeWithValidationError:65 검증 실패 재표시에 파일 업로드 제약값을 담을 Model 파라미터가 없다
[ERROR]   EgovFaqControllerFileUploadRestoreTest.updateFaqCnRestoresFileUploadLimits:88 fileUploadMaxSize가 담겨야 한다 ==> expected: <true> but was: <false>
```

수정 후(GREEN, 일지관리 테스트와 함께)

```
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.139 s -- in egovframework.com.uss.olh.faq.web.EgovFaqControllerFileUploadRestoreTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.013 s -- in egovframework.com.cop.smt.dsm.web.EgovDiaryManageControllerFileUploadRestoreTest
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```
