### PR TITLE
fix: 위키북마크 일괄삭제 시 소유권 검증 추가

### DIFF
--- a/src/main/java/egovframework/com/uss/ion/wik/bmk/web/EgovWikiBookmarkController.java
+++ b/src/main/java/egovframework/com/uss/ion/wik/bmk/web/EgovWikiBookmarkController.java
@@ -96,6 +96,15 @@ public class EgovWikiBookmarkController {
 
         	for(String checkData : checkList) {
         		LOGGER.debug("===>>> checkData = "+checkData);
+
+        		// 작성자 본인 또는 관리자만 삭제 가능하도록 소유권 검증
+        		String loginUniqId = loginVO == null ? "" : EgovStringUtil.isNullToString(loginVO.getUniqId());
+        		WikiBookmark ownershipCheck = new WikiBookmark();
+        		ownershipCheck.setWikiBkmkId(checkData);
+        		ownershipCheck.setFrstRegisterId(loginUniqId);
+        		boolean owns = egovWikiBookmarkService.selectWikiBookmarkListCnt(ownershipCheck) > 0;
+        		egovAssertAdminOrOwner(owns ? loginUniqId : null);
+
                 wikiBookmark.setWikiBkmkId(checkData);
 	            egovWikiBookmarkService.deleteWikiBookmark(wikiBookmark);
             }

--- a/src/main/resources/egovframework/mapper/com/uss/ion/wik/bmk/EgovWikiBookmark_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/wik/bmk/EgovWikiBookmark_SQL_altibase.xml
@@ -65,6 +65,9 @@
 		FROM COMTNWIKIBKMK A
 		WHERE 1=1
 		AND A.FRST_REGISTER_ID=#{frstRegisterId}
+	 <if test="wikiBkmkId != null and wikiBkmkId != ''">
+	 	 AND A.WIKI_BKMK_ID = #{wikiBkmkId}
+	 </if>
 	 <if test="searchCondition == 'A.WIKI_BKMK_NM'">
 	 	
 	 		

--- a/src/main/resources/egovframework/mapper/com/uss/ion/wik/bmk/EgovWikiBookmark_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/wik/bmk/EgovWikiBookmark_SQL_cubrid.xml
@@ -65,6 +65,9 @@
 		FROM COMTNWIKIBKMK A
 		WHERE 1=1
 		AND A.FRST_REGISTER_ID=#{frstRegisterId}
+	 <if test="wikiBkmkId != null and wikiBkmkId != ''">
+	 	 AND A.WIKI_BKMK_ID = #{wikiBkmkId}
+	 </if>
 	 <if test="searchCondition == 'A.WIKI_BKMK_NM'">
 	 	
 	 		

--- a/src/main/resources/egovframework/mapper/com/uss/ion/wik/bmk/EgovWikiBookmark_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/wik/bmk/EgovWikiBookmark_SQL_goldilocks.xml
@@ -65,6 +65,9 @@
 		FROM COMTNWIKIBKMK A
 		WHERE 1=1
 		AND A.FRST_REGISTER_ID=#{frstRegisterId}
+	 <if test="wikiBkmkId != null and wikiBkmkId != ''">
+	 	 AND A.WIKI_BKMK_ID = #{wikiBkmkId}
+	 </if>
 	 <if test="searchCondition == 'A.WIKI_BKMK_NM'">
 	 	
 	 		

--- a/src/main/resources/egovframework/mapper/com/uss/ion/wik/bmk/EgovWikiBookmark_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/wik/bmk/EgovWikiBookmark_SQL_maria.xml
@@ -55,6 +55,9 @@
 		FROM COMTNWIKIBKMK A
 		WHERE 1=1
 		AND A.FRST_REGISTER_ID=#{frstRegisterId}
+	 <if test="wikiBkmkId != null and wikiBkmkId != ''">
+	 	 AND A.WIKI_BKMK_ID = #{wikiBkmkId}
+	 </if>
 	 <if test="searchCondition == 'A.WIKI_BKMK_NM'">
 	 	
 	 		

--- a/src/main/resources/egovframework/mapper/com/uss/ion/wik/bmk/EgovWikiBookmark_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/wik/bmk/EgovWikiBookmark_SQL_mysql.xml
@@ -55,6 +55,9 @@
 		FROM COMTNWIKIBKMK A
 		WHERE 1=1
 		AND A.FRST_REGISTER_ID=#{frstRegisterId}
+	 <if test="wikiBkmkId != null and wikiBkmkId != ''">
+	 	 AND A.WIKI_BKMK_ID = #{wikiBkmkId}
+	 </if>
 	 <if test="searchCondition == 'A.WIKI_BKMK_NM'">
 	 	
 	 		

--- a/src/main/resources/egovframework/mapper/com/uss/ion/wik/bmk/EgovWikiBookmark_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/wik/bmk/EgovWikiBookmark_SQL_oracle.xml
@@ -65,6 +65,9 @@
 		FROM COMTNWIKIBKMK A
 		WHERE 1=1
 		AND A.FRST_REGISTER_ID=#{frstRegisterId}
+	 <if test="wikiBkmkId != null and wikiBkmkId != ''">
+	 	 AND A.WIKI_BKMK_ID = #{wikiBkmkId}
+	 </if>
 	 <if test="searchCondition == 'A.WIKI_BKMK_NM'">
 	 	
 	 		

--- a/src/main/resources/egovframework/mapper/com/uss/ion/wik/bmk/EgovWikiBookmark_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/wik/bmk/EgovWikiBookmark_SQL_postgres.xml
@@ -55,6 +55,9 @@
 		FROM COMTNWIKIBKMK A
 		WHERE 1=1
 		AND A.FRST_REGISTER_ID=#{frstRegisterId}
+	 <if test="wikiBkmkId != null and wikiBkmkId != ''">
+	 	 AND A.WIKI_BKMK_ID = #{wikiBkmkId}
+	 </if>
 	 <if test="searchCondition == 'A.WIKI_BKMK_NM'">
 	 	
 	 		

--- a/src/main/resources/egovframework/mapper/com/uss/ion/wik/bmk/EgovWikiBookmark_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/wik/bmk/EgovWikiBookmark_SQL_tibero.xml
@@ -65,6 +65,9 @@
 		FROM COMTNWIKIBKMK A
 		WHERE 1=1
 		AND A.FRST_REGISTER_ID=#{frstRegisterId}
+	 <if test="wikiBkmkId != null and wikiBkmkId != ''">
+	 	 AND A.WIKI_BKMK_ID = #{wikiBkmkId}
+	 </if>
 	 <if test="searchCondition == 'A.WIKI_BKMK_NM'">
 	 	
 	 		

--- a/src/test/java/egovframework/com/uss/ion/wik/bmk/web/EgovWikiBookmarkControllerOwnershipTest.java
+++ b/src/test/java/egovframework/com/uss/ion/wik/bmk/web/EgovWikiBookmarkControllerOwnershipTest.java
@@ -1,0 +1,209 @@
+package egovframework.com.uss.ion.wik.bmk.web;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.ui.ModelMap;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import egovframework.com.cmm.EgovMessageSource;
+import egovframework.com.cmm.LoginVO;
+import egovframework.com.cmm.service.EgovUserDetailsService;
+import egovframework.com.cmm.util.EgovUserDetailsHelper;
+import egovframework.com.uss.ion.wik.bmk.service.EgovWikiBookmarkService;
+import egovframework.com.uss.ion.wik.bmk.service.WikiBookmark;
+
+/**
+ * 위키북마크 일괄삭제(cmd=del)의 소유권 검증 회귀 테스트.
+ *
+ * 로그인 사용자가 checkList에 자신이 등록하지 않은 wikiBkmkId를 실어 다른 회원의
+ * 북마크를 삭제하려 하면 egovAssertAdminOrOwner가 IllegalStateException을 던져
+ * 차단해야 한다(IDOR 방지). 수정 전 코드는 인증 여부만 확인하고 checkList의 각
+ * ID에 대해 소유자 대조 없이 그대로 삭제했다.
+ */
+class EgovWikiBookmarkControllerOwnershipTest {
+
+	private static final String OWNER = "USRCNFRM_00000000001";
+	private static final String ATTACKER = "USRCNFRM_00000000009";
+	private static final String OWNED_ID = "8000001";
+	private static final String OTHERS_ID = "8000002";
+
+	/** selectWikiBookmarkListCnt는 wikiBkmkId+frstRegisterId 조합이 실제 소유 관계일 때만 1을 돌려주는 스텁. */
+	private static final class StubService implements EgovWikiBookmarkService {
+		private final Map<String, String> ownerByBookmarkId = new HashMap<>();
+		private boolean deleteCalled = false;
+
+		StubService(String ownedId, String ownerUniqId) {
+			ownerByBookmarkId.put(ownedId, ownerUniqId);
+		}
+
+		@Override
+		public int selectWikiBookmarkListCnt(WikiBookmark wikiBookmark) {
+			String owner = ownerByBookmarkId.get(wikiBookmark.getWikiBkmkId());
+			return (owner != null && owner.equals(wikiBookmark.getFrstRegisterId())) ? 1 : 0;
+		}
+
+		@Override
+		public void deleteWikiBookmark(WikiBookmark wikiBookmark) {
+			deleteCalled = true;
+		}
+
+		@Override
+		public List<?> selectWikiBookmarkList(WikiBookmark wikiBookmark) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public int selectWikiBookmarkDuplicationCnt(WikiBookmark wikiBookmark) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public void insertWikiBookmark(WikiBookmark wikiBookmark) {
+			throw new UnsupportedOperationException();
+		}
+	}
+
+	@AfterEach
+	void clearRequestContext() {
+		RequestContextHolder.resetRequestAttributes();
+	}
+
+	private static void bindLoginUser(String uniqId) {
+		LoginVO login = new LoginVO();
+		login.setUniqId(uniqId);
+		EgovUserDetailsService stub = new EgovUserDetailsService() {
+			@Override
+			public Object getAuthenticatedUser() {
+				return login;
+			}
+
+			@Override
+			public List<String> getAuthorities() {
+				return List.of();
+			}
+
+			@Override
+			public Boolean isAuthenticated() {
+				return Boolean.TRUE;
+			}
+		};
+		new EgovUserDetailsHelper().setEgovUserDetailsService(stub);
+	}
+
+	/**
+	 * MockHttpServletRequest는 이 로컬 환경의 test classpath에 Jakarta Servlet 6.0 API가 없어
+	 * NoClassDefFoundError(ServletConnection)를 던진다(기존 EgovAccessTest도 동일하게 깨져 있음 —
+	 * pom.xml의 주석 처리된 jakarta.servlet-api 6.0.0 test 의존성이 그 증거). 컨트롤러가 실제로
+	 * 쓰는 메서드(getMethod)만 최소 구현한 프록시로 우회한다.
+	 */
+	private static void bindPostRequest() {
+		jakarta.servlet.http.HttpServletRequest request = (jakarta.servlet.http.HttpServletRequest) java.lang.reflect.Proxy.newProxyInstance(
+				EgovWikiBookmarkControllerOwnershipTest.class.getClassLoader(),
+				new Class<?>[] { jakarta.servlet.http.HttpServletRequest.class },
+				(proxy, method, args) -> {
+					if ("getMethod".equals(method.getName())) {
+						return "POST";
+					}
+					Class<?> returnType = method.getReturnType();
+					if (returnType == boolean.class) {
+						return false;
+					}
+					return null;
+				});
+		RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+	}
+
+	private static EgovWikiBookmarkController controllerWith(StubService service) {
+		EgovWikiBookmarkController controller = new EgovWikiBookmarkController();
+		try {
+			java.lang.reflect.Field serviceField = EgovWikiBookmarkController.class.getDeclaredField("egovWikiBookmarkService");
+			serviceField.setAccessible(true);
+			serviceField.set(controller, service);
+		} catch (ReflectiveOperationException e) {
+			throw new IllegalStateException(e);
+		}
+		controller.egovMessageSource = new EgovMessageSource() {
+			@Override
+			public String getMessage(String code) {
+				return code;
+			}
+		};
+		return controller;
+	}
+
+	private static String callDelete(StubService service, String loginUniqId, String targetId) throws Exception {
+		EgovWikiBookmarkController controller = controllerWith(service);
+		bindLoginUser(loginUniqId);
+		bindPostRequest();
+
+		WikiBookmark searchVO = new WikiBookmark();
+		WikiBookmark wikiBookmark = new WikiBookmark();
+		Map<String, String> commandMap = new HashMap<>();
+		commandMap.put("cmd", "del");
+		ModelMap model = new ModelMap();
+
+		return controller.EgovWikiBookmarkList(searchVO, wikiBookmark, commandMap, List.of(targetId), model);
+	}
+
+	@Test
+	void deleteByNonOwnerIsRejected() {
+		StubService service = new StubService(OWNED_ID, OWNER);
+		assertThrows(IllegalStateException.class, () -> callDelete(service, ATTACKER, OWNED_ID),
+				"A logged-in non-owner must not be able to delete another member's wiki bookmark via checkList.");
+		assertFalse(service.deleteCalled, "deleteWikiBookmark must not be reached by a non-owner.");
+	}
+
+	@Test
+	void deleteByOwnerSucceeds() throws Exception {
+		StubService service = new StubService(OWNED_ID, OWNER);
+		String view = callDelete(service, OWNER, OWNED_ID);
+		assertTrue(service.deleteCalled, "The owner must be able to delete their own wiki bookmark.");
+		assertEquals("redirect:/uss/ion/wik/bmk/listWikiBookmark.do", view);
+	}
+
+	@Test
+	void deleteByAdminSucceedsEvenWhenNotOwner() throws Exception {
+		StubService service = new StubService(OTHERS_ID, OWNER);
+		bindLoginUser(ATTACKER);
+		EgovUserDetailsService adminStub = new EgovUserDetailsService() {
+			@Override
+			public Object getAuthenticatedUser() {
+				LoginVO login = new LoginVO();
+				login.setUniqId(ATTACKER);
+				return login;
+			}
+
+			@Override
+			public List<String> getAuthorities() {
+				return List.of("ROLE_ADMIN");
+			}
+
+			@Override
+			public Boolean isAuthenticated() {
+				return Boolean.TRUE;
+			}
+		};
+		new EgovUserDetailsHelper().setEgovUserDetailsService(adminStub);
+		bindPostRequest();
+
+		EgovWikiBookmarkController controller = controllerWith(service);
+		WikiBookmark searchVO = new WikiBookmark();
+		WikiBookmark wikiBookmark = new WikiBookmark();
+		Map<String, String> commandMap = new HashMap<>();
+		commandMap.put("cmd", "del");
+		ModelMap model = new ModelMap();
+
+		controller.EgovWikiBookmarkList(searchVO, wikiBookmark, commandMap, List.of(OTHERS_ID), model);
+		assertTrue(service.deleteCalled, "An admin must be able to delete any member's wiki bookmark.");
+	}
+}


### PR DESCRIPTION
## 수정 사유

- [x] 버그수정
- [ ] 기능개선
- [ ] 리팩터링

## 문제 상황

위키북마크 일괄삭제(`/uss/ion/wik/bmk/listWikiBookmark.do?cmd=del`)가 인증 여부와 POST 메서드만 확인하고 요청으로 받은 `checkList`의 각 `wikiBkmkId`를 소유자 대조 없이 그대로 삭제합니다. 그래서 로그인한 사용자가 `checkList`에 다른 회원의 `wikiBkmkId`를 실으면 그 북마크를 삭제할 수 있습니다.

이 파일에도 2026.07.13 KISA 보안취약점 조치가 `egovAssertLoginUser`·`egovAssertAdminOrOwner` 헬퍼를 정의해 뒀습니다. 그런데 별도 조치를 받은 건 `usid`를 로그인 사용자로 고정한 등록 경로(`registWikiBookmark.do`)뿐이라 삭제 경로는 그대로 남았고, 이 헬퍼는 어디서도 호출되지 않는 죽은 코드였습니다.

같은 계열의 소유권 검증을 `EgovBBSSatisfactionController`(#1197)와 `EgovMemoTodoController`(#1201)에도 적용했습니다. 이 PR은 그 패턴을 위키북마크에 적용하는 세 번째 카드입니다.

## 발생 흐름

```java
if(sCmd.equals("del")){
    // POST만 허용하는 검증만 있고, 소유자 검증은 없음
    for(String checkData : checkList) {
        wikiBookmark.setWikiBkmkId(checkData);
        egovWikiBookmarkService.deleteWikiBookmark(wikiBookmark);
    }
    ...
}
```

삭제 SQL도 소유자 조건 없이 PK만으로 지웁니다.

```sql
DELETE FROM COMTNWIKIBKMK WHERE WIKI_BKMK_ID = #{wikiBkmkId}
```

## 변경 내용

삭제 루프 안에서 이 파일에 이미 있던 `egovAssertAdminOrOwner`를 그대로 사용해 소유자 또는 `ROLE_ADMIN`만 통과하게 했습니다.

```java
String loginUniqId = loginVO == null ? "" : EgovStringUtil.isNullToString(loginVO.getUniqId());
WikiBookmark ownershipCheck = new WikiBookmark();
ownershipCheck.setWikiBkmkId(checkData);
ownershipCheck.setFrstRegisterId(loginUniqId);
boolean owns = egovWikiBookmarkService.selectWikiBookmarkListCnt(ownershipCheck) > 0;
egovAssertAdminOrOwner(owns ? loginUniqId : null);
```

소유권을 확인할 단건 조회 메서드가 없어서 이미 있는 `selectWikiBookmarkListCnt`(목록조회 개수)에 `wikiBkmkId` 필터 조건을 추가해 재사용했습니다. `frstRegisterId=로그인 uniqId`와 `wikiBkmkId=대상 ID`로 개수를 셌을 때 0보다 크면 그 레코드가 로그인 사용자 소유라는 뜻입니다.

```xml
<if test="wikiBkmkId != null and wikiBkmkId != ''">
    AND A.WIKI_BKMK_ID = #{wikiBkmkId}
</if>
```

목록조회에 쓰는 `selectWikiBookmarkList`(개수조회 아님)는 건드리지 않았습니다. 8개 방언 매퍼(altibase·cubrid·goldilocks·maria·mysql·oracle·postgres·tibero) 모두 동일하게 반영했습니다.

`frstRegisterId`는 등록 경로(`registWikiBookmark.do`)에서 서버가 로그인 세션으로 직접 설정하는 값이라 위조할 수 없습니다.

## 영향 범위

- `EgovWikiBookmarkController.EgovWikiBookmarkList`(cmd=del 분기): 소유권 검증 추가. 정상 소유자와 `ROLE_ADMIN`의 삭제는 그대로 동작하고 비소유자만 차단됩니다.
- `EgovWikiBookmark_SQL_*.xml`(8개 방언): `selectWikiBookmarkListCnt`에 선택적 `wikiBkmkId` 필터 추가. 이 쿼리를 부르는 다른 호출부(목록 조회 시 전체 개수 집계, `wikiBkmkId` 미지정)는 조건이 안 걸리므로 영향이 없습니다.

## 테스트 방법

### 재현 (수정 전)

로그인한 사용자가 다른 회원 명의의 위키북마크 `wikiBkmkId`를 `checkList`에 실어 삭제를 요청합니다. 인증만 확인하고 소유자 대조가 없어 그대로 삭제됩니다.

### 확인 (수정 후)

같은 요청이 소유권 검증에 걸려 `IllegalStateException`으로 차단됩니다.

### 단위 테스트

`EgovWikiBookmarkControllerOwnershipTest`를 추가했습니다. 비소유자 차단(예외 발생, 삭제 서비스 미호출)·소유자 정상동작·관리자 우회(`ROLE_ADMIN`) 3케이스를 검증합니다.

```
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0
```

소유권 검증 호출을 제거하면 비소유자 테스트가 다음과 같이 실패합니다.

```
Tests run: 3, Failures: 1, Errors: 0, Skipped: 0
  deleteByNonOwnerIsRejected: Expected java.lang.IllegalStateException to be thrown, but nothing was thrown.
```

