### PR TITLE
fix: 설문항목관리 목록팝업 일괄삭제에 관리자 검증 추가

### DIFF
--- a/src/main/java/egovframework/com/uss/olp/qim/web/EgovQustnrItemManageController.java
+++ b/src/main/java/egovframework/com/uss/olp/qim/web/EgovQustnrItemManageController.java
@@ -87,6 +87,11 @@ public class EgovQustnrItemManageController {
 			if (!"POST".equalsIgnoreCase(_req.getMethod())) {
 				throw new org.springframework.web.HttpRequestMethodNotSupportedException(_req.getMethod());
 			}
+			// 형제 경로 egovQustnrItemManageDetail의 cmd=del과 동일한 관리자 검증
+			java.util.List<String> auth = EgovUserDetailsHelper.getAuthorities();
+			if (auth == null || !auth.contains("ROLE_ADMIN")) {
+				throw new IllegalStateException("권한이 없습니다.");
+			}
 			egovQustnrItemManageService.deleteQustnrItemManage(qustnrItemManageVO);
 		}
 

--- a/src/test/java/egovframework/com/uss/olp/qim/web/EgovQustnrItemManageControllerAdminCheckTest.java
+++ b/src/test/java/egovframework/com/uss/olp/qim/web/EgovQustnrItemManageControllerAdminCheckTest.java
@@ -1,0 +1,195 @@
+package egovframework.com.uss.olp.qim.web;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.ui.ModelMap;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import egovframework.com.cmm.ComDefaultVO;
+import egovframework.com.cmm.LoginVO;
+import egovframework.com.cmm.service.EgovUserDetailsService;
+import egovframework.com.cmm.util.EgovUserDetailsHelper;
+import egovframework.com.uss.olp.qim.service.EgovQustnrItemManageService;
+import egovframework.com.uss.olp.qim.service.QustnrItemManageVO;
+
+/**
+ * 설문항목관리 목록팝업 일괄삭제(cmd=del)의 관리자 검증 회귀 테스트.
+ *
+ * 형제 경로 egovQustnrItemManageDetail의 cmd=del은 이미 ROLE_ADMIN 검증을 거치는데,
+ * 동일한 deleteQustnrItemManage를 호출하는 egovQustnrItemManageListPopup의 cmd=del은
+ * 그 검증이 빠져 있었다. 로그인만 한 일반 사용자가 이 팝업 경로로 설문항목을 삭제할 수
+ * 있었다(형제 경로 비교로 드러나는 자기모순).
+ */
+class EgovQustnrItemManageControllerAdminCheckTest {
+
+	private static final class StubService implements EgovQustnrItemManageService {
+		private boolean deleteCalled = false;
+
+		@Override
+		public void deleteQustnrItemManage(QustnrItemManageVO qustnrItemManageVO) {
+			deleteCalled = true;
+		}
+
+		@Override
+		public List<org.egovframe.rte.psl.dataaccess.util.EgovMap> selectQustnrTmplatManageList(QustnrItemManageVO qustnrItemManageVO) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public List<org.egovframe.rte.psl.dataaccess.util.EgovMap> selectQustnrItemManageList(ComDefaultVO searchVO) {
+			return List.of();
+		}
+
+		@Override
+		public List<org.egovframe.rte.psl.dataaccess.util.EgovMap> selectQustnrItemManageDetail(QustnrItemManageVO qustnrItemManageVO) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public int selectQustnrItemManageListCnt(ComDefaultVO searchVO) {
+			return 0;
+		}
+
+		@Override
+		public void insertQustnrItemManage(QustnrItemManageVO qustnrItemManageVO) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public void updateQustnrItemManage(QustnrItemManageVO qustnrItemManageVO) {
+			throw new UnsupportedOperationException();
+		}
+	}
+
+	@AfterEach
+	void clearRequestContext() {
+		RequestContextHolder.resetRequestAttributes();
+	}
+
+	private static void bindLoginUser(String uniqId, List<String> authorities) {
+		LoginVO login = new LoginVO();
+		login.setUniqId(uniqId);
+		EgovUserDetailsService stub = new EgovUserDetailsService() {
+			@Override
+			public Object getAuthenticatedUser() {
+				return login;
+			}
+
+			@Override
+			public List<String> getAuthorities() {
+				return authorities;
+			}
+
+			@Override
+			public Boolean isAuthenticated() {
+				return Boolean.TRUE;
+			}
+		};
+		new EgovUserDetailsHelper().setEgovUserDetailsService(stub);
+	}
+
+	/**
+	 * MockHttpServletRequest는 이 로컬 환경에서 NoClassDefFoundError로 깨진다
+	 * ([[shell-and-egov-test-env-traps]]). 컨트롤러가 실제로 쓰는 getMethod()만
+	 * 최소 구현한 프록시로 대체한다.
+	 */
+	private static void bindPostRequest() {
+		jakarta.servlet.http.HttpServletRequest request = (jakarta.servlet.http.HttpServletRequest) java.lang.reflect.Proxy.newProxyInstance(
+				EgovQustnrItemManageControllerAdminCheckTest.class.getClassLoader(),
+				new Class<?>[] { jakarta.servlet.http.HttpServletRequest.class },
+				(proxy, method, args) -> {
+					if ("getMethod".equals(method.getName())) {
+						return "POST";
+					}
+					Class<?> returnType = method.getReturnType();
+					if (returnType == boolean.class) {
+						return false;
+					}
+					return null;
+				});
+		RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+	}
+
+	/** getInt(...)에 10을 돌려주는 것 외엔 페이징 계산에 관여하지 않는 최소 프록시. */
+	private static org.egovframe.rte.fdl.property.EgovPropertyService noopPropertiesService() {
+		return (org.egovframe.rte.fdl.property.EgovPropertyService) java.lang.reflect.Proxy.newProxyInstance(
+				EgovQustnrItemManageControllerAdminCheckTest.class.getClassLoader(),
+				new Class<?>[] { org.egovframe.rte.fdl.property.EgovPropertyService.class },
+				(proxy, method, args) -> {
+					Class<?> returnType = method.getReturnType();
+					if (returnType == int.class) {
+						return 10;
+					}
+					if (returnType == boolean.class) {
+						return false;
+					}
+					if (returnType == long.class) {
+						return 0L;
+					}
+					if (returnType == double.class) {
+						return 0.0d;
+					}
+					if (returnType == float.class) {
+						return 0.0f;
+					}
+					return null;
+				});
+	}
+
+	private static void setPrivateField(Object target, String fieldName, Object value) {
+		try {
+			java.lang.reflect.Field field = target.getClass().getDeclaredField(fieldName);
+			field.setAccessible(true);
+			field.set(target, value);
+		} catch (ReflectiveOperationException e) {
+			throw new IllegalStateException(e);
+		}
+	}
+
+	private static EgovQustnrItemManageController controllerWith(StubService service) {
+		EgovQustnrItemManageController controller = new EgovQustnrItemManageController();
+		setPrivateField(controller, "egovQustnrItemManageService", service);
+		setPrivateField(controller, "propertiesService", noopPropertiesService());
+		return controller;
+	}
+
+	private static String callListPopupDelete(StubService service) throws Exception {
+		EgovQustnrItemManageController controller = controllerWith(service);
+		bindPostRequest();
+
+		ComDefaultVO searchVO = new ComDefaultVO();
+		Map<String, String> commandMap = new HashMap<>();
+		commandMap.put("cmd", "del");
+		QustnrItemManageVO qustnrItemManageVO = new QustnrItemManageVO();
+		ModelMap model = new ModelMap();
+
+		return controller.egovQustnrItemManageListPopup(searchVO, commandMap, qustnrItemManageVO, model);
+	}
+
+	@Test
+	void deleteByNonAdminIsRejected() {
+		StubService service = new StubService();
+		bindLoginUser("USRCNFRM_00000000009", List.of());
+
+		assertThrows(IllegalStateException.class, () -> callListPopupDelete(service),
+				"A logged-in non-admin must not be able to delete a survey item via the list popup.");
+		assertTrue(!service.deleteCalled, "deleteQustnrItemManage must not be reached by a non-admin.");
+	}
+
+	@Test
+	void deleteByAdminSucceeds() throws Exception {
+		StubService service = new StubService();
+		bindLoginUser("USRCNFRM_00000000001", List.of("ROLE_ADMIN"));
+
+		callListPopupDelete(service);
+		assertTrue(service.deleteCalled, "An admin must be able to delete a survey item via the list popup.");
+	}
+}


### PR DESCRIPTION
## 수정 사유

- [x] 버그수정
- [ ] 기능개선
- [ ] 리팩터링

## 문제 상황

설문항목 일괄삭제가 두 경로에 있습니다. 상세화면(`EgovQustnrItemManageDetail.do?cmd=del`)과 목록팝업(`EgovQustnrItemManageListPopup.do?cmd=del`)입니다. 둘 다 같은 `deleteQustnrItemManage`를 호출하는데, 상세화면 쪽에만 관리자 검증이 있습니다.

```java
// EgovQustnrItemManageDetail.do (cmd=del)
java.util.List<String> auth = EgovUserDetailsHelper.getAuthorities();
if (auth == null || !auth.contains("ROLE_ADMIN")) {
    throw new IllegalStateException("권한이 없습니다.");
}
egovQustnrItemManageService.deleteQustnrItemManage(qustnrItemManageVO);
```

```java
// EgovQustnrItemManageListPopup.do (cmd=del) — 검증 없음
egovQustnrItemManageService.deleteQustnrItemManage(qustnrItemManageVO);
```

그래서 로그인만 한 일반 사용자도 목록팝업 경로로 들어가면 설문항목을 삭제할 수 있습니다.

## 발생 흐름

삭제 SQL은 소유자·권한 조건 없이 PK만으로 처리합니다.

```sql
DELETE FROM COMTNQUSTNRIEM WHERE QUSTNR_IEM_ID = #{qustnrIemId}
```

Java 코드의 관리자 검증이 유일한 방어선인데, 목록팝업 경로에는 그 방어선이 없습니다.

## 변경 내용

목록팝업의 `cmd=del` 분기에 상세화면과 동일한 검증을 그대로 옮겼습니다.

```java
// 형제 경로 egovQustnrItemManageDetail의 cmd=del과 동일한 관리자 검증
java.util.List<String> auth = EgovUserDetailsHelper.getAuthorities();
if (auth == null || !auth.contains("ROLE_ADMIN")) {
    throw new IllegalStateException("권한이 없습니다.");
}
```

등록(`qustnrItemManageRegist`)·수정(`qustnrItemManageModify`)에는 애초에 관리자 검증이 없습니다(로그인만 요구). `frstRegisterId`도 소유권이 아니라 등록자 기록용(audit) 필드여서 개인 소유 리소스는 아닙니다. 이 모듈군(설문항목·설문템플릿 관리)의 기존 관례가 "삭제만 관리자 전용, 등록·수정은 로그인만"이라 이번 PR에서는 건드리지 않았습니다.

## 영향 범위

- `EgovQustnrItemManageController.egovQustnrItemManageListPopup`(`cmd=del` 분기): 관리자 검증 추가. 관리자의 삭제는 그대로 동작하고 비관리자만 차단됩니다.
- 매퍼 변경 없음.

## 테스트 방법

### 재현 (수정 전)

로그인만 한 일반 사용자가 목록팝업 경로로 설문항목 삭제를 요청합니다. POST 메서드 확인만 통과하면 그대로 삭제됩니다.

### 확인 (수정 후)

같은 요청이 관리자 검증에 걸려 `IllegalStateException`으로 차단됩니다.

### 단위 테스트

`EgovQustnrItemManageControllerAdminCheckTest`를 추가했습니다. 비관리자 차단(예외 발생, 삭제 서비스 미호출)·관리자 정상동작 2케이스를 검증합니다.

```
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
```

검증 블록을 제거하면 비관리자 테스트가 다음과 같이 실패합니다.

```
Tests run: 2, Failures: 1, Errors: 0, Skipped: 0
  deleteByNonAdminIsRejected: Expected java.lang.IllegalStateException to be thrown, but nothing was thrown.
```

