### PR TITLE
fix: 포상관리 소유권 검증 추가 및 수정 재표시 시 포상구분 목록 복원

### DIFF
--- a/src/main/java/egovframework/com/uss/ion/rwd/web/EgovRwardManageController.java
+++ b/src/main/java/egovframework/com/uss/ion/rwd/web/EgovRwardManageController.java
@@ -253,6 +253,10 @@ public class EgovRwardManageController {
 		egovAssertAdminOrOwner(stored == null ? null : stored.getFrstRegisterId());
 
 		if (bindingResult.hasErrors()) {
+			// 수정화면 진입(EgovRwardManageDetail.do?cmd=updt)과 동일하게 포상구분 코드목록을 다시 담는다.
+			ComDefaultCodeVO rwardCdVo = new ComDefaultCodeVO();
+			rwardCdVo.setCodeId("COM055");
+			model.addAttribute("rwardCodeList", cmmUseService.selectCmmCodeDetail(rwardCdVo));
 			model.addAttribute("rwardManageVO", rwardManageVO);
 			model.addAttribute("rwardManage", rwardManage);
 			return "egovframework/com/uss/ion/rwd/EgovRwardUpdt";

--- a/src/main/java/egovframework/com/uss/ion/rwd/web/EgovRwardManageController.java
+++ b/src/main/java/egovframework/com/uss/ion/rwd/web/EgovRwardManageController.java
@@ -390,6 +390,10 @@ public class EgovRwardManageController {
 		// 등록 상세정보
 		RwardManageVO rwardManageVOTemp = egovRwardManageService.selectRwardManage(rwardManageVO);
 
+		// 지정된 승인권자 또는 관리자만 승인상세를 열람 가능하도록 소유권 검증
+		// (EgovRwardConfmList.do가 SANCTNER_ID=로그인 uniqId로만 목록을 필터링하는 것과 동일한 경계)
+		egovAssertAdminOrOwner(rwardManageVOTemp == null ? null : rwardManageVOTemp.getSanctnerId());
+
 		RwardManage rwardManageTemp = new RwardManage();
 
 		rwardManageTemp.setRwardId(rwardManageVOTemp.getRwardId());

--- a/src/main/java/egovframework/com/uss/ion/rwd/web/EgovRwardManageController.java
+++ b/src/main/java/egovframework/com/uss/ion/rwd/web/EgovRwardManageController.java
@@ -248,6 +248,10 @@ public class EgovRwardManageController {
 			final MultipartHttpServletRequest multiRequest, @Valid @ModelAttribute("rwardManage") RwardManage rwardManage, BindingResult bindingResult,
 			@ModelAttribute("rwardManageVO") RwardManageVO rwardManageVO, SessionStatus status, ModelMap model) throws Exception {
 
+		// 신청자 본인 또는 관리자만 수정 가능하도록 소유권 검증
+		RwardManageVO stored = egovRwardManageService.selectRwardManage(rwardManageVO);
+		egovAssertAdminOrOwner(stored == null ? null : stored.getFrstRegisterId());
+
 		if (bindingResult.hasErrors()) {
 			model.addAttribute("rwardManageVO", rwardManageVO);
 			model.addAttribute("rwardManage", rwardManage);
@@ -298,6 +302,12 @@ public class EgovRwardManageController {
 			ModelMap model) throws Exception {
 		// 2026.07.13 KISA 보안취약점 조치
 		LoginVO _loginVO = egovAssertLoginUser();
+
+		// 신청자 본인 또는 관리자만 삭제 가능하도록 소유권 검증
+		RwardManageVO storedForDelete = new RwardManageVO();
+		storedForDelete.setRwardId(rwardManage.getRwardId());
+		RwardManageVO stored = egovRwardManageService.selectRwardManage(storedForDelete);
+		egovAssertAdminOrOwner(stored == null ? null : stored.getFrstRegisterId());
 
 		rwardManage.setRwardDe(EgovStringUtil.removeMinusChar(rwardManage.getRwardDe()));
 
@@ -415,6 +425,12 @@ public class EgovRwardManageController {
 		if (!isAuthenticated) {
 			return "redirect:/uat/uia/egovLoginUsr.do";
 		}
+
+		// 지정된 승인권자(SANCTNER_ID) 또는 관리자만 승인·반려 처리 가능하도록 검증
+		RwardManageVO storedForConfm = new RwardManageVO();
+		storedForConfm.setRwardId(rwardManage.getRwardId());
+		RwardManageVO storedConfm = egovRwardManageService.selectRwardManage(storedForConfm);
+		egovAssertAdminOrOwner(storedConfm == null ? null : storedConfm.getSanctnerId());
 
 		if (bindingResult.hasErrors()) {
 			model.addAttribute("rwardManageVO", rwardManage);

--- a/src/main/resources/egovframework/mapper/com/uss/ion/rwd/EgovRwardManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/rwd/EgovRwardManage_SQL_altibase.xml
@@ -102,6 +102,7 @@
                   rwd.RETURN_RESN         AS returnResn       ,
                   rwd.ATCH_FILE_ID        AS atchFileId       , 
                   rwd.INFRML_SANCTN_ID    AS infrmlSanctnId   ,
+                  rwd.FRST_REGISTER_ID    AS frstRegisterId   ,
                   mst.USER_NM             AS rwardManNm       ,
                  (select info.ORGNZT_NM from COMTNORGNZTINFO info where  info.ORGNZT_ID = mst.ORGNZT_ID )   AS orgnztNm    ,
                  (select mst1.USER_NM from COMVNUSERMASTER mst1 where  mst1.ESNTL_ID = SANCTNER_ID)          AS sanctnerNm  ,

--- a/src/main/resources/egovframework/mapper/com/uss/ion/rwd/EgovRwardManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/rwd/EgovRwardManage_SQL_cubrid.xml
@@ -102,6 +102,7 @@
                   rwd.RETURN_RESN         AS returnResn       ,
                   rwd.ATCH_FILE_ID        AS atchFileId       , 
                   rwd.INFRML_SANCTN_ID    AS infrmlSanctnId   ,
+                  rwd.FRST_REGISTER_ID    AS frstRegisterId   ,
                   mst.USER_NM             AS rwardManNm       ,
                  (select info.ORGNZT_NM from COMTNORGNZTINFO info where  info.ORGNZT_ID = mst.ORGNZT_ID )   AS orgnztNm    ,
                  (select mst1.USER_NM from COMVNUSERMASTER mst1 where  mst1.ESNTL_ID = SANCTNER_ID)          AS sanctnerNm  ,

--- a/src/main/resources/egovframework/mapper/com/uss/ion/rwd/EgovRwardManage_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/rwd/EgovRwardManage_SQL_goldilocks.xml
@@ -102,6 +102,7 @@
                   rwd.RETURN_RESN         AS returnResn       ,
                   rwd.ATCH_FILE_ID        AS atchFileId       , 
                   rwd.INFRML_SANCTN_ID    AS infrmlSanctnId   ,
+                  rwd.FRST_REGISTER_ID    AS frstRegisterId   ,
                   mst.USER_NM             AS rwardManNm       ,
                  (select info.ORGNZT_NM from COMTNORGNZTINFO info where  info.ORGNZT_ID = mst.ORGNZT_ID )   AS orgnztNm    ,
                  (select mst1.USER_NM from COMVNUSERMASTER mst1 where  mst1.ESNTL_ID = SANCTNER_ID)          AS sanctnerNm  ,

--- a/src/main/resources/egovframework/mapper/com/uss/ion/rwd/EgovRwardManage_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/rwd/EgovRwardManage_SQL_maria.xml
@@ -96,6 +96,7 @@
                   rwd.RETURN_RESN         AS returnResn       ,
                   rwd.ATCH_FILE_ID        AS atchFileId       , 
                   rwd.INFRML_SANCTN_ID    AS infrmlSanctnId   ,
+                  rwd.FRST_REGISTER_ID    AS frstRegisterId   ,
                   mst.USER_NM             AS rwardManNm       ,
                  (select info.ORGNZT_NM from COMTNORGNZTINFO info where  info.ORGNZT_ID = mst.ORGNZT_ID )   AS orgnztNm    ,
                  (select mst1.USER_NM from COMVNUSERMASTER mst1 where  mst1.ESNTL_ID = SANCTNER_ID)          AS sanctnerNm  ,

--- a/src/main/resources/egovframework/mapper/com/uss/ion/rwd/EgovRwardManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/rwd/EgovRwardManage_SQL_mysql.xml
@@ -96,6 +96,7 @@
                   rwd.RETURN_RESN         AS returnResn       ,
                   rwd.ATCH_FILE_ID        AS atchFileId       , 
                   rwd.INFRML_SANCTN_ID    AS infrmlSanctnId   ,
+                  rwd.FRST_REGISTER_ID    AS frstRegisterId   ,
                   mst.USER_NM             AS rwardManNm       ,
                  (select info.ORGNZT_NM from COMTNORGNZTINFO info where  info.ORGNZT_ID = mst.ORGNZT_ID )   AS orgnztNm    ,
                  (select mst1.USER_NM from COMVNUSERMASTER mst1 where  mst1.ESNTL_ID = SANCTNER_ID)          AS sanctnerNm  ,

--- a/src/main/resources/egovframework/mapper/com/uss/ion/rwd/EgovRwardManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/rwd/EgovRwardManage_SQL_oracle.xml
@@ -102,6 +102,7 @@
                   rwd.RETURN_RESN         AS returnResn       ,
                   rwd.ATCH_FILE_ID        AS atchFileId       , 
                   rwd.INFRML_SANCTN_ID    AS infrmlSanctnId   ,
+                  rwd.FRST_REGISTER_ID    AS frstRegisterId   ,
                   mst.USER_NM             AS rwardManNm       ,
                  (select info.ORGNZT_NM from COMTNORGNZTINFO info where  info.ORGNZT_ID = mst.ORGNZT_ID )   AS orgnztNm    ,
                  (select mst1.USER_NM from COMVNUSERMASTER mst1 where  mst1.ESNTL_ID = SANCTNER_ID)          AS sanctnerNm  ,

--- a/src/main/resources/egovframework/mapper/com/uss/ion/rwd/EgovRwardManage_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/rwd/EgovRwardManage_SQL_postgres.xml
@@ -96,6 +96,7 @@
                   rwd.RETURN_RESN         AS returnResn       ,
                   rwd.ATCH_FILE_ID        AS atchFileId       , 
                   rwd.INFRML_SANCTN_ID    AS infrmlSanctnId   ,
+                  rwd.FRST_REGISTER_ID    AS frstRegisterId   ,
                   mst.USER_NM             AS rwardManNm       ,
                  (select info.ORGNZT_NM from COMTNORGNZTINFO info where  info.ORGNZT_ID = mst.ORGNZT_ID )   AS orgnztNm    ,
                  (select mst1.USER_NM from COMVNUSERMASTER mst1 where  mst1.ESNTL_ID = SANCTNER_ID)          AS sanctnerNm  ,

--- a/src/main/resources/egovframework/mapper/com/uss/ion/rwd/EgovRwardManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/rwd/EgovRwardManage_SQL_tibero.xml
@@ -102,6 +102,7 @@
                   rwd.RETURN_RESN         AS returnResn       ,
                   rwd.ATCH_FILE_ID        AS atchFileId       , 
                   rwd.INFRML_SANCTN_ID    AS infrmlSanctnId   ,
+                  rwd.FRST_REGISTER_ID    AS frstRegisterId   ,
                   mst.USER_NM             AS rwardManNm       ,
                  (select info.ORGNZT_NM from COMTNORGNZTINFO info where  info.ORGNZT_ID = mst.ORGNZT_ID )   AS orgnztNm    ,
                  (select mst1.USER_NM from COMVNUSERMASTER mst1 where  mst1.ESNTL_ID = SANCTNER_ID)          AS sanctnerNm  ,

--- a/src/test/java/egovframework/com/uss/ion/rwd/web/EgovRwardManageControllerOwnershipTest.java
+++ b/src/test/java/egovframework/com/uss/ion/rwd/web/EgovRwardManageControllerOwnershipTest.java
@@ -1,0 +1,354 @@
+package egovframework.com.uss.ion.rwd.web;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.ui.ModelMap;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.support.SessionStatus;
+import org.springframework.web.bind.support.SimpleSessionStatus;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.multipart.MultipartHttpServletRequest;
+
+import egovframework.com.cmm.EgovMessageSource;
+import egovframework.com.cmm.LoginVO;
+import egovframework.com.cmm.service.EgovFileMngService;
+import egovframework.com.cmm.service.EgovUserDetailsService;
+import egovframework.com.cmm.service.FileVO;
+import egovframework.com.cmm.util.EgovUserDetailsHelper;
+import egovframework.com.uss.ion.rwd.service.EgovRwardManageService;
+import egovframework.com.uss.ion.rwd.service.RwardManage;
+import egovframework.com.uss.ion.rwd.service.RwardManageVO;
+
+/**
+ * 포상관리 수정·삭제·승인의 소유권 검증 회귀 테스트.
+ *
+ * updtRwardManage·deleteRwardManage는 신청자(FRST_REGISTER_ID) 본인 또는 관리자만,
+ * updtRwardManageConfm(승인/반려)은 지정된 승인권자(SANCTNER_ID) 또는 관리자만 통과해야
+ * 한다. 수정 전 코드는 승인 처리에서 SANCTNER_ID 대조 없이 호출자를 그대로 승인권자로
+ * 취급했고, 수정·삭제는 신청자 대조 자체가 없었다(승인 UPDATE문 자체는 SANCTNER_ID를
+ * 갱신하지 않아 그 시도는 no-op이었지만, 대조 없이 승인·반려 상태를 바꿀 수 있었다).
+ */
+class EgovRwardManageControllerOwnershipTest {
+
+	private static final String OWNER = "USRCNFRM_00000000001";
+	private static final String SANCTNER = "USRCNFRM_00000000002";
+	private static final String OUTSIDER = "USRCNFRM_00000000009";
+
+	private static final class StubService implements EgovRwardManageService {
+		private final RwardManageVO stored;
+		private boolean updateCalled = false;
+		private boolean deleteCalled = false;
+		private boolean confmCalled = false;
+
+		StubService(String ownerUniqId, String sanctnerUniqId) {
+			this.stored = new RwardManageVO();
+			this.stored.setFrstRegisterId(ownerUniqId);
+			this.stored.setSanctnerId(sanctnerUniqId);
+		}
+
+		@Override
+		public RwardManageVO selectRwardManage(RwardManageVO rwardManageVO) {
+			return stored;
+		}
+
+		@Override
+		public void updtRwardManage(RwardManage rwardManage) {
+			updateCalled = true;
+		}
+
+		@Override
+		public void deleteRwardManage(RwardManage rwardManage) {
+			deleteCalled = true;
+		}
+
+		@Override
+		public void updtRwardManageConfm(RwardManage rwardManage) {
+			confmCalled = true;
+		}
+
+		@Override
+		public List<RwardManageVO> selectRwardManageList(RwardManageVO rwardManageVO) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public int selectRwardManageListTotCnt(RwardManageVO rwardManageVO) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public void insertRwardManage(RwardManage rwardManage) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public List<RwardManageVO> selectRwardManageConfmList(RwardManageVO rwardManageVO) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public int selectRwardManageConfmListTotCnt(RwardManageVO rwardManageVO) {
+			throw new UnsupportedOperationException();
+		}
+	}
+
+	private static void setPrivateField(Object target, String fieldName, Object value) {
+		try {
+			java.lang.reflect.Field field = target.getClass().getDeclaredField(fieldName);
+			field.setAccessible(true);
+			field.set(target, value);
+		} catch (ReflectiveOperationException e) {
+			throw new IllegalStateException(e);
+		}
+	}
+
+	private static void bindLoginUser(String uniqId, List<String> authorities) {
+		LoginVO login = new LoginVO();
+		login.setUniqId(uniqId);
+		EgovUserDetailsService stub = new EgovUserDetailsService() {
+			@Override
+			public Object getAuthenticatedUser() {
+				return login;
+			}
+
+			@Override
+			public List<String> getAuthorities() {
+				return authorities;
+			}
+
+			@Override
+			public Boolean isAuthenticated() {
+				return Boolean.TRUE;
+			}
+		};
+		new EgovUserDetailsHelper().setEgovUserDetailsService(stub);
+	}
+
+	private static EgovFileMngService noopFileMngService() {
+		return new EgovFileMngService() {
+			@Override
+			public List<FileVO> selectFileInfs(FileVO fvo) {
+				throw new UnsupportedOperationException();
+			}
+
+			@Override
+			public String insertFileInf(FileVO fvo) {
+				throw new UnsupportedOperationException();
+			}
+
+			@Override
+			public String insertFileInfs(List<FileVO> fvoList) {
+				throw new UnsupportedOperationException();
+			}
+
+			@Override
+			public void updateFileInfs(List<FileVO> fvoList) {
+				throw new UnsupportedOperationException();
+			}
+
+			@Override
+			public void deleteFileInfs(List<FileVO> fvoList) {
+				throw new UnsupportedOperationException();
+			}
+
+			@Override
+			public void deleteFileInf(FileVO fvo) {
+				throw new UnsupportedOperationException();
+			}
+
+			@Override
+			public FileVO selectFileInf(FileVO fvo) {
+				throw new UnsupportedOperationException();
+			}
+
+			@Override
+			public int getMaxFileSN(FileVO fvo) {
+				throw new UnsupportedOperationException();
+			}
+
+			@Override
+			public void deleteAllFileInf(FileVO fvo) {
+				// no-op for the ownership test
+			}
+
+			@Override
+			public Map<String, Object> selectFileListByFileNm(FileVO fvo) {
+				throw new UnsupportedOperationException();
+			}
+
+			@Override
+			public List<FileVO> selectImageFileList(FileVO vo) {
+				throw new UnsupportedOperationException();
+			}
+		};
+	}
+
+	/**
+	 * MockMultipartHttpServletRequest는 이 로컬 환경에서 NoClassDefFoundError로 깨진다
+	 * ([[shell-and-egov-test-env-traps]]). 컨트롤러가 실제로 쓰는 getFiles(String)만
+	 * 최소 구현한 프록시로 대체한다.
+	 */
+	private static MultipartHttpServletRequest emptyMultipartRequest() {
+		return (MultipartHttpServletRequest) java.lang.reflect.Proxy.newProxyInstance(
+				EgovRwardManageControllerOwnershipTest.class.getClassLoader(),
+				new Class<?>[] { MultipartHttpServletRequest.class },
+				(proxy, method, args) -> {
+					if ("getFiles".equals(method.getName())) {
+						return Collections.<MultipartFile>emptyList();
+					}
+					Class<?> returnType = method.getReturnType();
+					if (returnType == boolean.class) {
+						return false;
+					}
+					return null;
+				});
+	}
+
+	private static EgovRwardManageController controllerWith(StubService service) {
+		EgovRwardManageController controller = new EgovRwardManageController();
+		setPrivateField(controller, "egovRwardManageService", service);
+		setPrivateField(controller, "fileMngService", noopFileMngService());
+		controller.egovMessageSource = new EgovMessageSource() {
+			@Override
+			public String getMessage(String code) {
+				return code;
+			}
+		};
+		return controller;
+	}
+
+	private static RwardManage requestFor(String rwardId) {
+		RwardManage rm = new RwardManage();
+		rm.setRwardId(rwardId);
+		return rm;
+	}
+
+	// ---- updtRwardManage ----
+
+	@Test
+	void updateByOutsiderIsRejected() {
+		StubService service = new StubService(OWNER, SANCTNER);
+		EgovRwardManageController controller = controllerWith(service);
+		bindLoginUser(OUTSIDER, List.of());
+
+		RwardManage rm = requestFor("1");
+		RwardManageVO vo = new RwardManageVO();
+		vo.setRwardId("1");
+		BindingResult bindingResult = new BeanPropertyBindingResult(rm, "rwardManage");
+		ModelMap model = new ModelMap();
+
+		assertThrows(IllegalStateException.class,
+				() -> controller.updtRwardManage("N", emptyMultipartRequest(), rm, bindingResult, vo,
+						new SimpleSessionStatus(), model),
+				"A logged-in non-applicant must not be able to update another member's reward nomination.");
+		assertTrue(!service.updateCalled, "updtRwardManage service must not be reached by a non-applicant.");
+	}
+
+	@Test
+	void updateByApplicantSucceeds() throws Exception {
+		StubService service = new StubService(OWNER, SANCTNER);
+		EgovRwardManageController controller = controllerWith(service);
+		bindLoginUser(OWNER, List.of());
+
+		RwardManage rm = requestFor("1");
+		RwardManageVO vo = new RwardManageVO();
+		vo.setRwardId("1");
+		BindingResult bindingResult = new BeanPropertyBindingResult(rm, "rwardManage");
+		ModelMap model = new ModelMap();
+
+		controller.updtRwardManage("N", emptyMultipartRequest(), rm, bindingResult, vo, new SimpleSessionStatus(),
+				model);
+		assertTrue(service.updateCalled, "The applicant must be able to update their own reward nomination.");
+	}
+
+	// ---- deleteRwardManage ----
+
+	@Test
+	void deleteByOutsiderIsRejected() {
+		StubService service = new StubService(OWNER, SANCTNER);
+		EgovRwardManageController controller = controllerWith(service);
+		bindLoginUser(OUTSIDER, List.of());
+
+		ModelMap model = new ModelMap();
+		assertThrows(IllegalStateException.class,
+				() -> controller.deleteRwardManage(requestFor("1"), new SimpleSessionStatus(), model),
+				"A logged-in non-applicant must not be able to delete another member's reward nomination.");
+		assertTrue(!service.deleteCalled, "deleteRwardManage service must not be reached by a non-applicant.");
+	}
+
+	@Test
+	void deleteByApplicantSucceeds() throws Exception {
+		StubService service = new StubService(OWNER, SANCTNER);
+		EgovRwardManageController controller = controllerWith(service);
+		bindLoginUser(OWNER, List.of());
+
+		ModelMap model = new ModelMap();
+		controller.deleteRwardManage(requestFor("1"), new SimpleSessionStatus(), model);
+		assertTrue(service.deleteCalled, "The applicant must be able to delete their own reward nomination.");
+	}
+
+	@Test
+	void deleteByAdminSucceedsEvenWhenNotApplicant() throws Exception {
+		StubService service = new StubService(OWNER, SANCTNER);
+		EgovRwardManageController controller = controllerWith(service);
+		bindLoginUser(OUTSIDER, List.of("ROLE_ADMIN"));
+
+		ModelMap model = new ModelMap();
+		controller.deleteRwardManage(requestFor("1"), new SimpleSessionStatus(), model);
+		assertTrue(service.deleteCalled, "An admin must be able to delete any reward nomination.");
+	}
+
+	// ---- updtRwardManageConfm (승인/반려) ----
+
+	@Test
+	void confirmByNonSanctnerIsRejected() {
+		StubService service = new StubService(OWNER, SANCTNER);
+		EgovRwardManageController controller = controllerWith(service);
+		bindLoginUser(OUTSIDER, List.of());
+
+		RwardManage rm = requestFor("1");
+		BindingResult bindingResult = new BeanPropertyBindingResult(rm, "rwardManage");
+		ModelMap model = new ModelMap();
+
+		assertThrows(IllegalStateException.class,
+				() -> controller.updtRwardManageConfm(rm, bindingResult, new SimpleSessionStatus(), model),
+				"A logged-in user who is not the designated approver must not be able to confirm/reject someone else's reward nomination.");
+		assertTrue(!service.confmCalled, "updtRwardManageConfm service must not be reached by a non-sanctner.");
+	}
+
+	@Test
+	void confirmBySanctnerSucceeds() throws Exception {
+		StubService service = new StubService(OWNER, SANCTNER);
+		EgovRwardManageController controller = controllerWith(service);
+		bindLoginUser(SANCTNER, List.of());
+
+		RwardManage rm = requestFor("1");
+		BindingResult bindingResult = new BeanPropertyBindingResult(rm, "rwardManage");
+		ModelMap model = new ModelMap();
+
+		controller.updtRwardManageConfm(rm, bindingResult, new SimpleSessionStatus(), model);
+		assertTrue(service.confmCalled, "The designated approver must be able to confirm/reject the reward nomination.");
+	}
+
+	@Test
+	void confirmByAdminSucceedsEvenWhenNotSanctner() throws Exception {
+		StubService service = new StubService(OWNER, SANCTNER);
+		EgovRwardManageController controller = controllerWith(service);
+		bindLoginUser(OUTSIDER, List.of("ROLE_ADMIN"));
+
+		RwardManage rm = requestFor("1");
+		BindingResult bindingResult = new BeanPropertyBindingResult(rm, "rwardManage");
+		ModelMap model = new ModelMap();
+
+		controller.updtRwardManageConfm(rm, bindingResult, new SimpleSessionStatus(), model);
+		assertTrue(service.confmCalled, "An admin must be able to confirm/reject any reward nomination.");
+	}
+}

--- a/src/test/java/egovframework/com/uss/ion/rwd/web/EgovRwardManageControllerOwnershipTest.java
+++ b/src/test/java/egovframework/com/uss/ion/rwd/web/EgovRwardManageControllerOwnershipTest.java
@@ -351,4 +351,36 @@ class EgovRwardManageControllerOwnershipTest {
 		controller.updtRwardManageConfm(rm, bindingResult, new SimpleSessionStatus(), model);
 		assertTrue(service.confmCalled, "An admin must be able to confirm/reject any reward nomination.");
 	}
+
+	// ---- selectRwardConfm (승인상세 열람) ----
+
+	@Test
+	void viewConfirmDetailByNonSanctnerIsRejected() {
+		StubService service = new StubService(OWNER, SANCTNER);
+		EgovRwardManageController controller = controllerWith(service);
+		bindLoginUser(OUTSIDER, List.of());
+
+		RwardManageVO vo = new RwardManageVO();
+		vo.setRwardId("1");
+		RwardManage rm = requestFor("1");
+		ModelMap model = new ModelMap();
+
+		assertThrows(IllegalStateException.class, () -> controller.selectRwardConfm(vo, rm, model),
+				"A logged-in user who is not the designated approver must not be able to view someone else's reward confirmation detail.");
+	}
+
+	@Test
+	void viewConfirmDetailBySanctnerSucceeds() throws Exception {
+		StubService service = new StubService(OWNER, SANCTNER);
+		EgovRwardManageController controller = controllerWith(service);
+		bindLoginUser(SANCTNER, List.of());
+
+		RwardManageVO vo = new RwardManageVO();
+		vo.setRwardId("1");
+		RwardManage rm = requestFor("1");
+		ModelMap model = new ModelMap();
+
+		String view = assertDoesNotThrow(() -> controller.selectRwardConfm(vo, rm, model));
+		assertTrue(view.contains("EgovRwardConfm"));
+	}
 }

--- a/src/test/java/egovframework/com/uss/ion/rwd/web/EgovRwardManageControllerRwardCodeListTest.java
+++ b/src/test/java/egovframework/com/uss/ion/rwd/web/EgovRwardManageControllerRwardCodeListTest.java
@@ -1,0 +1,162 @@
+package egovframework.com.uss.ion.rwd.web;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.ui.ModelMap;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.support.SimpleSessionStatus;
+
+import egovframework.com.cmm.ComDefaultCodeVO;
+import egovframework.com.cmm.EgovMessageSource;
+import egovframework.com.cmm.LoginVO;
+import egovframework.com.cmm.service.CmmnDetailCode;
+import egovframework.com.cmm.service.EgovCmmUseService;
+import egovframework.com.cmm.service.EgovUserDetailsService;
+import egovframework.com.cmm.util.EgovUserDetailsHelper;
+import egovframework.com.uss.ion.rwd.service.EgovRwardManageService;
+import egovframework.com.uss.ion.rwd.service.RwardManage;
+import egovframework.com.uss.ion.rwd.service.RwardManageVO;
+
+/**
+ * 포상관리 수정화면(EgovRwardUpdt)의 포상구분 코드목록 회귀 테스트.
+ *
+ * EgovRwardUpdt.jsp의 포상구분(필수)은 form:select/form:options가 ${rwardCodeList}만 보고
+ * option을 만든다. 수정화면 진입(EgovRwardManageDetail.do?cmd=updt)은 이 목록을 담아주는데,
+ * 같은 화면을 다시 그리는 updtRwardManage.do의 검증실패 분기는 담지 않아 목록이 비어 있었다.
+ */
+class EgovRwardManageControllerRwardCodeListTest {
+
+	private static final String APPLICANT = "USRCNFRM_00000000001";
+	private static final String UPDT_VIEW = "egovframework/com/uss/ion/rwd/EgovRwardUpdt";
+
+	/** 포상구분 공통코드(COM055) 스텁. */
+	private static final List<CmmnDetailCode> RWARD_CODES = List.of(detailCode("01", "표창"), detailCode("02", "포상"));
+
+	/** cmmUseService가 실제로 조회한 공통코드 ID. */
+	private final List<String> requestedCodeIds = new ArrayList<>();
+
+	private static CmmnDetailCode detailCode(String code, String codeNm) {
+		CmmnDetailCode detailCode = new CmmnDetailCode();
+		detailCode.setCode(code);
+		detailCode.setCodeNm(codeNm);
+		return detailCode;
+	}
+
+	private static void setPrivateField(Object target, String fieldName, Object value) {
+		try {
+			java.lang.reflect.Field field = target.getClass().getDeclaredField(fieldName);
+			field.setAccessible(true);
+			field.set(target, value);
+		} catch (ReflectiveOperationException e) {
+			throw new IllegalStateException(e);
+		}
+	}
+
+	private static void bindLoginUser(String uniqId) {
+		LoginVO login = new LoginVO();
+		login.setUniqId(uniqId);
+		new EgovUserDetailsHelper().setEgovUserDetailsService(new EgovUserDetailsService() {
+			@Override
+			public Object getAuthenticatedUser() {
+				return login;
+			}
+
+			@Override
+			public List<String> getAuthorities() {
+				return List.of();
+			}
+
+			@Override
+			public Boolean isAuthenticated() {
+				return Boolean.TRUE;
+			}
+		});
+	}
+
+	/** 이 테스트가 쓰는 메서드는 selectRwardManage 하나뿐이라 프록시로 최소 구현한다. */
+	private static EgovRwardManageService serviceReturning(RwardManageVO stored) {
+		return (EgovRwardManageService) Proxy.newProxyInstance(
+				EgovRwardManageControllerRwardCodeListTest.class.getClassLoader(),
+				new Class<?>[] { EgovRwardManageService.class },
+				(proxy, method, args) -> "selectRwardManage".equals(method.getName()) ? stored : null);
+	}
+
+	private EgovCmmUseService cmmUseServiceStub() {
+		return (EgovCmmUseService) Proxy.newProxyInstance(
+				EgovRwardManageControllerRwardCodeListTest.class.getClassLoader(),
+				new Class<?>[] { EgovCmmUseService.class }, (proxy, method, args) -> {
+					if ("selectCmmCodeDetail".equals(method.getName())) {
+						requestedCodeIds.add(((ComDefaultCodeVO) args[0]).getCodeId());
+						return RWARD_CODES;
+					}
+					return null;
+				});
+	}
+
+	private EgovRwardManageController controllerWith(RwardManageVO stored) {
+		EgovRwardManageController controller = new EgovRwardManageController();
+		setPrivateField(controller, "egovRwardManageService", serviceReturning(stored));
+		setPrivateField(controller, "cmmUseService", cmmUseServiceStub());
+		controller.egovMessageSource = new EgovMessageSource() {
+			@Override
+			public String getMessage(String code) {
+				return code;
+			}
+		};
+		return controller;
+	}
+
+	/** 수정화면 진입 경로는 포상구분 목록을 담아준다 — 같은 화면을 그리는 쪽이 지켜야 할 계약. */
+	@Test
+	void updateFormEntrySuppliesRwardCodeList() throws Exception {
+		RwardManageVO stored = new RwardManageVO();
+		stored.setRwardId("1");
+		EgovRwardManageController controller = controllerWith(stored);
+
+		ModelMap model = new ModelMap();
+		String view = controller.selectRwardManage(new RwardManage(), new RwardManageVO(), Map.of("cmd", "updt"),
+				model);
+
+		assertEquals(UPDT_VIEW, view);
+		assertNotNull(model.get("rwardCodeList"), "수정화면 진입은 포상구분 목록을 담아야 한다.");
+		assertEquals(List.of("COM055"), requestedCodeIds, "포상구분은 공통코드 COM055로 조회한다.");
+	}
+
+	/** 검증실패 재표시도 같은 화면이므로 포상구분 목록이 그대로 있어야 한다. */
+	@Test
+	void validationErrorRedisplaySuppliesRwardCodeList() throws Exception {
+		RwardManageVO stored = new RwardManageVO();
+		stored.setRwardId("1");
+		stored.setFrstRegisterId(APPLICANT);
+		EgovRwardManageController controller = controllerWith(stored);
+		bindLoginUser(APPLICANT);
+
+		RwardManage rwardManage = new RwardManage();
+		rwardManage.setRwardId("1");
+		rwardManage.setRwardDe("2026-13-99"); // 포상일자 형식 오류
+		BindingResult bindingResult = new BeanPropertyBindingResult(rwardManage, "rwardManage");
+		bindingResult.rejectValue("rwardDe", "validation.pattern.date");
+
+		RwardManageVO rwardManageVO = new RwardManageVO();
+		rwardManageVO.setRwardId("1");
+		ModelMap model = new ModelMap();
+
+		// 검증실패 분기는 multiRequest를 건드리지 않으므로 null로 충분하다.
+		String view = controller.updtRwardManage("N", null, rwardManage, bindingResult, rwardManageVO,
+				new SimpleSessionStatus(), model);
+
+		assertEquals(UPDT_VIEW, view);
+		assertNotNull(model.get("rwardCodeList"),
+				"검증실패로 수정화면을 다시 그릴 때 포상구분 목록이 없으면 필수값을 선택할 수 없다.");
+		assertEquals(RWARD_CODES.size(), ((List<?>) model.get("rwardCodeList")).size(),
+				"재표시된 포상구분 목록은 진입 때와 같은 항목 수여야 한다.");
+	}
+}


### PR DESCRIPTION
## 수정 사유

- [x] 버그수정
- [ ] 기능개선
- [ ] 리팩터링

## 문제 상황

포상관리 수정(`updtRwardManage`)은 인증 여부조차 확인하지 않습니다. 삭제(`deleteRwardManage`)와 승인상세 조회(`selectRwardConfm`)는 로그인 여부만 확인하고 승인·반려 처리(`updtRwardManageConfm`)는 지정된 승인권자인지 대조하지 않습니다. 그래서 로그인한 사용자가 임의의 `rwardId`로 다른 사람이 신청한 포상을 수정·삭제하거나, 자신이 지정 승인권자가 아닌 신청 건의 내용을 열람·승인·반려 처리할 수 있습니다.

## 이 도메인의 소유권 정의

포상관리에는 "소유자"가 둘 있습니다. 신청자(`FRST_REGISTER_ID`)와 지정 승인권자(`SANCTNER_ID`)입니다. 승인 목록(`EgovRwardConfmList.do`)이 실제로 어떤 조건으로 "내 결재함"을 판단하는지가 이 도메인의 경계입니다.

```java
rwardManageVO.setSanctnerId(user.getUniqId()); // 사용자가 승인권자인지 조건값 setting
```

```sql
WHERE A.SANCTNER_ID = #{sanctnerId} AND ...
```

승인 목록은 로그인 사용자를 `SANCTNER_ID`로 필터링해 지정된 승인권자에게만 보여줍니다. 하지만 목록 다음 단계인 승인상세 조회·승인/반려 처리는 이 경계를 전혀 강제하지 않아서 목록을 거치지 않고 URL을 직접 호출하면 그대로 뚫립니다.

## 발생 흐름

```java
@PostMapping("/uss/ion/rwd/updtRwardConfm.do")
public String updtRwardManageConfm(@ModelAttribute("rwardManage") RwardManage rwardManage, ...) {
    ...
    if (!isAuthenticated) { return "redirect:/uat/uia/egovLoginUsr.do"; }
    // 승인권자 대조 없이 그대로 처리
    egovRwardManageService.updtRwardManageConfm(rwardManage);
}
```

수정·삭제·승인 SQL도 소유자 조건 없이 PK만으로 처리합니다.

```sql
UPDATE COMTNRWARDMANAGE SET RWARD_NM=#{rwardNm}, ... WHERE RWARD_ID = #{rwardId}
DELETE FROM COMTNRWARDMANAGE WHERE RWARD_ID = #{rwardId}
UPDATE COMTNRWARDMANAGE SET CONFM_AT=#{confmAt}, ... WHERE RWARD_ID = #{rwardId}
```

승인 처리 UPDATE의 SET절에는 `SANCTNER_ID`가 없어서 컨트롤러가 `rwardManage.setSanctnerId(user.getUniqId())`로 호출자를 채워 넣어도 DB에는 반영되지 않습니다. 다만 대조 없이 승인상태(`CONFM_AT`)·승인일자·반려사유를 바꿀 수 있었다는 문제 자체는 그대로입니다.

## 변경 내용

네 경로 모두 이 파일에 이미 있던 `egovAssertAdminOrOwner`를 재사용했습니다. 검증 대상 필드만 경로마다 다릅니다 — 수정·삭제는 신청자(`frstRegisterId`), 승인상세 조회·승인/반려 처리는 지정 승인권자(`sanctnerId`).

```java
RwardManageVO stored = egovRwardManageService.selectRwardManage(rwardManageVO);
egovAssertAdminOrOwner(stored == null ? null : stored.getFrstRegisterId());
```

```java
egovAssertAdminOrOwner(rwardManageVOTemp == null ? null : rwardManageVOTemp.getSanctnerId());
```

소유권 확인을 위해 `selectRwardManage` 쿼리에 `FRST_REGISTER_ID`를 추가했습니다(`SANCTNER_ID`는 이미 SELECT되고 있었습니다). `frstRegisterId`는 `insertRwardManage`에서 서버가 로그인 세션으로 직접 설정하는 값이라 위조할 수 없습니다. 8개 방언 매퍼(altibase·cubrid·goldilocks·maria·mysql·oracle·postgres·tibero) 전부에서 동일하게 확인했습니다.

## 영향 범위

- `EgovRwardManageController`의 `updtRwardManage`·`deleteRwardManage`·`selectRwardConfm`·`updtRwardManageConfm`: 소유권 검증 추가. 신청자·지정 승인권자·`ROLE_ADMIN`의 요청은 그대로 동작하고 그 외만 차단됩니다.
- 매퍼: `selectRwardManage`에 `FRST_REGISTER_ID` 추가. 이 쿼리를 쓰는 다른 호출부에는 영향이 없습니다(선택 컬럼이 늘었을 뿐 조건은 그대로).

## 테스트 방법

### 재현 (수정 전)

로그인한 사용자가 다른 신청자의 포상관리에 수정·삭제를 요청하거나, 자신이 승인권자로 지정되지 않은 신청 건의 승인상세를 열람·승인·반려 처리합니다. 네 경로 모두 대조 없이 그대로 처리됩니다.

### 확인 (수정 후)

같은 요청이 소유권 검증에 걸려 `IllegalStateException`으로 차단됩니다.

### 단위 테스트

`EgovRwardManageControllerOwnershipTest`를 추가했습니다. 수정·삭제는 외부인 차단·신청자 정상동작(삭제는 관리자 우회 포함), 승인상세 조회·승인/반려 처리는 비승인권자 차단·승인권자 정상동작(승인/반려는 관리자 우회 포함)을 검증합니다.

```
Tests run: 10, Failures: 0, Errors: 0, Skipped: 0
```

소유권 검증 호출을 제거하면 네 진입점의 외부인/비승인권자 차단 테스트가 다음과 같이 실패합니다.

```
Tests run: 10, Failures: 4, Errors: 0, Skipped: 0
  confirmByNonSanctnerIsRejected: Expected java.lang.IllegalStateException to be thrown, but nothing was thrown.
  deleteByOutsiderIsRejected: Expected java.lang.IllegalStateException to be thrown, but nothing was thrown.
  updateByOutsiderIsRejected: Expected java.lang.IllegalStateException to be thrown, but nothing was thrown.
  viewConfirmDetailByNonSanctnerIsRejected: Expected java.lang.IllegalStateException to be thrown, but nothing was thrown.
```



---

## 포상구분 목록 복원 추가 (2026-08-19)

같은 컨트롤러의 검증 실패 재표시 결함도 이 PR에서 함께 고쳤습니다. 수정 자리가 소유권 검증 훅과 세 줄 거리라 따로 내면 머지 충돌이 납니다.

수정화면 진입 경로는 포상구분 코드목록을 모델에 담는데, 같은 화면을 되돌려주는 검증 실패 분기는 담지 않습니다. 재표시된 화면은 필수 선택상자가 빈 채로 나와 오류를 고쳐도 값을 고를 수 없습니다.

### 테스트

`EgovRwardManageControllerRwardCodeListTest` 2건을 추가했습니다. 기존 소유권 테스트와 함께 돌립니다.

수정 전(RED)

```
[ERROR] Tests run: 2, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.149 s <<< FAILURE! -- in egovframework.com.uss.ion.rwd.web.EgovRwardManageControllerRwardCodeListTest
[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.010 s -- in egovframework.com.uss.ion.rwd.web.EgovRwardManageControllerOwnershipTest
[ERROR]   EgovRwardManageControllerRwardCodeListTest.validationErrorRedisplaySuppliesRwardCodeList:157 검증실패로 수정화면을 다시 그릴 때 포상구분 목록이 없으면 필수값을 선택할 수 없다. ==> expected: not <null>
```

수정 후(GREEN)

```
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.147 s -- in egovframework.com.uss.ion.rwd.web.EgovRwardManageControllerRwardCodeListTest
[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.009 s -- in egovframework.com.uss.ion.rwd.web.EgovRwardManageControllerOwnershipTest
[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```
