### PR TITLE
fix: 방언 매퍼 namespace 불일치로 오라클 장애처리·티베로 부서관리가 전면 실패하는 문제 수정

### DIFF
--- a/src/main/resources/egovframework/mapper/com/sym/tbm/tbp/EgovTroblProcess_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/sym/tbm/tbp/EgovTroblProcess_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="troblProcessDA">
+<mapper namespace="troblProcessDAO">
 
     <resultMap id="troblProcess" type="egovframework.com.sym.tbm.tbp.service.TroblProcessVO">
         <result property="troblId" column="TROBL_ID"/>

--- a/src/main/resources/egovframework/mapper/com/uss/umt/EgovDeptManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/umt/EgovDeptManage_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="DeptManage">
+<mapper namespace="deptManageDAO">
 
     <resultMap id="deptManageVO" type="egovframework.com.uss.umt.service.DeptManageVO">
         <result property="orgnztId" column="ORGNZT_ID"/>

--- a/src/test/java/egovframework/com/sym/tbm/tbp/service/impl/EgovTroblProcessMapperNamespaceTest.java
+++ b/src/test/java/egovframework/com/sym/tbm/tbp/service/impl/EgovTroblProcessMapperNamespaceTest.java
@@ -1,0 +1,64 @@
+package egovframework.com.sym.tbm.tbp.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.ibatis.builder.xml.XMLMapperBuilder;
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.session.Configuration;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * 장애처리 매퍼가 8개 DB 방언 모두에서 {@link TroblProcessDAO}가 호출하는 statement id를
+ * 등록하는지 검증한다.
+ *
+ * <p>{@code context-mapper.xml}의 {@code mapperLocations}가
+ * {@code classpath:/egovframework/mapper/com/**}{@code /*_${Globals.DbType}.xml}이므로 런타임에는
+ * 방언 매퍼가 하나만 로드된다. 따라서 특정 방언의 매퍼 namespace가 다르면 그 DB에서만
+ * {@code Mapped Statements collection does not contain value} 로 기능 전체가 실패한다.</p>
+ *
+ * <p>매퍼가 완전수식 클래스명과 로컬 resultMap만 사용하므로 실제 DB 연결 없이 매퍼 파싱만으로
+ * 검증된다.</p>
+ */
+class EgovTroblProcessMapperNamespaceTest {
+
+	/** TroblProcessDAO가 하드코딩해 호출하는 statement id. */
+	private static final String[] CALLED_STATEMENT_IDS = {
+		"troblProcessDAO.selectTroblProcessList",
+		"troblProcessDAO.selectTroblProcessListTotCnt",
+		"troblProcessDAO.selectTroblProcess",
+		"troblProcessDAO.insertTroblProcess",
+		"troblProcessDAO.deleteTroblProcess"
+	};
+
+	private Configuration loadMapper(String dialect) throws Exception {
+		String resource = "egovframework/mapper/com/sym/tbm/tbp/EgovTroblProcess_SQL_" + dialect + ".xml";
+		Configuration configuration = new Configuration();
+		try (InputStream inputStream = Resources.getResourceAsStream(resource)) {
+			new XMLMapperBuilder(inputStream, configuration, resource, configuration.getSqlFragments()).parse();
+		}
+		return configuration;
+	}
+
+	@ParameterizedTest(name = "{0}")
+	@ValueSource(strings = { "mysql", "maria", "oracle", "postgres", "tibero", "altibase", "cubrid", "goldilocks" })
+	@DisplayName("모든 방언 매퍼가 TroblProcessDAO가 호출하는 statement id를 등록한다")
+	void mapperRegistersStatementIdsCalledByDao(String dialect) throws Exception {
+		Configuration configuration = loadMapper(dialect);
+
+		List<String> missing = new ArrayList<>();
+		for (String statementId : CALLED_STATEMENT_IDS) {
+			if (!configuration.hasStatement(statementId, false)) {
+				missing.add(statementId);
+			}
+		}
+
+		assertTrue(missing.isEmpty(),
+			dialect + " 매퍼에 TroblProcessDAO가 호출하는 statement가 등록되지 않았다: " + missing);
+	}
+}

--- a/src/test/java/egovframework/com/uss/umt/service/impl/EgovDeptManageMapperNamespaceTest.java
+++ b/src/test/java/egovframework/com/uss/umt/service/impl/EgovDeptManageMapperNamespaceTest.java
@@ -1,0 +1,65 @@
+package egovframework.com.uss.umt.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.ibatis.builder.xml.XMLMapperBuilder;
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.session.Configuration;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * 부서관리 매퍼가 8개 DB 방언 모두에서 {@link DeptManageDAO}가 호출하는 statement id를
+ * 등록하는지 검증한다.
+ *
+ * <p>{@code context-mapper.xml}의 {@code mapperLocations}가
+ * {@code classpath:/egovframework/mapper/com/**}{@code /*_${Globals.DbType}.xml}이므로 런타임에는
+ * 방언 매퍼가 하나만 로드된다. 따라서 특정 방언의 매퍼 namespace가 다르면 그 DB에서만
+ * {@code Mapped Statements collection does not contain value} 로 기능 전체가 실패한다.</p>
+ *
+ * <p>매퍼가 완전수식 클래스명과 로컬 resultMap만 사용하므로 실제 DB 연결 없이 매퍼 파싱만으로
+ * 검증된다.</p>
+ */
+class EgovDeptManageMapperNamespaceTest {
+
+	/** DeptManageDAO가 하드코딩해 호출하는 statement id. */
+	private static final String[] CALLED_STATEMENT_IDS = {
+		"deptManageDAO.selectDeptManageList",
+		"deptManageDAO.selectDeptManageListTotCnt",
+		"deptManageDAO.selectDeptManage",
+		"deptManageDAO.insertDeptManage",
+		"deptManageDAO.updateDeptManage",
+		"deptManageDAO.deleteDeptManage"
+	};
+
+	private Configuration loadMapper(String dialect) throws Exception {
+		String resource = "egovframework/mapper/com/uss/umt/EgovDeptManage_SQL_" + dialect + ".xml";
+		Configuration configuration = new Configuration();
+		try (InputStream inputStream = Resources.getResourceAsStream(resource)) {
+			new XMLMapperBuilder(inputStream, configuration, resource, configuration.getSqlFragments()).parse();
+		}
+		return configuration;
+	}
+
+	@ParameterizedTest(name = "{0}")
+	@ValueSource(strings = { "mysql", "maria", "oracle", "postgres", "tibero", "altibase", "cubrid", "goldilocks" })
+	@DisplayName("모든 방언 매퍼가 DeptManageDAO가 호출하는 statement id를 등록한다")
+	void mapperRegistersStatementIdsCalledByDao(String dialect) throws Exception {
+		Configuration configuration = loadMapper(dialect);
+
+		List<String> missing = new ArrayList<>();
+		for (String statementId : CALLED_STATEMENT_IDS) {
+			if (!configuration.hasStatement(statementId, false)) {
+				missing.add(statementId);
+			}
+		}
+
+		assertTrue(missing.isEmpty(),
+			dialect + " 매퍼에 DeptManageDAO가 호출하는 statement가 등록되지 않았다: " + missing);
+	}
+}


### PR DESCRIPTION
## 수정 사유

- [x] 버그수정
- [ ] 기능개선
- [ ] 리팩터링

## 변경 이유

방언별 매퍼 XML의 namespace가 DAO가 호출하는 이름과 어긋난 곳이 두 곳 있습니다.

```xml
<!-- EgovTroblProcess_SQL_oracle.xml (나머지 7개 방언은 troblProcessDAO) -->
<mapper namespace="troblProcessDA">

<!-- EgovDeptManage_SQL_tibero.xml (나머지 7개 방언은 deptManageDAO) -->
<mapper namespace="DeptManage">
```

`TroblProcessDAO`는 `troblProcessDAO.*` 5개를, `DeptManageDAO`는 `deptManageDAO.*` 6개를 하드코딩해 호출합니다. `context-mapper.xml`의 `mapperLocations`는 `classpath:/egovframework/mapper/com/**/*_${Globals.DbType}.xml`이라 런타임에는 방언 매퍼가 하나만 로드되므로 다른 방언 파일이 대신 등록해 줄 수 없습니다. 결과적으로

- `Globals.DbType=oracle` 환경에서는 장애처리결과관리 메뉴 전체(목록·상세·등록·삭제)가
- `Globals.DbType=tibero` 환경에서는 부서관리 메뉴 전체(목록·상세·등록·수정·삭제)가

첫 진입인 목록 조회부터 `Mapped Statements collection does not contain value for ...` 예외로 동작하지 않습니다. 두 화면 모두 `@IncludedInfo`로 기능목록 메뉴에 노출되는 살아있는 화면입니다. 잘못된 namespace(`troblProcessDA`·`DeptManage`)를 참조하는 코드는 저장소 어디에도 없어 오타로 판단했습니다. 기본값이 `Globals.DbType = mysql`이라 지금까지 드러나지 않은 것으로 보입니다.

전 매퍼 8방언×153개 패밀리의 namespace를 대조한 결과 이 유형의 불일치는 위 2건이 전부입니다. 방언 매퍼의 잘못된 참조를 바로잡은 선례로 #781(postgres 매퍼의 query id 정정)이 병합돼 있습니다.

## 변경 내용

두 파일의 namespace를 나머지 7개 방언과 동일하게 맞춥니다.

AS-IS
```xml
<mapper namespace="troblProcessDA">   <!-- oracle -->
<mapper namespace="DeptManage">       <!-- tibero -->
```

TO-BE
```xml
<mapper namespace="troblProcessDAO">
<mapper namespace="deptManageDAO">
```

두 매퍼 모두 statement id 5·6종은 8개 방언이 이미 동일해 namespace만 어긋나 있었습니다. 매퍼 내부의 `resultMap` 참조는 namespace-local이라 함께 이동하며 `<include refid>`·`cache-ref` 등 외부 참조는 없습니다.

## 영향 범위

- 오라클의 장애처리결과관리(`/sym/tbm/tbp/*`), 티베로의 부서관리(`/uss/umt/dpt/*`) 경로가 정상 동작하게 됩니다.
- 다른 방언과 다른 기능에는 변화가 없습니다. 두 namespace의 기존 참조처가 없으므로 깨지는 곳도 없습니다.

## 테스트 방법

`EgovTroblProcessMapperNamespaceTest`·`EgovDeptManageMapperNamespaceTest`를 추가했습니다. 방언 8종 매퍼를 각각 파싱해 DAO가 호출하는 statement id가 등록되는지 확인합니다. 매퍼가 완전수식 클래스명과 로컬 resultMap만 사용해 DB 없이 실행됩니다. 로딩 방식은 런타임(`SqlSessionFactoryBean`)과 같은 `XMLMapperBuilder` 경로입니다.

프로젝트 `pom.xml`이 `skipTests`를 기본값 true로 두므로 아래처럼 해제하고 실행합니다.

```
mvn -Dtest='EgovTroblProcessMapperNamespaceTest,EgovDeptManageMapperNamespaceTest' test
```

수정 전에는 오라클·티베로 케이스만 실패합니다.

```
[ERROR] Tests run: 8, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.231 s <<< FAILURE! -- in egovframework.com.sym.tbm.tbp.service.impl.EgovTroblProcessMapperNamespaceTest
[ERROR]   EgovTroblProcessMapperNamespaceTest.mapperRegistersStatementIdsCalledByDao:61 oracle 매퍼에 TroblProcessDAO가 호출하는 statement가 등록되지 않았다: [troblProcessDAO.selectTroblProcessList, troblProcessDAO.selectTroblProcessListTotCnt, troblProcessDAO.selectTroblProcess, troblProcessDAO.insertTroblProcess, troblProcessDAO.deleteTroblProcess] ==> expected: <true> but was: <false>
```

```
[ERROR] Tests run: 8, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.225 s <<< FAILURE! -- in egovframework.com.uss.umt.service.impl.EgovDeptManageMapperNamespaceTest
[ERROR]   EgovDeptManageMapperNamespaceTest.mapperRegistersStatementIdsCalledByDao:62 tibero 매퍼에 DeptManageDAO가 호출하는 statement가 등록되지 않았다: [deptManageDAO.selectDeptManageList, deptManageDAO.selectDeptManageListTotCnt, deptManageDAO.selectDeptManage, deptManageDAO.insertDeptManage, deptManageDAO.updateDeptManage, deptManageDAO.deleteDeptManage] ==> expected: <true> but was: <false>
```

수정 후에는 16개 케이스가 모두 통과합니다.

```
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.189 s -- in egovframework.com.sym.tbm.tbp.service.impl.EgovTroblProcessMapperNamespaceTest
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.028 s -- in egovframework.com.uss.umt.service.impl.EgovDeptManageMapperNamespaceTest
[INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```
