### PR TITLE
fix: 뷰 이름 인젝션 검사의 Locale 의존 대문자 변환 우회 수정 (WEB-INF, CWE-176)

### DIFF
--- a/src/main/java/egovframework/com/cop/cmy/web/EgovCommuManageController.java
+++ b/src/main/java/egovframework/com/cop/cmy/web/EgovCommuManageController.java
@@ -32,6 +32,7 @@ import egovframework.com.cop.tpl.service.EgovTemplateManageService;
 import egovframework.com.cop.tpl.service.TemplateInfVO;
 import egovframework.com.utl.fcc.service.EgovStringUtil;
 import jakarta.annotation.Resource;
+import java.util.Locale;
 import jakarta.servlet.http.HttpServletRequest;
 
 /**
@@ -539,7 +540,7 @@ public class EgovCommuManageController {
 
 		// 뷰 이름 인젝션 방지 - forward:/redirect: 등 스킴 접두사나 콜론이 포함된 값,
 		// 화이트리스트 등록값이라도 WEB-INF 등 애플리케이션 내부 자원을 가리키는 값은 뷰 이름으로 사용할 수 없다.
-		if (tmplatCours.contains(":") || tmplatCours.startsWith("/") || tmplatCours.toUpperCase().contains("WEB-INF")) {
+		if (tmplatCours.contains(":") || tmplatCours.startsWith("/") || tmplatCours.toUpperCase(Locale.ROOT).contains("WEB-INF")) {
 			LOGGER.debug("Template > Unsafe tmplatCours rejected: {}", tmplatCours);
 			return "egovframework/com/cmm/egovError";
 		}

--- a/src/main/java/egovframework/com/uss/ion/pwm/web/EgovPopupManageController.java
+++ b/src/main/java/egovframework/com/uss/ion/pwm/web/EgovPopupManageController.java
@@ -31,6 +31,7 @@ import egovframework.com.uss.ion.pwm.service.PopupManageVO;
 import egovframework.com.utl.fcc.service.EgovStringUtil;
 import jakarta.annotation.Resource;
 import jakarta.servlet.http.HttpServletResponse;
+import java.util.Locale;
 import jakarta.validation.Valid;
 
 /**
@@ -393,7 +394,7 @@ public class EgovPopupManageController {
 
 		// 뷰 이름 인젝션 방지 - forward:/redirect: 등 스킴 접두사나 콜론이 포함된 값,
 		// 화이트리스트 등록값이라도 WEB-INF 등 애플리케이션 내부 자원을 가리키는 값은 뷰 이름으로 사용할 수 없다.
-		if (fileUrl2.contains(":") || fileUrl2.startsWith("/") || fileUrl2.toUpperCase().contains("WEB-INF")) {
+		if (fileUrl2.contains(":") || fileUrl2.startsWith("/") || fileUrl2.toUpperCase(Locale.ROOT).contains("WEB-INF")) {
 			LOGGER.debug("Open Popup > Unsafe fileUrl rejected: {}", fileUrl2);
 			return "egovframework/com/cmm/egovError";
 		}


### PR DESCRIPTION
## 요약
뷰 이름 인젝션을 막는 보안 검사가 사용자 입력을 **Locale 미지정 `toUpperCase()`** 로 변환해 `"WEB-INF"` 포함 여부를 판단합니다. 터키어 등 일부 로케일에서 대문자 변환 규칙 차이로 **검사가 우회**됩니다(CWE-176 Improper Handling of Unicode Encoding / 로케일 의존 케이스 변환).

## 문제 (재현)
두 컨트롤러의 동일 패턴:
```java
if (v.contains(":") || v.startsWith("/") || v.toUpperCase().contains("WEB-INF")) { ... 차단 ... }
```
터키어 로케일에서 `"web-inf".toUpperCase()` = `"WEB-İNF"`(점 있는 대문자 İ)라, ASCII `"WEB-INF"` 를 `contains` 하지 못해 통과됩니다.

- 대상: `EgovCommuManageController`(tmplatCours), `EgovPopupManageController`(fileUrl2) — 둘 다 뷰 이름 인젝션 방지 검사.
- 실증(JDK17): 공격 입력 `templates/web-inf/secret.jsp`(콜론 없음·`/`로 시작 안 함 → 앞 두 조건 회피, WEB-INF 조건만이 차단 근거)
  - **기존**: EN 로케일 차단=true, **TR 로케일 차단=false (우회)**
  - **수정**: TR 로케일 차단=true (정상 차단)
  - 정상 입력(`templates/normal_view`)은 두 경우 모두 차단 안 됨 → 동작 불변

## 수정
로케일 독립적인 `Locale.ROOT` 를 명시합니다.
```java
v.toUpperCase(Locale.ROOT).contains("WEB-INF")
```
각 파일에 `import java.util.Locale;` 추가 + 호출 1곳 수정(각 +2/−1).

## 영향 범위
- 보안 검사의 로케일 우회만 제거. 정상 입력 동작·공개 시그니처 불변. `String.toUpperCase(Locale)` 은 표준 JDK API.
- 서버 기본 로케일이 터키어/아제르바이잔어 등으로 설정된 환경에서 특히 유효합니다.