### PR TITLE
fix: 만족도 수정 시 소유권 검증 누락으로 다른 회원의 만족도를 변경할 수 있는 문제 수정

### DIFF
--- a/src/main/java/egovframework/com/cop/stf/web/EgovBBSSatisfactionController.java
+++ b/src/main/java/egovframework/com/cop/stf/web/EgovBBSSatisfactionController.java
@@ -497,6 +497,15 @@ public class EgovBBSSatisfactionController {
 		}
 
 		if (isAuthenticated) {
+		    // 작성자 본인만 수정 가능하도록 소유권 검증 (회원 만족도조사는 로그인 사용자 명의로만 등록됨)
+		    Satisfaction stored = bbsSatisfactionService.selectSatisfaction(satisfactionVO);
+		    String loginUniqId = (user == null || user.getUniqId() == null) ? "" : user.getUniqId();
+		    if (stored == null || stored.getFrstRegisterId() == null
+			    || !stored.getFrstRegisterId().equals(loginUniqId)) {
+			model.addAttribute("subMsg", egovMessageSource.getMessage("errors.xss.checkerUser"));
+			return "forward:/cop/bbs/selectArticleDetail.do";
+		    }
+
 		    satisfaction.setLastUpdusrId(user == null ? "" : EgovStringUtil.isNullToString(user.getUniqId()));
 
 		    satisfaction.setStsfdgPassword("");	// dummy

--- a/src/main/resources/egovframework/mapper/com/cop/stf/EgovBBSSatisfaction_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/stf/EgovBBSSatisfaction_SQL_altibase.xml
@@ -27,6 +27,7 @@
 		<result property="stsfdgCn" column="STSFDG_CN"/>
 		<result property="stsfdg" column="STSFDG"/>
 		<result property="useAt" column="USE_AT"/>
+		<result property="frstRegisterId" column="FRST_REGISTER_ID"/>
 		<result property="frstRegisterPnttm" column="FRST_REGIST_PNTTM"/>
 		<result property="frstRegisterNm" column="FRST_REGISTER_NM"/>
 	</resultMap>
@@ -95,6 +96,7 @@
 			SELECT
 				a.STSFDG_NO, a.NTT_ID, a.BBS_ID, 
 				a.WRTER_ID, a.WRTER_NM, a.PASSWORD, a.STSFDG_CN, a.STSFDG, a.USE_AT,
+				a.FRST_REGISTER_ID,
 				TO_CHAR(a.FRST_REGIST_PNTTM, 'YYYY-MM-DD HH24:MI:SS')
 				as FRST_REGIST_PNTTM,
 				b.USER_NM as FRST_REGISTER_NM

--- a/src/main/resources/egovframework/mapper/com/cop/stf/EgovBBSSatisfaction_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/stf/EgovBBSSatisfaction_SQL_cubrid.xml
@@ -27,6 +27,7 @@
 		<result property="stsfdgCn" column="STSFDG_CN"/>
 		<result property="stsfdg" column="STSFDG"/>
 		<result property="useAt" column="USE_AT"/>
+		<result property="frstRegisterId" column="FRST_REGISTER_ID"/>
 		<result property="frstRegisterPnttm" column="FRST_REGIST_PNTTM"/>
 		<result property="frstRegisterNm" column="FRST_REGISTER_NM"/>
 	</resultMap>
@@ -95,6 +96,7 @@
 			SELECT
 				a.STSFDG_NO, a.NTT_ID, a.BBS_ID, 
 				a.WRTER_ID, a.WRTER_NM, a.PASSWORD, a.STSFDG_CN, a.STSFDG, a.USE_AT,
+				a.FRST_REGISTER_ID,
 				TO_CHAR(a.FRST_REGIST_PNTTM, 'YYYY-MM-DD HH24:MI:SS')
 				as FRST_REGIST_PNTTM,
 				b.USER_NM as FRST_REGISTER_NM

--- a/src/main/resources/egovframework/mapper/com/cop/stf/EgovBBSSatisfaction_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/stf/EgovBBSSatisfaction_SQL_goldilocks.xml
@@ -27,6 +27,7 @@
 		<result property="stsfdgCn" column="STSFDG_CN"/>
 		<result property="stsfdg" column="STSFDG"/>
 		<result property="useAt" column="USE_AT"/>
+		<result property="frstRegisterId" column="FRST_REGISTER_ID"/>
 		<result property="frstRegisterPnttm" column="FRST_REGIST_PNTTM"/>
 		<result property="frstRegisterNm" column="FRST_REGISTER_NM"/>
 	</resultMap>
@@ -95,6 +96,7 @@
 			SELECT
 				a.STSFDG_NO, a.NTT_ID, a.BBS_ID, 
 				a.WRTER_ID, a.WRTER_NM, a.PASSWORD, a.STSFDG_CN, a.STSFDG, a.USE_AT,
+				a.FRST_REGISTER_ID,
 				TO_CHAR(a.FRST_REGIST_PNTTM, 'YYYY-MM-DD HH24:MI:SS')
 				as FRST_REGIST_PNTTM,
 				b.USER_NM as FRST_REGISTER_NM

--- a/src/main/resources/egovframework/mapper/com/cop/stf/EgovBBSSatisfaction_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/stf/EgovBBSSatisfaction_SQL_maria.xml
@@ -27,6 +27,7 @@
 		<result property="stsfdgCn" column="STSFDG_CN"/>
 		<result property="stsfdg" column="STSFDG"/>
 		<result property="useAt" column="USE_AT"/>
+		<result property="frstRegisterId" column="FRST_REGISTER_ID"/>
 		<result property="frstRegisterPnttm" column="FRST_REGIST_PNTTM"/>
 		<result property="frstRegisterNm" column="FRST_REGISTER_NM"/>
 	</resultMap>
@@ -94,6 +95,7 @@
 			SELECT
 				a.STSFDG_NO, a.NTT_ID, a.BBS_ID, 
 				a.WRTER_ID, a.WRTER_NM, a.PASSWORD, a.STSFDG_CN, a.STSFDG, a.USE_AT,
+				a.FRST_REGISTER_ID,
 				DATE_FORMAT(a.FRST_REGIST_PNTTM, '%Y-%m-%d %H:%i:%S') 
 				as FRST_REGIST_PNTTM,
 				b.USER_NM as FRST_REGISTER_NM

--- a/src/main/resources/egovframework/mapper/com/cop/stf/EgovBBSSatisfaction_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/stf/EgovBBSSatisfaction_SQL_mysql.xml
@@ -91,12 +91,12 @@
 	</update>
 	
 	<select id="selectSatisfaction" parameterType="egovframework.com.cop.bbs.service.SatisfactionVO" resultMap="satisfactionDetail">
-
+		
 			SELECT
-				a.STSFDG_NO, a.NTT_ID, a.BBS_ID,
+				a.STSFDG_NO, a.NTT_ID, a.BBS_ID, 
 				a.WRTER_ID, a.WRTER_NM, a.PASSWORD, a.STSFDG_CN, a.STSFDG, a.USE_AT,
 				a.FRST_REGISTER_ID,
-				DATE_FORMAT(a.FRST_REGIST_PNTTM, '%Y-%m-%d %H:%i:%S')
+				DATE_FORMAT(a.FRST_REGIST_PNTTM, '%Y-%m-%d %H:%i:%S') 
 				as FRST_REGIST_PNTTM,
 				b.USER_NM as FRST_REGISTER_NM
 			FROM

--- a/src/main/resources/egovframework/mapper/com/cop/stf/EgovBBSSatisfaction_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/stf/EgovBBSSatisfaction_SQL_mysql.xml
@@ -27,6 +27,7 @@
 		<result property="stsfdgCn" column="STSFDG_CN"/>
 		<result property="stsfdg" column="STSFDG"/>
 		<result property="useAt" column="USE_AT"/>
+		<result property="frstRegisterId" column="FRST_REGISTER_ID"/>
 		<result property="frstRegisterPnttm" column="FRST_REGIST_PNTTM"/>
 		<result property="frstRegisterNm" column="FRST_REGISTER_NM"/>
 	</resultMap>
@@ -90,11 +91,12 @@
 	</update>
 	
 	<select id="selectSatisfaction" parameterType="egovframework.com.cop.bbs.service.SatisfactionVO" resultMap="satisfactionDetail">
-		
+
 			SELECT
-				a.STSFDG_NO, a.NTT_ID, a.BBS_ID, 
+				a.STSFDG_NO, a.NTT_ID, a.BBS_ID,
 				a.WRTER_ID, a.WRTER_NM, a.PASSWORD, a.STSFDG_CN, a.STSFDG, a.USE_AT,
-				DATE_FORMAT(a.FRST_REGIST_PNTTM, '%Y-%m-%d %H:%i:%S') 
+				a.FRST_REGISTER_ID,
+				DATE_FORMAT(a.FRST_REGIST_PNTTM, '%Y-%m-%d %H:%i:%S')
 				as FRST_REGIST_PNTTM,
 				b.USER_NM as FRST_REGISTER_NM
 			FROM

--- a/src/main/resources/egovframework/mapper/com/cop/stf/EgovBBSSatisfaction_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/stf/EgovBBSSatisfaction_SQL_oracle.xml
@@ -27,6 +27,7 @@
 		<result property="stsfdgCn" column="STSFDG_CN"/>
 		<result property="stsfdg" column="STSFDG"/>
 		<result property="useAt" column="USE_AT"/>
+		<result property="frstRegisterId" column="FRST_REGISTER_ID"/>
 		<result property="frstRegisterPnttm" column="FRST_REGIST_PNTTM"/>
 		<result property="frstRegisterNm" column="FRST_REGISTER_NM"/>
 	</resultMap>
@@ -95,6 +96,7 @@
 			SELECT
 				a.STSFDG_NO, a.NTT_ID, a.BBS_ID, 
 				a.WRTER_ID, a.WRTER_NM, a.PASSWORD, a.STSFDG_CN, a.STSFDG, a.USE_AT,
+				a.FRST_REGISTER_ID,
 				TO_CHAR(a.FRST_REGIST_PNTTM, 'YYYY-MM-DD HH24:MI:SS')
 				as FRST_REGIST_PNTTM,
 				b.USER_NM as FRST_REGISTER_NM

--- a/src/main/resources/egovframework/mapper/com/cop/stf/EgovBBSSatisfaction_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/stf/EgovBBSSatisfaction_SQL_postgres.xml
@@ -27,6 +27,7 @@
 		<result property="stsfdgCn" column="STSFDG_CN"/>
 		<result property="stsfdg" column="STSFDG"/>
 		<result property="useAt" column="USE_AT"/>
+		<result property="frstRegisterId" column="FRST_REGISTER_ID"/>
 		<result property="frstRegisterPnttm" column="FRST_REGIST_PNTTM"/>
 		<result property="frstRegisterNm" column="FRST_REGISTER_NM"/>
 	</resultMap>
@@ -94,6 +95,7 @@
 			SELECT
 				a.STSFDG_NO, a.NTT_ID, a.BBS_ID, 
 				a.WRTER_ID, a.WRTER_NM, a.PASSWORD, a.STSFDG_CN, a.STSFDG, a.USE_AT,
+				a.FRST_REGISTER_ID,
 				TO_CHAR(a.FRST_REGIST_PNTTM, 'YYYY-mm-dd HH24:MI:SS') 
 				as FRST_REGIST_PNTTM,
 				b.USER_NM as FRST_REGISTER_NM

--- a/src/main/resources/egovframework/mapper/com/cop/stf/EgovBBSSatisfaction_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/stf/EgovBBSSatisfaction_SQL_tibero.xml
@@ -27,6 +27,7 @@
 		<result property="stsfdgCn" column="STSFDG_CN"/>
 		<result property="stsfdg" column="STSFDG"/>
 		<result property="useAt" column="USE_AT"/>
+		<result property="frstRegisterId" column="FRST_REGISTER_ID"/>
 		<result property="frstRegisterPnttm" column="FRST_REGIST_PNTTM"/>
 		<result property="frstRegisterNm" column="FRST_REGISTER_NM"/>
 	</resultMap>
@@ -95,6 +96,7 @@
 			SELECT
 				a.STSFDG_NO, a.NTT_ID, a.BBS_ID, 
 				a.WRTER_ID, a.WRTER_NM, a.PASSWORD, a.STSFDG_CN, a.STSFDG, a.USE_AT,
+				a.FRST_REGISTER_ID,
 				TO_CHAR(a.FRST_REGIST_PNTTM, 'YYYY-MM-DD HH24:MI:SS')
 				as FRST_REGIST_PNTTM,
 				b.USER_NM as FRST_REGISTER_NM

--- a/src/test/java/egovframework/com/cop/stf/web/EgovBBSSatisfactionControllerOwnershipTest.java
+++ b/src/test/java/egovframework/com/cop/stf/web/EgovBBSSatisfactionControllerOwnershipTest.java
@@ -133,8 +133,11 @@ class EgovBBSSatisfactionControllerOwnershipTest {
 	void updateByNonOwnerDoesNotReachTheUpdateService() throws Exception {
 		Object[] r = callUpdate(OWNER, ATTACKER);
 		StubService service = (StubService) r[0];
+		ModelMap model = (ModelMap) r[2];
 		assertFalse(service.updateCalled,
 				"A logged-in non-owner must not be able to update another member's satisfaction record.");
+		assertEquals("forward:/cop/bbs/selectArticleDetail.do", r[1]);
+		assertTrue(model.containsAttribute("subMsg"), "The rejection must surface the checkerUser message.");
 	}
 
 	@Test

--- a/src/test/java/egovframework/com/cop/stf/web/EgovBBSSatisfactionControllerOwnershipTest.java
+++ b/src/test/java/egovframework/com/cop/stf/web/EgovBBSSatisfactionControllerOwnershipTest.java
@@ -1,0 +1,146 @@
+package egovframework.com.cop.stf.web;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.ui.ModelMap;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.BindingResult;
+
+import egovframework.com.cmm.EgovMessageSource;
+import egovframework.com.cmm.LoginVO;
+import egovframework.com.cmm.service.EgovUserDetailsService;
+import egovframework.com.cmm.util.EgovUserDetailsHelper;
+import egovframework.com.cop.bbs.service.EgovBBSSatisfactionService;
+import egovframework.com.cop.bbs.service.Satisfaction;
+import egovframework.com.cop.bbs.service.SatisfactionVO;
+
+/**
+ * updateSatisfaction의 소유권 검증 회귀 테스트.
+ *
+ * 로그인 사용자가 자신이 등록하지 않은 만족도 레코드를 수정하려 하면 차단돼야 한다(IDOR 방지).
+ * 수정 전 코드는 인증 여부만 확인하고 소유자를 대조하지 않아, 아래 attacker 테스트가 실패한다.
+ */
+class EgovBBSSatisfactionControllerOwnershipTest {
+
+	private static final String OWNER = "USRCNFRM_00000000001";
+	private static final String ATTACKER = "USRCNFRM_00000000009";
+
+	/** selectSatisfaction은 저장된 소유자를 돌려주고, updateSatisfaction 호출 여부를 기록하는 스텁. */
+	private static final class StubService implements EgovBBSSatisfactionService {
+		private final Satisfaction stored;
+		private boolean updateCalled = false;
+
+		StubService(String ownerUniqId) {
+			this.stored = new Satisfaction();
+			this.stored.setFrstRegisterId(ownerUniqId);
+		}
+
+		@Override
+		public Satisfaction selectSatisfaction(SatisfactionVO satisfactionVO) {
+			return stored;
+		}
+
+		@Override
+		public void updateSatisfaction(Satisfaction satisfaction) {
+			updateCalled = true;
+		}
+
+		@Override
+		public boolean canUseSatisfaction(String bbsId) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public Map<String, Object> selectSatisfactionList(SatisfactionVO satisfactionVO) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public void insertSatisfaction(Satisfaction satisfaction) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public void deleteSatisfaction(SatisfactionVO satisfactionVO) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public String getSatisfactionPassword(Satisfaction satisfaction) {
+			throw new UnsupportedOperationException();
+		}
+	}
+
+	private static void bindLoginUser(String uniqId) {
+		LoginVO login = new LoginVO();
+		login.setUniqId(uniqId);
+		EgovUserDetailsService stub = new EgovUserDetailsService() {
+			@Override
+			public Object getAuthenticatedUser() {
+				return login;
+			}
+
+			@Override
+			public List<String> getAuthorities() {
+				return List.of();
+			}
+
+			@Override
+			public Boolean isAuthenticated() {
+				return Boolean.TRUE;
+			}
+		};
+		new EgovUserDetailsHelper().setEgovUserDetailsService(stub);
+	}
+
+	private static EgovBBSSatisfactionController controllerWith(StubService service) {
+		EgovBBSSatisfactionController controller = new EgovBBSSatisfactionController();
+		controller.bbsSatisfactionService = service;
+		controller.egovMessageSource = new EgovMessageSource() {
+			@Override
+			public String getMessage(String code) {
+				return code;
+			}
+		};
+		return controller;
+	}
+
+	private static Object[] callUpdate(String ownerUniqId, String loginUniqId) throws Exception {
+		StubService service = new StubService(ownerUniqId);
+		EgovBBSSatisfactionController controller = controllerWith(service);
+		bindLoginUser(loginUniqId);
+
+		SatisfactionVO searchVO = new SatisfactionVO();
+		Satisfaction satisfaction = new Satisfaction();
+		satisfaction.setStsfdgNo("8000001");
+		satisfaction.setWrterNm("edited");
+		satisfaction.setStsfdg(1);
+		satisfaction.setStsfdgPassword("dummy");
+		BindingResult bindingResult = new BeanPropertyBindingResult(satisfaction, "satisfaction");
+
+		ModelMap model = new ModelMap();
+		String view = controller.updateSatisfaction(searchVO, satisfaction, bindingResult, model);
+		return new Object[] { service, view, model };
+	}
+
+	@Test
+	void updateByNonOwnerDoesNotReachTheUpdateService() throws Exception {
+		Object[] r = callUpdate(OWNER, ATTACKER);
+		StubService service = (StubService) r[0];
+		assertFalse(service.updateCalled,
+				"A logged-in non-owner must not be able to update another member's satisfaction record.");
+	}
+
+	@Test
+	void updateByOwnerReachesTheUpdateService() throws Exception {
+		Object[] r = callUpdate(OWNER, OWNER);
+		StubService service = (StubService) r[0];
+		assertTrue(service.updateCalled, "The owner must be able to update their own satisfaction record.");
+	}
+}


### PR DESCRIPTION
## 수정 사유

- [x] 버그수정
- [ ] 기능개선
- [ ] 리팩터링

## 문제 상황

게시판 만족도조사의 회원 수정 경로 `updateSatisfaction`(`/cop/stf/updateSatisfaction.do`)이 인증 여부만 확인하고 작성자 본인인지는 대조하지 않습니다. 그래서 로그인한 사용자가 다른 회원이 등록한 만족도 레코드의 작성자명·내용·점수를 바꿀 수 있습니다.

같은 컨트롤러의 형제 경로는 모두 보호되어 있습니다. `deleteSatisfaction`은 커밋 `23d01889`(NCSC·NIA 보안점검, 2026-07-21)에서 소유권 검증을 받았고, `updateAnonymousSatisfaction`은 KISA 보안취약점 조치(2026-07-13)로 `egovAssertLoginUser()`를 받았습니다. `updateSatisfaction`만 관문이 없습니다.

수정하려고 보니 형제 `deleteSatisfaction`의 소유권 검증도 실제로는 동작하지 않고 있었습니다. `selectSatisfaction`이 조회 결과에 `FRST_REGISTER_ID`를 담지 않기 때문입니다. `Satisfaction.frstRegisterId`의 기본값은 빈 문자열이라, 조회로 채워지지 않으면 소유권 비교가 항상 실패해 **작성자 본인의 삭제까지 막힙니다.** 이 커밋은 두 문제를 함께 고칩니다.

## 발생 흐름

`updateSatisfaction`은 요청의 `stsfdgNo`(만족도 번호, PK)를 받아 인증 여부만 확인한 뒤 그대로 수정합니다.

```java
if (isAuthenticated) {
    satisfaction.setLastUpdusrId(user == null ? "" : EgovStringUtil.isNullToString(user.getUniqId()));
    satisfaction.setStsfdgPassword("");	// dummy
    bbsSatisfactionService.updateSatisfaction(satisfaction);
```

수정 SQL은 소유자 조건 없이 PK만으로 갱신합니다.

```sql
UPDATE COMTNSTSFDG SET WRTER_NM = #{wrterNm}, ..., STSFDG = #{stsfdg}, ...
WHERE STSFDG_NO = #{stsfdgNo}
```

따라서 로그인한 사용자가 남의 `STSFDG_NO`를 요청에 실으면 그 레코드가 그대로 덮어써집니다. 목록 화면(`EgovSatisfactionList.jsp`)은 수정·삭제 버튼을 `${result.wrterId == sessionUniqId}` 조건으로 감추지만, 이는 화면 표시일 뿐이라 직접 요청에는 적용되지 않습니다.

한편 `selectSatisfaction`의 조회 결과 매핑(`satisfactionDetail`)과 SELECT 목록에는 `FRST_REGISTER_ID`가 없습니다(조인의 ON 절에만 등장). 그래서 `deleteSatisfaction`의 소유권 검증

```java
if (stored == null || stored.getFrstRegisterId() == null
        || !stored.getFrstRegisterId().equals(loginUniqId)) { ... 차단 ... }
```

은 `stored.getFrstRegisterId()`가 항상 빈 문자열이라 로그인 사용자 누구에 대해서도 참이 되어, 작성자 본인의 삭제까지 차단합니다.

## 변경 내용

**1. `updateSatisfaction`에 소유권 검증 추가** — 형제 `deleteSatisfaction`과 동일한 검증을 인증 분기 안에 넣었습니다.

```java
if (isAuthenticated) {
    // 작성자 본인만 수정 가능하도록 소유권 검증 (회원 만족도조사는 로그인 사용자 명의로만 등록됨)
    Satisfaction stored = bbsSatisfactionService.selectSatisfaction(satisfactionVO);
    String loginUniqId = (user == null || user.getUniqId() == null) ? "" : user.getUniqId();
    if (stored == null || stored.getFrstRegisterId() == null
            || !stored.getFrstRegisterId().equals(loginUniqId)) {
        model.addAttribute("subMsg", egovMessageSource.getMessage("errors.xss.checkerUser"));
        return "forward:/cop/bbs/selectArticleDetail.do";
    }
    ...
```

검증에 쓰는 `satisfactionVO`의 `stsfdgNo`와 실제 수정에 쓰는 `satisfaction`의 `stsfdgNo`는 서로 다른 객체지만, 두 `@ModelAttribute`가 같은 요청 파라미터 `stsfdgNo` 하나에서 바인딩되므로 항상 같은 값입니다. 즉 "내 레코드로 검증하고 남의 레코드를 수정"하는 우회는 성립하지 않습니다.

**2. 조회 결과에 작성자 ID 복원** — `selectSatisfaction`의 resultMap `satisfactionDetail`에 `frstRegisterId` 매핑을, SELECT 목록에 `a.FRST_REGISTER_ID`를 추가했습니다. 이 조회는 update와 delete의 소유권 검증이 공통으로 쓰므로, **이 변경이 update의 새 검증을 실제로 동작하게 하는 동시에, 그동안 빈 문자열 때문에 작성자 본인까지 막던 delete의 검증도 정상화합니다.** resultMap과 SELECT는 DB 방언별 XML로 나뉘어 있어 8개 방언(altibase·cubrid·goldilocks·maria·mysql·oracle·postgres·tibero) 모두에 동일하게 반영했습니다.

## 영향 범위

- `EgovBBSSatisfactionController.updateSatisfaction`: 소유권 검증 추가. 정상 소유자의 수정은 그대로 동작하고, 비소유자만 차단됩니다.
- `EgovBBSSatisfaction_SQL_*.xml`(8개 방언): `selectSatisfaction` 조회에 `FRST_REGISTER_ID` 복원. 이 resultMap을 쓰는 쿼리는 `selectSatisfaction` 하나뿐이라 목록 조회 등 다른 경로에는 영향이 없습니다.
- **부수 효과(의도된 것):** 위 2번으로 `deleteSatisfaction`의 소유권 검증이 실제로 동작하게 됩니다. 기존에는 작성자 본인의 삭제도 막혀 있었습니다.

## 테스트 방법

### 재현 (수정 전)

로그인한 사용자가 다른 회원 명의의 만족도 레코드를 수정 요청합니다. 피해자 레코드는 회원 등록 경로가 만드는 형태(`FRST_REGISTER_ID` = 소유자)로 두고, 공격자만 실제 세션으로 엔드포인트를 호출합니다.

```
① 피해자 명의 레코드:  STSFDG_NO=8000001  WRTER_NM=VICTIM   STSFDG_CN=ORIGINAL-BY-VICTIM  STSFDG=5  FRST_REGISTER_ID=<victim>
② 공격자(다른 로그인 회원)가 STSFDG_NO=8000001로 updateSatisfaction.do POST 후:
    STSFDG_NO=8000001  WRTER_NM=ATTACKER  STSFDG_CN=OVERWRITTEN-BY-ATTACKER  STSFDG=1  FRST_REGISTER_ID=<victim>  LAST_UPDUSR_ID=<attacker>
```

남의 레코드가 덮어써졌습니다(작성자명·내용·점수 변경, `LAST_UPDUSR_ID`에 공격자 기록).

### 확인 (수정 후)

같은 요청이 소유권 검증에 걸려 레코드가 보존됩니다.

```
A. 공격자가 남의 레코드 수정  → 내용=[ORIGINAL-BY-VICTIM]  차단됨
B. 소유자 본인이 자기 레코드 수정 → 내용=[B-MYEDIT]        정상 반영
C. 소유자 본인이 자기 레코드 삭제 → USE_AT=[N]             정상 삭제(수정 전에는 USE_AT=Y로 삭제 불가였음)
```

A로 IDOR이 막히고, B로 정상 소유자의 수정에 회귀가 없음을, C로 삭제 검증이 함께 살아난 것을 확인할 수 있습니다.

### 단위 테스트

`EgovBBSSatisfactionControllerOwnershipTest`를 추가했습니다. 비소유자의 수정 요청이 수정 서비스에 도달하지 않고 게시글 상세로 forward되며 안내 메시지가 실리는지, 소유자 본인의 요청은 수정 서비스에 도달하는지 확인합니다.

```
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
```

소유권 검증 블록을 제거하면 비소유자 테스트가 다음과 같이 실패합니다.

```
updateByNonOwnerDoesNotReachTheUpdateService:136
  A logged-in non-owner must not be able to update another member's satisfaction record.
  ==> expected: <false> but was: <true>
```
