### PR TITLE
fix: 메모할일 조회·수정·삭제 시 소유권 검증 추가

### DIFF
--- a/src/main/java/egovframework/com/cop/smt/mtm/web/EgovMemoTodoController.java
+++ b/src/main/java/egovframework/com/cop/smt/mtm/web/EgovMemoTodoController.java
@@ -198,6 +198,8 @@ public class EgovMemoTodoController {
     	model.addAttribute("todoEndMin", getTimeMM());
 
     	MemoTodoVO resultVO = memoTodoService.selectMemoTodo(memoTodoVO);
+    	// 작성자 본인 또는 관리자만 수정폼에 접근 가능하도록 소유권 검증 (2026.07.13 KISA 조치의 selectMemoTodo와 동일 관례)
+    	egovAssertAdminOrOwner(resultVO == null ? null : resultVO.getFrstRegisterId());
 		resultVO.setSearchCnd(memoTodoVO.getSearchCnd());
 		resultVO.setSearchWrd(memoTodoVO.getSearchWrd());
 		resultVO.setSearchBgnDe(memoTodoVO.getSearchBgnDe());
@@ -228,6 +230,11 @@ public class EgovMemoTodoController {
 		}
 
 		if (isAuthenticated) {
+		    // 작성자 본인 또는 관리자만 수정 가능하도록 소유권 검증 (selectMemoTodo의 KISA 조치와 동일하게
+		    // 이 파일이 이미 정의해 둔 egovAssertAdminOrOwner를 사용)
+		    MemoTodoVO stored = memoTodoService.selectMemoTodo(memoTodoVO);
+		    egovAssertAdminOrOwner(stored == null ? null : stored.getFrstRegisterId());
+
 			memoTodoVO.setTodoBeginTime(memoTodoVO.getTodoDe() + memoTodoVO.getTodoBeginHour() + memoTodoVO.getTodoBeginMin());
 			memoTodoVO.setTodoEndTime(memoTodoVO.getTodoDe() + memoTodoVO.getTodoEndHour() + memoTodoVO.getTodoEndMin());
 
@@ -291,6 +298,11 @@ public class EgovMemoTodoController {
     		model.addAttribute("message", egovMessageSource.getMessage("fail.common.login"));
         	return "redirect:/uat/uia/egovLoginUsr.do";
     	}
+
+    	// 작성자 본인 또는 관리자만 삭제 가능하도록 소유권 검증
+    	MemoTodoVO stored = memoTodoService.selectMemoTodo(memoTodoVO);
+    	egovAssertAdminOrOwner(stored == null ? null : stored.getFrstRegisterId());
+
     	memoTodoService.deleteMemoTodo(memoTodoVO);
 		return "forward:/cop/smt/mtm/selectMemoTodoList.do";
 	}

--- a/src/test/java/egovframework/com/cop/smt/mtm/web/EgovMemoTodoControllerOwnershipTest.java
+++ b/src/test/java/egovframework/com/cop/smt/mtm/web/EgovMemoTodoControllerOwnershipTest.java
@@ -1,0 +1,238 @@
+package egovframework.com.cop.smt.mtm.web;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.ui.ModelMap;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.BindingResult;
+
+import egovframework.com.cmm.EgovMessageSource;
+import egovframework.com.cmm.LoginVO;
+import egovframework.com.cmm.service.EgovUserDetailsService;
+import egovframework.com.cmm.util.EgovUserDetailsHelper;
+import egovframework.com.cop.smt.mtm.service.EgovMemoTodoService;
+import egovframework.com.cop.smt.mtm.service.MemoTodo;
+import egovframework.com.cop.smt.mtm.service.MemoTodoVO;
+
+/**
+ * modifyMemoTodo·updateMemoTodo·deleteMemoTodo의 소유권 검증 회귀 테스트.
+ *
+ * 로그인 사용자가 자신이 등록하지 않은 메모할일을 열람(수정폼 진입)·수정·삭제하려 하면
+ * egovAssertAdminOrOwner가 IllegalStateException을 던져 차단해야 한다(IDOR 방지).
+ * 수정 전 코드는 인증 여부만 확인하고 소유자를 대조하지 않아, 아래 attacker 테스트가 실패한다.
+ * ROLE_ADMIN 보유자는 소유자가 아니어도 통과해야 한다(selectMemoTodo의 기존 KISA 조치와 동일 관례).
+ */
+class EgovMemoTodoControllerOwnershipTest {
+
+	private static final String OWNER = "USRCNFRM_00000000001";
+	private static final String ATTACKER = "USRCNFRM_00000000009";
+
+	/** selectMemoTodo는 저장된 소유자를 돌려주고, update/delete 호출 여부를 기록하는 스텁. */
+	private static final class StubService implements EgovMemoTodoService {
+		private final MemoTodoVO stored;
+		private boolean updateCalled = false;
+		private boolean deleteCalled = false;
+
+		StubService(String ownerUniqId) {
+			this.stored = new MemoTodoVO();
+			this.stored.setFrstRegisterId(ownerUniqId);
+		}
+
+		@Override
+		public MemoTodoVO selectMemoTodo(MemoTodoVO memoTodoVO) {
+			return stored;
+		}
+
+		@Override
+		public void updateMemoTodo(MemoTodo memoTodo) {
+			updateCalled = true;
+		}
+
+		@Override
+		public void deleteMemoTodo(MemoTodo memoTodo) {
+			deleteCalled = true;
+		}
+
+		@Override
+		public Map<String, Object> selectMemoTodoList(MemoTodoVO memoTodoVO) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public void insertMemoTodo(MemoTodo memoTodo) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public List<MemoTodoVO> selectMemoTodoListToday(MemoTodoVO memoTodoVO) {
+			throw new UnsupportedOperationException();
+		}
+	}
+
+	private static void bindLoginUser(String uniqId, List<String> authorities) {
+		LoginVO login = new LoginVO();
+		login.setUniqId(uniqId);
+		EgovUserDetailsService stub = new EgovUserDetailsService() {
+			@Override
+			public Object getAuthenticatedUser() {
+				return login;
+			}
+
+			@Override
+			public List<String> getAuthorities() {
+				return authorities;
+			}
+
+			@Override
+			public Boolean isAuthenticated() {
+				return Boolean.TRUE;
+			}
+		};
+		new EgovUserDetailsHelper().setEgovUserDetailsService(stub);
+	}
+
+	private static EgovMemoTodoController controllerWith(StubService service) {
+		EgovMemoTodoController controller = new EgovMemoTodoController();
+		controller.memoTodoService = service;
+		controller.egovMessageSource = new EgovMessageSource() {
+			@Override
+			public String getMessage(String code) {
+				return code;
+			}
+		};
+		return controller;
+	}
+
+	private static MemoTodoVO requestFor(String todoId) {
+		MemoTodoVO memoTodoVO = new MemoTodoVO();
+		memoTodoVO.setTodoId(todoId);
+		memoTodoVO.setTodoNm("edited");
+		return memoTodoVO;
+	}
+
+	// ---- modifyMemoTodo (수정폼 진입, 정보노출 IDOR) ----
+
+	@Test
+	void modifyByNonOwnerIsRejected() {
+		StubService service = new StubService(OWNER);
+		EgovMemoTodoController controller = controllerWith(service);
+		bindLoginUser(ATTACKER, List.of());
+
+		MemoTodoVO memoTodoVO = requestFor("8000001");
+		BindingResult bindingResult = new BeanPropertyBindingResult(memoTodoVO, "memoTodoVO");
+		ModelMap model = new ModelMap();
+
+		assertThrows(IllegalStateException.class,
+				() -> controller.modifyMemoTodo(memoTodoVO, bindingResult, model),
+				"A logged-in non-owner must not be able to open another member's memo/todo edit form.");
+	}
+
+	@Test
+	void modifyByOwnerSucceeds() throws Exception {
+		StubService service = new StubService(OWNER);
+		EgovMemoTodoController controller = controllerWith(service);
+		bindLoginUser(OWNER, List.of());
+
+		MemoTodoVO memoTodoVO = requestFor("8000001");
+		BindingResult bindingResult = new BeanPropertyBindingResult(memoTodoVO, "memoTodoVO");
+		ModelMap model = new ModelMap();
+
+		String view = controller.modifyMemoTodo(memoTodoVO, bindingResult, model);
+		assertTrue(view.contains("EgovMemoTodoUpdt"));
+	}
+
+	@Test
+	void modifyByAdminSucceedsEvenWhenNotOwner() throws Exception {
+		StubService service = new StubService(OWNER);
+		EgovMemoTodoController controller = controllerWith(service);
+		bindLoginUser(ATTACKER, List.of("ROLE_ADMIN"));
+
+		MemoTodoVO memoTodoVO = requestFor("8000001");
+		BindingResult bindingResult = new BeanPropertyBindingResult(memoTodoVO, "memoTodoVO");
+		ModelMap model = new ModelMap();
+
+		String view = controller.modifyMemoTodo(memoTodoVO, bindingResult, model);
+		assertTrue(view.contains("EgovMemoTodoUpdt"));
+	}
+
+	// ---- updateMemoTodo ----
+
+	@Test
+	void updateByNonOwnerDoesNotReachTheUpdateService() {
+		StubService service = new StubService(OWNER);
+		EgovMemoTodoController controller = controllerWith(service);
+		bindLoginUser(ATTACKER, List.of());
+
+		MemoTodoVO memoTodoVO = requestFor("8000001");
+		BindingResult bindingResult = new BeanPropertyBindingResult(memoTodoVO, "memoTodoVO");
+		ModelMap model = new ModelMap();
+
+		assertThrows(IllegalStateException.class,
+				() -> controller.updateMemoTodo(memoTodoVO, bindingResult, model),
+				"A logged-in non-owner must not be able to update another member's memo/todo.");
+		assertTrue(!service.updateCalled, "updateMemoTodo service must not be reached by a non-owner.");
+	}
+
+	@Test
+	void updateByOwnerReachesTheUpdateService() throws Exception {
+		StubService service = new StubService(OWNER);
+		EgovMemoTodoController controller = controllerWith(service);
+		bindLoginUser(OWNER, List.of());
+
+		MemoTodoVO memoTodoVO = requestFor("8000001");
+		BindingResult bindingResult = new BeanPropertyBindingResult(memoTodoVO, "memoTodoVO");
+		ModelMap model = new ModelMap();
+
+		controller.updateMemoTodo(memoTodoVO, bindingResult, model);
+		assertTrue(service.updateCalled, "The owner must be able to update their own memo/todo.");
+	}
+
+	@Test
+	void updateByAdminReachesTheUpdateServiceEvenWhenNotOwner() throws Exception {
+		StubService service = new StubService(OWNER);
+		EgovMemoTodoController controller = controllerWith(service);
+		bindLoginUser(ATTACKER, List.of("ROLE_ADMIN"));
+
+		MemoTodoVO memoTodoVO = requestFor("8000001");
+		BindingResult bindingResult = new BeanPropertyBindingResult(memoTodoVO, "memoTodoVO");
+		ModelMap model = new ModelMap();
+
+		controller.updateMemoTodo(memoTodoVO, bindingResult, model);
+		assertTrue(service.updateCalled, "An admin must be able to update any member's memo/todo.");
+	}
+
+	// ---- deleteMemoTodo ----
+
+	@Test
+	void deleteByNonOwnerDoesNotReachTheDeleteService() {
+		StubService service = new StubService(OWNER);
+		EgovMemoTodoController controller = controllerWith(service);
+		bindLoginUser(ATTACKER, List.of());
+
+		MemoTodoVO memoTodoVO = requestFor("8000001");
+		ModelMap model = new ModelMap();
+
+		assertThrows(IllegalStateException.class,
+				() -> controller.deleteMemoTodo(memoTodoVO, model),
+				"A logged-in non-owner must not be able to delete another member's memo/todo.");
+		assertTrue(!service.deleteCalled, "deleteMemoTodo service must not be reached by a non-owner.");
+	}
+
+	@Test
+	void deleteByOwnerReachesTheDeleteService() throws Exception {
+		StubService service = new StubService(OWNER);
+		EgovMemoTodoController controller = controllerWith(service);
+		bindLoginUser(OWNER, List.of());
+
+		MemoTodoVO memoTodoVO = requestFor("8000001");
+		ModelMap model = new ModelMap();
+
+		controller.deleteMemoTodo(memoTodoVO, model);
+		assertTrue(service.deleteCalled, "The owner must be able to delete their own memo/todo.");
+	}
+}


### PR DESCRIPTION
## 수정 사유

- [x] 버그수정
- [ ] 기능개선
- [ ] 리팩터링

## 문제 상황

메모할일의 수정폼 진입 `modifyMemoTodo`(`/cop/smt/mtm/modifyMemoTodo.do`), 수정 `updateMemoTodo`, 삭제 `deleteMemoTodo`가 인증 여부만 확인하고 작성자 본인인지는 대조하지 않습니다. 그래서 로그인한 사용자가 임의의 `todoId`로 다른 회원의 메모할일 내용을 열람(수정폼에 렌더링)·수정·삭제할 수 있습니다.

같은 파일의 상세조회 `selectMemoTodo`(`/cop/smt/mtm/selectMemoTodo.do`)에는 소유자 또는 `ROLE_ADMIN`만 허용하는 검증이 이미 인라인으로 들어 있습니다(2026.07.13 KISA 보안취약점 조치). 그때 같은 목적의 헬퍼 `egovAssertLoginUser`·`egovAssertAdminOrOwner`도 이 파일에 함께 정의했습니다. 정작 `selectMemoTodo` 자신은 이 헬퍼를 쓰지 않고 로직을 인라인으로 중복 작성했고, 다른 세 경로에서는 아예 호출되지 않는 죽은 코드로 남아 있었습니다.

## 발생 흐름

`updateMemoTodo`는 요청의 `todoId`(PK)를 받아 인증 여부만 확인한 뒤 그대로 수정합니다.

```java
if (isAuthenticated) {
    memoTodoVO.setTodoBeginTime(...);
    memoTodoVO.setTodoEndTime(...);
    memoTodoVO.setLastUpdusrId(user == null ? "" : EgovStringUtil.isNullToString(user.getUniqId()));
    memoTodoService.updateMemoTodo(memoTodoVO);
}
```

수정·삭제 SQL은 소유자 조건 없이 PK만으로 갱신·삭제합니다.

```sql
UPDATE COMTNMEMOTODO SET TODO_SJ=#{todoNm}, ... WHERE TODO_ID = #{todoId}
DELETE FROM COMTNMEMOTODO WHERE TODO_ID = #{todoId}
```

따라서 로그인한 사용자가 남의 `todoId`를 요청에 실으면 그 레코드가 그대로 수정·삭제됩니다. `modifyMemoTodo`(수정폼 진입) 역시 소유권을 확인하지 않고 조회 결과를 그대로 모델에 담아 폼에 렌더링하므로 수정 시도 없이 조회만으로도 다른 회원의 메모 제목·본문이 노출됩니다.

## 변경 내용

세 경로 모두 이 파일에 이미 있던 `egovAssertAdminOrOwner`를 그대로 사용해 `selectMemoTodo`와 동일한 관례(예외로 차단, 관리자는 우회)를 따르게 했습니다.

```java
MemoTodoVO stored = memoTodoService.selectMemoTodo(memoTodoVO);
egovAssertAdminOrOwner(stored == null ? null : stored.getFrstRegisterId());
```

소유자 판정은 `frstRegisterId`를 씁니다. `insertMemoTodo`에서 서버가 로그인 세션(`loginVO.getUniqId()`)으로 직접 설정하는 값이라 위조할 수 없습니다. `selectMemoTodo`가 쓰는 `wrterId`는 등록 폼의 hidden 필드(`EgovMemoTodoRegist.jsp`)로 제출됩니다. 등록 시점에 클라이언트가 조작할 수 있는 값이라 이번 검증에는 쓰지 않았습니다.

`selectMemoTodo`의 조회 결과 매핑(`MemoTodoDetail`)에는 `frstRegisterId`가 이미 포함돼 있어(만족도 카드와 달리) 매퍼 수정은 필요 없었습니다. 8개 방언 매퍼(altibase·cubrid·goldilocks·maria·mysql·oracle·postgres·tibero) 전부에서 동일하게 확인했습니다.

## 영향 범위

- `EgovMemoTodoController.modifyMemoTodo`·`updateMemoTodo`·`deleteMemoTodo`: 소유권 검증 추가. 정상 소유자와 `ROLE_ADMIN`의 요청은 그대로 동작하고 비소유자만 차단됩니다.
- 매퍼 변경 없음(8개 방언 모두 `frstRegisterId`가 이미 매핑되어 있음을 확인).

## 테스트 방법

### 재현 (수정 전)

로그인한 사용자가 다른 회원 명의의 메모할일에 수정·삭제·수정폼 진입을 요청합니다. 피해자 레코드는 등록 경로가 만드는 형태(`frstRegisterId` = 소유자)로 두고 공격자만 실제 세션으로 엔드포인트를 호출합니다. 세 경로 모두 인증만 확인하고 소유자 대조가 없어 그대로 처리됩니다.

### 확인 (수정 후)

같은 요청이 소유권 검증에 걸려 `IllegalStateException`으로 차단됩니다(선점 컨트롤러 `selectMemoTodo`가 예외가 나면 "시스템 에러" 화면으로 안전하게 처리하는 것과 같은 방식입니다).

### 단위 테스트

`EgovMemoTodoControllerOwnershipTest`를 추가했습니다. `modifyMemoTodo`·`updateMemoTodo`·`deleteMemoTodo` 각각을 비소유자 차단(예외 발생, 서비스 미호출)·소유자 정상동작·관리자 우회(`ROLE_ADMIN`) 3케이스씩 검증합니다.

```
Tests run: 8, Failures: 0, Errors: 0, Skipped: 0
```

소유권 검증 호출을 제거하면 비소유자 테스트 3건이 다음과 같이 실패합니다.

```
Tests run: 8, Failures: 3, Errors: 0, Skipped: 0
  deleteByNonOwnerDoesNotReachTheDeleteService: Expected java.lang.IllegalStateException to be thrown, but nothing was thrown.
  modifyByNonOwnerIsRejected: Expected java.lang.IllegalStateException to be thrown, but nothing was thrown.
  updateByNonOwnerDoesNotReachTheUpdateService: Expected java.lang.IllegalStateException to be thrown, but nothing was thrown.
```

