### PR TITLE
fix: 주민등록번호 세기 판정을 성별구분 숫자 기준으로 교정

### DIFF
--- a/src/main/java/egovframework/com/utl/fcc/service/EgovNumberCheckUtil.java
+++ b/src/main/java/egovframework/com/utl/fcc/service/EgovNumberCheckUtil.java
@@ -53,23 +53,29 @@ public class EgovNumberCheckUtil {
 			totalId += countNum * addNum; // 유효자리 검증식을 적용
 		}
 
-		if (Character.getNumericValue(juminNumber.charAt(0)) == 0
-				|| Character.getNumericValue(juminNumber.charAt(0)) == 1) {
-			if (Character.getNumericValue(juminNumber.charAt(6)) > 4) {
-				return false;
-			}
-			String temp = "20" + juminNumber.substring(0, 6);
-			if (!EgovDateUtil.checkDate(temp)) {
-				return false;
-			}
-		} else {
-			if (Character.getNumericValue(juminNumber.charAt(6)) > 2) {
-				return false;
-			}
-			String temp = "19" + juminNumber.substring(0, 6);
-			if (!EgovDateUtil.checkDate(temp)) {
-				return false;
-			}
+		// 출생 세기는 생년 앞자리가 아니라 성별구분 숫자(7번째 자리)가 결정한다.
+		// 0·9:1800년대, 1·2:1900년대, 3·4:2000년대. 5~8은 외국인등록번호의 성별구분 숫자로 checkForeignNumber에서 처리한다.
+		String century;
+		switch (Character.getNumericValue(juminNumber.charAt(6))) {
+		case 9:
+		case 0:
+			century = "18";
+			break;
+		case 1:
+		case 2:
+			century = "19";
+			break;
+		case 3:
+		case 4:
+			century = "20";
+			break;
+		default:
+			return false;
+		}
+
+		String temp = century + juminNumber.substring(0, 6);
+		if (!EgovDateUtil.checkDate(temp)) {
+			return false;
 		} // 주민번호 앞자리 날짜유효성체크 & 성별구분 숫자 체크
 
 		if (Character.getNumericValue(juminNumber.charAt(12)) == (11 - (totalId % 11)) % 10) { // 마지막 유효숫자와 검증식을 통한 값의

--- a/src/test/java/egovframework/com/utl/fcc/service/EgovNumberCheckUtilTest.java
+++ b/src/test/java/egovframework/com/utl/fcc/service/EgovNumberCheckUtilTest.java
@@ -20,6 +20,53 @@ public class EgovNumberCheckUtilTest {
         assertFalse(EgovNumberCheckUtil.checkForeignNumber("881212", "5134560"), "체크섬 검증 실패");
     }
 
+	// 아래 주민등록번호는 모두 검증번호 산식(가중치 2,3,4,5,6,7,8,9,2,3,4,5)만 만족하도록 생성한 합성값이다.
+	// 일련번호 자리를 모두 0으로 고정했으므로 실제 발급된 번호가 아니다.
+
+	@Test
+	void testJuminCenturyFollowsGenderCode() {
+        // 출생 세기는 생년 앞자리가 아니라 성별구분 숫자가 결정한다.
+        assertTrue(EgovNumberCheckUtil.checkJuminNumber("8503150000001"), "성별 0 → 1885-03-15");
+        assertTrue(EgovNumberCheckUtil.checkJuminNumber("8503159000006"), "성별 9 → 1885-03-15");
+        assertTrue(EgovNumberCheckUtil.checkJuminNumber("8503151000004"), "성별 1 → 1985-03-15");
+        assertTrue(EgovNumberCheckUtil.checkJuminNumber("8503152000007"), "성별 2 → 1985-03-15");
+        assertTrue(EgovNumberCheckUtil.checkJuminNumber("0001013000008"), "성별 3 → 2000-01-01");
+        assertTrue(EgovNumberCheckUtil.checkJuminNumber("1907014000007"), "성별 4 → 2019-07-01");
+    }
+
+	@Test
+	void testJuminBornIn2020sIsValid() {
+        // 생년 앞자리가 2 이상이라는 이유로 1900년대로 단정하면 2020년 이후 출생자가 모두 무효 판정된다.
+        assertTrue(EgovNumberCheckUtil.checkJuminNumber("2001023000008"), "2020-01-02 출생");
+        assertTrue(EgovNumberCheckUtil.checkJuminNumber("2103153000001"), "2021-03-15 출생");
+        assertTrue(EgovNumberCheckUtil.checkJuminNumber("2411084000008"), "2024-11-08 출생");
+        assertTrue(EgovNumberCheckUtil.checkJuminNumber("2602013000003"), "2026-02-01 출생");
+        assertTrue(EgovNumberCheckUtil.checkJuminNumber("9912314000005"), "2099-12-31 출생");
+    }
+
+	@Test
+	void testJuminRejectsForeignGenderCode() {
+        // 5~8은 외국인등록번호의 성별구분 숫자이므로 주민등록번호로는 무효다.
+        assertFalse(EgovNumberCheckUtil.checkJuminNumber("8503155000005"), "성별 5");
+        assertFalse(EgovNumberCheckUtil.checkJuminNumber("8503156000008"), "성별 6");
+        assertFalse(EgovNumberCheckUtil.checkJuminNumber("8503157000001"), "성별 7");
+        assertFalse(EgovNumberCheckUtil.checkJuminNumber("8503158000003"), "성별 8");
+    }
+
+	@Test
+	void testJuminLeapDayFollowsResolvedCentury() {
+        assertTrue(EgovNumberCheckUtil.checkJuminNumber("9602292000006"), "1996-02-29 (윤년)");
+        assertTrue(EgovNumberCheckUtil.checkJuminNumber("0002293000001"), "2000-02-29 (윤년)");
+        assertTrue(EgovNumberCheckUtil.checkJuminNumber("2002293000008"), "2020-02-29 (윤년)");
+        assertFalse(EgovNumberCheckUtil.checkJuminNumber("0002291000006"), "1900-02-29 (평년이므로 없는 날짜)");
+    }
+
+	@Test
+	void testJuminRejectsInvalidDate() {
+        assertFalse(EgovNumberCheckUtil.checkJuminNumber("8502301000000"), "존재하지 않는 날짜 (2월 30일)");
+        assertFalse(EgovNumberCheckUtil.checkJuminNumber("8513151000001"), "존재하지 않는 월 (13월)");
+    }
+
 	@Test
 	void testNullReturnsFalseWithoutException() {
         // 단일 인자 검증 메서드는 null 입력 시 NPE가 아니라 false(무효)를 반환해야 한다.


### PR DESCRIPTION
## 변경 이유

`EgovNumberCheckUtil.checkJuminNumber`가 출생 세기를 성별구분 숫자(7번째 자리)가 아니라 생년 앞자리(`charAt(0)`)로 추정합니다. 앞자리가 0이나 1이면 2000년대로 보고 성별구분 숫자 4 이하를 허용합니다. 그 외에는 1900년대로 보고 2 이하만 허용합니다.

그래서 2020년 이후 출생자의 주민등록번호가 전부 무효로 판정됩니다. 생년 앞자리가 2 이상이라 1900년대 분기로 들어가는데, 2000년대 출생의 성별구분 숫자 3·4는 그 분기의 "2 이하" 조건에 걸리기 때문입니다. 2026년 기준으로 만 0~6세 전 연령이 여기에 해당합니다. 검증번호 산식을 만족하는 합성값 `2001023234560`, `2103153234563`, `2411084234560`, `2602013234565`가 모두 `false`를 반환합니다.

## 변경 내용

세기를 성별구분 숫자로 판정하도록 바꿨습니다. 0·9는 1800년대, 1·2는 1900년대, 3·4는 2000년대입니다. 5~8은 외국인등록번호의 성별구분 숫자이므로 무효 처리합니다. 검증번호 산식은 그대로입니다.

기존에는 세기 분기마다 성별구분 숫자 상한 검사와 날짜 검사를 따로 두는 이중 if/else 구조였습니다. 세기가 성별구분 숫자 하나로 결정되므로 매핑을 `switch` 한 곳으로 합치고 날짜 검사는 분기 밖에서 한 번만 수행하도록 정리했습니다.

## 테스트 방법

이 저장소는 POM의 surefire 설정이 `skipTests`를 켜 두어 `mvn test`로는 테스트가 실행되지 않습니다. `junit-platform-console-standalone`으로 직접 실행했습니다.

```bash
mvn -o test-compile
java -jar ~/.m2/repository/org/junit/platform/junit-platform-console-standalone/1.12.1/junit-platform-console-standalone-1.12.1.jar \
  execute -cp target/classes:target/test-classes \
  --select-class=egovframework.com.utl.fcc.service.EgovNumberCheckUtilTest
```

`EgovNumberCheckUtilTest` 8건이 모두 통과합니다. `EgovNumberCheckUtil`만 수정 전 코드로 되돌리고 같은 테스트를 돌리면 3건이 실패합니다. 성별구분 숫자 9의 세기 판정, 2020년대 출생, 세기에 따른 윤년 판정입니다.

세기 매핑이 실제 날짜 검사와 맞물리는지 `EgovDateUtil.checkDate`로 따로 확인했습니다. 1885-03-15 수용, 1888-02-29 수용(윤년), 1800-02-29 거부, 1900-02-29 거부, 2000-02-29 수용입니다.

추가한 테스트는 이번 수정의 회귀 가드입니다. 이중 if/else를 `switch`로 합치면서 기존 거부 동작이 그대로 유지되는지도 함께 검증합니다. 테스트에 쓴 번호는 실제 개인 식별번호가 아니라 검증번호 산식만 만족하도록 만든 합성값입니다. 일련번호 자리는 0으로 고정했습니다. 합성값이라는 사실은 테스트 파일 상단 주석에 적어 두었습니다.

## 영향 범위

수정 대상은 `checkJuminNumber` 한 메서드입니다. 세기 판정 기준이 바뀌므로 수용집합이 어떻게 달라지는지 전수 대조했습니다. 날짜·성별 조합 10,000,000건(YY·MM·DD 각 00~99 × 성별구분 숫자 0~9)에 일련번호를 고정하고 검증번호를 산출해 수정 전후 결과를 비교했습니다.

| 성별구분 숫자 | 수정 전 | 수정 후 | 변화 |
|---|---|---|---|
| 0 | 36,525 | 36,524 | −1 |
| 1 | 36,525 | 36,524 | −1 |
| 2 | 36,525 | 36,524 | −1 |
| 3 | 7,305 | 36,525 | +29,220 |
| 4 | 7,305 | 36,525 | +29,220 |
| 5~8 | 0 | 0 | 0 |
| 9 | 0 | 36,524 | +36,524 |
| 계 | 124,185 | 219,146 | +94,961 |

세기 판정 기준이 바뀌면서 기존에 수용되던 입력 중 `000229`로 시작하는 3개 조합(성별 0·1·2)이 거부됩니다. 기존 코드가 2000-02-29(윤년)로 오인해 수용하던 것으로, 실제로는 성별 1·2가 1900-02-29, 성별 0이 1800-02-29이고 두 해 모두 평년이라 존재하지 않는 날짜입니다. 거부로 바뀌는 입력은 이 3개 조합뿐이며 나머지 변화(성별 3·4 각 +29,220, 성별 9 +36,524)는 모두 수용 확대입니다. 외국인등록번호의 성별구분 숫자 5~8은 수정 전후 모두 거부되며 `checkForeignNumber`가 담당합니다.
