### PR TITLE
fix: 개인정보처리방침 등록·수정·삭제에 관리자 검증 추가

### DIFF
--- a/src/main/java/egovframework/com/uss/sam/ipm/web/EgovIndvdlInfoPolicyController.java
+++ b/src/main/java/egovframework/com/uss/sam/ipm/web/EgovIndvdlInfoPolicyController.java
@@ -19,6 +19,7 @@ import egovframework.com.cmm.ComDefaultVO;
 import egovframework.com.cmm.EgovMessageSource;
 import egovframework.com.cmm.LoginVO;
 import egovframework.com.cmm.annotation.IncludedInfo;
+import egovframework.com.cmm.annotation.RequireAdmin;
 import egovframework.com.cmm.util.EgovUserDetailsHelper;
 import egovframework.com.uss.sam.ipm.service.EgovIndvdlInfoPolicyService;
 import egovframework.com.uss.sam.ipm.service.IndvdlInfoPolicy;
@@ -129,6 +130,11 @@ public class EgovIndvdlInfoPolicyController {
 		String sCmd = commandMap.get("cmd") == null ? "" : (String) commandMap.get("cmd");
 
 		if (sCmd.equals("del")) {
+			// 2026.08.09 KISA 보안취약점 조치 - 관리자만 삭제 가능
+			java.util.List<String> auth = EgovUserDetailsHelper.getAuthorities();
+			if (auth == null || !auth.contains("ROLE_ADMIN")) {
+				throw new IllegalStateException("권한이 없습니다.");
+			}
 			egovIndvdlInfoPolicyService.deleteIndvdlInfoPolicy(indvdlInfoPolicy);
 			sLocationUrl = "forward:/uss/sam/ipm/listIndvdlInfoPolicy.do";
 		} else {
@@ -180,6 +186,7 @@ public class EgovIndvdlInfoPolicyController {
 	 * @throws Exception
 	 */
 	@PostMapping("/uss/sam/ipm/updtIndvdlInfoPolicy.do")
+	@RequireAdmin
 	public String egovIndvdlInfoPolicyModify(@ModelAttribute("searchVO") ComDefaultVO searchVO,
 			@RequestParam Map<?, ?> commandMap, @Valid @ModelAttribute("indvdlInfoPolicy") IndvdlInfoPolicy indvdlInfoPolicy,
 			BindingResult bindingResult,
@@ -245,6 +252,7 @@ public class EgovIndvdlInfoPolicyController {
 	 * @throws Exception
 	 */
 	@PostMapping("/uss/sam/ipm/registIndvdlInfoPolicy.do")
+	@RequireAdmin
 	public String egovIndvdlInfoPolicyRegist(@ModelAttribute("searchVO") ComDefaultVO searchVO,
 			@RequestParam Map<?, ?> commandMap, @Valid @ModelAttribute("indvdlInfoPolicy") IndvdlInfoPolicy indvdlInfoPolicy,
 			BindingResult bindingResult,

--- a/src/test/java/egovframework/com/uss/sam/ipm/web/EgovIndvdlInfoPolicyControllerAdminCheckTest.java
+++ b/src/test/java/egovframework/com/uss/sam/ipm/web/EgovIndvdlInfoPolicyControllerAdminCheckTest.java
@@ -1,0 +1,156 @@
+package egovframework.com.uss.sam.ipm.web;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.egovframe.rte.psl.dataaccess.util.EgovMap;
+import org.junit.jupiter.api.Test;
+import org.springframework.ui.ModelMap;
+
+import egovframework.com.cmm.ComDefaultVO;
+import egovframework.com.cmm.LoginVO;
+import egovframework.com.cmm.annotation.RequireAdmin;
+import egovframework.com.cmm.service.EgovUserDetailsService;
+import egovframework.com.cmm.util.EgovUserDetailsHelper;
+import egovframework.com.uss.sam.ipm.service.EgovIndvdlInfoPolicyService;
+import egovframework.com.uss.sam.ipm.service.IndvdlInfoPolicy;
+
+/**
+ * 개인정보처리방침 등록·수정·삭제의 관리자 검증 회귀 테스트.
+ *
+ * 등록(registIndvdlInfoPolicy.do)·수정(updtIndvdlInfoPolicy.do)은 @RequireAdmin으로 보호한다.
+ * @RequireAdmin은 Spring AOP로 위빙되므로 컨트롤러를 직접 new해서 부르는 단위 테스트로는 실제
+ * 차단 동작을 재현할 수 없다(프록시를 거치지 않음) — 그 전제는 이미 별도 E2E로 확인됐고, 여기서는
+ * 애노테이션이 실제로 붙어있는지만 리플렉션으로 고정한다.
+ *
+ * 삭제(cmd=del)는 상세조회와 같은 메서드(egovIndvdlInfoPolicyDetail) 안에 있어 @RequireAdmin을
+ * 메서드 전체에 붙일 수 없다(그러면 일반 열람까지 막힘). 그래서 형제 파일(EgovQustnrItemManageController)과
+ * 같은 인라인 ROLE_ADMIN 체크를 추가했고, 이건 AOP 없이 메서드 본문에서 직접 실행되므로 실제
+ * 차단 동작을 컨트롤러 직접 호출로 검증할 수 있다.
+ */
+class EgovIndvdlInfoPolicyControllerAdminCheckTest {
+
+	private static final class StubService implements EgovIndvdlInfoPolicyService {
+		private boolean deleteCalled = false;
+
+		@Override
+		public List<EgovMap> selectIndvdlInfoPolicyList(ComDefaultVO searchVO) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public int selectIndvdlInfoPolicyListCnt(ComDefaultVO searchVO) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public IndvdlInfoPolicy selectIndvdlInfoPolicyDetail(IndvdlInfoPolicy indvdlInfoPolicy) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public void insertIndvdlInfoPolicy(IndvdlInfoPolicy indvdlInfoPolicy) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public void updateIndvdlInfoPolicy(IndvdlInfoPolicy indvdlInfoPolicy) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public void deleteIndvdlInfoPolicy(IndvdlInfoPolicy indvdlInfoPolicy) {
+			deleteCalled = true;
+		}
+	}
+
+	private static void bindLoginUser(List<String> authorities) {
+		LoginVO login = new LoginVO();
+		login.setUniqId("USRCNFRM_00000000001");
+		EgovUserDetailsService stub = new EgovUserDetailsService() {
+			@Override
+			public Object getAuthenticatedUser() {
+				return login;
+			}
+
+			@Override
+			public List<String> getAuthorities() {
+				return authorities;
+			}
+
+			@Override
+			public Boolean isAuthenticated() {
+				return Boolean.TRUE;
+			}
+		};
+		new EgovUserDetailsHelper().setEgovUserDetailsService(stub);
+	}
+
+	private static EgovIndvdlInfoPolicyController controllerWith(StubService service) throws Exception {
+		EgovIndvdlInfoPolicyController controller = new EgovIndvdlInfoPolicyController();
+		Field serviceField = EgovIndvdlInfoPolicyController.class.getDeclaredField("egovIndvdlInfoPolicyService");
+		serviceField.setAccessible(true);
+		serviceField.set(controller, service);
+		return controller;
+	}
+
+	// ---- 등록·수정: 구조 테스트(리플렉션) ----
+
+	@Test
+	void updateRequiresAdmin() throws Exception {
+		Method m = EgovIndvdlInfoPolicyController.class.getDeclaredMethod("egovIndvdlInfoPolicyModify",
+				ComDefaultVO.class, Map.class, IndvdlInfoPolicy.class,
+				org.springframework.validation.BindingResult.class,
+				org.springframework.web.servlet.mvc.support.RedirectAttributes.class, ModelMap.class);
+		assertTrue(m.isAnnotationPresent(RequireAdmin.class), "개인정보처리방침 수정은 관리자만 가능해야 한다.");
+	}
+
+	@Test
+	void registRequiresAdmin() throws Exception {
+		Method m = EgovIndvdlInfoPolicyController.class.getDeclaredMethod("egovIndvdlInfoPolicyRegist",
+				ComDefaultVO.class, Map.class, IndvdlInfoPolicy.class,
+				org.springframework.validation.BindingResult.class,
+				org.springframework.web.servlet.mvc.support.RedirectAttributes.class, ModelMap.class);
+		assertTrue(m.isAnnotationPresent(RequireAdmin.class), "개인정보처리방침 등록은 관리자만 가능해야 한다.");
+	}
+
+	// ---- 삭제: 실제 동작 테스트(인라인 체크) ----
+
+	@Test
+	void deleteByNonAdminIsRejected() throws Exception {
+		StubService service = new StubService();
+		EgovIndvdlInfoPolicyController controller = controllerWith(service);
+		bindLoginUser(List.of());
+
+		IndvdlInfoPolicy indvdlInfoPolicy = new IndvdlInfoPolicy();
+		Map<String, String> commandMap = new HashMap<>();
+		commandMap.put("cmd", "del");
+		ModelMap model = new ModelMap();
+
+		assertThrows(IllegalStateException.class,
+				() -> controller.egovIndvdlInfoPolicyDetail(new ComDefaultVO(), indvdlInfoPolicy, commandMap, model),
+				"관리자가 아니면 개인정보처리방침을 삭제할 수 없어야 한다.");
+		assertTrue(!service.deleteCalled, "deleteIndvdlInfoPolicy 서비스가 호출되면 안 된다.");
+	}
+
+	@Test
+	void deleteByAdminSucceeds() throws Exception {
+		StubService service = new StubService();
+		EgovIndvdlInfoPolicyController controller = controllerWith(service);
+		bindLoginUser(List.of("ROLE_ADMIN"));
+
+		IndvdlInfoPolicy indvdlInfoPolicy = new IndvdlInfoPolicy();
+		Map<String, String> commandMap = new HashMap<>();
+		commandMap.put("cmd", "del");
+		ModelMap model = new ModelMap();
+
+		controller.egovIndvdlInfoPolicyDetail(new ComDefaultVO(), indvdlInfoPolicy, commandMap, model);
+		assertTrue(service.deleteCalled, "관리자는 개인정보처리방침을 삭제할 수 있어야 한다.");
+	}
+}


### PR DESCRIPTION
## 수정 사유

- [x] 버그수정
- [ ] 기능개선
- [ ] 리팩터링

## 문제 상황

개인정보처리방침은 사이트 전체가 공유하는 공식 정책 텍스트입니다. 목록조회는 로그인조차 필요 없고 상세조회는 로그인만 확인합니다(누구나 읽는 공개 문서). 그런데 실제로 내용을 바꾸는 등록(`registIndvdlInfoPolicy.do`)·수정(`updtIndvdlInfoPolicy.do`)·삭제(`detailIndvdlInfoPolicy.do`의 `cmd=del`)에는 관리자 검증이 전혀 없습니다. 로그인만 하면 누구나 사이트의 공식 개인정보처리방침을 등록·수정·삭제할 수 있습니다.

## 변경 내용

등록·수정은 `@RequireAdmin`으로 막았습니다.

```java
@PostMapping("/uss/sam/ipm/updtIndvdlInfoPolicy.do")
@RequireAdmin
public String egovIndvdlInfoPolicyModify(...)
```

삭제는 상세조회와 같은 메서드(`egovIndvdlInfoPolicyDetail`) 안에 `cmd=del` 분기로 들어있어 메서드 전체에 애노테이션을 붙일 수 없습니다(그러면 정상 열람까지 막힘). 그래서 같은 세션에서 먼저 제출한 형제 PR `EgovQustnrItemManageController`(#1205, 같은 패턴으로 리뷰 중)와 동일한 인라인 `ROLE_ADMIN` 체크를 추가했습니다.

```java
if (sCmd.equals("del")) {
    java.util.List<String> auth = EgovUserDetailsHelper.getAuthorities();
    if (auth == null || !auth.contains("ROLE_ADMIN")) {
        throw new IllegalStateException("권한이 없습니다.");
    }
    egovIndvdlInfoPolicyService.deleteIndvdlInfoPolicy(indvdlInfoPolicy);
    ...
```

## 영향 범위

`EgovIndvdlInfoPolicyController`의 등록·수정·삭제 처리 메서드만 변경했습니다. 목록조회·상세조회(읽기 경로)는 건드리지 않아 기존처럼 공개 열람이 유지됩니다.

## 테스트 방법

### 재현 (수정 전)

로그인만 한 일반 사용자가 등록·수정·삭제 URL을 직접 호출하면 관리자가 아니어도 그대로 처리됩니다.

### 확인 (수정 후)

관리자가 아니면 세 경로 모두 차단됩니다.

### 단위 테스트

`EgovIndvdlInfoPolicyControllerAdminCheckTest`를 추가했습니다. 등록·수정은 `@RequireAdmin`이 Spring AOP로 위빙되는 방식이라, 컨트롤러를 직접 호출해서는 실제 차단이 재현되지 않습니다. 그래서 애노테이션이 붙어 있는지를 리플렉션으로 확인합니다. 삭제는 인라인 체크라 컨트롤러를 직접 호출해 실제 차단·통과를 모두 검증합니다.

```
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
```

세 검증을 모두 제거하면:

```
Tests run: 4, Failures: 3, Errors: 0, Skipped: 0
  deleteByNonAdminIsRejected: 관리자가 아니면 개인정보처리방침을 삭제할 수 없어야 한다. ==> Expected java.lang.IllegalStateException to be thrown, but nothing was thrown.
  registRequiresAdmin: 개인정보처리방침 등록은 관리자만 가능해야 한다. ==> expected: <true> but was: <false>
  updateRequiresAdmin: 개인정보처리방침 수정은 관리자만 가능해야 한다. ==> expected: <true> but was: <false>
```

