### PR TITLE
fix: 상담정보 수정 시 소유권 검증 추가

### DIFF
--- a/src/main/java/egovframework/com/uss/olp/cns/web/EgovCnsltManageController.java
+++ b/src/main/java/egovframework/com/uss/olp/cns/web/EgovCnsltManageController.java
@@ -464,6 +464,15 @@ public class EgovCnsltManageController {
 
 		}
 
+		// 2026.08.08 KISA 보안취약점 조치 - 소유권 검증(관리자 또는 작성자 본인만 수정 가능)
+		CnsltManageVO stored = cnsltManageService.selectCnsltListDetail(cnsltManageVO);
+		egovAssertAdminOrOwner(stored == null ? null : stored.getFrstRegisterId());
+
+		// updateCnsltDtls.do는 등록자ID를 폼으로 받지 않아 바인딩되지 않는다.
+		// 수정 매퍼가 FRST_REGISTER_ID를 매번 재기록하므로, 원래 등록자 값을 그대로 보존해야
+		// 다음 수정 시점에도 소유권 검증이 계속 유효하다(비워두면 다음 수정부터 관리자만 통과).
+		cnsltManageVO.setFrstRegisterId(stored == null ? null : stored.getFrstRegisterId());
+
 		// 첨부파일 관련 ID 생성 start....
 		String atchFileId = cnsltManageVO.getAtchFileId();
 

--- a/src/test/java/egovframework/com/uss/olp/cns/web/EgovCnsltManageControllerOwnershipTest.java
+++ b/src/test/java/egovframework/com/uss/olp/cns/web/EgovCnsltManageControllerOwnershipTest.java
@@ -1,0 +1,240 @@
+package egovframework.com.uss.olp.cns.web;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.ui.ModelMap;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.multipart.MultipartHttpServletRequest;
+
+import egovframework.com.cmm.LoginVO;
+import egovframework.com.cmm.service.EgovUserDetailsService;
+import egovframework.com.cmm.util.EgovUserDetailsHelper;
+import egovframework.com.uss.olp.cns.service.CnsltManageDefaultVO;
+import egovframework.com.uss.olp.cns.service.CnsltManageVO;
+import egovframework.com.uss.olp.cns.service.EgovCnsltManageService;
+
+/**
+ * updateCnsltDtls의 소유권 검증 회귀 테스트.
+ *
+ * 수정 전 코드는 소유자를 전혀 대조하지 않아, 로그인만 하면(또는 비로그인 상태로도)
+ * 임의의 cnsltId를 넣어 타인의 상담정보를 수정할 수 있었다(IDOR).
+ * ROLE_ADMIN 보유자는 소유자가 아니어도 통과해야 한다(다른 카드와 동일 관례).
+ */
+class EgovCnsltManageControllerOwnershipTest {
+
+	private static final String OWNER = "USRCNFRM_00000000001";
+	private static final String ATTACKER = "USRCNFRM_00000000009";
+
+	/** selectCnsltListDetail은 저장된 등록자를 돌려주고, updateCnsltDtls 호출 여부를 기록하는 스텁. */
+	private static final class StubService implements EgovCnsltManageService {
+		private final CnsltManageVO stored;
+		private boolean updateCalled = false;
+		private CnsltManageVO lastUpdateArg;
+
+		StubService(String ownerUniqId) {
+			this.stored = new CnsltManageVO();
+			this.stored.setFrstRegisterId(ownerUniqId);
+		}
+
+		@Override
+		public CnsltManageVO selectCnsltListDetail(CnsltManageVO vo) {
+			return stored;
+		}
+
+		@Override
+		public void updateCnsltInqireCo(CnsltManageVO vo) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public List<org.egovframe.rte.psl.dataaccess.util.EgovMap> selectCnsltList(CnsltManageDefaultVO searchVO) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public int selectCnsltListTotCnt(CnsltManageDefaultVO searchVO) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public void insertCnsltDtls(CnsltManageVO vo) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public int selectCnsltPasswordConfirmCnt(CnsltManageVO vo) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public void updateCnsltDtls(CnsltManageVO vo) {
+			updateCalled = true;
+			lastUpdateArg = vo;
+		}
+
+		@Override
+		public void deleteCnsltDtls(CnsltManageVO vo) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public CnsltManageVO selectCnsltAnswerListDetail(CnsltManageVO vo) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public List<org.egovframe.rte.psl.dataaccess.util.EgovMap> selectCnsltAnswerList(
+				CnsltManageDefaultVO searchVO) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public int selectCnsltAnswerListTotCnt(CnsltManageDefaultVO searchVO) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public void updateCnsltDtlsAnswer(CnsltManageVO vo) {
+			throw new UnsupportedOperationException();
+		}
+	}
+
+	private static void bindLoginUser(String uniqId, List<String> authorities) {
+		LoginVO login = new LoginVO();
+		login.setUniqId(uniqId);
+		EgovUserDetailsService stub = new EgovUserDetailsService() {
+			@Override
+			public Object getAuthenticatedUser() {
+				return login;
+			}
+
+			@Override
+			public List<String> getAuthorities() {
+				return authorities;
+			}
+
+			@Override
+			public Boolean isAuthenticated() {
+				return Boolean.TRUE;
+			}
+		};
+		new EgovUserDetailsHelper().setEgovUserDetailsService(stub);
+	}
+
+	private static EgovCnsltManageController controllerWith(StubService service) throws Exception {
+		EgovCnsltManageController controller = new EgovCnsltManageController();
+		Field serviceField = EgovCnsltManageController.class.getDeclaredField("cnsltManageService");
+		serviceField.setAccessible(true);
+		serviceField.set(controller, service);
+		return controller;
+	}
+
+	/** getFiles("file_1")만 빈 리스트를 돌려주는 최소 스텁. 그 외 메서드는 호출되지 않아야 한다(그러면 실패). */
+	private static MultipartHttpServletRequest emptyMultiRequest() {
+		InvocationHandler handler = new InvocationHandler() {
+			@Override
+			public Object invoke(Object proxy, Method method, Object[] args) {
+				if ("getFiles".equals(method.getName())) {
+					return Collections.<MultipartFile>emptyList();
+				}
+				throw new UnsupportedOperationException("Unexpected call: " + method.getName());
+			}
+		};
+		return (MultipartHttpServletRequest) Proxy.newProxyInstance(
+				EgovCnsltManageControllerOwnershipTest.class.getClassLoader(),
+				new Class<?>[] { MultipartHttpServletRequest.class }, handler);
+	}
+
+	private static CnsltManageVO requestFor(String cnsltId) {
+		CnsltManageVO vo = new CnsltManageVO();
+		vo.setCnsltId(cnsltId);
+		vo.setCnsltSj("edited subject");
+		vo.setCnsltCn("edited content");
+		vo.setWrterNm("attacker");
+		vo.setAreaNo("02");
+		vo.setMiddleTelno("1234");
+		vo.setEndTelno("5678");
+		vo.setWritngPassword("pw");
+		return vo;
+	}
+
+	@Test
+	void updateByNonOwnerDoesNotReachTheUpdateService() throws Exception {
+		StubService service = new StubService(OWNER);
+		EgovCnsltManageController controller = controllerWith(service);
+		bindLoginUser(ATTACKER, List.of());
+
+		CnsltManageVO vo = requestFor("1");
+		BindingResult bindingResult = new BeanPropertyBindingResult(vo, "cnsltManageVO");
+		ModelMap model = new ModelMap();
+
+		assertThrows(IllegalStateException.class,
+				() -> controller.updateCnsltDtls("N", emptyMultiRequest(), new CnsltManageDefaultVO(), vo,
+						bindingResult, model),
+				"A logged-in non-owner must not be able to update another member's consultation record.");
+		assertTrue(!service.updateCalled, "updateCnsltDtls service must not be reached by a non-owner.");
+	}
+
+	@Test
+	void updateByOwnerReachesTheUpdateService() throws Exception {
+		StubService service = new StubService(OWNER);
+		EgovCnsltManageController controller = controllerWith(service);
+		bindLoginUser(OWNER, List.of());
+
+		CnsltManageVO vo = requestFor("1");
+		BindingResult bindingResult = new BeanPropertyBindingResult(vo, "cnsltManageVO");
+		ModelMap model = new ModelMap();
+
+		controller.updateCnsltDtls("N", emptyMultiRequest(), new CnsltManageDefaultVO(), vo, bindingResult, model);
+		assertTrue(service.updateCalled, "The owner must be able to update their own consultation record.");
+	}
+
+	/**
+	 * CnsltDtlsUpdt.jsp 폼에는 frstRegisterId 히든필드가 없어 요청 바인딩 결과는 항상 null이다.
+	 * 그 null을 그대로 서비스에 넘기면 UPDATE문이 FRST_REGISTER_ID를 매번 지워버려,
+	 * 같은 소유자가 두 번째로 수정을 시도할 때 저장된 등록자가 null이 되어 영원히 차단된다.
+	 * 컨트롤러는 조회해둔 stored의 값을 복원해서 넘겨야 한다.
+	 */
+	@Test
+	void updateRestoresFrstRegisterIdSoTheNextEditByTheSameOwnerStillWorks() throws Exception {
+		StubService service = new StubService(OWNER);
+		EgovCnsltManageController controller = controllerWith(service);
+		bindLoginUser(OWNER, List.of());
+
+		CnsltManageVO vo = requestFor("1");
+		assertTrue(vo.getFrstRegisterId() == null, "요청 바인딩은 frstRegisterId를 채우지 않는다(JSP에 히든필드 없음).");
+		BindingResult bindingResult = new BeanPropertyBindingResult(vo, "cnsltManageVO");
+		ModelMap model = new ModelMap();
+
+		controller.updateCnsltDtls("N", emptyMultiRequest(), new CnsltManageDefaultVO(), vo, bindingResult, model);
+
+		assertTrue(service.lastUpdateArg.getFrstRegisterId() != null
+				&& OWNER.equals(service.lastUpdateArg.getFrstRegisterId()),
+				"수정 시 등록자ID를 보존하지 않으면 다음 수정부터 소유권 검증이 실패한다(자기 글 락아웃).");
+	}
+
+	@Test
+	void updateByAdminReachesTheUpdateServiceEvenWhenNotOwner() throws Exception {
+		StubService service = new StubService(OWNER);
+		EgovCnsltManageController controller = controllerWith(service);
+		bindLoginUser(ATTACKER, List.of("ROLE_ADMIN"));
+
+		CnsltManageVO vo = requestFor("1");
+		BindingResult bindingResult = new BeanPropertyBindingResult(vo, "cnsltManageVO");
+		ModelMap model = new ModelMap();
+
+		controller.updateCnsltDtls("N", emptyMultiRequest(), new CnsltManageDefaultVO(), vo, bindingResult, model);
+		assertTrue(service.updateCalled, "An admin must be able to update any member's consultation record.");
+	}
+}


### PR DESCRIPTION
## 수정 사유

- [x] 버그수정
- [ ] 기능개선
- [ ] 리팩터링

## 문제 상황

상담정보 수정(`CnsltDtlsUpdt.do`)은 소유자를 전혀 대조하지 않습니다. 로그인한 사용자(비로그인이어도 예외 없이 통과)가 임의의 `cnsltId`를 폼에 넣으면 다른 사람이 작성한 상담글(연락처·이메일·상담내용·작성비밀번호 포함)을 수정할 수 있습니다. 같은 파일의 삭제(`deleteCnsltDtls`)는 이미 `EgovXssChecker.checkerUserXss`로 등록자를 대조하는데, 수정 경로만 이 검증이 빠져 있습니다.

## 발생 흐름

```java
@PostMapping("/uss/olp/cns/CnsltDtlsUpdt.do")
public String updateCnsltDtls(@RequestParam("atchFileAt") String atchFileAt,
        final MultipartHttpServletRequest multiRequest, ...,
        @Valid @ModelAttribute("cnsltManageVO") CnsltManageVO cnsltManageVO, ...) {
    if (bindingResult.hasErrors()) { return "..."; }
    // 소유자 대조 없이 그대로 수정
    cnsltManageService.updateCnsltDtls(cnsltManageVO);
}
```

수정 SQL도 `CNSLT_ID` PK만으로 처리합니다.

```sql
UPDATE COMTNCNSLTLIST SET CNSLT_SJ=#{cnsltSj}, ... WHERE CNSLT_ID=#{cnsltId}
```

## 변경 내용

파일 하단에 이미 있던 `egovAssertAdminOrOwner(String ownerUniqId)`를 재사용했습니다. 2026.07.13 KISA 조치로 정의만 되고 이 메서드에서는 호출되지 않던 헬퍼입니다. 최초 등록자(`frstRegisterId`)는 등록(`insertCnsltDtls`)에서만 서버가 로그인 세션으로 직접 채우는 값이라 위조할 수 없습니다. 조회 매퍼(`selectCnsltListDetail`)도 이미 이 컬럼을 SELECT하고 있어 별도 매퍼 수정 없이 바로 쓸 수 있었습니다.

```java
CnsltManageVO stored = cnsltManageService.selectCnsltListDetail(cnsltManageVO);
egovAssertAdminOrOwner(stored == null ? null : stored.getFrstRegisterId());
```

구현 중 3렌즈 검증에서 두 렌즈가 독립적으로 같은 문제를 짚었습니다: 수정 폼(`EgovCnsltDtlsUpdt.jsp`)에는 `frstRegisterId` 히든필드가 없어 요청 바인딩 시 항상 null이고 수정 SQL은 `FRST_REGISTER_ID=#{frstRegisterId}`로 이 컬럼을 매번 재기록합니다(컬럼은 NULL 허용). 소유권 검증만 추가하고 이 값을 흘려보내지 않으면 정상 소유자가 자기 글을 처음 수정하는 순간 DB의 등록자ID가 null이 됩니다. 그다음 수정부터는 본인조차 차단당하는 회귀가 생깁니다. 조회해 둔 `stored`의 값을 그대로 복원해 이 문제를 막았습니다.

```java
// updateCnsltDtls.do는 등록자ID를 폼으로 받지 않아 바인딩되지 않는다.
// 수정 매퍼가 FRST_REGISTER_ID를 매번 재기록하므로, 원래 등록자 값을 그대로 보존해야
// 다음 수정 시점에도 소유권 검증이 계속 유효하다(비워두면 다음 수정부터 관리자만 통과).
cnsltManageVO.setFrstRegisterId(stored == null ? null : stored.getFrstRegisterId());
```

## 영향 범위

`EgovCnsltManageController.updateCnsltDtls`만 변경했습니다. 등록자·`ROLE_ADMIN` 보유자의 정상 수정 흐름은 그대로 동작하고 그 외 요청만 차단됩니다. 매퍼·JSP·다른 메서드는 건드리지 않았습니다.

## 테스트 방법

### 재현 (수정 전)

로그인한 사용자가 다른 사람이 작성한 상담글의 `cnsltId`로 수정을 요청하면 대조 없이 그대로 처리됩니다.

### 확인 (수정 후)

같은 요청이 소유권 검증에 걸려 `IllegalStateException`으로 차단됩니다.

### 단위 테스트

`EgovCnsltManageControllerOwnershipTest`를 추가했습니다. 비소유자 차단, 소유자 정상동작, 관리자 우회, 그리고 소유자가 수정해도 등록자ID가 보존되는지(두 번째 수정 시 락아웃 방지)를 검증합니다.

```
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
```

소유권 검증 호출을 제거하면:

```
Tests run: 4, Failures: 1, Errors: 0, Skipped: 0
  updateByNonOwnerDoesNotReachTheUpdateService: Expected java.lang.IllegalStateException to be thrown, but nothing was thrown.
```

등록자ID 보존 코드만 제거하면:

```
Tests run: 4, Failures: 1, Errors: 0, Skipped: 0
  updateRestoresFrstRegisterIdSoTheNextEditByTheSameOwnerStillWorks: 수정 시 등록자ID를 보존하지 않으면 다음 수정부터 소유권 검증이 실패한다(자기 글 락아웃). ==> expected: <true> but was: <false>
```
