### PR TITLE
feat: 한글 초성 추출·초성 검색 유틸 추가

### DIFF
--- a/src/main/java/egovframework/com/utl/fcc/service/EgovHangulSearchUtil.java
+++ b/src/main/java/egovframework/com/utl/fcc/service/EgovHangulSearchUtil.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright The eGovFrame Open Community (http://open.egovframe.go.kr)).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package egovframework.com.utl.fcc.service;
+
+/**
+ * 한글 초성 추출 및 초성 검색 유틸리티.
+ *
+ * <p>한글 음절(가~힣)의 초성을 유니코드 산술로 추출해, "ㅅㅅ"으로 "삼성"을 찾는 초성 검색을 제공한다.
+ * 게시판·행정용어·기관명 등 한국어 목록의 빠른 필터링에 사용한다. 초성은 키보드 입력과 동일한
+ * 호환 자모(U+3131~)로 산출한다.</p>
+ *
+ * @author z3rotig4r
+ * @since 2026.07.28
+ * @version 1.0
+ */
+public final class EgovHangulSearchUtil {
+
+	private static final char HANGUL_BASE = 0xAC00; // '가'
+	private static final char HANGUL_LAST = 0xD7A3; // '힣'
+	private static final int JUNGSUNG_COUNT = 21;
+	private static final int JONGSUNG_COUNT = 28;
+	private static final int SYLLABLE_BLOCK = JUNGSUNG_COUNT * JONGSUNG_COUNT; // 588
+
+	/** 초성 19자(호환 자모). */
+	private static final char[] CHOSUNG = { 'ㄱ', 'ㄲ', 'ㄴ', 'ㄷ', 'ㄸ', 'ㄹ', 'ㅁ', 'ㅂ', 'ㅃ', 'ㅅ', 'ㅆ', 'ㅇ', 'ㅈ', 'ㅉ',
+			'ㅊ', 'ㅋ', 'ㅌ', 'ㅍ', 'ㅎ' };
+
+	private EgovHangulSearchUtil() {
+	}
+
+	/**
+	 * 문자열의 각 한글 음절을 초성으로 치환한 문자열을 반환한다. 한글 음절이 아닌 문자는 그대로 둔다.
+	 *
+	 * <pre>
+	 * extractChosung("삼성전자")   = "ㅅㅅㅈㅈ"
+	 * extractChosung("가나다")     = "ㄱㄴㄷ"
+	 * extractChosung("A동 101호")  = "A동 101호" 중 한글만 초성화 → "A동" 유지 규칙에 따름
+	 * </pre>
+	 *
+	 * @param text 원본 문자열
+	 * @return 초성 치환 문자열(null 입력은 빈 문자열)
+	 */
+	public static String extractChosung(String text) {
+		if (text == null) {
+			return "";
+		}
+		StringBuilder sb = new StringBuilder(text.length());
+		for (int i = 0; i < text.length(); i++) {
+			char ch = text.charAt(i);
+			if (isHangulSyllable(ch)) {
+				sb.append(CHOSUNG[(ch - HANGUL_BASE) / SYLLABLE_BLOCK]);
+			} else {
+				sb.append(ch);
+			}
+		}
+		return sb.toString();
+	}
+
+	/**
+	 * 텍스트의 초성열이 초성 질의를 부분 문자열로 포함하는지 확인한다.
+	 *
+	 * <pre>
+	 * matchesChosung("삼성전자", "ㅅㅅ")   = true  (삼성)
+	 * matchesChosung("삼성전자", "ㅅㅈ")   = true  (성전 — 초성열의 연속 부분)
+	 * matchesChosung("삼성전자", "ㅈㅅ")   = false (역순 초성은 불일치)
+	 * </pre>
+	 *
+	 * @param text  대상 텍스트
+	 * @param query 초성 질의(예: "ㅅㅅ"). 일반 한글 음절이 섞이면 그 음절의 초성으로 정규화한다.
+	 * @return 초성 검색 매칭 여부. query가 비어 있으면 true.
+	 */
+	public static boolean matchesChosung(String text, String query) {
+		if (EgovStringUtil.isEmpty(query)) {
+			return true;
+		}
+		if (text == null) {
+			return false;
+		}
+		return extractChosung(text).contains(normalizeQuery(query));
+	}
+
+	/**
+	 * 한글 음절 여부.
+	 *
+	 * @param ch 문자
+	 * @return 가~힣 범위이면 true
+	 */
+	public static boolean isHangulSyllable(char ch) {
+		return ch >= HANGUL_BASE && ch <= HANGUL_LAST;
+	}
+
+	/** 질의에 완성형 한글 음절이 섞이면 초성으로 바꾼다(호환 자모·기타 문자는 그대로). */
+	private static String normalizeQuery(String query) {
+		StringBuilder sb = new StringBuilder(query.length());
+		for (int i = 0; i < query.length(); i++) {
+			char ch = query.charAt(i);
+			if (isHangulSyllable(ch)) {
+				sb.append(CHOSUNG[(ch - HANGUL_BASE) / SYLLABLE_BLOCK]);
+			} else {
+				sb.append(ch);
+			}
+		}
+		return sb.toString();
+	}
+}

--- a/src/test/java/egovframework/com/utl/fcc/service/EgovHangulSearchUtilTest.java
+++ b/src/test/java/egovframework/com/utl/fcc/service/EgovHangulSearchUtilTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright The eGovFrame Open Community (http://open.egovframe.go.kr)).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package egovframework.com.utl.fcc.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@link EgovHangulSearchUtil}의 초성 추출·초성 검색을 검증한다.
+ */
+class EgovHangulSearchUtilTest {
+
+	@Test
+	void extractChosung_basic() {
+		assertEquals("ㅅㅅㅈㅈ", EgovHangulSearchUtil.extractChosung("삼성전자"));
+		assertEquals("ㄱㄴㄷ", EgovHangulSearchUtil.extractChosung("가나다"));
+		assertEquals("ㅎ", EgovHangulSearchUtil.extractChosung("힣"));
+		assertEquals("ㄱ", EgovHangulSearchUtil.extractChosung("가"));
+	}
+
+	@Test
+	void extractChosung_keepsNonHangul() {
+		assertEquals("Aㄷ 101ㅎ", EgovHangulSearchUtil.extractChosung("A동 101호"));
+		assertEquals("", EgovHangulSearchUtil.extractChosung(null));
+		assertEquals("hello", EgovHangulSearchUtil.extractChosung("hello"));
+	}
+
+	@Test
+	void matchesChosung_search() {
+		assertTrue(EgovHangulSearchUtil.matchesChosung("삼성전자", "ㅅㅅ"));
+		assertTrue(EgovHangulSearchUtil.matchesChosung("삼성전자", "ㅈㅈ"));
+		assertTrue(EgovHangulSearchUtil.matchesChosung("삼성전자", "ㅅㅈ"), "성전 = ㅅㅈ 연속 매칭");
+		assertFalse(EgovHangulSearchUtil.matchesChosung("삼성전자", "ㅈㅅ"), "역순 초성은 불일치");
+		assertTrue(EgovHangulSearchUtil.matchesChosung("행정안전부", "ㅎㅈ"));
+		assertFalse(EgovHangulSearchUtil.matchesChosung("행정안전부", "ㅁㅁ"));
+	}
+
+	@Test
+	void matchesChosung_edgeCases() {
+		assertTrue(EgovHangulSearchUtil.matchesChosung("무엇이든", ""), "빈 질의는 매칭");
+		assertFalse(EgovHangulSearchUtil.matchesChosung(null, "ㅅ"), "null 텍스트는 불일치");
+	}
+
+	@Test
+	void matchesChosung_normalizesSyllableQuery() {
+		// 질의에 완성형 음절이 섞이면 초성으로 정규화하여 비교한다.
+		assertTrue(EgovHangulSearchUtil.matchesChosung("삼성전자", "삼ㅅ"), "'삼'→'ㅅ'로 정규화되어 'ㅅㅅ' 매칭");
+	}
+
+	@Test
+	void isHangulSyllable() {
+		assertTrue(EgovHangulSearchUtil.isHangulSyllable('가'));
+		assertTrue(EgovHangulSearchUtil.isHangulSyllable('힣'));
+		assertFalse(EgovHangulSearchUtil.isHangulSyllable('ㄱ'), "호환 자모는 음절이 아니다");
+		assertFalse(EgovHangulSearchUtil.isHangulSyllable('A'));
+	}
+}


### PR DESCRIPTION
## 배경

한국어 목록(게시판·행정용어·기관명 등)에서 "ㅅㅅ"으로 "삼성"을 찾는 초성 검색은 흔한 요구입니다. 코드베이스에 `AdministrationWordVO.choseongA`·`choseongB` 같은 초성 검색용 필드는 있으나, 초성을 산출하는 Java 로직은 없어 DB 저장·수기 채움에 의존합니다.

## 기능

`EgovHangulSearchUtil`은 한글 음절(가~힣)의 초성을 유니코드 산술로 추출합니다.

- `extractChosung(text)`: 각 한글 음절을 초성(키보드 입력과 동일한 호환 자모)으로 치환하고, 비한글 문자는 그대로 둡니다. 예) "삼성전자" → "ㅅㅅㅈㅈ"
- `matchesChosung(text, query)`: 텍스트의 초성열이 초성 질의를 부분 문자열로 포함하는지 판정합니다. 질의에 완성형 음절이 섞이면 초성으로 정규화합니다.
- `isHangulSyllable(char)`: 한글 음절 여부.

## 설계

기존 클래스를 수정하지 않는 순수 유틸(가산형)입니다. 유니코드 산술(0xAC00 기반, 초성 19자)이라 외부 기준에 의존하지 않고 결정적입니다.

## 검증

초성 추출·비한글 유지·초성 검색·완성형 질의 정규화·경계(가·힣)·호환 자모 구분 단위 테스트를 추가했습니다.