### PR TITLE
fix: 부서일정 삭제·수정 시 담당자·등록자 소유권 검증 추가

### DIFF
--- a/src/main/java/egovframework/com/cop/smt/sdm/web/EgovDeptSchdulManageController.java
+++ b/src/main/java/egovframework/com/cop/smt/sdm/web/EgovDeptSchdulManageController.java
@@ -535,6 +535,11 @@ public class EgovDeptSchdulManageController {
 	@PostMapping(value = "/cop/smt/sdm/EgovDeptSchdulManageDetail.do", params = "cmd=del")
 	public String egovDeptSchdulManageDelete(DeptSchdulManageVO deptSchdulManageVO) throws Exception {
 
+		// 담당자·등록자 또는 관리자만 삭제 가능하도록 소유권 검증
+		DeptSchdulManageVO stored = egovDeptSchdulManageService.selectDeptSchdulManageDetailVO(deptSchdulManageVO);
+		egovAssertAdminOrChargerOrOwner(stored == null ? null : stored.getSchdulChargerId(),
+				stored == null ? null : stored.getFrstRegisterId());
+
 		egovDeptSchdulManageService.deleteDeptSchdulManage(deptSchdulManageVO);
 		return "redirect:/cop/smt/sdm/EgovDeptSchdulManageList.do";
 	}
@@ -556,6 +561,12 @@ public class EgovDeptSchdulManageController {
 		// 2026.07.13 KISA 보안취약점 조치
 		LoginVO _loginVO = egovAssertLoginUser();
 
+		// 담당자·등록자 또는 관리자만 수정폼에 접근 가능하도록 소유권 검증 (불필요한 조회 전에 먼저 확인)
+		DeptSchdulManageVO resultDeptSchdulManageVOReuslt = egovDeptSchdulManageService
+				.selectDeptSchdulManageDetailVO(deptSchdulManageVO);
+		egovAssertAdminOrChargerOrOwner(
+				resultDeptSchdulManageVOReuslt == null ? null : resultDeptSchdulManageVOReuslt.getSchdulChargerId(),
+				resultDeptSchdulManageVOReuslt == null ? null : resultDeptSchdulManageVOReuslt.getFrstRegisterId());
 
 		String sLocationUrl = "egovframework/com/cop/smt/sdm/EgovDeptSchdulManageModify";
 
@@ -583,9 +594,6 @@ public class EgovDeptSchdulManageController {
 		model.addAttribute("schdulEnddeHH", getTimeHH());
 		// 일정종료일자(분)
 		model.addAttribute("schdulEnddeMM", getTimeMM());
-
-		DeptSchdulManageVO resultDeptSchdulManageVOReuslt = egovDeptSchdulManageService
-				.selectDeptSchdulManageDetailVO(deptSchdulManageVO);
 
 		String sSchdulBgnde = resultDeptSchdulManageVOReuslt.getSchdulBgnde();
 		String sSchdulEndde = resultDeptSchdulManageVOReuslt.getSchdulEndde();
@@ -631,6 +639,12 @@ public class EgovDeptSchdulManageController {
 
 		// 로그인 객체 선언
 		LoginVO loginVO = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();
+
+		// 담당자·등록자 또는 관리자만 수정 가능하도록 소유권 검증
+		DeptSchdulManageVO storedBeforeUpdate = egovDeptSchdulManageService.selectDeptSchdulManageDetailVO(deptSchdulManageVO);
+		egovAssertAdminOrChargerOrOwner(
+				storedBeforeUpdate == null ? null : storedBeforeUpdate.getSchdulChargerId(),
+				storedBeforeUpdate == null ? null : storedBeforeUpdate.getFrstRegisterId());
 
 		String sLocationUrl = "egovframework/com/cop/smt/sdm/EgovDeptSchdulManageModify";
 
@@ -945,6 +959,25 @@ public class EgovDeptSchdulManageController {
 	private void egovAssertAdminOrOwner(String ownerUniqId) {
 		LoginVO loginVO = egovAssertLoginUser();
 		if (ownerUniqId != null && ownerUniqId.equals(loginVO.getUniqId())) {
+			return;
+		}
+		java.util.List<String> auth = EgovUserDetailsHelper.getAuthorities();
+		if (auth != null && auth.contains("ROLE_ADMIN")) {
+			return;
+		}
+		throw new IllegalStateException("권한이 없습니다.");
+	}
+
+	/**
+	 * 관리자 또는 담당자 또는 등록자만 통과 (부서일정은 EgovDeptSchdulManageMainList의
+	 * "SCHDUL_CHARGER_ID = uniqId OR FRST_REGISTER_ID = uniqId" 조건이 실제 소유권 정의라
+	 * 담당자·등록자 둘 다 owner로 인정한다)
+	 */
+	private void egovAssertAdminOrChargerOrOwner(String chargerUniqId, String registerUniqId) {
+		LoginVO loginVO = egovAssertLoginUser();
+		String uniqId = loginVO.getUniqId();
+		if ((chargerUniqId != null && chargerUniqId.equals(uniqId))
+				|| (registerUniqId != null && registerUniqId.equals(uniqId))) {
 			return;
 		}
 		java.util.List<String> auth = EgovUserDetailsHelper.getAuthorities();

--- a/src/test/java/egovframework/com/cop/smt/sdm/web/EgovDeptSchdulManageControllerOwnershipTest.java
+++ b/src/test/java/egovframework/com/cop/smt/sdm/web/EgovDeptSchdulManageControllerOwnershipTest.java
@@ -1,0 +1,319 @@
+package egovframework.com.cop.smt.sdm.web;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.ui.ModelMap;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.multipart.MultipartHttpServletRequest;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+import org.springframework.web.servlet.mvc.support.RedirectAttributesModelMap;
+
+import egovframework.com.cmm.ComDefaultVO;
+import egovframework.com.cmm.EgovMessageSource;
+import egovframework.com.cmm.LoginVO;
+import egovframework.com.cmm.service.EgovUserDetailsService;
+import egovframework.com.cmm.util.EgovUserDetailsHelper;
+import egovframework.com.cop.smt.sdm.service.DeptSchdulManageVO;
+import egovframework.com.cop.smt.sdm.service.EgovDeptSchdulManageService;
+import org.egovframe.rte.psl.dataaccess.util.EgovMap;
+
+/**
+ * 부서일정 삭제·수정의 소유권 검증 회귀 테스트.
+ *
+ * EgovDeptSchdulManageMainList의 "SCHDUL_CHARGER_ID = uniqId OR FRST_REGISTER_ID = uniqId"
+ * 조건이 이 도메인의 실제 소유권 정의다. 담당자·등록자 중 아무도 아닌 로그인 사용자가
+ * 부서일정을 삭제·수정하려 하면 egovAssertAdminOrChargerOrOwner가 IllegalStateException을
+ * 던져 차단해야 한다. 담당자·등록자·ROLE_ADMIN은 모두 통과해야 한다.
+ */
+class EgovDeptSchdulManageControllerOwnershipTest {
+
+	private static final String CHARGER = "USRCNFRM_00000000001";
+	private static final String REGISTRANT = "USRCNFRM_00000000002";
+	private static final String OUTSIDER = "USRCNFRM_00000000009";
+
+	private static final class StubService implements EgovDeptSchdulManageService {
+		private final DeptSchdulManageVO stored;
+		private boolean deleteCalled = false;
+		private boolean updateCalled = false;
+
+		StubService(String chargerUniqId, String registerUniqId) {
+			this.stored = new DeptSchdulManageVO();
+			this.stored.setSchdulChargerId(chargerUniqId);
+			this.stored.setFrstRegisterId(registerUniqId);
+			this.stored.setSchdulBgnde("202608080900");
+			this.stored.setSchdulEndde("202608081000");
+		}
+
+		@Override
+		public DeptSchdulManageVO selectDeptSchdulManageDetailVO(DeptSchdulManageVO deptSchdulManageVO) {
+			return stored;
+		}
+
+		@Override
+		public void deleteDeptSchdulManage(DeptSchdulManageVO deptSchdulManageVO) {
+			deleteCalled = true;
+		}
+
+		@Override
+		public void updateDeptSchdulManage(DeptSchdulManageVO deptSchdulManageVO) {
+			updateCalled = true;
+		}
+
+		@Override
+		public List<EgovMap> selectDeptSchdulManageAuthorGroupPopup(ComDefaultVO searchVO) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public List<EgovMap> selectDeptSchdulManageEmpLyrPopup(ComDefaultVO searchVO) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public List<EgovMap> selectDeptSchdulManageMainList(Map<String, String> map) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public List<EgovMap> selectDeptSchdulManageRetrieve(Map<String, String> map) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public List<EgovMap> selectDeptSchdulManageList(ComDefaultVO searchVO) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public List<EgovMap> selectDeptSchdulManageDetail(DeptSchdulManageVO deptSchdulManageVO) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public int selectDeptSchdulManageListCnt(ComDefaultVO searchVO) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public void insertDeptSchdulManage(DeptSchdulManageVO deptSchdulManageVO) {
+			throw new UnsupportedOperationException();
+		}
+	}
+
+	@AfterEach
+	void clearRequestContext() {
+		org.springframework.web.context.request.RequestContextHolder.resetRequestAttributes();
+	}
+
+	private static void bindLoginUser(String uniqId, List<String> authorities) {
+		LoginVO login = new LoginVO();
+		login.setUniqId(uniqId);
+		EgovUserDetailsService stub = new EgovUserDetailsService() {
+			@Override
+			public Object getAuthenticatedUser() {
+				return login;
+			}
+
+			@Override
+			public List<String> getAuthorities() {
+				return authorities;
+			}
+
+			@Override
+			public Boolean isAuthenticated() {
+				return Boolean.TRUE;
+			}
+		};
+		new EgovUserDetailsHelper().setEgovUserDetailsService(stub);
+	}
+
+	private static void setPrivateField(Object target, String fieldName, Object value) {
+		try {
+			java.lang.reflect.Field field = target.getClass().getDeclaredField(fieldName);
+			field.setAccessible(true);
+			field.set(target, value);
+		} catch (ReflectiveOperationException e) {
+			throw new IllegalStateException(e);
+		}
+	}
+
+	private static EgovDeptSchdulManageController controllerWith(StubService service) {
+		EgovDeptSchdulManageController controller = new EgovDeptSchdulManageController();
+		setPrivateField(controller, "egovDeptSchdulManageService", service);
+		setPrivateField(controller, "cmmUseService", new egovframework.com.cmm.service.EgovCmmUseService() {
+			@Override
+			public List<egovframework.com.cmm.service.CmmnDetailCode> selectCmmCodeDetail(egovframework.com.cmm.ComDefaultCodeVO comDefaultCodeVO) {
+				return Collections.emptyList();
+			}
+
+			@Override
+			public Map<String, List<egovframework.com.cmm.service.CmmnDetailCode>> selectCmmCodeDetails(
+					List<egovframework.com.cmm.ComDefaultCodeVO> comDefaultCodeVOs) {
+				return Collections.emptyMap();
+			}
+
+			@Override
+			public List<egovframework.com.cmm.service.CmmnDetailCode> selectOgrnztIdDetail(egovframework.com.cmm.ComDefaultCodeVO comDefaultCodeVO) {
+				return Collections.emptyList();
+			}
+
+			@Override
+			public List<egovframework.com.cmm.service.CmmnDetailCode> selectGroupIdDetail(egovframework.com.cmm.ComDefaultCodeVO comDefaultCodeVO) {
+				return Collections.emptyList();
+			}
+		});
+		controller.egovMessageSource = new EgovMessageSource() {
+			@Override
+			public String getMessage(String code) {
+				return code;
+			}
+		};
+		return controller;
+	}
+
+	/**
+	 * MockMultipartHttpServletRequest는 MockHttpServletRequest를 상속해 이 로컬 환경에서
+	 * NoClassDefFoundError(ServletConnection)로 깨진다([[shell-and-egov-test-env-traps]]).
+	 * 컨트롤러가 실제로 쓰는 getFiles(String)만 최소 구현한 프록시로 대체한다.
+	 */
+	private static MultipartHttpServletRequest emptyMultipartRequest() {
+		return (MultipartHttpServletRequest) java.lang.reflect.Proxy.newProxyInstance(
+				EgovDeptSchdulManageControllerOwnershipTest.class.getClassLoader(),
+				new Class<?>[] { MultipartHttpServletRequest.class },
+				(proxy, method, args) -> {
+					if ("getFiles".equals(method.getName())) {
+						return Collections.<MultipartFile>emptyList();
+					}
+					Class<?> returnType = method.getReturnType();
+					if (returnType == boolean.class) {
+						return false;
+					}
+					return null;
+				});
+	}
+
+	private static DeptSchdulManageVO requestFor(String schdulId) {
+		DeptSchdulManageVO vo = new DeptSchdulManageVO();
+		vo.setSchdulId(schdulId);
+		return vo;
+	}
+
+	// ---- egovDeptSchdulManageDelete: 담당자/등록자/관리자 4갈래 ----
+
+	@Test
+	void deleteByOutsiderIsRejected() {
+		StubService service = new StubService(CHARGER, REGISTRANT);
+		EgovDeptSchdulManageController controller = controllerWith(service);
+		bindLoginUser(OUTSIDER, List.of());
+
+		assertThrows(IllegalStateException.class, () -> controller.egovDeptSchdulManageDelete(requestFor("1")),
+				"A logged-in user who is neither charger nor registrant must not delete a department schedule.");
+	}
+
+	@Test
+	void deleteByChargerSucceeds() throws Exception {
+		StubService service = new StubService(CHARGER, REGISTRANT);
+		EgovDeptSchdulManageController controller = controllerWith(service);
+		bindLoginUser(CHARGER, List.of());
+
+		assertDoesNotThrow(() -> controller.egovDeptSchdulManageDelete(requestFor("1")));
+		org.junit.jupiter.api.Assertions.assertTrue(service.deleteCalled, "The charger must be able to delete the schedule.");
+	}
+
+	@Test
+	void deleteByRegistrantSucceeds() throws Exception {
+		StubService service = new StubService(CHARGER, REGISTRANT);
+		EgovDeptSchdulManageController controller = controllerWith(service);
+		bindLoginUser(REGISTRANT, List.of());
+
+		assertDoesNotThrow(() -> controller.egovDeptSchdulManageDelete(requestFor("1")));
+		org.junit.jupiter.api.Assertions.assertTrue(service.deleteCalled, "The registrant must be able to delete the schedule.");
+	}
+
+	@Test
+	void deleteByAdminSucceedsEvenWhenNeitherChargerNorRegistrant() throws Exception {
+		StubService service = new StubService(CHARGER, REGISTRANT);
+		EgovDeptSchdulManageController controller = controllerWith(service);
+		bindLoginUser(OUTSIDER, List.of("ROLE_ADMIN"));
+
+		assertDoesNotThrow(() -> controller.egovDeptSchdulManageDelete(requestFor("1")));
+		org.junit.jupiter.api.Assertions.assertTrue(service.deleteCalled, "An admin must be able to delete any department schedule.");
+	}
+
+	// ---- deptSchdulManageModify (수정폼 진입) ----
+
+	@Test
+	void modifyFormByOutsiderIsRejected() {
+		StubService service = new StubService(CHARGER, REGISTRANT);
+		EgovDeptSchdulManageController controller = controllerWith(service);
+		bindLoginUser(OUTSIDER, List.of());
+
+		ComDefaultVO searchVO = new ComDefaultVO();
+		ModelMap model = new ModelMap();
+		assertThrows(IllegalStateException.class,
+				() -> controller.deptSchdulManageModify(searchVO, requestFor("1"), model),
+				"A logged-in outsider must not reach the modify form of another department schedule.");
+	}
+
+	@Test
+	void modifyFormByChargerSucceeds() throws Exception {
+		StubService service = new StubService(CHARGER, REGISTRANT);
+		EgovDeptSchdulManageController controller = controllerWith(service);
+		bindLoginUser(CHARGER, List.of());
+
+		ComDefaultVO searchVO = new ComDefaultVO();
+		ModelMap model = new ModelMap();
+		String view = controller.deptSchdulManageModify(searchVO, requestFor("1"), model);
+		org.junit.jupiter.api.Assertions.assertTrue(view.contains("EgovDeptSchdulManageModify"));
+	}
+
+	// ---- deptSchdulManageModifyActor (실제 수정 처리) ----
+
+	@Test
+	void modifyActorByOutsiderIsRejected() {
+		StubService service = new StubService(CHARGER, REGISTRANT);
+		EgovDeptSchdulManageController controller = controllerWith(service);
+		bindLoginUser(OUTSIDER, List.of());
+
+		MultipartHttpServletRequest multiRequest = emptyMultipartRequest();
+		Map<String, String> commandMap = Map.of("cmd", "save");
+		DeptSchdulManageVO vo = requestFor("1");
+		BindingResult bindingResult = new BeanPropertyBindingResult(vo, "deptSchdulManageVO");
+		ModelMap model = new ModelMap();
+		RedirectAttributes redirectAttributes = new RedirectAttributesModelMap();
+
+		assertThrows(IllegalStateException.class,
+				() -> controller.deptSchdulManageModifyActor(multiRequest, commandMap, vo, bindingResult, model,
+						redirectAttributes),
+				"A logged-in outsider must not be able to save changes to another department schedule.");
+		org.junit.jupiter.api.Assertions.assertTrue(!service.updateCalled, "updateDeptSchdulManage must not be reached by an outsider.");
+	}
+
+	@Test
+	void modifyActorByRegistrantSucceeds() throws Exception {
+		StubService service = new StubService(CHARGER, REGISTRANT);
+		EgovDeptSchdulManageController controller = controllerWith(service);
+		bindLoginUser(REGISTRANT, List.of());
+
+		MultipartHttpServletRequest multiRequest = emptyMultipartRequest();
+		Map<String, String> commandMap = Map.of("cmd", "save", "atchFileAt", "Y");
+		DeptSchdulManageVO vo = requestFor("1");
+		vo.setSchdulBgnde("202608080900");
+		vo.setSchdulEndde("202608081000");
+		BindingResult bindingResult = new BeanPropertyBindingResult(vo, "deptSchdulManageVO");
+		ModelMap model = new ModelMap();
+		RedirectAttributes redirectAttributes = new RedirectAttributesModelMap();
+
+		controller.deptSchdulManageModifyActor(multiRequest, commandMap, vo, bindingResult, model, redirectAttributes);
+		org.junit.jupiter.api.Assertions.assertTrue(service.updateCalled, "The registrant must be able to save changes.");
+	}
+}


### PR DESCRIPTION
## 수정 사유

- [x] 버그수정
- [ ] 기능개선
- [ ] 리팩터링

## 문제 상황

부서일정 삭제(`egovDeptSchdulManageDelete`)는 인증 여부조차 확인하지 않습니다. 수정폼 진입(`deptSchdulManageModify`)과 실제 수정 처리(`deptSchdulManageModifyActor`)는 로그인 여부만 확인하고 담당자·등록자인지는 대조하지 않습니다. 그래서 로그인한 사용자가 임의의 `schdulId`로 다른 부서일정을 열람·수정·삭제할 수 있습니다.

## 발생 흐름

```java
@PostMapping(value = "/cop/smt/sdm/EgovDeptSchdulManageDetail.do", params = "cmd=del")
public String egovDeptSchdulManageDelete(DeptSchdulManageVO deptSchdulManageVO) throws Exception {
    egovDeptSchdulManageService.deleteDeptSchdulManage(deptSchdulManageVO);
    return "redirect:/cop/smt/sdm/EgovDeptSchdulManageList.do";
}
```

삭제·수정 SQL도 소유자 조건 없이 PK만으로 처리합니다.

```sql
DELETE FROM COMTNSCHDULINFO WHERE SCHDUL_ID = #{schdulId}
UPDATE COMTNSCHDULINFO SET ... WHERE SCHDUL_ID = #{schdulId}
```

## 이 도메인의 소유권 정의

부서일정은 `EgovBBSSatisfactionController`(#1197)·`EgovMemoTodoController`(#1201)·`EgovWikiBookmarkController`(#1202)와 달리 등록자 단독 소유가 아닙니다. "내 일정" 대시보드(`EgovDeptSchdulManageMainList`)가 실제로 어떤 조건으로 "내 것"을 판단하는지가 이 도메인의 소유권 정의입니다.

```sql
WHERE A.SCHDUL_KND_CODE = '1'
AND (A.SCHDUL_CHARGER_ID = #{uniqId} OR A.FRST_REGISTER_ID = #{uniqId})
```

담당자(`SCHDUL_CHARGER_ID`)와 등록자(`FRST_REGISTER_ID`) 둘 다 "내 일정"으로 취급됩니다. 부서 전체를 훑어보는 `EgovDeptSchdulManageListPopup`은 이 필터가 없어 공유 브라우징용으로 보이지만 수정·삭제 같은 변경 작업은 담당자·등록자로 좁히는 쪽이 이 대시보드 쿼리와 일치합니다.

## 변경 내용

이 컨트롤러에 이미 있던 `egovAssertAdminOrOwner`는 단일 소유자만 인정해서 이 도메인에는 맞지 않습니다. 같은 관례(예외로 차단, `egovAssertLoginUser` 재사용, 관리자 우회)를 따르는 이중 소유자용 헬퍼를 추가했습니다.

```java
private void egovAssertAdminOrChargerOrOwner(String chargerUniqId, String registerUniqId) {
    LoginVO loginVO = egovAssertLoginUser();
    String uniqId = loginVO.getUniqId();
    if ((chargerUniqId != null && chargerUniqId.equals(uniqId))
            || (registerUniqId != null && registerUniqId.equals(uniqId))) {
        return;
    }
    List<String> auth = EgovUserDetailsHelper.getAuthorities();
    if (auth != null && auth.contains("ROLE_ADMIN")) {
        return;
    }
    throw new IllegalStateException("권한이 없습니다.");
}
```

세 경로 모두 `selectDeptSchdulManageDetailVO`로 저장된 레코드를 다시 조회해 이 헬퍼로 검증합니다.

```java
DeptSchdulManageVO stored = egovDeptSchdulManageService.selectDeptSchdulManageDetailVO(deptSchdulManageVO);
egovAssertAdminOrChargerOrOwner(stored == null ? null : stored.getSchdulChargerId(),
        stored == null ? null : stored.getFrstRegisterId());
```

수정폼 진입(`deptSchdulManageModify`)에서는 검증을 공통코드 조회 등 불필요한 작업보다 앞에 두었습니다. 원래 위치에서는 존재하지 않는 `schdulId`일 때 검증 전에 `NullPointerException`이 먼저 났습니다.

## 영향 범위

- `EgovDeptSchdulManageController`의 `egovDeptSchdulManageDelete`·`deptSchdulManageModify`·`deptSchdulManageModifyActor`: 소유권 검증 추가. 담당자·등록자·`ROLE_ADMIN`의 요청은 그대로 동작하고 그 외만 차단됩니다.
- 매퍼 변경 없음.

## 테스트 방법

### 재현 (수정 전)

로그인한 사용자가 다른 부서일정의 `schdulId`로 삭제·수정폼 진입·수정 저장을 요청합니다. delete는 인증조차 확인하지 않고 modify 둘은 로그인 여부만 확인해 그대로 처리됩니다.

### 확인 (수정 후)

같은 요청이 소유권 검증에 걸려 `IllegalStateException`으로 차단됩니다.

### 단위 테스트

`EgovDeptSchdulManageControllerOwnershipTest`를 추가했습니다. `egovDeptSchdulManageDelete`는 외부인 차단·담당자 성공·등록자 성공·관리자 성공 4케이스, `deptSchdulManageModify`·`deptSchdulManageModifyActor`는 각각 외부인 차단과 정상동작 케이스를 검증합니다.

```
Tests run: 8, Failures: 0, Errors: 0, Skipped: 0
```

소유권 검증을 비활성화하면 세 진입점의 외부인 차단 테스트가 다음과 같이 실패합니다.

```
Tests run: 8, Failures: 3, Errors: 0, Skipped: 0
  deleteByOutsiderIsRejected: Expected java.lang.IllegalStateException to be thrown, but nothing was thrown.
  modifyActorByOutsiderIsRejected: Expected java.lang.IllegalStateException to be thrown, but nothing was thrown.
  modifyFormByOutsiderIsRejected: Expected java.lang.IllegalStateException to be thrown, but nothing was thrown.
```

