### PR TITLE
fix: 장애신청 수정·처리요청·처리취소 시 소유권 검증 추가

### DIFF
--- a/src/main/java/egovframework/com/sym/tbm/tbr/web/EgovTroblReqstController.java
+++ b/src/main/java/egovframework/com/sym/tbm/tbr/web/EgovTroblReqstController.java
@@ -223,6 +223,12 @@ public class EgovTroblReqstController {
 			model.addAttribute("cmmCodeDetailList", getCmmCodeDetailList(new ComDefaultCodeVO(), "COM065"));
 			return "egovframework/com/sym/tbm/tbr/EgovTroblReqstUpdt";
 		} else {
+			// 2026.08.08 KISA 보안취약점 조치 - 소유권 검증(관리자 또는 신청자 본인만 수정 가능)
+			TroblReqstVO lookup = new TroblReqstVO();
+			lookup.setTroblId(troblReqst.getTroblId());
+			TroblReqstVO stored = egovTroblReqstService.selectTroblReqst(lookup);
+			egovAssertAdminOrOwnerById(stored == null ? null : stored.getFrstRegisterId());
+
 			LoginVO user = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();
 			troblReqst.setTroblOccrrncTime(EgovStringUtil.removeMinusChar(troblReqst.getTroblOccrrncTime()));
 			troblReqst.setTroblRequstTime(EgovStringUtil.removeMinusChar(troblReqst.getTroblRequstTime()));
@@ -263,6 +269,12 @@ public class EgovTroblReqstController {
 			@ModelAttribute("troblReqst") TroblReqst troblReqst, SessionStatus status, ModelMap model)
 			throws Exception {
 
+		// 2026.08.08 KISA 보안취약점 조치 - 소유권 검증(관리자 또는 신청자 본인만 처리요청 가능)
+		TroblReqstVO lookup = new TroblReqstVO();
+		lookup.setTroblId(troblId);
+		TroblReqstVO stored = egovTroblReqstService.selectTroblReqst(lookup);
+		egovAssertAdminOrOwnerById(stored == null ? null : stored.getFrstRegisterId());
+
 		troblReqst.setTroblId(troblId);
 		troblReqst.setProcessSttus("R");
 		LoginVO user = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();
@@ -283,6 +295,12 @@ public class EgovTroblReqstController {
 	public String requstTroblReqstCancl(@RequestParam("troblId") String troblId,
 			@ModelAttribute("troblReqst") TroblReqst troblReqst, SessionStatus status, ModelMap model)
 			throws Exception {
+
+		// 2026.08.08 KISA 보안취약점 조치 - 소유권 검증(관리자 또는 신청자 본인만 처리취소 가능)
+		TroblReqstVO lookup = new TroblReqstVO();
+		lookup.setTroblId(troblId);
+		TroblReqstVO stored = egovTroblReqstService.selectTroblReqst(lookup);
+		egovAssertAdminOrOwnerById(stored == null ? null : stored.getFrstRegisterId());
 
 		troblReqst.setTroblId(troblId);
 		troblReqst.setProcessSttus("A");
@@ -325,6 +343,24 @@ public class EgovTroblReqstController {
 	private void egovAssertAdminOrOwner(String ownerUniqId) {
 		LoginVO loginVO = egovAssertLoginUser();
 		if (ownerUniqId != null && ownerUniqId.equals(loginVO.getUniqId())) {
+			return;
+		}
+		java.util.List<String> auth = EgovUserDetailsHelper.getAuthorities();
+		if (auth != null && auth.contains("ROLE_ADMIN")) {
+			return;
+		}
+		throw new IllegalStateException("권한이 없습니다.");
+	}
+
+	/**
+	 * 2026.08.08 KISA 보안취약점 조치 - 관리자 또는 소유자(로그인ID 기준)
+	 * 이 컨트롤러는 등록자ID를 loginVO.getUniqId()가 아니라 loginVO.getId()(로그인 아이디)로 저장한다
+	 * (insertTroblReqst 참조). 위 egovAssertAdminOrOwner를 그대로 쓰면 필드가 어긋나 실제
+	 * 신청자까지 항상 차단되므로, 이 컨트롤러 전용으로 getId() 기준 비교를 별도로 둔다.
+	 */
+	private void egovAssertAdminOrOwnerById(String ownerLoginId) {
+		LoginVO loginVO = egovAssertLoginUser();
+		if (ownerLoginId != null && ownerLoginId.equals(loginVO.getId())) {
 			return;
 		}
 		java.util.List<String> auth = EgovUserDetailsHelper.getAuthorities();

--- a/src/test/java/egovframework/com/sym/tbm/tbr/web/EgovTroblReqstControllerOwnershipTest.java
+++ b/src/test/java/egovframework/com/sym/tbm/tbr/web/EgovTroblReqstControllerOwnershipTest.java
@@ -1,0 +1,247 @@
+package egovframework.com.sym.tbm.tbr.web;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Field;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.ui.ModelMap;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.support.SessionStatus;
+import org.springframework.web.bind.support.SimpleSessionStatus;
+
+import egovframework.com.cmm.LoginVO;
+import egovframework.com.cmm.service.EgovUserDetailsService;
+import egovframework.com.cmm.util.EgovUserDetailsHelper;
+import egovframework.com.sym.tbm.tbr.service.EgovTroblReqstService;
+import egovframework.com.sym.tbm.tbr.service.TroblReqst;
+import egovframework.com.sym.tbm.tbr.service.TroblReqstVO;
+
+/**
+ * updateTroblReqst·requstTroblReqst·requstTroblReqstCancl의 소유권 검증 회귀 테스트.
+ *
+ * 이 컨트롤러는 등록자ID를 loginVO.getUniqId()가 아니라 loginVO.getId()(로그인 아이디)로 저장한다
+ * (insertTroblReqst 참조). 그래서 이 카드는 다른 카드들의 uniqId 기반 egovAssertAdminOrOwner를
+ * 그대로 재사용할 수 없고, getId() 기준으로 비교하는 egovAssertAdminOrOwnerById를 새로 둔다.
+ * 만약 uniqId 기준으로 잘못 비교했다면, 실제 신청자(OWNER)조차 항상 차단되어 아래
+ * "OwnerReachesTheService" 계열 테스트가 실패했을 것이다.
+ */
+class EgovTroblReqstControllerOwnershipTest {
+
+	private static final String OWNER_LOGIN_ID = "owner1";
+	private static final String OWNER_UNIQ_ID = "USRCNFRM_00000000001";
+	private static final String ATTACKER_LOGIN_ID = "attacker1";
+	private static final String ATTACKER_UNIQ_ID = "USRCNFRM_00000000009";
+
+	/** selectTroblReqst는 저장된 등록자(로그인ID 기준)를 돌려주고, 각 서비스 호출 여부를 기록하는 스텁. */
+	private static final class StubService implements EgovTroblReqstService {
+		private final TroblReqstVO stored;
+		private boolean updateCalled = false;
+		private boolean requstCalled = false;
+
+		StubService(String ownerLoginId) {
+			this.stored = new TroblReqstVO();
+			this.stored.setFrstRegisterId(ownerLoginId);
+		}
+
+		@Override
+		public List<TroblReqstVO> selectTroblReqstList(TroblReqstVO troblReqstVO) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public int selectTroblReqstListTotCnt(TroblReqstVO troblReqstVO) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public TroblReqstVO selectTroblReqst(TroblReqstVO troblReqstVO) {
+			return stored;
+		}
+
+		@Override
+		public TroblReqstVO insertTroblReqst(TroblReqst troblReqst, TroblReqstVO troblReqstVO) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public void updateTroblReqst(TroblReqst troblReqst) {
+			updateCalled = true;
+		}
+
+		@Override
+		public void deleteTroblReqst(TroblReqst troblReqst) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public void requstTroblReqst(TroblReqst troblReqst) {
+			requstCalled = true;
+		}
+	}
+
+	private static void bindLoginUser(String loginId, String uniqId, List<String> authorities) {
+		LoginVO login = new LoginVO();
+		login.setId(loginId);
+		login.setUniqId(uniqId);
+		EgovUserDetailsService stub = new EgovUserDetailsService() {
+			@Override
+			public Object getAuthenticatedUser() {
+				return login;
+			}
+
+			@Override
+			public List<String> getAuthorities() {
+				return authorities;
+			}
+
+			@Override
+			public Boolean isAuthenticated() {
+				return Boolean.TRUE;
+			}
+		};
+		new EgovUserDetailsHelper().setEgovUserDetailsService(stub);
+	}
+
+	private static EgovTroblReqstController controllerWith(StubService service) throws Exception {
+		EgovTroblReqstController controller = new EgovTroblReqstController();
+		Field serviceField = EgovTroblReqstController.class.getDeclaredField("egovTroblReqstService");
+		serviceField.setAccessible(true);
+		serviceField.set(controller, service);
+
+		Field messageSourceField = EgovTroblReqstController.class.getDeclaredField("egovMessageSource");
+		messageSourceField.setAccessible(true);
+		messageSourceField.set(controller, new egovframework.com.cmm.EgovMessageSource() {
+			@Override
+			public String getMessage(String code) {
+				return code;
+			}
+		});
+		return controller;
+	}
+
+	private static TroblReqst requestFor(String troblId) {
+		TroblReqst troblReqst = new TroblReqst();
+		troblReqst.setTroblId(troblId);
+		troblReqst.setTroblNm("edited");
+		troblReqst.setTroblKnd("01");
+		return troblReqst;
+	}
+
+	// ---- updateTroblReqst ----
+
+	@Test
+	void updateByNonOwnerDoesNotReachTheUpdateService() throws Exception {
+		StubService service = new StubService(OWNER_LOGIN_ID);
+		EgovTroblReqstController controller = controllerWith(service);
+		bindLoginUser(ATTACKER_LOGIN_ID, ATTACKER_UNIQ_ID, List.of());
+
+		TroblReqst troblReqst = requestFor("T0000001");
+		BindingResult bindingResult = new BeanPropertyBindingResult(troblReqst, "troblReqst");
+		SessionStatus status = new SimpleSessionStatus();
+		ModelMap model = new ModelMap();
+
+		assertThrows(IllegalStateException.class,
+				() -> controller.updateTroblReqst(new TroblReqstVO(), troblReqst, bindingResult, status, model),
+				"A logged-in non-owner must not be able to update another member's incident request.");
+		assertTrue(!service.updateCalled, "updateTroblReqst service must not be reached by a non-owner.");
+	}
+
+	@Test
+	void updateByOwnerReachesTheUpdateService() throws Exception {
+		StubService service = new StubService(OWNER_LOGIN_ID);
+		EgovTroblReqstController controller = controllerWith(service);
+		bindLoginUser(OWNER_LOGIN_ID, OWNER_UNIQ_ID, List.of());
+
+		TroblReqst troblReqst = requestFor("T0000001");
+		BindingResult bindingResult = new BeanPropertyBindingResult(troblReqst, "troblReqst");
+		SessionStatus status = new SimpleSessionStatus();
+		ModelMap model = new ModelMap();
+
+		controller.updateTroblReqst(new TroblReqstVO(), troblReqst, bindingResult, status, model);
+		assertTrue(service.updateCalled,
+				"The requester must be able to update their own incident request (getId() must be compared, not getUniqId()).");
+	}
+
+	@Test
+	void updateByAdminReachesTheUpdateServiceEvenWhenNotOwner() throws Exception {
+		StubService service = new StubService(OWNER_LOGIN_ID);
+		EgovTroblReqstController controller = controllerWith(service);
+		bindLoginUser(ATTACKER_LOGIN_ID, ATTACKER_UNIQ_ID, List.of("ROLE_ADMIN"));
+
+		TroblReqst troblReqst = requestFor("T0000001");
+		BindingResult bindingResult = new BeanPropertyBindingResult(troblReqst, "troblReqst");
+		SessionStatus status = new SimpleSessionStatus();
+		ModelMap model = new ModelMap();
+
+		controller.updateTroblReqst(new TroblReqstVO(), troblReqst, bindingResult, status, model);
+		assertTrue(service.updateCalled, "An admin must be able to update any member's incident request.");
+	}
+
+	// ---- requstTroblReqst (처리요청) ----
+
+	@Test
+	void requstByNonOwnerDoesNotReachTheService() throws Exception {
+		StubService service = new StubService(OWNER_LOGIN_ID);
+		EgovTroblReqstController controller = controllerWith(service);
+		bindLoginUser(ATTACKER_LOGIN_ID, ATTACKER_UNIQ_ID, List.of());
+
+		TroblReqst troblReqst = requestFor("T0000001");
+		SessionStatus status = new SimpleSessionStatus();
+		ModelMap model = new ModelMap();
+
+		assertThrows(IllegalStateException.class,
+				() -> controller.requstTroblReqst("T0000001", troblReqst, status, model),
+				"A logged-in non-owner must not be able to submit another member's incident request for processing.");
+		assertTrue(!service.requstCalled, "requstTroblReqst service must not be reached by a non-owner.");
+	}
+
+	@Test
+	void requstByOwnerReachesTheService() throws Exception {
+		StubService service = new StubService(OWNER_LOGIN_ID);
+		EgovTroblReqstController controller = controllerWith(service);
+		bindLoginUser(OWNER_LOGIN_ID, OWNER_UNIQ_ID, List.of());
+
+		TroblReqst troblReqst = requestFor("T0000001");
+		SessionStatus status = new SimpleSessionStatus();
+		ModelMap model = new ModelMap();
+
+		controller.requstTroblReqst("T0000001", troblReqst, status, model);
+		assertTrue(service.requstCalled, "The requester must be able to submit their own incident request.");
+	}
+
+	// ---- requstTroblReqstCancl (처리취소) ----
+
+	@Test
+	void requstCanclByNonOwnerDoesNotReachTheService() throws Exception {
+		StubService service = new StubService(OWNER_LOGIN_ID);
+		EgovTroblReqstController controller = controllerWith(service);
+		bindLoginUser(ATTACKER_LOGIN_ID, ATTACKER_UNIQ_ID, List.of());
+
+		TroblReqst troblReqst = requestFor("T0000001");
+		SessionStatus status = new SimpleSessionStatus();
+		ModelMap model = new ModelMap();
+
+		assertThrows(IllegalStateException.class,
+				() -> controller.requstTroblReqstCancl("T0000001", troblReqst, status, model),
+				"A logged-in non-owner must not be able to cancel another member's incident request processing.");
+		assertTrue(!service.requstCalled, "requstTroblReqst service must not be reached by a non-owner via cancel.");
+	}
+
+	@Test
+	void requstCanclByOwnerReachesTheService() throws Exception {
+		StubService service = new StubService(OWNER_LOGIN_ID);
+		EgovTroblReqstController controller = controllerWith(service);
+		bindLoginUser(OWNER_LOGIN_ID, OWNER_UNIQ_ID, List.of());
+
+		TroblReqst troblReqst = requestFor("T0000001");
+		SessionStatus status = new SimpleSessionStatus();
+		ModelMap model = new ModelMap();
+
+		controller.requstTroblReqstCancl("T0000001", troblReqst, status, model);
+		assertTrue(service.requstCalled, "The requester must be able to cancel their own incident request processing.");
+	}
+}


### PR DESCRIPTION
## 수정 사유

- [x] 버그수정
- [ ] 기능개선
- [ ] 리팩터링

## 문제 상황

장애신청 수정(`updtTroblReqst.do`)·처리요청(`requstTroblReqst.do`)·처리취소(`requstTroblReqstCancl.do`)는 로그인 여부조차 확인하지 않습니다. 로그인한 임의 사용자가 남의 `troblId`로 장애신청을 수정하거나 처리요청/취소 상태를 바꿀 수 있습니다. 같은 파일의 상세조회·삭제는 `@RequireAdmin`으로 이미 보호돼 있는데 이 세 경로만 빠져 있습니다.

## 이 컨트롤러의 소유자 필드에 대해

`insertTroblReqst`는 등록자ID를 `user.getUniqId()`가 아니라 `user.getId()`(로그인 아이디)로 저장합니다.

```java
troblReqst.setFrstRegisterId(user == null ? "" : EgovStringUtil.isNullToString(user.getId()));
```

`LoginVO`에서 `id`(로그인 아이디, DB `mber_id`)와 `uniqId`(내부 고유식별자, DB `esntl_id`)는 서로 다른 컬럼에서 옵니다(`EgovLoginUsr_SQL_mysql.xml`의 `actionLogin`: `mber_id AS id`, `esntl_id AS uniqId`). 이 파일에 이미 있는 공용 헬퍼 `egovAssertAdminOrOwner(String)`는 `loginVO.getUniqId()`와 비교하도록 되어 있어서 그대로 재사용하면 실제 신청자 본인도 항상 차단됩니다. 그래서 `loginVO.getId()`와 비교하는 `egovAssertAdminOrOwnerById(String)`를 새로 추가해 이 세 경로에만 적용했습니다. 기존 `egovAssertAdminOrOwner`는 이 파일에서 이 PR 이전부터 미사용 상태였고(2026.07.13 KISA 조치로 정의만 추가됨), 저장소 전역에 같은 패턴(정의는 있지만 필드가 안 맞아 호출 안 되는 헬퍼)이 반복되는 것으로 봐서 이 프로젝트의 기존 관례입니다.

## 변경 내용

```java
TroblReqstVO lookup = new TroblReqstVO();
lookup.setTroblId(troblId);
TroblReqstVO stored = egovTroblReqstService.selectTroblReqst(lookup);
egovAssertAdminOrOwnerById(stored == null ? null : stored.getFrstRegisterId());
```

세 메서드 모두 처리 전에 기존 레코드를 조회해 등록자(로그인 아이디)를 대조합니다. `ROLE_ADMIN` 보유자는 소유자가 아니어도 통과합니다.

## 영향 범위

`EgovTroblReqstController`의 `updateTroblReqst`·`requstTroblReqst`·`requstTroblReqstCancl`만 변경했습니다. 매퍼의 `updateTroblReqst`·`requstTroblReqst` UPDATE문은 `FRST_REGISTER_ID`를 SET절에 포함하지 않아(수정해도 등록자ID가 지워지지 않음) 다음 수정 시 소유권 검증이 계속 유효합니다. 상세조회·삭제(`@RequireAdmin`)와 수정폼 진입(`egovAssertLoginUser()`로 로그인만 확인, 기존 동작)은 건드리지 않았습니다.

## 테스트 방법

### 재현 (수정 전)

로그인한 사용자가 다른 사람이 신청한 장애신청의 `troblId`로 수정·처리요청·처리취소를 요청하면 대조 없이 그대로 처리됩니다.

### 확인 (수정 후)

같은 요청이 소유권 검증에 걸려 `IllegalStateException`으로 차단됩니다.

### 단위 테스트

`EgovTroblReqstControllerOwnershipTest`를 추가했습니다. 세 경로 각각 비신청자 차단, 신청자 정상동작을 검증하고, 수정 경로는 관리자 우회도 검증합니다.

```
Tests run: 7, Failures: 0, Errors: 0, Skipped: 0
```

세 소유권 검증 호출을 모두 제거하면:

```
Tests run: 7, Failures: 3, Errors: 0, Skipped: 0
  requstByNonOwnerDoesNotReachTheService: Expected java.lang.IllegalStateException to be thrown, but nothing was thrown.
  requstCanclByNonOwnerDoesNotReachTheService: Expected java.lang.IllegalStateException to be thrown, but nothing was thrown.
  updateByNonOwnerDoesNotReachTheUpdateService: Expected java.lang.IllegalStateException to be thrown, but nothing was thrown.
```
