### PR TITLE
feat: 숫자 금액을 한글로 표기하는 유틸 추가

### DIFF
--- a/src/main/java/egovframework/com/utl/fcc/service/EgovKoreanCurrencyUtil.java
+++ b/src/main/java/egovframework/com/utl/fcc/service/EgovKoreanCurrencyUtil.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright The eGovFrame Open Community (http://open.egovframe.go.kr)).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package egovframework.com.utl.fcc.service;
+
+import java.text.DecimalFormat;
+
+/**
+ * 숫자 금액을 한글로 표기하는 유틸리티.
+ *
+ * <p>지출결의서·계약서·세금계산서 등 공문서에서 금액 위·변조 방지를 위해 아라비아 숫자 옆에 한글 금액을
+ * 병기하는 한국 행정 관행을 지원한다. 위·변조 방지 표기 관례에 따라 자리 계수가 1이어도 "일"을 표기한다
+ * (예: 1,000 → "일천", 10,000 → "일만").</p>
+ *
+ * @author z3rotig4r
+ * @since 2026.07.28
+ * @version 1.0
+ */
+public final class EgovKoreanCurrencyUtil {
+
+	private static final char[] DIGITS = { '영', '일', '이', '삼', '사', '오', '육', '칠', '팔', '구' };
+	private static final String[] SMALL_UNITS = { "", "십", "백", "천" };
+	private static final String[] BIG_UNITS = { "", "만", "억", "조", "경" };
+
+	private EgovKoreanCurrencyUtil() {
+	}
+
+	/**
+	 * 금액을 한글 읽기로 변환한다.
+	 *
+	 * <pre>
+	 * toKoreanReading(0)       = "영"
+	 * toKoreanReading(15)      = "일십오"
+	 * toKoreanReading(1000)    = "일천"
+	 * toKoreanReading(5000)    = "오천"
+	 * toKoreanReading(1234567) = "일백이십삼만사천오백육십칠"
+	 * </pre>
+	 *
+	 * @param amount 0 이상의 금액
+	 * @return 한글 읽기 문자열
+	 * @throws IllegalArgumentException 음수인 경우
+	 */
+	public static String toKoreanReading(long amount) {
+		if (amount < 0) {
+			throw new IllegalArgumentException("금액은 음수일 수 없습니다: " + amount);
+		}
+		if (amount == 0) {
+			return String.valueOf(DIGITS[0]);
+		}
+
+		StringBuilder sb = new StringBuilder();
+		int bigUnitIndex = 0;
+		long remaining = amount;
+		String[] groupReadings = new String[BIG_UNITS.length];
+
+		while (remaining > 0 && bigUnitIndex < BIG_UNITS.length) {
+			int group = (int) (remaining % 10000);
+			if (group > 0) {
+				groupReadings[bigUnitIndex] = readGroup(group) + BIG_UNITS[bigUnitIndex];
+			}
+			remaining /= 10000;
+			bigUnitIndex++;
+		}
+
+		for (int i = groupReadings.length - 1; i >= 0; i--) {
+			if (groupReadings[i] != null) {
+				sb.append(groupReadings[i]);
+			}
+		}
+		return sb.toString();
+	}
+
+	/**
+	 * 금액을 공문서 표준 한글 금액 표기("일금 …원정")로 변환한다.
+	 *
+	 * <pre>
+	 * toKoreanCurrency(5000)    = "일금 오천원정"
+	 * toKoreanCurrency(1500000) = "일금 일백오십만원정"
+	 * </pre>
+	 *
+	 * @param amount 0 이상의 금액
+	 * @return "일금 …원정" 형식 문자열
+	 */
+	public static String toKoreanCurrency(long amount) {
+		return "일금 " + toKoreanReading(amount) + "원정";
+	}
+
+	/**
+	 * 아라비아 숫자와 한글 금액을 병기한다.
+	 *
+	 * <pre>
+	 * toKoreanAmountMixed(1234) = "1,234원(일금 일천이백삼십사원정)"
+	 * </pre>
+	 *
+	 * @param amount 0 이상의 금액
+	 * @return "1,234원(일금 …원정)" 형식 문자열
+	 */
+	public static String toKoreanAmountMixed(long amount) {
+		return new DecimalFormat("#,##0").format(amount) + "원(" + toKoreanCurrency(amount) + ")";
+	}
+
+	/** 4자리 이하 그룹(1~9999)을 한글로 읽는다. 위·변조 방지 표기라 계수 1도 "일"로 표기한다. */
+	private static String readGroup(int group) {
+		StringBuilder sb = new StringBuilder();
+		for (int pos = 3; pos >= 0; pos--) {
+			int unit = (int) Math.pow(10, pos);
+			int digit = (group / unit) % 10;
+			if (digit != 0) {
+				sb.append(DIGITS[digit]).append(SMALL_UNITS[pos]);
+			}
+		}
+		return sb.toString();
+	}
+}

--- a/src/test/java/egovframework/com/utl/fcc/service/EgovKoreanCurrencyUtilTest.java
+++ b/src/test/java/egovframework/com/utl/fcc/service/EgovKoreanCurrencyUtilTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright The eGovFrame Open Community (http://open.egovframe.go.kr)).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package egovframework.com.utl.fcc.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@link EgovKoreanCurrencyUtil}의 숫자→한글 금액 변환을 검증한다.
+ */
+class EgovKoreanCurrencyUtilTest {
+
+	@Test
+	void toKoreanReading_values() {
+		assertEquals("영", EgovKoreanCurrencyUtil.toKoreanReading(0));
+		assertEquals("오", EgovKoreanCurrencyUtil.toKoreanReading(5));
+		assertEquals("일십오", EgovKoreanCurrencyUtil.toKoreanReading(15));
+		assertEquals("일백", EgovKoreanCurrencyUtil.toKoreanReading(100));
+		assertEquals("일천", EgovKoreanCurrencyUtil.toKoreanReading(1000));
+		assertEquals("오천", EgovKoreanCurrencyUtil.toKoreanReading(5000));
+		assertEquals("일만", EgovKoreanCurrencyUtil.toKoreanReading(10000));
+		assertEquals("일천이백삼십사", EgovKoreanCurrencyUtil.toKoreanReading(1234));
+		assertEquals("일백이십삼만사천오백육십칠", EgovKoreanCurrencyUtil.toKoreanReading(1234567));
+	}
+
+	@Test
+	void toKoreanReading_largeUnits() {
+		assertEquals("일억", EgovKoreanCurrencyUtil.toKoreanReading(100000000L));
+		assertEquals("일조", EgovKoreanCurrencyUtil.toKoreanReading(1000000000000L));
+		// 큰 단위 사이에 0 그룹은 건너뛴다: 100,000,001 = 일억일
+		assertEquals("일억일", EgovKoreanCurrencyUtil.toKoreanReading(100000001L));
+	}
+
+	@Test
+	void toKoreanCurrency_documentForm() {
+		assertEquals("일금 오천원정", EgovKoreanCurrencyUtil.toKoreanCurrency(5000));
+		assertEquals("일금 일백오십만원정", EgovKoreanCurrencyUtil.toKoreanCurrency(1500000));
+		assertEquals("일금 영원정", EgovKoreanCurrencyUtil.toKoreanCurrency(0));
+	}
+
+	@Test
+	void toKoreanAmountMixed_form() {
+		assertEquals("1,234원(일금 일천이백삼십사원정)", EgovKoreanCurrencyUtil.toKoreanAmountMixed(1234));
+	}
+
+	@Test
+	void toKoreanReading_negativeThrows() {
+		assertThrows(IllegalArgumentException.class, () -> EgovKoreanCurrencyUtil.toKoreanReading(-1));
+	}
+}


### PR DESCRIPTION
## 배경

지출결의서·계약서·세금계산서 등 공문서는 금액 위·변조 방지를 위해 아라비아 숫자 옆에 한글 금액을 병기합니다(예: "일금 오천원정"). 이는 한국 행정의 고유 관행이며, 숫자를 이 형식으로 변환하는 유틸이 코드베이스에 없습니다.

## 기능

- `toKoreanReading(long)`: 12345 → "일만이천삼백사십오"
- `toKoreanCurrency(long)`: 5000 → "일금 오천원정" (공문서 표준)
- `toKoreanAmountMixed(long)`: 1234 → "1,234원(일금 일천이백삼십사원정)"

위·변조 방지 표기 관례에 따라 자리 계수가 1이어도 "일"을 표기합니다(1,000 → 일천, 10,000 → 일만). 만·억·조·경 단위를 4자리 그룹으로 처리하며 `long` 범위로 한정해 오버플로를 피합니다.

## 설계

기존 클래스를 수정하지 않는 순수 유틸(가산형)입니다. 순수 Java·결정적이라 외부 기준에 의존하지 않습니다.

## 검증

금액 읽기·큰 단위(억·조·경, Long.MAX 포함)·중간 0 그룹·공문서 표기·숫자 병기·음수 예외 단위 테스트를 추가했습니다.