### PR TITLE
fix: 사이트관리 등록·수정·삭제에 관리자 검증 추가

### DIFF
--- a/src/main/java/egovframework/com/uss/ion/sit/web/EgovSiteController.java
+++ b/src/main/java/egovframework/com/uss/ion/sit/web/EgovSiteController.java
@@ -15,6 +15,7 @@ import egovframework.com.cmm.ComDefaultCodeVO;
 import egovframework.com.cmm.EgovMessageSource;
 import egovframework.com.cmm.LoginVO;
 import egovframework.com.cmm.annotation.IncludedInfo;
+import egovframework.com.cmm.annotation.RequireAdmin;
 import egovframework.com.cmm.service.EgovCmmUseService;
 import egovframework.com.cmm.util.EgovUserDetailsHelper;
 import egovframework.com.uss.ion.sit.service.EgovSiteService;
@@ -147,6 +148,7 @@ public class EgovSiteController {
 	 * @throws Exception
 	 */
 	@PostMapping("/uss/ion/sit/insertSite.do")
+	@RequireAdmin
 	public String insertSite(@Valid @ModelAttribute("siteVO") SiteVO siteVO, BindingResult bindingResult, ModelMap model) throws Exception {
 
 		if (bindingResult.hasErrors()) {
@@ -192,6 +194,7 @@ public class EgovSiteController {
 	 * @throws Exception
 	 */
 	@PostMapping("/uss/ion/sit/updateSite.do")
+	@RequireAdmin
 	public String updateSite(@Valid @ModelAttribute("siteVO") SiteVO siteVO, BindingResult bindingResult, ModelMap model) throws Exception {
 
 		if (bindingResult.hasErrors()) {
@@ -219,6 +222,7 @@ public class EgovSiteController {
 	 * @throws Exception
 	 */
 	@PostMapping("/uss/ion/sit/deleteSite.do")
+	@RequireAdmin
 	public String deleteSite(@ModelAttribute("siteVO") SiteVO siteVO) throws Exception {
 		egovSiteService.deleteSite(siteVO);
 

--- a/src/test/java/egovframework/com/uss/ion/sit/web/EgovSiteControllerAdminCheckTest.java
+++ b/src/test/java/egovframework/com/uss/ion/sit/web/EgovSiteControllerAdminCheckTest.java
@@ -1,0 +1,47 @@
+package egovframework.com.uss.ion.sit.web;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.Test;
+
+import egovframework.com.cmm.annotation.RequireAdmin;
+
+/**
+ * insertSite·updateSite·deleteSite에 @RequireAdmin이 붙어있는지 확인한다.
+ *
+ * 사이트관리는 포털이 운영하는 사이트(다중 사이트) 목록을 관리하는 기능이다. 세 메서드 모두
+ * 이 PR 이전에는 로그인 여부조차 확인하지 않았다.
+ *
+ * @RequireAdmin은 Spring AOP(`@annotation(RequireAdmin)` 포인트컷)로 위빙되므로 컨트롤러를
+ * 직접 new해서 부르는 단위 테스트로는 실제 차단 동작을 재현할 수 없다(프록시를 거치지 않음).
+ * 이 AOP 자체가 실제로 작동한다는 것은 이미 별도로 E2E 확인됐다. 이 테스트는 그 전제 위에서
+ * "애노테이션이 세 메서드에 실제로 붙어있는가"라는 구조적 사실만 고정한다.
+ */
+class EgovSiteControllerAdminCheckTest {
+
+	private static Method method(String name, Class<?>... paramTypes) throws NoSuchMethodException {
+		return EgovSiteController.class.getDeclaredMethod(name, paramTypes);
+	}
+
+	@Test
+	void insertSiteRequiresAdmin() throws Exception {
+		Method m = method("insertSite", egovframework.com.uss.ion.sit.service.SiteVO.class,
+				org.springframework.validation.BindingResult.class, org.springframework.ui.ModelMap.class);
+		assertTrue(m.isAnnotationPresent(RequireAdmin.class), "사이트 등록은 관리자만 가능해야 한다.");
+	}
+
+	@Test
+	void updateSiteRequiresAdmin() throws Exception {
+		Method m = method("updateSite", egovframework.com.uss.ion.sit.service.SiteVO.class,
+				org.springframework.validation.BindingResult.class, org.springframework.ui.ModelMap.class);
+		assertTrue(m.isAnnotationPresent(RequireAdmin.class), "사이트 수정은 관리자만 가능해야 한다.");
+	}
+
+	@Test
+	void deleteSiteRequiresAdmin() throws Exception {
+		Method m = method("deleteSite", egovframework.com.uss.ion.sit.service.SiteVO.class);
+		assertTrue(m.isAnnotationPresent(RequireAdmin.class), "사이트 삭제는 관리자만 가능해야 한다.");
+	}
+}


### PR DESCRIPTION
## 수정 사유

- [x] 버그수정
- [ ] 기능개선
- [ ] 리팩터링

## 문제 상황

사이트관리는 관리자 인프라 설정으로, 포털이 운영하는 다중 사이트 목록을 다룹니다. 등록(`insertSite.do`)·수정(`updateSite.do`)·삭제(`deleteSite.do`) 세 메서드 모두 로그인 여부조차 확인하지 않았습니다. 이 URL들을 가로채는 필터나 Spring Security 인가 규칙도 따로 없어서 회원가입조차 하지 않은 익명 사용자가 직접 POST로 사이트를 임의로 생성·삭제할 수 있었습니다.

## 변경 내용

세 메서드 모두 `@RequireAdmin`으로 막았습니다.

```java
@PostMapping("/uss/ion/sit/deleteSite.do")
@RequireAdmin
public String deleteSite(...)
```

`SiteVO`에는 소유자 필드가 없습니다(`frstRegisterId`는 등록자 기록용 감사 필드일 뿐, 권한 판단에 쓰이지 않습니다). 같은 파일에 이미 있는 `egovAssertAdminOrOwner` 헬퍼도 이 컨트롤러 어디서도 호출되지 않습니다. 애초에 소유자 개념 없는 순수 관리자 자원으로 설계됐다는 뜻입니다.

## 영향 범위

`EgovSiteController`의 등록·수정·삭제 처리 메서드만 변경했습니다. 조회(`selectSiteList`·`selectSiteDetail`)와 폼 진입(`*View.do`)은 건드리지 않았습니다.

## 테스트 방법

### 재현 (수정 전)

로그인하지 않은 사용자도 세 URL을 직접 호출하면 그대로 처리됩니다.

### 확인 (수정 후)

관리자가 아니면 세 경로 모두 차단됩니다.

### 단위 테스트

`EgovSiteControllerAdminCheckTest`를 추가했습니다. `@RequireAdmin`은 Spring AOP로 위빙되는 방식이라 컨트롤러를 직접 호출해서는 실제 차단이 재현되지 않습니다. 그래서 애노테이션이 붙어 있는지를 리플렉션으로 확인합니다.

```
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0
```

애노테이션 3개를 모두 제거하면:

```
Tests run: 3, Failures: 3, Errors: 0, Skipped: 0
  insertSiteRequiresAdmin: 사이트 등록은 관리자만 가능해야 한다. ==> expected: <true> but was: <false>
  updateSiteRequiresAdmin: 사이트 수정은 관리자만 가능해야 한다. ==> expected: <true> but was: <false>
  deleteSiteRequiresAdmin: 사이트 삭제는 관리자만 가능해야 한다. ==> expected: <true> but was: <false>
```
