### PR TITLE
fix: 로그인정책 등록·수정·삭제에 관리자 검증 추가

### DIFF
--- a/src/main/java/egovframework/com/uat/uap/web/EgovLoginPolicyController.java
+++ b/src/main/java/egovframework/com/uat/uap/web/EgovLoginPolicyController.java
@@ -143,6 +143,7 @@ public class EgovLoginPolicyController {
 	 * @return String - 리턴 Url
 	 */
 	@PostMapping("/uat/uap/addLoginPolicy.do")
+	@RequireAdmin
 	public String insertLoginPolicy(@Valid @ModelAttribute("loginPolicy") LoginPolicy loginPolicy,
 			                         BindingResult bindingResult,
                                      ModelMap model) throws Exception {
@@ -173,6 +174,7 @@ public class EgovLoginPolicyController {
 	 * @return String - 리턴 Url
 	 */
 	@PostMapping("/uat/uap/updtLoginPolicy.do")
+	@RequireAdmin
 	public String updateLoginPolicy(@Valid @ModelAttribute("loginPolicy") LoginPolicy loginPolicy,
 			                         BindingResult bindingResult,
                                      ModelMap model) throws Exception {
@@ -201,6 +203,7 @@ public class EgovLoginPolicyController {
 	 * @return String - 리턴 Url
 	 */
 	@PostMapping("/uat/uap/removeLoginPolicy.do")
+	@RequireAdmin
 	public String deleteLoginPolicy(@ModelAttribute("loginPolicy") LoginPolicy loginPolicy,
                                      ModelMap model) throws Exception {
 

--- a/src/test/java/egovframework/com/uat/uap/web/EgovLoginPolicyControllerAdminCheckTest.java
+++ b/src/test/java/egovframework/com/uat/uap/web/EgovLoginPolicyControllerAdminCheckTest.java
@@ -1,0 +1,50 @@
+package egovframework.com.uat.uap.web;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.Test;
+
+import egovframework.com.cmm.annotation.RequireAdmin;
+
+/**
+ * insertLoginPolicy·updateLoginPolicy·deleteLoginPolicy에 @RequireAdmin이 붙어있는지 확인한다.
+ *
+ * @RequireAdmin은 Spring AOP(`@annotation(RequireAdmin)` 포인트컷)로 위빙되므로 컨트롤러를
+ * 직접 new해서 부르는 단위 테스트로는 실제 차단 동작을 재현할 수 없다(프록시를 거치지 않음).
+ * 이 AOP 자체가 실제로 작동한다는 것은 이미 별도로 E2E 확인됐다(샌드박스에서 비관리자 계정으로
+ * @RequireAdmin 붙은 엔드포인트를 호출해 HTTP 302 → accessDenied 확인). 이 테스트는 그 전제 위에서
+ * "애노테이션이 세 메서드에 실제로 붙어있는가"라는 구조적 사실만 고정한다 — 애노테이션이 실수로
+ * 빠지거나 지워지는 회귀를 잡기 위함이다.
+ */
+class EgovLoginPolicyControllerAdminCheckTest {
+
+	private static Method method(String name, Class<?>... paramTypes) throws NoSuchMethodException {
+		return EgovLoginPolicyController.class.getDeclaredMethod(name, paramTypes);
+	}
+
+	@Test
+	void insertLoginPolicyRequiresAdmin() throws Exception {
+		Method m = method("insertLoginPolicy", egovframework.com.uat.uap.service.LoginPolicy.class,
+				org.springframework.validation.BindingResult.class, org.springframework.ui.ModelMap.class);
+		assertTrue(m.isAnnotationPresent(RequireAdmin.class),
+				"로그인정책 신규등록은 관리자만 가능해야 한다.");
+	}
+
+	@Test
+	void updateLoginPolicyRequiresAdmin() throws Exception {
+		Method m = method("updateLoginPolicy", egovframework.com.uat.uap.service.LoginPolicy.class,
+				org.springframework.validation.BindingResult.class, org.springframework.ui.ModelMap.class);
+		assertTrue(m.isAnnotationPresent(RequireAdmin.class),
+				"로그인정책 수정은 관리자만 가능해야 한다.");
+	}
+
+	@Test
+	void deleteLoginPolicyRequiresAdmin() throws Exception {
+		Method m = method("deleteLoginPolicy", egovframework.com.uat.uap.service.LoginPolicy.class,
+				org.springframework.ui.ModelMap.class);
+		assertTrue(m.isAnnotationPresent(RequireAdmin.class),
+				"로그인정책 삭제는 관리자만 가능해야 한다.");
+	}
+}


### PR DESCRIPTION
## 수정 사유

- [x] 버그수정
- [ ] 기능개선
- [ ] 리팩터링

## 문제 상황

로그인정책(계정 잠금 등 보안 설정)의 상세조회(`getLoginPolicy.do`)는 `@RequireAdmin`으로 관리자만 접근 가능한데, 실제로 값을 바꾸는 등록(`addLoginPolicy.do`)·수정(`updtLoginPolicy.do`)·삭제(`removeLoginPolicy.do`)에는 이 애노테이션이 없습니다. 로그인만 하면 관리자가 아니어도 다른 직원의 로그인정책을 등록·수정·삭제할 수 있습니다(등록 화면 진입은 `egovAssertLoginUser()`로 로그인 여부만 확인합니다).

## 변경 내용

형제 메서드(`selectLoginPolicy`)와 동일한 방식으로 세 메서드에 `@RequireAdmin`을 추가했습니다.

```java
@PostMapping("/uat/uap/addLoginPolicy.do")
@RequireAdmin
public String insertLoginPolicy(...)
```

## 영향 범위

`EgovLoginPolicyController`의 `insertLoginPolicy`·`updateLoginPolicy`·`deleteLoginPolicy`에 애노테이션만 추가했습니다. 이 화면들은 관리자 콘솔(`EgovLoginPolicyList.jsp` 등)에서만 호출됩니다. 로그인한 사용자 본인의 정책을 셀프서비스로 다루는 화면은 없습니다.

## 테스트 방법

### 재현 (수정 전)

로그인만 한 일반 사용자가 `addLoginPolicy.do`·`updtLoginPolicy.do`·`removeLoginPolicy.do`를 직접 호출하면 관리자 여부와 무관하게 처리됩니다.

### 확인 (수정 후)

관리자가 아니면 차단됩니다(`@RequireAdmin` AOP가 다른 관리자 전용 메서드들과 동일하게 처리).

### 단위 테스트

`EgovLoginPolicyControllerAdminCheckTest`를 추가했습니다. `@RequireAdmin`은 Spring AOP로 위빙되므로 컨트롤러를 직접 생성해 호출하는 단위 테스트로는 실제 차단 동작을 재현할 수 없습니다. 그래서 이 테스트는 세 메서드에 애노테이션이 실제로 붙어 있는지를 리플렉션으로 확인해, 나중에 실수로 지워지는 회귀를 잡습니다.

```
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0
```

애노테이션 3개를 모두 제거하면:

```
Tests run: 3, Failures: 3, Errors: 0, Skipped: 0
  insertLoginPolicyRequiresAdmin: 로그인정책 신규등록은 관리자만 가능해야 한다. ==> expected: <true> but was: <false>
  updateLoginPolicyRequiresAdmin: 로그인정책 수정은 관리자만 가능해야 한다. ==> expected: <true> but was: <false>
  deleteLoginPolicyRequiresAdmin: 로그인정책 삭제는 관리자만 가능해야 한다. ==> expected: <true> but was: <false>
```
