### PR TITLE
fix: 약관관리 등록·수정·삭제에 관리자 검증 추가

### DIFF
--- a/src/main/java/egovframework/com/uss/sam/stp/web/EgovStplatManageController.java
+++ b/src/main/java/egovframework/com/uss/sam/stp/web/EgovStplatManageController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import egovframework.com.cmm.EgovMessageSource;
 import egovframework.com.cmm.LoginVO;
 import egovframework.com.cmm.annotation.IncludedInfo;
+import egovframework.com.cmm.annotation.RequireAdmin;
 import egovframework.com.cmm.util.EgovUserDetailsHelper;
 import egovframework.com.uss.sam.stp.service.EgovStplatManageService;
 import egovframework.com.uss.sam.stp.service.StplatManageDefaultVO;
@@ -164,6 +165,7 @@ public class EgovStplatManageController {
 	 * @throws Exception
 	 */
 	@PostMapping("/uss/sam/stp/StplatCnRegist.do")
+	@RequireAdmin
 	public String insertStplatCn(@ModelAttribute("searchVO") StplatManageDefaultVO searchVO,
 			@Valid @ModelAttribute("stplatManageVO") StplatManageVO stplatManageVO, BindingResult bindingResult,
 			ModelMap model) throws Exception {
@@ -228,6 +230,7 @@ public class EgovStplatManageController {
 	 * @throws Exception
 	 */
 	@PostMapping("/uss/sam/stp/StplatCnUpdt.do")
+	@RequireAdmin
 	public String updateStplatCn(@ModelAttribute("searchVO") StplatManageDefaultVO searchVO,
 			@Valid @ModelAttribute("stplatManageVO") StplatManageVO stplatManageVO, BindingResult bindingResult)
 			throws Exception {
@@ -261,6 +264,7 @@ public class EgovStplatManageController {
 	 * @throws Exception
 	 */
 	@PostMapping("/uss/sam/stp/StplatCnDelete.do")
+	@RequireAdmin
 	public String deleteStplatCn(StplatManageVO stplatManageVO,
 			@ModelAttribute("searchVO") StplatManageDefaultVO searchVO) throws Exception {
 

--- a/src/test/java/egovframework/com/uss/sam/stp/web/EgovStplatManageControllerAdminCheckTest.java
+++ b/src/test/java/egovframework/com/uss/sam/stp/web/EgovStplatManageControllerAdminCheckTest.java
@@ -1,0 +1,52 @@
+package egovframework.com.uss.sam.stp.web;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.Test;
+
+import egovframework.com.cmm.annotation.RequireAdmin;
+
+/**
+ * insertStplatCn·updateStplatCn·deleteStplatCn에 @RequireAdmin이 붙어있는지 확인한다.
+ *
+ * 약관관리(StplatManage)는 사이트 전체가 공유하는 이용약관 텍스트다. 목록조회·상세조회는 로그인조차
+ * 필요 없는 공개 열람이고(EgovStplatListInqire.do·EgovStplatDetailInqire.do 둘 다 인증 체크 없음),
+ * 등록·수정은 로그인만, 삭제는 그마저도 확인하지 않았다 — 등록·수정·삭제 전부 이 PR 이전에는
+ * 관리자 여부를 가리지 않았다.
+ *
+ * @RequireAdmin은 Spring AOP(`@annotation(RequireAdmin)` 포인트컷)로 위빙되므로 컨트롤러를
+ * 직접 new해서 부르는 단위 테스트로는 실제 차단 동작을 재현할 수 없다(프록시를 거치지 않음).
+ * 이 AOP 자체가 실제로 작동한다는 것은 이미 별도로 E2E 확인됐다. 이 테스트는 그 전제 위에서
+ * "애노테이션이 세 메서드에 실제로 붙어있는가"라는 구조적 사실만 고정한다.
+ */
+class EgovStplatManageControllerAdminCheckTest {
+
+	private static Method method(String name, Class<?>... paramTypes) throws NoSuchMethodException {
+		return EgovStplatManageController.class.getDeclaredMethod(name, paramTypes);
+	}
+
+	@Test
+	void insertStplatCnRequiresAdmin() throws Exception {
+		Method m = method("insertStplatCn", egovframework.com.uss.sam.stp.service.StplatManageDefaultVO.class,
+				egovframework.com.uss.sam.stp.service.StplatManageVO.class,
+				org.springframework.validation.BindingResult.class, org.springframework.ui.ModelMap.class);
+		assertTrue(m.isAnnotationPresent(RequireAdmin.class), "약관 등록은 관리자만 가능해야 한다.");
+	}
+
+	@Test
+	void updateStplatCnRequiresAdmin() throws Exception {
+		Method m = method("updateStplatCn", egovframework.com.uss.sam.stp.service.StplatManageDefaultVO.class,
+				egovframework.com.uss.sam.stp.service.StplatManageVO.class,
+				org.springframework.validation.BindingResult.class);
+		assertTrue(m.isAnnotationPresent(RequireAdmin.class), "약관 수정은 관리자만 가능해야 한다.");
+	}
+
+	@Test
+	void deleteStplatCnRequiresAdmin() throws Exception {
+		Method m = method("deleteStplatCn", egovframework.com.uss.sam.stp.service.StplatManageVO.class,
+				egovframework.com.uss.sam.stp.service.StplatManageDefaultVO.class);
+		assertTrue(m.isAnnotationPresent(RequireAdmin.class), "약관 삭제는 관리자만 가능해야 한다.");
+	}
+}


### PR DESCRIPTION
## 수정 사유

- [x] 버그수정
- [ ] 기능개선
- [ ] 리팩터링

## 문제 상황

약관관리는 사이트 전체가 공유하는 이용약관 텍스트입니다. 목록조회·상세조회는 로그인조차 필요 없는 공개 열람인데, 실제로 내용을 바꾸는 등록(`StplatCnRegist.do`)·수정(`StplatCnUpdt.do`)에는 로그인만 확인하고 삭제(`StplatCnDelete.do`)는 그마저도 확인하지 않았습니다 — 로그인하지 않은 사용자도 사이트의 이용약관을 통째로 삭제할 수 있었습니다.

## 변경 내용

세 메서드 모두 `@RequireAdmin`으로 막았습니다.

```java
@PostMapping("/uss/sam/stp/StplatCnDelete.do")
@RequireAdmin
public String deleteStplatCn(...)
```

`StplatManageVO`에는 소유자 필드가 없고 매퍼의 UPDATE/DELETE도 `WHERE USE_STPLAT_ID=#{useStplatId}` 하나뿐입니다 — 개인 소유 자원이 아니라 사이트 전체가 공유하는 콘텐츠입니다. 소유권 대조가 아니라 관리자 검증이 맞는 설계입니다.

## 영향 범위

`EgovStplatManageController`의 등록·수정·삭제 처리 메서드만 변경했습니다. 목록조회·상세조회(읽기 경로)와 폼 진입(`*View.do`)은 건드리지 않았습니다.

## 테스트 방법

### 재현 (수정 전)

로그인하지 않은 사용자도 `StplatCnDelete.do`를 직접 호출하면 이용약관이 삭제됩니다. 로그인만 한 사용자는 등록·수정도 가능합니다.

### 확인 (수정 후)

관리자가 아니면 세 경로 모두 차단됩니다.

### 단위 테스트

`EgovStplatManageControllerAdminCheckTest`를 추가했습니다. `@RequireAdmin`은 Spring AOP로 위빙되는 방식이라 컨트롤러를 직접 호출해서는 실제 차단이 재현되지 않습니다. 그래서 애노테이션이 붙어 있는지를 리플렉션으로 확인합니다.

```
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0
```

애노테이션 3개를 모두 제거하면:

```
Tests run: 3, Failures: 3, Errors: 0, Skipped: 0
  insertStplatCnRequiresAdmin: 약관 등록은 관리자만 가능해야 한다. ==> expected: <true> but was: <false>
  updateStplatCnRequiresAdmin: 약관 수정은 관리자만 가능해야 한다. ==> expected: <true> but was: <false>
  deleteStplatCnRequiresAdmin: 약관 삭제는 관리자만 가능해야 한다. ==> expected: <true> but was: <false>
```
