### PR TITLE
feat(datasource): HikariCP 기반 커넥션 풀을 적용

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -163,6 +163,11 @@
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-dbcp2</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>com.zaxxer</groupId>
+			<artifactId>HikariCP</artifactId>
+			<version>6.3.3</version>
+		</dependency>
 
 		<!-- Jakarta -->
 		<dependency>

--- a/src/main/resources/egovframework/spring/com/context-datasource.xml
+++ b/src/main/resources/egovframework/spring/com/context-datasource.xml
@@ -18,103 +18,106 @@
 	
 	<!-- MySQL -->
 	<beans profile="mysql">  
-	<bean id="dataSource" class="org.apache.commons.dbcp2.BasicDataSource" destroy-method="close">
+	<bean id="dataSource" class="com.zaxxer.hikari.HikariDataSource" destroy-method="close">
 		<property name="driverClassName" value="${Globals.mysql.DriverClassName}"/>
-		<property name="url" value="${Globals.mysql.Url}" />
+		<property name="jdbcUrl" value="${Globals.mysql.Url}" />
 		<property name="username" value="${Globals.mysql.UserName}"/>
 		<!-- 암호화(Crypto) 관련 서비스 https://www.egovframe.go.kr/wiki/doku.php?id=egovframework:rte2:fdl:crypto_simplify_v3_8 참조 -->
 		<property name="password" value="#{egovPasswordResolver.resolvePassword('Globals.mysql.Password')}"/>
+		<property name="maximumPoolSize" value="10"/>
 	</bean>
 	</beans>
 	
 	<!-- oracle -->
 	<beans profile="oracle">
-	<bean id="dataSource" class="org.apache.commons.dbcp2.BasicDataSource" destroy-method="close">
+	<bean id="dataSource" class="com.zaxxer.hikari.HikariDataSource" destroy-method="close">
 		<property name="driverClassName" value="${Globals.oracle.DriverClassName}"/>
-		<property name="url" value="${Globals.oracle.Url}" />
+		<property name="jdbcUrl" value="${Globals.oracle.Url}" />
 		<property name="username" value="${Globals.oracle.UserName}"/>
 		<property name="password" value="#{egovPasswordResolver.resolvePassword('Globals.oracle.Password')}"/>
+		<property name="maximumPoolSize" value="10"/>
 	</bean>
 	</beans>
 
 	<!-- altibase -->
 	<beans profile="altibase">
-	<bean id="dataSource" class="org.apache.commons.dbcp2.BasicDataSource" destroy-method="close">
+	<bean id="dataSource" class="com.zaxxer.hikari.HikariDataSource" destroy-method="close">
 		<property name="driverClassName" value="${Globals.altibase.DriverClassName}"/>
-		<property name="url" value="${Globals.altibase.Url}" />
+		<property name="jdbcUrl" value="${Globals.altibase.Url}" />
 		<property name="username" value="${Globals.altibase.UserName}"/>
 		<property name="password" value="#{egovPasswordResolver.resolvePassword('Globals.altibase.Password')}"/>
+		<property name="maximumPoolSize" value="10"/>
 		
-		<property name="validationQuery" value="select 1"/>
-        <property name="testWhileIdle" value="true"/>
+		<property name="connectionTestQuery" value="select 1"/>
 	</bean>
 	</beans>
 
 	<!-- tibero -->
 	<beans profile="tibero">
-	<bean id="dataSource" class="org.apache.commons.dbcp2.BasicDataSource" destroy-method="close">
+	<bean id="dataSource" class="com.zaxxer.hikari.HikariDataSource" destroy-method="close">
 		<property name="driverClassName" value="${Globals.tibero.DriverClassName}"/>
-		<property name="url" value="${Globals.tibero.Url}" />
+		<property name="jdbcUrl" value="${Globals.tibero.Url}" />
 		<property name="username" value="${Globals.tibero.UserName}"/>
 		<property name="password" value="#{egovPasswordResolver.resolvePassword('Globals.tibero.Password')}"/>
+		<property name="maximumPoolSize" value="10"/>
 	</bean>
 	</beans>
 
     <!-- cubrid -->
     <beans profile="cubrid">
-    <bean id="dataSource" class="org.apache.commons.dbcp2.BasicDataSource" destroy-method="close">
+    <bean id="dataSource" class="com.zaxxer.hikari.HikariDataSource" destroy-method="close">
         <property name="driverClassName" value="${Globals.cubrid.DriverClassName}"/>
-        <property name="url" value="${Globals.cubrid.Url}" />
+        <property name="jdbcUrl" value="${Globals.cubrid.Url}" />
         <property name="username" value="${Globals.cubrid.UserName}"/>
         <property name="password" value="#{egovPasswordResolver.resolvePassword('Globals.cubrid.Password')}"/>
+        <property name="maximumPoolSize" value="10"/>
         
-        <property name="validationQuery" value="select 1"/>
-        <property name="testOnBorrow" value="false"/>
+        <property name="connectionTestQuery" value="select 1"/>
     </bean>
     </beans>
     <!--
     	CUBRID 가이드 참조
     	https://www.cubrid.com/tutorial/3794188
-    	* DBCP를 통해 최초 connection 시 해당 connection이 유효한지 체크하는 isValid를 호출
+        * HikariCP의 connectionTestQuery를 통해 connection 유효성을 확인
      -->
 
 	<!-- MariaDB -->
 	<beans profile="maria">
-	<bean id="dataSource" class="org.apache.commons.dbcp2.BasicDataSource" destroy-method="close">
+	<bean id="dataSource" class="com.zaxxer.hikari.HikariDataSource" destroy-method="close">
 		<property name="driverClassName" value="${Globals.maria.DriverClassName}"/>
-		<property name="url" value="${Globals.maria.Url}" />
+		<property name="jdbcUrl" value="${Globals.maria.Url}" />
 		<property name="username" value="${Globals.maria.UserName}"/>
 		<property name="password" value="#{egovPasswordResolver.resolvePassword('Globals.maria.Password')}"/>
+		<property name="maximumPoolSize" value="10"/>
 	</bean>
 	</beans>
 
 	<!-- PostresSQL -->
 	<beans profile="postgres">  
-	<bean id="dataSource" class="org.apache.commons.dbcp2.BasicDataSource" destroy-method="close">
+	<bean id="dataSource" class="com.zaxxer.hikari.HikariDataSource" destroy-method="close">
 		<property name="driverClassName" value="${Globals.postgres.DriverClassName}"/>
-		<property name="url" value="${Globals.postgres.Url}" />
+		<property name="jdbcUrl" value="${Globals.postgres.Url}" />
 		<property name="username" value="${Globals.postgres.UserName}"/>
 		<property name="password" value="#{egovPasswordResolver.resolvePassword('Globals.postgres.Password')}"/>
+		<property name="maximumPoolSize" value="10"/>
 	</bean>
 	</beans>
 	
 	<!-- GOLDILOCKS -->
 	<beans profile="goldilocks">  
-	<bean id="dataSource" class="org.apache.commons.dbcp2.BasicDataSource" destroy-method="close">
+	<bean id="dataSource" class="com.zaxxer.hikari.HikariDataSource" destroy-method="close">
 		<property name="driverClassName" value="${Globals.goldilocks.DriverClassName}"/>
-		<property name="url" value="${Globals.goldilocks.Url}" />
+		<property name="jdbcUrl" value="${Globals.goldilocks.Url}" />
 		<property name="username" value="${Globals.goldilocks.UserName}"/>
 		<property name="password" value="#{egovPasswordResolver.resolvePassword('Globals.goldilocks.Password')}"/>
+		<property name="maximumPoolSize" value="10"/>
 	</bean>
 	</beans>
 
-    <!-- DB Pool이 생성이 되더라고 특정 시간 호출되지 않으면 DBMS 설정에 따라 연결을 끊어질 때
-		이 경우 DBCP를 사용하셨다면.. 다음과 같은 설정을 추가하시면 연결을 유지시켜 줍니다. -->
+	<!-- DBMS가 유휴 connection을 종료하는 경우 다음 HikariCP 설정으로 연결 유지 주기를 지정할 수 있습니다. -->
 	<!--
-	<property name="validationQuery" value="select 1 from dual" />
-	<property name="testWhileIdle" value="true" />
-	<property name="timeBetweenEvictionRunsMillis" value="60000" /> -->  <!-- 1분 -->
+	<property name="keepaliveTime" value="60000" /> -->  <!-- 1분 -->
 
-	<!-- DBCP가 아닌 WAS의 DataSource를 사용하시는 경우도 WAS별로 동일한 설정을 하실 수 있습니다.
+	<!-- HikariCP가 아닌 WAS의 DataSource를 사용하시는 경우도 WAS별로 동일한 설정을 하실 수 있습니다.
 		(WAS별 구체적인 설정은 WAS document 확인) -->
 </beans>


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [x] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

###  개요

Spring 데이터소스의 기본 커넥션 풀을 DBCP2에서 HikariCP로 전환합니다.

###  변경 사항

- HikariCP 6.3.3 의존성 추가
- MySQL, Oracle, Altibase, Tibero, CUBRID, MariaDB, PostgreSQL, GOLDILOCKS 데이터소스를 `HikariDataSource`로 변경
- `url`을 HikariCP 형식인 `jdbcUrl`로 변경
- 모든 DB 프로필의 `maximumPoolSize`를 10으로 설정
- Altibase와 CUBRID의 연결 검증 설정을 `connectionTestQuery`로 변경
- `keepaliveTime` 설정 예시 등 관련 주석 수정
- `SmsBasicDBUtil` 호환성을 위해 기존 DBCP2 의존성 유지

###  검증

- [x] Spring 데이터소스 XML 구문 확인
- [x] 전체 8개 DB 프로필의 HikariCP 설정 확인
- [x] `git diff --check` 통과
- [x] JDK 17 및 Maven 3.9.9 환경에서 `mvn -DskipTests compile` 성공

###  참고

단위 테스트는 실행하지 않았으며, 테스트를 제외한 전체 소스 컴파일을 수행했습니다.

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [x] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

테스트 후

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/e7423086-7f1e-43b5-853e-effd0713b222" />
