### PR TITLE
fix(X연동): RestTemplate connect/read 타임아웃 설정 (무응답 무한 블록 방지, CWE-400)

### DIFF
--- a/src/main/java/egovframework/com/uss/ion/tir/service/EgovXClient.java
+++ b/src/main/java/egovframework/com/uss/ion/tir/service/EgovXClient.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.client.RestTemplate;
@@ -30,7 +31,11 @@ public class EgovXClient {
      * REST API 호출용 RestTemplate을 초기화한다.
      */
     public EgovXClient() {
-        this.restTemplate = new RestTemplate();
+        // 안정성: 외부 X(Twitter) API 무응답 시 스레드 무한 블록 방지(CWE-400)
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(5000);
+        factory.setReadTimeout(30000);
+        this.restTemplate = new RestTemplate(factory);
     }
 
     /**

--- a/src/main/java/egovframework/com/uss/ion/tir/service/EgovXOAuthService.java
+++ b/src/main/java/egovframework/com/uss/ion/tir/service/EgovXOAuthService.java
@@ -15,6 +15,7 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.client.RestTemplate;
@@ -37,7 +38,18 @@ public class EgovXOAuthService {
     private static final Pattern ACCESS_TOKEN_PATTERN =
             Pattern.compile("\"access_token\"\\s*:\\s*\"([^\"]+)\"");
 
-    private final RestTemplate restTemplate = new RestTemplate();
+    // 안정성: 기본 RestTemplate 은 connect/read 타임아웃이 없어(무한 대기) 외부 X(Twitter)
+    // API 무응답 시 호출 스레드가 영구 블록될 수 있다(CWE-400). 타임아웃을 설정해 사용한다.
+    private static final int CONNECT_TIMEOUT_MS = 5000;
+    private static final int READ_TIMEOUT_MS = 30000;
+    private final RestTemplate restTemplate = createRestTemplate();
+
+    private static RestTemplate createRestTemplate() {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(CONNECT_TIMEOUT_MS);
+        factory.setReadTimeout(READ_TIMEOUT_MS);
+        return new RestTemplate(factory);
+    }
 
     /**
      * state별로 PKCE verifier와 client 인증정보를 함께 보관하기 위한 컨텍스트 객체.


### PR DESCRIPTION
## 요약
Twitter(X) 연동 서비스 2개가 기본 `RestTemplate`(타임아웃 없음)으로 외부 X API(`api.x.com`)를 호출합니다. 무응답 시 호출 스레드가 무한 대기하는 **CWE-400 자원 고갈**을 수정합니다.

## 문제 (재현)
- `EgovXOAuthService`: `private final RestTemplate restTemplate = new RestTemplate();` — `requestAccessToken()`이 `https://api.x.com/2/oauth2/token`에 `postForEntity` 호출.
- `EgovXClient`: 생성자에서 `new RestTemplate()` — `api.x.com/2` REST API를 `exchange`/`postForEntity`로 호출.
- 기본 `SimpleClientHttpRequestFactory`는 connect/read 타임아웃이 0(무한)이라, X 서버가 응답하지 않으면 요청 처리 스레드가 영구 블록됩니다.
- 재현(소켓 레벨, 무응답 서버 모사): 타임아웃 미설정은 3초 관찰에도 **무한 블록**, 설정 시 `SocketTimeoutException`으로 3초에 복귀.

## 수정
타임아웃을 설정한 요청 팩토리로 `RestTemplate`을 구성합니다(connect 5s / read 30s).
```java
SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
factory.setConnectTimeout(5000);
factory.setReadTimeout(30000);
return new RestTemplate(factory);
```

## 검증
- 소켓 레벨 재현 하네스로 무한 블록 → 타임아웃 복귀 확인.
- 스텁 `javac` 컴파일 통과. 공개 시그니처·호출 로직 불변(EgovXClient +6/−1, EgovXOAuthService +13/−1).

## 비고
- 동일 결함(외부 호출 타임아웃 부재)은 코드수신 서비스(#1134)에서 별도로 다룹니다. 본 PR은 **X 연동 계열**로 범위를 좁혔습니다.
- 타임아웃 값(5s/30s)은 보수적 기본값이며 운영 정책에 맞춰 조정 가능합니다.