### PR TITLE
fix(EgovEhgtCalcUtil): 외부 URL openConnection 타임아웃 설정 (무응답 무한 블록 방지, CWE-400)

### DIFF
--- a/src/main/java/egovframework/com/utl/fcc/service/EgovEhgtCalcUtil.java
+++ b/src/main/java/egovframework/com/utl/fcc/service/EgovEhgtCalcUtil.java
@@ -76,6 +76,9 @@ public class EgovEhgtCalcUtil {
 			URL url = new URL(EHGT_URL + str);
 
 			con = (HttpURLConnection) url.openConnection();
+			// 안정성: 외부 URL 무응답 시 스레드 무한 블록 방지(CWE-400)
+			con.setConnectTimeout(5000);
+			con.setReadTimeout(30000);
 
 			try (InputStream is = con.getInputStream();
 					InputStreamReader reader = new InputStreamReader(is, "euc-kr");) {


### PR DESCRIPTION
## 요약
`EgovEhgtCalcUtil.readHtmlParsing()`가 외부 URL의 HTML을 기본 `openConnection()`(타임아웃 없음)으로 읽습니다. 원격 서버 무응답 시 호출 스레드가 무한 대기하는 **CWE-400 자원 고갈**을 수정합니다.

## 문제 (재현)
```java
con = (HttpURLConnection) url.openConnection();
try (InputStream is = con.getInputStream(); ...) { ... }   // 타임아웃 없음
```
`HttpURLConnection`은 기본 connect/read 타임아웃이 0(무한)이라, 외부 서버가 응답하지 않으면 `getInputStream()`에서 스레드가 영구 블록됩니다.
- 재현(소켓 레벨, 무응답 서버 모사): 타임아웃 미설정은 3초 관찰에도 **무한 블록**, 설정 시 `SocketTimeoutException`으로 3초에 복귀.

## 수정
`openConnection()` 직후 타임아웃을 설정합니다(connect 5s / read 30s).
```java
con = (HttpURLConnection) url.openConnection();
con.setConnectTimeout(5000);
con.setReadTimeout(30000);
```

## 검증
- 소켓 레벨 재현 하네스로 무한 블록 → 타임아웃 복귀 확인.
- 표준 `URLConnection` setter 2줄 추가(신규 import 불필요), 기존 로직·리소스 관리(try-with-resources·finally) 불변. 순수 추가(+3 / −0).

## 비고
동일 축(외부 호출 타임아웃 부재)의 다른 지점은 코드수신 서비스(#1134)·X 연동(#1188)에서 별도로 다룹니다. 타임아웃 값은 보수적 기본값이며 조정 가능합니다.