### PR TITLE
fix: 장애처리결과 등록·삭제에 관리자 검증 추가

### DIFF
--- a/src/main/java/egovframework/com/sym/tbm/tbp/web/EgovTroblProcessController.java
+++ b/src/main/java/egovframework/com/sym/tbm/tbp/web/EgovTroblProcessController.java
@@ -15,6 +15,7 @@ import egovframework.com.cmm.ComDefaultCodeVO;
 import egovframework.com.cmm.EgovMessageSource;
 import egovframework.com.cmm.LoginVO;
 import egovframework.com.cmm.annotation.IncludedInfo;
+import egovframework.com.cmm.annotation.RequireAdmin;
 import egovframework.com.cmm.service.CmmnDetailCode;
 import egovframework.com.cmm.service.EgovCmmUseService;
 import egovframework.com.cmm.util.EgovUserDetailsHelper;
@@ -142,6 +143,7 @@ public class EgovTroblProcessController {
 	 * @return String - 리턴 Url
 	 */
 	@PostMapping("/sym/tbm/tbp/addTroblProcess.do")
+	@RequireAdmin
 	public String insertTroblProcess(@ModelAttribute("troblProcessVO") TroblProcessVO troblProcessVO,
 			@Valid @ModelAttribute("troblProcess") TroblProcess troblProcess,
 			BindingResult bindingResult, SessionStatus status, ModelMap model) throws Exception {
@@ -168,6 +170,7 @@ public class EgovTroblProcessController {
 	 * @return String - 리턴 Url
 	 */
 	@PostMapping("/sym/tbm/tbp/removeTroblProcess.do")
+	@RequireAdmin
 	public String deleteTroblProcess(@RequestParam("troblId") String troblId,
 			@ModelAttribute("troblProcess") TroblProcess troblProcess, ModelMap model) throws Exception {
 		// 2026.07.13 KISA 보안취약점 조치

--- a/src/test/java/egovframework/com/sym/tbm/tbp/web/EgovTroblProcessControllerAdminCheckTest.java
+++ b/src/test/java/egovframework/com/sym/tbm/tbp/web/EgovTroblProcessControllerAdminCheckTest.java
@@ -1,0 +1,46 @@
+package egovframework.com.sym.tbm.tbp.web;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.Test;
+
+import egovframework.com.cmm.annotation.RequireAdmin;
+
+/**
+ * insertTroblProcess·deleteTroblProcess에 @RequireAdmin이 붙어있는지 확인한다.
+ *
+ * TroblProcess(장애처리결과)는 troblOpetrNm(처리자명) 필드로 알 수 있듯 신청자 본인이 아니라
+ * IT 운영자가 장애를 처리·기록하는 관리자 기능이다(신청자 개인소유 자원인 장애신청/TroblReqst와는
+ * 다른 모듈). 이 파일에는 이 PR 이전에 @RequireAdmin이 붙은 형제 메서드가 없어, FAQ 등 이
+ * 저장소에서 이미 확립된 관리자 전용 패턴을 그대로 적용했다.
+ *
+ * @RequireAdmin은 Spring AOP(`@annotation(RequireAdmin)` 포인트컷)로 위빙되므로 컨트롤러를
+ * 직접 new해서 부르는 단위 테스트로는 실제 차단 동작을 재현할 수 없다(프록시를 거치지 않음).
+ * 이 AOP 자체가 실제로 작동한다는 것은 이미 별도로 E2E 확인됐다(샌드박스에서 비관리자 계정으로
+ * @RequireAdmin 붙은 엔드포인트를 호출해 HTTP 302 → accessDenied 확인). 이 테스트는 그 전제 위에서
+ * "애노테이션이 두 메서드에 실제로 붙어있는가"라는 구조적 사실만 고정한다.
+ */
+class EgovTroblProcessControllerAdminCheckTest {
+
+	private static Method method(String name, Class<?>... paramTypes) throws NoSuchMethodException {
+		return EgovTroblProcessController.class.getDeclaredMethod(name, paramTypes);
+	}
+
+	@Test
+	void insertTroblProcessRequiresAdmin() throws Exception {
+		Method m = method("insertTroblProcess", egovframework.com.sym.tbm.tbp.service.TroblProcessVO.class,
+				egovframework.com.sym.tbm.tbp.service.TroblProcess.class,
+				org.springframework.validation.BindingResult.class,
+				org.springframework.web.bind.support.SessionStatus.class, org.springframework.ui.ModelMap.class);
+		assertTrue(m.isAnnotationPresent(RequireAdmin.class), "장애처리결과 등록은 관리자만 가능해야 한다.");
+	}
+
+	@Test
+	void deleteTroblProcessRequiresAdmin() throws Exception {
+		Method m = method("deleteTroblProcess", String.class, egovframework.com.sym.tbm.tbp.service.TroblProcess.class,
+				org.springframework.ui.ModelMap.class);
+		assertTrue(m.isAnnotationPresent(RequireAdmin.class), "장애처리결과 삭제는 관리자만 가능해야 한다.");
+	}
+}


### PR DESCRIPTION
## 수정 사유

- [x] 버그수정
- [ ] 기능개선
- [ ] 리팩터링

## 문제 상황

장애처리결과 등록(`addTroblProcess.do`)·삭제(`removeTroblProcess.do`)에는 관리자 검증이 없어 로그인만 하면 누구나 IT 운영자 대신 장애 처리결과를 기록하거나 지울 수 있습니다.

이 두 메서드는 시민이 별도 모듈(장애신청, `EgovTroblReqstController`)로 신고한 건에 IT 운영자가 처리결과를 채우는 기능입니다. 신규 자원을 만드는 게 아니라 이미 존재하는 신고 건을 갱신합니다.

```sql
-- insertTroblProcess가 실행하는 SQL(신규 INSERT가 아니라 UPDATE)
UPDATE COMTNTROBLINFO SET TROBL_PROCESS_RESULT=..., TROBL_OPETR_NM=..., TROBL_PROCESS_TIME=..., PROCESS_STTUS='C' WHERE TROBL_ID=#{troblId}
```

`TroblProcess` VO에는 소유자 필드(`frstRegisterId`)가 정의만 있고 이 두 메서드 어디서도 세팅되지 않습니다 — 개인 소유 자원이 아니라 관리자 전용 처리 워크플로우이기 때문입니다. 장애신청(TroblReqst, 시민이 신고하는 개인소유 자원)은 별도 PR #1207에서 IDOR로 이미 처리했습니다. 이 PR이 다루는 장애처리결과(TroblProcess)는 그와 구분되는 관리자 전용 모듈입니다.

같은 파일 안에는 형제 애노테이션이 없지만, 짝을 이루는 인접 모듈 `EgovTroblReqstController`의 상세조회(`selectTroblReqst`)·삭제(`deleteTroblReqst`)에는 이미 `@RequireAdmin`이 붙어 있습니다. 같은 메뉴군(gid=60) 안에서 확립된 패턴입니다.

## 변경 내용

```java
@PostMapping("/sym/tbm/tbp/addTroblProcess.do")
@RequireAdmin
public String insertTroblProcess(...)
```

## 영향 범위

`EgovTroblProcessController`의 `insertTroblProcess`·`deleteTroblProcess`에 애노테이션만 추가했습니다. 상세조회(`selectTroblProcess`)는 이번 PR에서 건드리지 않았습니다.

## 테스트 방법

### 재현 (수정 전)

로그인만 한 일반 사용자가 `addTroblProcess.do`·`removeTroblProcess.do`를 직접 호출하면 관리자 여부와 무관하게 처리됩니다.

### 확인 (수정 후)

관리자가 아니면 차단됩니다(`@RequireAdmin` AOP가 다른 관리자 전용 메서드들과 동일하게 처리).

### 단위 테스트

`EgovTroblProcessControllerAdminCheckTest`를 추가했습니다. `@RequireAdmin`은 Spring AOP로 위빙되므로 컨트롤러를 직접 생성해 호출하는 단위 테스트로는 실제 차단 동작을 재현할 수 없습니다. 그래서 이 테스트는 두 메서드에 애노테이션이 실제로 붙어 있는지를 리플렉션으로 확인해 나중에 실수로 지워지는 회귀를 잡습니다.

```
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
```

애노테이션 2개를 모두 제거하면:

```
Tests run: 2, Failures: 2, Errors: 0, Skipped: 0
  insertTroblProcessRequiresAdmin: 장애처리결과 등록은 관리자만 가능해야 한다. ==> expected: <true> but was: <false>
  deleteTroblProcessRequiresAdmin: 장애처리결과 삭제는 관리자만 가능해야 한다. ==> expected: <true> but was: <false>
```
