### PR TITLE
fix: 행정전문용어사전 등록·수정·삭제에 관리자 검증 추가

### DIFF
--- a/src/main/java/egovframework/com/uss/olh/awm/web/EgovAdministrationWordController.java
+++ b/src/main/java/egovframework/com/uss/olh/awm/web/EgovAdministrationWordController.java
@@ -17,6 +17,7 @@ import egovframework.com.cmm.ComDefaultCodeVO;
 import egovframework.com.cmm.EgovMessageSource;
 import egovframework.com.cmm.LoginVO;
 import egovframework.com.cmm.annotation.IncludedInfo;
+import egovframework.com.cmm.annotation.RequireAdmin;
 import egovframework.com.cmm.service.EgovCmmUseService;
 import egovframework.com.cmm.util.EgovUserDetailsHelper;
 import egovframework.com.uss.olh.awm.service.AdministrationWordVO;
@@ -213,6 +214,7 @@ public class EgovAdministrationWordController {
 	 * @throws Exception
 	 */
 	@PostMapping("/uss/olh/awm/insertAdministrationWord.do")
+	@RequireAdmin
 	public String insertAdministrationWord(@ModelAttribute("searchVO") AdministrationWordVO searchVO,
 			@Valid @ModelAttribute("administrationWordVO") AdministrationWordVO administrationWordVO,
 			BindingResult bindingResult,
@@ -279,6 +281,7 @@ public class EgovAdministrationWordController {
 	 * @throws Exception
 	 */
 	@PostMapping("/uss/olh/awm/updateAdministrationWord.do")
+	@RequireAdmin
 	public String updateAdministrationWord(@ModelAttribute("searchVO") AdministrationWordVO searchVO,
 			@Valid @ModelAttribute("administrationWordVO") AdministrationWordVO administrationWordVO,
 			BindingResult bindingResult,
@@ -313,6 +316,7 @@ public class EgovAdministrationWordController {
 	 * @throws Exception
 	 */
 	@PostMapping("/uss/olh/awm/deleteAdministrationWord.do")
+	@RequireAdmin
 	public String deleteAdministrationWord(AdministrationWordVO administrationWordVO,
 			@ModelAttribute("searchVO") AdministrationWordVO searchVO) throws Exception {
 

--- a/src/test/java/egovframework/com/uss/olh/awm/web/EgovAdministrationWordControllerAdminCheckTest.java
+++ b/src/test/java/egovframework/com/uss/olh/awm/web/EgovAdministrationWordControllerAdminCheckTest.java
@@ -1,0 +1,52 @@
+package egovframework.com.uss.olh.awm.web;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.Test;
+
+import egovframework.com.cmm.annotation.RequireAdmin;
+
+/**
+ * insertAdministrationWord·updateAdministrationWord·deleteAdministrationWord에
+ * @RequireAdmin이 붙어있는지 확인한다.
+ *
+ * 행정전문용어사전은 사이트 전체가 공유하는 용어 사전이다. 같은 gid=50 메뉴군의 FAQ(EgovFaqController)는
+ * 이미 등록/수정/삭제에 @RequireAdmin으로 보호되는데, 이 컨트롤러는 세 메서드 모두 로그인 여부조차
+ * 확인하지 않았다.
+ *
+ * @RequireAdmin은 Spring AOP(`@annotation(RequireAdmin)` 포인트컷)로 위빙되므로 컨트롤러를
+ * 직접 new해서 부르는 단위 테스트로는 실제 차단 동작을 재현할 수 없다(프록시를 거치지 않음).
+ * 이 AOP 자체가 실제로 작동한다는 것은 이미 별도로 E2E 확인됐다. 이 테스트는 그 전제 위에서
+ * "애노테이션이 세 메서드에 실제로 붙어있는가"라는 구조적 사실만 고정한다.
+ */
+class EgovAdministrationWordControllerAdminCheckTest {
+
+	private static Method method(String name, Class<?>... paramTypes) throws NoSuchMethodException {
+		return EgovAdministrationWordController.class.getDeclaredMethod(name, paramTypes);
+	}
+
+	@Test
+	void insertRequiresAdmin() throws Exception {
+		Method m = method("insertAdministrationWord", egovframework.com.uss.olh.awm.service.AdministrationWordVO.class,
+				egovframework.com.uss.olh.awm.service.AdministrationWordVO.class,
+				org.springframework.validation.BindingResult.class, org.springframework.ui.Model.class);
+		assertTrue(m.isAnnotationPresent(RequireAdmin.class), "행정전문용어사전 등록은 관리자만 가능해야 한다.");
+	}
+
+	@Test
+	void updateRequiresAdmin() throws Exception {
+		Method m = method("updateAdministrationWord", egovframework.com.uss.olh.awm.service.AdministrationWordVO.class,
+				egovframework.com.uss.olh.awm.service.AdministrationWordVO.class,
+				org.springframework.validation.BindingResult.class, org.springframework.ui.Model.class);
+		assertTrue(m.isAnnotationPresent(RequireAdmin.class), "행정전문용어사전 수정은 관리자만 가능해야 한다.");
+	}
+
+	@Test
+	void deleteRequiresAdmin() throws Exception {
+		Method m = method("deleteAdministrationWord", egovframework.com.uss.olh.awm.service.AdministrationWordVO.class,
+				egovframework.com.uss.olh.awm.service.AdministrationWordVO.class);
+		assertTrue(m.isAnnotationPresent(RequireAdmin.class), "행정전문용어사전 삭제는 관리자만 가능해야 한다.");
+	}
+}


### PR DESCRIPTION
## 수정 사유

- [x] 버그수정
- [ ] 기능개선
- [ ] 리팩터링

## 문제 상황

행정전문용어사전은 사이트 전체가 공유하는 용어 사전입니다. 같은 메뉴군(gid=50)의 FAQ(`EgovFaqController`)는 등록·수정·삭제 모두 `@RequireAdmin`으로 보호되는데, 이 컨트롤러는 등록(`insertAdministrationWord.do`)·수정(`updateAdministrationWord.do`)·삭제(`deleteAdministrationWord.do`) 세 메서드 모두 로그인 여부조차 확인하지 않았습니다.

## 변경 내용

FAQ와 동일한 방식으로 세 메서드에 `@RequireAdmin`을 추가했습니다.

```java
@PostMapping("/uss/olh/awm/deleteAdministrationWord.do")
@RequireAdmin
public String deleteAdministrationWord(...)
```

`AdministrationWordVO`에는 소유자 필드가 없어 소유권 대조가 아니라 관리자 검증이 맞는 설계입니다.

## 영향 범위

`EgovAdministrationWordController`의 등록·수정·삭제 처리 메서드만 변경했습니다. 조회(`selectAdministrationWordList`·`selectAdministrationWordDetail` 등)와 폼 진입(`*View.do`)은 건드리지 않았습니다.

## 테스트 방법

### 재현 (수정 전)

로그인하지 않은 사용자도 세 URL을 직접 호출하면 그대로 처리됩니다.

### 확인 (수정 후)

관리자가 아니면 세 경로 모두 차단됩니다.

### 단위 테스트

`EgovAdministrationWordControllerAdminCheckTest`를 추가했습니다. `@RequireAdmin`은 Spring AOP로 위빙되는 방식이라 컨트롤러를 직접 호출해서는 실제 차단이 재현되지 않습니다. 그래서 애노테이션이 붙어 있는지를 리플렉션으로 확인합니다.

```
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0
```

애노테이션 3개를 모두 제거하면:

```
Tests run: 3, Failures: 3, Errors: 0, Skipped: 0
  insertRequiresAdmin: 행정전문용어사전 등록은 관리자만 가능해야 한다. ==> expected: <true> but was: <false>
  updateRequiresAdmin: 행정전문용어사전 수정은 관리자만 가능해야 한다. ==> expected: <true> but was: <false>
  deleteRequiresAdmin: 행정전문용어사전 삭제는 관리자만 가능해야 한다. ==> expected: <true> but was: <false>
```
