### PR TITLE
fix: 서버(장비)관리 등록·수정·연계에 관리자 검증 추가

### DIFF
--- a/src/main/java/egovframework/com/sym/sym/srv/web/EgovServerController.java
+++ b/src/main/java/egovframework/com/sym/sym/srv/web/EgovServerController.java
@@ -166,6 +166,7 @@ public class EgovServerController {
 	 * @param serverEqpmn
 	 */
 	@PostMapping("/sym/sym/srv/addServerEqpmn.do")
+	@RequireAdmin
 	public String insertServerEqpmn(@ModelAttribute("serverEqpmnVO") ServerEqpmnVO serverEqpmnVO,
 			@Valid @ModelAttribute("serverEqpmn") ServerEqpmn serverEqpmn, BindingResult bindingResult, ModelMap model)
 			throws Exception {
@@ -209,6 +210,7 @@ public class EgovServerController {
 	 * @param serverEqpmn
 	 */
 	@PostMapping("/sym/sym/srv/updtServerEqpmn.do")
+	@RequireAdmin
 	public String updateServerEqpmn(@ModelAttribute("serverEqpmnVO") ServerEqpmnVO serverEqpmnVO,
 			@Valid @ModelAttribute("serverEqpmn") ServerEqpmn serverEqpmn, BindingResult bindingResult,
 			SessionStatus status, ModelMap model) throws Exception {
@@ -349,6 +351,7 @@ public class EgovServerController {
 	 * @param server
 	 */
 	@PostMapping("/sym/sym/srv/addServer.do")
+	@RequireAdmin
 	public String insertServer(@ModelAttribute("serverVO") ServerVO serverVO,
 			@Valid @ModelAttribute("server") Server server, BindingResult bindingResult,
 			ModelMap model) throws Exception {
@@ -393,6 +396,7 @@ public class EgovServerController {
 	 * @param server
 	 */
 	@PostMapping("/sym/sym/srv/updtServer.do")
+	@RequireAdmin
 	public String updateServer(@ModelAttribute("serverVO") ServerVO serverVO,
 			@Valid @ModelAttribute("server") Server server, BindingResult bindingResult,
 			SessionStatus status, ModelMap model) throws Exception {
@@ -482,6 +486,7 @@ public class EgovServerController {
 	 * @param serverEqpmnRelate
 	 */
 	@PostMapping("/sym/sym/srv/saveServerEqpmnRelate.do")
+	@RequireAdmin
 	public String saveServerEqpmnRelate(@RequestParam("serverId") String serverId,
 			@RequestParam("serverEqpmnIds") String serverEqpmnIds, @RequestParam("regYns") String regYns,
 			@ModelAttribute("serverEqpmnRelate") ServerEqpmnRelate serverEqpmnRelate, SessionStatus status,

--- a/src/test/java/egovframework/com/sym/sym/srv/web/EgovServerControllerAdminCheckTest.java
+++ b/src/test/java/egovframework/com/sym/sym/srv/web/EgovServerControllerAdminCheckTest.java
@@ -1,0 +1,68 @@
+package egovframework.com.sym.sym.srv.web;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.Test;
+
+import egovframework.com.cmm.annotation.RequireAdmin;
+
+/**
+ * insertServerEqpmn·updateServerEqpmn·insertServer·updateServer·saveServerEqpmnRelate에
+ * @RequireAdmin이 붙어있는지 확인한다.
+ *
+ * @RequireAdmin은 Spring AOP(`@annotation(RequireAdmin)` 포인트컷)로 위빙되므로 컨트롤러를
+ * 직접 new해서 부르는 단위 테스트로는 실제 차단 동작을 재현할 수 없다(프록시를 거치지 않음).
+ * 이 AOP 자체가 실제로 작동한다는 것은 이미 별도로 E2E 확인됐다(샌드박스에서 비관리자 계정으로
+ * @RequireAdmin 붙은 엔드포인트를 호출해 HTTP 302 → accessDenied 확인). 이 테스트는 그 전제 위에서
+ * "애노테이션이 다섯 메서드에 실제로 붙어있는가"라는 구조적 사실만 고정한다.
+ */
+class EgovServerControllerAdminCheckTest {
+
+	private static Method method(String name, Class<?>... paramTypes) throws NoSuchMethodException {
+		return EgovServerController.class.getDeclaredMethod(name, paramTypes);
+	}
+
+	@Test
+	void insertServerEqpmnRequiresAdmin() throws Exception {
+		Method m = method("insertServerEqpmn", egovframework.com.sym.sym.srv.service.ServerEqpmnVO.class,
+				egovframework.com.sym.sym.srv.service.ServerEqpmn.class,
+				org.springframework.validation.BindingResult.class, org.springframework.ui.ModelMap.class);
+		assertTrue(m.isAnnotationPresent(RequireAdmin.class), "서버장비 신규등록은 관리자만 가능해야 한다.");
+	}
+
+	@Test
+	void updateServerEqpmnRequiresAdmin() throws Exception {
+		Method m = method("updateServerEqpmn", egovframework.com.sym.sym.srv.service.ServerEqpmnVO.class,
+				egovframework.com.sym.sym.srv.service.ServerEqpmn.class,
+				org.springframework.validation.BindingResult.class,
+				org.springframework.web.bind.support.SessionStatus.class, org.springframework.ui.ModelMap.class);
+		assertTrue(m.isAnnotationPresent(RequireAdmin.class), "서버장비 수정은 관리자만 가능해야 한다.");
+	}
+
+	@Test
+	void insertServerRequiresAdmin() throws Exception {
+		Method m = method("insertServer", egovframework.com.sym.sym.srv.service.ServerVO.class,
+				egovframework.com.sym.sym.srv.service.Server.class,
+				org.springframework.validation.BindingResult.class, org.springframework.ui.ModelMap.class);
+		assertTrue(m.isAnnotationPresent(RequireAdmin.class), "서버 신규등록은 관리자만 가능해야 한다.");
+	}
+
+	@Test
+	void updateServerRequiresAdmin() throws Exception {
+		Method m = method("updateServer", egovframework.com.sym.sym.srv.service.ServerVO.class,
+				egovframework.com.sym.sym.srv.service.Server.class,
+				org.springframework.validation.BindingResult.class,
+				org.springframework.web.bind.support.SessionStatus.class, org.springframework.ui.ModelMap.class);
+		assertTrue(m.isAnnotationPresent(RequireAdmin.class), "서버 수정은 관리자만 가능해야 한다.");
+	}
+
+	@Test
+	void saveServerEqpmnRelateRequiresAdmin() throws Exception {
+		Method m = method("saveServerEqpmnRelate", String.class, String.class, String.class,
+				egovframework.com.sym.sym.srv.service.ServerEqpmnRelate.class,
+				org.springframework.web.bind.support.SessionStatus.class, org.springframework.ui.ModelMap.class);
+		assertTrue(m.isAnnotationPresent(RequireAdmin.class), "서버-장비 연계 저장은 관리자만 가능해야 한다.");
+	}
+}


### PR DESCRIPTION
## 수정 사유

- [x] 버그수정
- [ ] 기능개선
- [ ] 리팩터링

## 문제 상황

서버(장비)관리의 상세조회·삭제는 `@RequireAdmin`으로 관리자만 접근 가능한데, 실제로 값을 바꾸는 등록·수정·연계저장 5개 메서드(`insertServerEqpmn`·`updateServerEqpmn`·`insertServer`·`updateServer`·`saveServerEqpmnRelate`)에는 이 애노테이션이 없습니다. 로그인만 하면 관리자가 아니어도 서버·서버장비 정보를 등록·수정하거나 서버-장비 연계를 바꿀 수 있습니다.

## 변경 내용

형제 메서드(`selectServerEqpmn`·`deleteServerEqpmn`·`selectServer`·`deleteServer`)와 동일한 방식으로 다섯 메서드에 `@RequireAdmin`을 추가했습니다.

```java
@PostMapping("/sym/sym/srv/addServerEqpmn.do")
@RequireAdmin
public String insertServerEqpmn(...)
```

## 영향 범위

`EgovServerController`의 다섯 메서드에 애노테이션만 추가했습니다. 이 화면들은 관리자 콘솔 JSP(`EgovServerRegist.jsp`·`EgovServerUpdt.jsp`·`EgovServerEqpmnRegist.jsp`·`EgovServerEqpmnUpdt.jsp`·`EgovServerEqpmnRelateRegist.jsp`)에서만 호출되고 일반 사용자 셀프서비스 화면은 없습니다.

## 테스트 방법

### 재현 (수정 전)

로그인만 한 일반 사용자가 다섯 URL을 직접 호출하면 관리자 여부와 무관하게 처리됩니다.

### 확인 (수정 후)

관리자가 아니면 차단됩니다(`@RequireAdmin` AOP가 형제 메서드들과 동일하게 처리).

### 단위 테스트

`EgovServerControllerAdminCheckTest`를 추가했습니다. `@RequireAdmin`은 Spring AOP로 위빙되므로 컨트롤러를 직접 생성해 호출하는 단위 테스트로는 실제 차단 동작을 재현할 수 없습니다. 그래서 이 테스트는 다섯 메서드에 애노테이션이 실제로 붙어 있는지를 리플렉션으로 확인해 나중에 실수로 지워지는 회귀를 잡습니다.

```
Tests run: 5, Failures: 0, Errors: 0, Skipped: 0
```

애노테이션 5개를 모두 제거하면:

```
Tests run: 5, Failures: 5, Errors: 0, Skipped: 0
  insertServerEqpmnRequiresAdmin: 서버장비 신규등록은 관리자만 가능해야 한다. ==> expected: <true> but was: <false>
  updateServerEqpmnRequiresAdmin: 서버장비 수정은 관리자만 가능해야 한다. ==> expected: <true> but was: <false>
  insertServerRequiresAdmin: 서버 신규등록은 관리자만 가능해야 한다. ==> expected: <true> but was: <false>
  updateServerRequiresAdmin: 서버 수정은 관리자만 가능해야 한다. ==> expected: <true> but was: <false>
  saveServerEqpmnRelateRequiresAdmin: 서버-장비 연계 저장은 관리자만 가능해야 한다. ==> expected: <true> but was: <false>
```
