### PR TITLE
fix: 로그인 정책 필터에서 필수 파라미터 누락 시 리다이렉트 후 요청 종료

### DIFF
--- a/src/main/java/egovframework/com/uat/uap/filter/EgovLoginPolicyFilter.java
+++ b/src/main/java/egovframework/com/uat/uap/filter/EgovLoginPolicyFilter.java
@@ -87,6 +87,7 @@ public class EgovLoginPolicyFilter implements Filter {
 
 		if (id == null || userSe == null) {
 			((HttpServletResponse) response).sendRedirect(httpRequest.getContextPath() + "/uat/uia/egovLoginUsr.do");
+			return;
 		}
 
 		// 1. LoginVO를 DB로 부터 가져오는 과정

--- a/src/test/java/egovframework/com/uat/uap/filter/EgovLoginPolicyFilterTest.java
+++ b/src/test/java/egovframework/com/uat/uap/filter/EgovLoginPolicyFilterTest.java
@@ -1,0 +1,183 @@
+package egovframework.com.uat.uap.filter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockFilterConfig;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockServletContext;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+import org.springframework.web.context.support.StaticWebApplicationContext;
+
+import egovframework.com.cmm.EgovMessageSource;
+import egovframework.com.uat.uap.service.EgovLoginPolicyService;
+import egovframework.com.uat.uap.service.LoginPolicy;
+import egovframework.com.uat.uap.service.LoginPolicyVO;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+
+class EgovLoginPolicyFilterTest {
+
+	private static final String LOGIN_URL = "/uat/uia/egovLoginUsr.do";
+
+	private MockHttpServletRequest request;
+	private MockHttpServletResponse response;
+	private StubLoginPolicyService loginPolicyService;
+	private RecordingFilterChain filterChain;
+	private EgovLoginPolicyFilter filter;
+
+	@BeforeEach
+	void setUp() throws ServletException {
+		MockServletContext servletContext = new MockServletContext();
+		StaticWebApplicationContext ctx = new StaticWebApplicationContext();
+		ctx.setServletContext(servletContext);
+		ctx.refresh();
+
+		loginPolicyService = new StubLoginPolicyService();
+		ctx.getBeanFactory().registerSingleton("egovLoginPolicyService", loginPolicyService);
+		ctx.getBeanFactory().registerSingleton("egovMessageSource", new StubEgovMessageSource());
+		servletContext.setAttribute(WebApplicationContext.ROOT_WEB_APPLICATION_CONTEXT_ATTRIBUTE, ctx);
+
+		request = new MockHttpServletRequest("POST", "/uat/uia/actionLogin.do");
+		response = new MockHttpServletResponse();
+		filterChain = new RecordingFilterChain();
+		filter = new EgovLoginPolicyFilter();
+		filter.init(new MockFilterConfig(servletContext));
+
+		RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+	}
+
+	@AfterEach
+	void tearDown() {
+		RequestContextHolder.resetRequestAttributes();
+	}
+
+	@Test
+	void missingIdDoesNotContinueFilterChain() throws IOException, ServletException {
+		// id 파라미터가 없으면 로그인 화면으로 리다이렉트하고 즉시 종료한다.
+		request.setParameter("userSe", "USR");
+
+		filter.doFilter(request, response, filterChain);
+
+		assertFalse(filterChain.called);
+		assertTrue(response.isCommitted());
+		assertEquals(request.getContextPath() + LOGIN_URL, response.getRedirectedUrl());
+		assertEquals(0, loginPolicyService.selectLoginPolicyCallCount);
+	}
+
+	@Test
+	void missingUserSeDoesNotContinueFilterChain() throws IOException, ServletException {
+		// userSe 파라미터가 없으면 로그인 화면으로 리다이렉트하고 즉시 종료한다.
+		request.setParameter("id", "tester");
+
+		filter.doFilter(request, response, filterChain);
+
+		assertFalse(filterChain.called);
+		assertTrue(response.isCommitted());
+		assertEquals(request.getContextPath() + LOGIN_URL, response.getRedirectedUrl());
+		assertEquals(0, loginPolicyService.selectLoginPolicyCallCount);
+	}
+
+	@Test
+	void existingIdAndUserSeWithNoPolicyContinuesFilterChain() throws IOException, ServletException {
+		// 로그인 정책이 없으면 기존 동작처럼 요청을 다음 필터로 전달한다.
+		request.setParameter("id", "tester");
+		request.setParameter("userSe", "USR");
+		loginPolicyService.loginPolicyVO = null;
+
+		filter.doFilter(request, response, filterChain);
+
+		assertTrue(filterChain.called);
+		assertEquals(1, filterChain.callCount);
+		assertNull(response.getRedirectedUrl());
+	}
+
+	@Test
+	void limitedPolicyWithDifferentIpRedirectsLogin() throws IOException, ServletException {
+		// 제한 정책의 IP와 요청 IP가 다르면 체인을 호출하지 않고 로그인 화면으로 보낸다.
+		request.setParameter("id", "tester");
+		request.setParameter("userSe", "USR");
+		request.setRemoteAddr("10.0.0.1");
+
+		LoginPolicyVO loginPolicyVO = new LoginPolicyVO();
+		loginPolicyVO.setEmplyrId("tester");
+		loginPolicyVO.setLmttAt("Y");
+		loginPolicyVO.setIpInfo("10.0.0.2");
+		loginPolicyService.loginPolicyVO = loginPolicyVO;
+
+		filter.doFilter(request, response, filterChain);
+
+		assertFalse(filterChain.called);
+		assertTrue(response.getRedirectedUrl().startsWith(LOGIN_URL + "?loginMessage="));
+	}
+
+	private static class StubLoginPolicyService implements EgovLoginPolicyService {
+
+		private LoginPolicyVO loginPolicyVO;
+		private int selectLoginPolicyCallCount;
+
+		@Override
+		public List<LoginPolicyVO> selectLoginPolicyList(LoginPolicyVO loginPolicyVO) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public int selectLoginPolicyListTotCnt(LoginPolicyVO loginPolicyVO) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public LoginPolicyVO selectLoginPolicy(LoginPolicyVO loginPolicyVO) {
+			selectLoginPolicyCallCount++;
+			return this.loginPolicyVO;
+		}
+
+		@Override
+		public void insertLoginPolicy(LoginPolicy loginPolicy) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public void updateLoginPolicy(LoginPolicy loginPolicy) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public void deleteLoginPolicy(LoginPolicy loginPolicy) {
+			throw new UnsupportedOperationException();
+		}
+	}
+
+	private static class StubEgovMessageSource extends EgovMessageSource {
+
+		@Override
+		public String getMessage(String code) {
+			return "login-ip-denied";
+		}
+	}
+
+	private static class RecordingFilterChain implements FilterChain {
+
+		private boolean called;
+		private int callCount;
+
+		@Override
+		public void doFilter(ServletRequest request, ServletResponse response) {
+			called = true;
+			callCount++;
+		}
+	}
+}


### PR DESCRIPTION
## 변경 이유

`EgovLoginPolicyFilter.doFilter`는 `id` 또는 `userSe` 파라미터가 없으면 로그인 화면으로 `sendRedirect`합니다. 그런데 그 뒤에 `return`이 없어서 메서드가 끝나지 않고 아래 코드가 그대로 이어집니다.

리다이렉트 후에도 로그인 정책 조회가 한 번 수행되고, 정책이 없으면 `loginPolicyYn`이 `true`가 되어 `chain.doFilter`가 호출됩니다. 필터의 매핑 대상이 `/uat/uia/actionLogin.do`이므로, 필터가 끝냈다고 본 요청이 `EgovLoginController.actionLogin`까지 도달합니다. 이 동작은 함께 추가한 테스트로 수정 전 상태에서 재현했습니다.

이미 커밋된 응답을 다시 건드리는 문제도 있습니다. 서블릿 규약상 커밋된 응답을 forward하거나 `sendRedirect`하면 `IllegalStateException` 대상입니다. `id`가 없으면 컨트롤러가 `@Valid` 검증 실패로 로그인 JSP를 forward하고, `userSe`가 없는 상태에서 IP 제한까지 걸리면 필터가 `sendRedirect`를 한 번 더 호출합니다. 다만 이 항목은 서블릿 규약에 근거한 판단입니다. `MockHttpServletResponse`는 커밋 이후의 호출을 막지 않아 단위 테스트로는 재현하지 못했고, 컨테이너에서도 확인하지 않았습니다.

접근 제한이 우회되는 문제는 아닙니다. 제한 대상 IP라면 `loginPolicyYn`이 `false`가 되어 `chain.doFilter`가 호출되지 않으므로 IP 접근 제한은 그대로 걸립니다. `id`가 없는 경우에는 조회 결과 자체가 없어 적용할 제한이 없습니다. 보안 통제가 뚫리는 상황이 아니라, 종료되어야 할 요청이 계속 처리되는 제어 흐름 문제입니다.

같은 메서드 안에서도 이 지점만 형태가 다릅니다. `doFilter` 안의 `sendRedirect`는 모두 네 곳인데, 나머지 세 곳(IP 제한 분기, `IOException` catch, 그 외 예외 catch)은 각자 분기의 마지막 문장이라 호출 후 메서드가 자연히 끝납니다. 파라미터 누락 분기만 뒤에 코드가 남아 있습니다.

## 변경 내용

- `EgovLoginPolicyFilter.doFilter`의 `id`/`userSe` 누락 분기에서 `sendRedirect` 다음에 `return;`을 추가했습니다. 운영 코드 변경은 이 한 줄입니다.
- `EgovLoginPolicyFilterTest`를 새로 추가했습니다(4건).
  - `missingIdDoesNotContinueFilterChain` — `id` 누락 시 체인이 호출되지 않고 정책 조회도 수행되지 않음을 검증합니다.
  - `missingUserSeDoesNotContinueFilterChain` — `userSe` 누락 시 동일하게 검증합니다.
  - `existingIdAndUserSeWithNoPolicyContinuesFilterChain` — 정책이 없는 정상 로그인 경로가 종전대로 체인으로 넘어가는지 확인하는 회귀 가드입니다.
  - `limitedPolicyWithDifferentIpRedirectsLogin` — 제한 정책의 IP와 요청 IP가 다르면 체인을 호출하지 않고 로그인 화면으로 보내는, 기존 IP 차단 동작이 유지되는지 확인하는 회귀 가드입니다.

테스트 구성은 한 가지 덧붙일 점이 있습니다. 이 저장소에는 Mockito 의존성이 없어서 로그인 정책 서비스, 필터 체인, 메시지 소스 스텁을 테스트 파일 안에 직접 작성했습니다. 183줄 중 실제 검증부는 약 55줄이고 나머지는 스텁 클래스입니다.

## 테스트 방법

이 저장소는 `pom.xml`의 surefire 설정에 `skipTests`가 `true`로 들어 있어 `mvn test`로는 테스트가 실행되지 않습니다. 명령행에서 `-DskipTests=false`를 줘도 재정의되지 않고 조용히 건너뜁니다. 테스트 클래스패스의 `jakarta.servlet-api`도 5.0.0으로 해석되는데, `spring-test` 6.2.11의 Mock 클래스는 Servlet 6.0 API를 요구합니다(pom에 6.0.0 의존성이 주석 처리되어 있습니다).

이 두 가지 때문에 아래와 같이 JUnit 콘솔 런처로 직접 실행해 확인했습니다. 저장소 루트에서 수행합니다.

```bash
mvn -o -DskipTests test-compile
mvn -o dependency:build-classpath -Dmdep.outputFile=cp.txt -Dmdep.includeScope=test
java -jar ~/.m2/repository/org/junit/platform/junit-platform-console-standalone/1.12.1/junit-platform-console-standalone-1.12.1.jar execute \
  -cp "$HOME/.m2/repository/jakarta/servlet/jakarta.servlet-api/6.0.0/jakarta.servlet-api-6.0.0.jar:target/test-classes:target/classes:$(cat cp.txt)" \
  -c egovframework.com.uat.uap.filter.EgovLoginPolicyFilterTest
```

결과는 4건 모두 통과입니다. 필터를 수정 전 코드로 되돌리고 같은 명령을 돌리면 `missingIdDoesNotContinueFilterChain`과 `missingUserSeDoesNotContinueFilterChain` 2건이 `filterChain` 호출 여부 검증에서 실패합니다.

위 빌드 설정은 확인한 사실을 적었을 뿐이며, 이 PR에서 `pom.xml`은 건드리지 않았습니다.

## 영향 범위

- 변경 파일은 `EgovLoginPolicyFilter.java`(1줄 추가)와 신규 테스트 파일 1개입니다.
- 이 필터는 `EgovWebApplicationInitializer`에서 `Globals.Auth`가 `session`일 때 `/uat/uia/actionLogin.do` 하나에만 등록됩니다. 다른 URL이나 다른 인증 설정에는 영향이 없습니다.
- 동작이 달라지는 경우는 `id` 또는 `userSe`가 없는 로그인 요청 하나뿐이며, 이때 로그인 화면으로 리다이렉트한 뒤 요청이 끝납니다. 두 파라미터가 모두 있는 정상 요청과 IP 제한 요청의 동작은 그대로입니다. 이 두 경로는 위 회귀 테스트로 확인했습니다.
- 공개 API 시그니처, 설정 파일, DB 스키마 변경은 없습니다.
