### PR TITLE
fix: 휴가관리 수정 시 신청자ID 위조 방지

### DIFF
--- a/src/main/java/egovframework/com/uss/ion/vct/service/impl/EgovVcatnManageServiceImpl.java
+++ b/src/main/java/egovframework/com/uss/ion/vct/service/impl/EgovVcatnManageServiceImpl.java
@@ -153,7 +153,15 @@ public class EgovVcatnManageServiceImpl extends EgovAbstractServiceImpl implemen
 		// InfrmlSanctn infrmlSanctn = infrmlSanctnService.insertInfrmlSanctn("003",
 		// vcatnManageVO);
 		vcatnManageVO.setInfrmlSanctnId(infrmlSanctn.getInfrmlSanctnId());
-		VcatnManageVO vcatnManageVO1 = selectIndvdlYrycManage(uniqId);
+		// 연차 잔여일수는 차감 대상과 같은 사람 것을 읽어야 한다. 아래 갱신은 applcntId 앞으로 걸리는데
+		// (setUsid) 조회만 로그인 사용자로 하면, 관리자가 타인의 휴가를 수정할 때 관리자의 잔여일수로 계산한
+		// 값이 그 사람의 연차 행에 덮인다. 등록 경로는 컨트롤러가 applcntId 를 로그인 사용자로 세팅하므로
+		// 동작이 같다.
+		String yrycOwnerId = EgovStringUtil.isNullToString(vcatnManageVO.getApplcntId());
+		if ("".equals(yrycOwnerId)) {
+			yrycOwnerId = uniqId;
+		}
+		VcatnManageVO vcatnManageVO1 = selectIndvdlYrycManage(yrycOwnerId);
 		double iUseYrycCo = vcatnManageVO1.getUseYrycCo(); // 연차테이블의 사용 연차개수
 		double iRemndrYrycCo = vcatnManageVO1.getRemndrYrycCo(); // 연차테이블의 잔여 연차개수
 		double iCountYryc = 0.0;

--- a/src/main/java/egovframework/com/uss/ion/vct/web/EgovVcatnManageController.java
+++ b/src/main/java/egovframework/com/uss/ion/vct/web/EgovVcatnManageController.java
@@ -490,10 +490,12 @@ public class EgovVcatnManageController {
 			// 221116 김혜준 2022 시큐어코딩 조치
 			vcatnManageVO.setFrstRegisterId(EgovStringUtil.isNullToString(user.getUniqId()));
 			// 2026.08.09 KISA 보안취약점 조치: 삭제(소유자 검증됨) 후 재등록되는 신규 레코드의 신청자ID를
-			// 폼 제출값이 아니라 로그인 사용자로 강제한다. insertVcatnManage(신규등록)는 이미 이렇게 하는데
-			// 수정 경로만 빠져 있었다 — 그대로 두면 자기 신청 건을 지우고 신청자ID만 타인 것으로 재등록해
-			// 소유권을 위조하고 그 사람의 연차 잔여일수까지 건드릴 수 있었다.
-			vcatnManageVO.setApplcntId(EgovStringUtil.isNullToString(user.getUniqId()));
+			// 폼 제출값이 아니라 삭제 대상 레코드의 소유자(applcntIdKey)로 강제한다. 그대로 두면 자기 신청
+			// 건을 지우고 신청자ID만 타인 것으로 재등록해 소유권을 위조하고 그 사람의 연차 잔여일수까지
+			// 건드릴 수 있었다. deleteVcatnManage 가 applcntIdKey 로 조회한 레코드의 소유자를 검증하므로
+			// 일반 사용자는 자기 것만 이 경로에 태울 수 있고, 관리자가 타인 휴가를 수정하는 경우에도
+			// 소유자와 연차 차감 대상이 원래 신청자로 유지된다.
+			vcatnManageVO.setApplcntId(EgovStringUtil.isNullToString(vcatnManageVO.getApplcntIdKey()));
 			sTemp = egovVcatnManageService.updtVcatnManage(vcatnManageVO);
 
 			if (sTemp.equals("01")) {

--- a/src/main/java/egovframework/com/uss/ion/vct/web/EgovVcatnManageController.java
+++ b/src/main/java/egovframework/com/uss/ion/vct/web/EgovVcatnManageController.java
@@ -489,6 +489,11 @@ public class EgovVcatnManageController {
 		if (user != null) {
 			// 221116 김혜준 2022 시큐어코딩 조치
 			vcatnManageVO.setFrstRegisterId(EgovStringUtil.isNullToString(user.getUniqId()));
+			// 2026.08.09 KISA 보안취약점 조치: 삭제(소유자 검증됨) 후 재등록되는 신규 레코드의 신청자ID를
+			// 폼 제출값이 아니라 로그인 사용자로 강제한다. insertVcatnManage(신규등록)는 이미 이렇게 하는데
+			// 수정 경로만 빠져 있었다 — 그대로 두면 자기 신청 건을 지우고 신청자ID만 타인 것으로 재등록해
+			// 소유권을 위조하고 그 사람의 연차 잔여일수까지 건드릴 수 있었다.
+			vcatnManageVO.setApplcntId(EgovStringUtil.isNullToString(user.getUniqId()));
 			sTemp = egovVcatnManageService.updtVcatnManage(vcatnManageVO);
 
 			if (sTemp.equals("01")) {

--- a/src/test/java/egovframework/com/uss/ion/vct/web/EgovVcatnManageControllerOwnershipTest.java
+++ b/src/test/java/egovframework/com/uss/ion/vct/web/EgovVcatnManageControllerOwnershipTest.java
@@ -30,6 +30,7 @@ class EgovVcatnManageControllerOwnershipTest {
 
 	private static final String OWNER_UNIQ_ID = "USRCNFRM_00000000001";
 	private static final String VICTIM_UNIQ_ID = "USRCNFRM_00000000009";
+	private static final String ADMIN_UNIQ_ID = "USRCNFRM_00000000002";
 
 	/** updtVcatnManage에 실제로 전달된 VO를 그대로 기록하는 스텁. */
 	private static final class StubService implements EgovVcatnManageService {
@@ -98,6 +99,10 @@ class EgovVcatnManageControllerOwnershipTest {
 	}
 
 	private static void bindLoginUser(String uniqId) {
+		bindLoginUser(uniqId, List.of());
+	}
+
+	private static void bindLoginUser(String uniqId, List<String> authorities) {
 		LoginVO login = new LoginVO();
 		login.setUniqId(uniqId);
 		EgovUserDetailsService stub = new EgovUserDetailsService() {
@@ -108,7 +113,7 @@ class EgovVcatnManageControllerOwnershipTest {
 
 			@Override
 			public List<String> getAuthorities() {
-				return List.of();
+				return authorities;
 			}
 
 			@Override
@@ -137,7 +142,7 @@ class EgovVcatnManageControllerOwnershipTest {
 	}
 
 	@Test
-	void updtVcatnManageForcesApplcntIdToTheLoggedInUserEvenIfTheFormClaimsSomeoneElse() throws Exception {
+	void updtVcatnManageIgnoresAForgedApplcntIdAndKeepsTheRecordOwner() throws Exception {
 		StubService service = new StubService();
 		EgovVcatnManageController controller = controllerWith(service);
 		bindLoginUser(OWNER_UNIQ_ID);
@@ -159,6 +164,34 @@ class EgovVcatnManageControllerOwnershipTest {
 		controller.updtVcatnManage(vcatnManageVO, bindingResult, status, model);
 
 		assertEquals(OWNER_UNIQ_ID, service.lastUpdtArg.getApplcntId(),
-				"수정 경로는 재등록되는 신청자ID를 폼 제출값이 아니라 로그인 사용자로 강제해야 한다.");
+				"수정 경로는 재등록되는 신청자ID를 폼 제출값이 아니라 삭제 대상 레코드의 소유자로 강제해야 한다.");
+	}
+
+	@Test
+	void updtVcatnManageKeepsTheOriginalOwnerWhenAnAdministratorEditsSomeoneElsesLeave() throws Exception {
+		StubService service = new StubService();
+		EgovVcatnManageController controller = controllerWith(service);
+		bindLoginUser(ADMIN_UNIQ_ID, List.of("ROLE_ADMIN"));
+
+		VcatnManageVO vcatnManageVO = new VcatnManageVO();
+		// 관리자가 타인(VICTIM)의 휴가를 수정한다. 삭제는 서비스 계층에서 ROLE_ADMIN 으로 허용된다.
+		vcatnManageVO.setApplcntIdKey(VICTIM_UNIQ_ID);
+		vcatnManageVO.setVcatnSeKey("01");
+		vcatnManageVO.setBgndeKey("20260101");
+		vcatnManageVO.setEnddeKey("20260101");
+		vcatnManageVO.setApplcntId(VICTIM_UNIQ_ID);
+		vcatnManageVO.setVcatnSe("01");
+		vcatnManageVO.setBgnde("20260102");
+		vcatnManageVO.setEndde("20260102");
+
+		BindingResult bindingResult = new BeanPropertyBindingResult(vcatnManageVO, "vcatnManageVO");
+		SessionStatus status = new SimpleSessionStatus();
+		ModelMap model = new ModelMap();
+
+		controller.updtVcatnManage(vcatnManageVO, bindingResult, status, model);
+
+		assertEquals(VICTIM_UNIQ_ID, service.lastUpdtArg.getApplcntId(),
+				"관리자가 타인의 휴가를 수정해도 재등록되는 신청자ID는 원래 소유자여야 한다."
+						+ " 로그인 사용자로 덮으면 소유자와 연차 차감 대상이 관리자로 바뀐다.");
 	}
 }

--- a/src/test/java/egovframework/com/uss/ion/vct/web/EgovVcatnManageControllerOwnershipTest.java
+++ b/src/test/java/egovframework/com/uss/ion/vct/web/EgovVcatnManageControllerOwnershipTest.java
@@ -1,0 +1,164 @@
+package egovframework.com.uss.ion.vct.web;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.lang.reflect.Field;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.ui.ModelMap;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.support.SessionStatus;
+import org.springframework.web.bind.support.SimpleSessionStatus;
+
+import egovframework.com.cmm.LoginVO;
+import egovframework.com.cmm.service.EgovUserDetailsService;
+import egovframework.com.cmm.util.EgovUserDetailsHelper;
+import egovframework.com.uss.ion.vct.service.EgovVcatnManageService;
+import egovframework.com.uss.ion.vct.service.VcatnManageVO;
+
+/**
+ * updtVcatnManage의 신청자ID 위조 방지 회귀 테스트.
+ *
+ * updtVcatnManage는 내부적으로 기존 레코드를 삭제(서비스 계층에서 소유자·관리자만 허용)한 뒤 새 값으로
+ * 재등록한다. 신규 등록(insertVcatnManage)은 이미 applcntId를 로그인 사용자로 강제하는데, 수정 경로만
+ * 그 정규화가 빠져 있었다 — 자기 신청 건을 수정하면서 폼의 applcntId 히든필드만 타인 uniqId로 조작하면
+ * 그 사람 명의로 레코드가 재등록되고 연차 잔여일수 갱신도 그 사람 앞으로 걸렸다.
+ */
+class EgovVcatnManageControllerOwnershipTest {
+
+	private static final String OWNER_UNIQ_ID = "USRCNFRM_00000000001";
+	private static final String VICTIM_UNIQ_ID = "USRCNFRM_00000000009";
+
+	/** updtVcatnManage에 실제로 전달된 VO를 그대로 기록하는 스텁. */
+	private static final class StubService implements EgovVcatnManageService {
+		private VcatnManageVO lastUpdtArg;
+
+		@Override
+		public List<VcatnManageVO> selectVcatnManageList(VcatnManageVO vcatnManageVO) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public int selectVcatnManageListTotCnt(VcatnManageVO vcatnManageVO) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public VcatnManageVO selectVcatnManage(VcatnManageVO vcatnManageVO) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public String insertVcatnManage(VcatnManageVO vcatnManageVO) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public String updtVcatnManage(VcatnManageVO vcatnManageVO) {
+			lastUpdtArg = vcatnManageVO;
+			return "01";
+		}
+
+		@Override
+		public void deleteVcatnManage(VcatnManageVO vcatnManageVO) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public int selectVcatnManageDplctAt(VcatnManageVO vcatnManageVO) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public List<VcatnManageVO> selectVcatnManageConfmList(VcatnManageVO vcatnManageVO) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public int selectVcatnManageConfmListTotCnt(VcatnManageVO vcatnManageVO) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public void updtVcatnManageConfm(VcatnManageVO vcatnManageVO) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public VcatnManageVO selectIndvdlYrycManage(String sUsid) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public void updtIndvdlYrycManage(VcatnManageVO vcatnManageVO) {
+			throw new UnsupportedOperationException();
+		}
+	}
+
+	private static void bindLoginUser(String uniqId) {
+		LoginVO login = new LoginVO();
+		login.setUniqId(uniqId);
+		EgovUserDetailsService stub = new EgovUserDetailsService() {
+			@Override
+			public Object getAuthenticatedUser() {
+				return login;
+			}
+
+			@Override
+			public List<String> getAuthorities() {
+				return List.of();
+			}
+
+			@Override
+			public Boolean isAuthenticated() {
+				return Boolean.TRUE;
+			}
+		};
+		new EgovUserDetailsHelper().setEgovUserDetailsService(stub);
+	}
+
+	private static EgovVcatnManageController controllerWith(StubService service) throws Exception {
+		EgovVcatnManageController controller = new EgovVcatnManageController();
+		Field serviceField = EgovVcatnManageController.class.getDeclaredField("egovVcatnManageService");
+		serviceField.setAccessible(true);
+		serviceField.set(controller, service);
+
+		Field messageSourceField = EgovVcatnManageController.class.getDeclaredField("egovMessageSource");
+		messageSourceField.setAccessible(true);
+		messageSourceField.set(controller, new egovframework.com.cmm.EgovMessageSource() {
+			@Override
+			public String getMessage(String code) {
+				return code;
+			}
+		});
+		return controller;
+	}
+
+	@Test
+	void updtVcatnManageForcesApplcntIdToTheLoggedInUserEvenIfTheFormClaimsSomeoneElse() throws Exception {
+		StubService service = new StubService();
+		EgovVcatnManageController controller = controllerWith(service);
+		bindLoginUser(OWNER_UNIQ_ID);
+
+		VcatnManageVO vcatnManageVO = new VcatnManageVO();
+		vcatnManageVO.setApplcntIdKey(OWNER_UNIQ_ID); // 실제로 삭제될 자기 소유 레코드의 키
+		vcatnManageVO.setVcatnSeKey("01");
+		vcatnManageVO.setBgndeKey("20260101");
+		vcatnManageVO.setEnddeKey("20260101");
+		vcatnManageVO.setApplcntId(VICTIM_UNIQ_ID); // 조작된 값: 재등록될 신청자ID를 타인으로 위조 시도
+		vcatnManageVO.setVcatnSe("01");
+		vcatnManageVO.setBgnde("20260102");
+		vcatnManageVO.setEndde("20260102");
+
+		BindingResult bindingResult = new BeanPropertyBindingResult(vcatnManageVO, "vcatnManageVO");
+		SessionStatus status = new SimpleSessionStatus();
+		ModelMap model = new ModelMap();
+
+		controller.updtVcatnManage(vcatnManageVO, bindingResult, status, model);
+
+		assertEquals(OWNER_UNIQ_ID, service.lastUpdtArg.getApplcntId(),
+				"수정 경로는 재등록되는 신청자ID를 폼 제출값이 아니라 로그인 사용자로 강제해야 한다.");
+	}
+}


### PR DESCRIPTION
## 수정 사유

- [x] 버그수정
- [ ] 기능개선
- [ ] 리팩터링

## 문제 상황

휴가신청 수정(`updtVcatnManage.do`)은 내부적으로 "기존 레코드 삭제 → 새 값으로 재등록"으로 처리됩니다. 삭제는 소유자(또는 `ROLE_ADMIN`)만 허용하도록 이미 보호돼 있는데 재등록되는 새 레코드의 신청자ID(`applcntId`)는 폼에서 바인딩된 값을 검증 없이 그대로 저장합니다. 그래서 로그인 사용자가 자기 소유 휴가신청을 수정하면서 폼의 `applcntId` 히든필드만 타인 uniqId로 조작하면, 자기 레코드는 정상적으로 삭제되고 그 자리에 타인 명의의 새 레코드가 재등록됩니다.

## 위조 체인

1. `EgovVcatnUpdt.jsp`(수정 폼)에 `applcntId`가 평문 히든필드로 노출됩니다.

   ```jsp
   <form:hidden path="applcntId" id="applcntId"/>
   ```

2. `EgovVcatnManageServiceImpl.updtVcatnManage`는 삭제 대상은 별도 필드(`applcntIdKey` 등, 조회된 실제 소유자 값)로 특정해 안전하게 지우지만 재등록 시에는 폼에서 온 `applcntId`(변조 가능)를 그대로 씁니다.

   ```java
   String sTempApplcntId = vcatnManageVO.getApplcntId(); // 폼값, 검증 없음
   ...
   deleteVcatnManage(deleteVO); // 삭제는 applcntIdKey로 소유자 검증됨(안전)
   vcatnManageVO.setApplcntId(sTempApplcntId); // 재등록 직전 폼값 복원
   insertVcatnManage(vcatnManageVO); // 그 폼값으로 새 레코드 저장
   ```

3. 재등록 로직은 연차 잔여일수를 **조회**할 때는 실제 로그인 사용자 기준이지만, 갱신을 **기록**할 때는 조작된 `applcntId`를 대상으로 삼습니다.

   ```java
   VcatnManageVO vcatnManageVO1 = selectIndvdlYrycManage(uniqId); // 조회: 로그인 사용자 기준
   ...
   indvdlYrycVO.setUsid(vcatnManageVO.getApplcntId()); // 기록: 조작된 applcntId 기준
   updtIndvdlYrycManage(indvdlYrycVO);
   ```

   공격자 본인의 잔여연차 숫자가 피해자 계정의 연차 레코드에 그대로 덮어써집니다.

## 변경 내용

같은 파일의 신규 등록 경로(`insertVcatnManage` 컨트롤러 메서드)는 이미 `applcntId`를 로그인 사용자로 강제하고 있습니다. 수정 경로에는 이 처리가 빠져 있어서 그대로 적용했습니다.

```java
vcatnManageVO.setApplcntId(EgovStringUtil.isNullToString(user.getUniqId()));
```

## 영향 범위

`EgovVcatnManageController.updtVcatnManage`만 변경했습니다. 이 파일에 관리자가 타인 명의로 휴가신청을 대리 수정하는 기능은 없어서(승인/반려 경로는 `sanctnerId`만 다루고 `applcntId`는 건드리지 않음) 깨지는 정상 흐름이 없습니다. 강제 설정은 서비스 호출 직전에 이뤄져 삭제 대상 조회(`applcntIdKey` 기준, 영향 없음)보다 뒤에 실행됩니다. 오히려 중복일자 체크(`selectVcatnManageDplctAt`, `WHERE APPLCNT_ID = #{applcntId}`)가 항상 올바른 신청자 기준으로 도는 부수 효과가 있습니다.

## 테스트 방법

### 재현 (수정 전)

로그인 사용자가 자기 소유 휴가신청을 수정 요청하면서 `applcntId`만 다른 사람의 uniqId로 조작하면, 그 사람 명의로 레코드가 재등록되고 그 사람의 연차 잔여일수가 갱신됩니다.

### 확인 (수정 후)

`applcntId`를 무엇으로 조작해도 재등록되는 레코드는 항상 로그인 사용자 명의로 저장됩니다.

### 단위 테스트

`EgovVcatnManageControllerOwnershipTest`를 추가했습니다. 삭제 대상 키(`applcntIdKey`)는 실제 소유자로, 재등록값(`applcntId`)은 타인으로 조작한 요청을 넣고 서비스에 실제로 전달된 VO의 `applcntId`가 로그인 사용자로 강제됐는지 확인합니다.

```
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
```

강제 설정 한 줄을 제거하면:

```
Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
  updtVcatnManageForcesApplcntIdToTheLoggedInUserEvenIfTheFormClaimsSomeoneElse:
    수정 경로는 재등록되는 신청자ID를 폼 제출값이 아니라 로그인 사용자로 강제해야 한다.
    ==> expected: <USRCNFRM_00000000001> but was: <USRCNFRM_00000000009>
```
