### PR TITLE
fix: 백업작업 등록·수정에 관리자 검증 추가

### DIFF
--- a/src/main/java/egovframework/com/sym/sym/bak/web/EgovBackupOpertController.java
+++ b/src/main/java/egovframework/com/sym/sym/bak/web/EgovBackupOpertController.java
@@ -126,6 +126,7 @@ public class EgovBackupOpertController {
 	 * @exception Exception Exception
 	 */
     @PostMapping("/sym/sym/bak/addBackupOpert.do")
+	@RequireAdmin
 	public String insertBackupOpert(@ModelAttribute("searchVO") BackupOpert searchVO,
 			@Valid @ModelAttribute("backupOpert") BackupOpert backupOpert, BindingResult bindingResult,
 			ModelMap model, RedirectAttributes redirectAttributes) throws Exception{
@@ -274,6 +275,7 @@ public class EgovBackupOpertController {
 	 * @exception Exception Exception
 	 */
 	@PostMapping("/sym/sym/bak/updateBackupOpert.do")
+	@RequireAdmin
 	public String updateBackupOpert(@ModelAttribute("searchVO") BackupOpert searchVO,
 			@Valid @ModelAttribute("backupOpert") BackupOpert backupOpert, BindingResult bindingResult,
 			ModelMap model, RedirectAttributes redirectAttributes) throws Exception{

--- a/src/test/java/egovframework/com/sym/sym/bak/web/EgovBackupOpertControllerAdminCheckTest.java
+++ b/src/test/java/egovframework/com/sym/sym/bak/web/EgovBackupOpertControllerAdminCheckTest.java
@@ -1,0 +1,45 @@
+package egovframework.com.sym.sym.bak.web;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.Test;
+
+import egovframework.com.cmm.annotation.RequireAdmin;
+
+/**
+ * insertBackupOpert·updateBackupOpert에 @RequireAdmin이 붙어있는지 확인한다.
+ *
+ * 삭제(deleteBackupOpert)·상세조회(selectBackupOpert)는 이미 @RequireAdmin이 붙어있는데
+ * 등록·수정에는 빠져 있었다 — 같은 파일 안 형제 메서드 미러링이라 가장 단순한 케이스다.
+ *
+ * @RequireAdmin은 Spring AOP(`@annotation(RequireAdmin)` 포인트컷)로 위빙되므로 컨트롤러를
+ * 직접 new해서 부르는 단위 테스트로는 실제 차단 동작을 재현할 수 없다(프록시를 거치지 않음).
+ * 이 AOP 자체가 실제로 작동한다는 것은 이미 별도로 E2E 확인됐다. 이 테스트는 그 전제 위에서
+ * "애노테이션이 두 메서드에 실제로 붙어있는가"라는 구조적 사실만 고정한다.
+ */
+class EgovBackupOpertControllerAdminCheckTest {
+
+	private static Method method(String name, Class<?>... paramTypes) throws NoSuchMethodException {
+		return EgovBackupOpertController.class.getDeclaredMethod(name, paramTypes);
+	}
+
+	@Test
+	void insertRequiresAdmin() throws Exception {
+		Method m = method("insertBackupOpert", egovframework.com.sym.sym.bak.service.BackupOpert.class,
+				egovframework.com.sym.sym.bak.service.BackupOpert.class,
+				org.springframework.validation.BindingResult.class, org.springframework.ui.ModelMap.class,
+				org.springframework.web.servlet.mvc.support.RedirectAttributes.class);
+		assertTrue(m.isAnnotationPresent(RequireAdmin.class), "백업작업 등록은 관리자만 가능해야 한다.");
+	}
+
+	@Test
+	void updateRequiresAdmin() throws Exception {
+		Method m = method("updateBackupOpert", egovframework.com.sym.sym.bak.service.BackupOpert.class,
+				egovframework.com.sym.sym.bak.service.BackupOpert.class,
+				org.springframework.validation.BindingResult.class, org.springframework.ui.ModelMap.class,
+				org.springframework.web.servlet.mvc.support.RedirectAttributes.class);
+		assertTrue(m.isAnnotationPresent(RequireAdmin.class), "백업작업 수정은 관리자만 가능해야 한다.");
+	}
+}


### PR DESCRIPTION
## 수정 사유

- [x] 버그수정
- [ ] 기능개선
- [ ] 리팩터링

## 문제 상황

백업작업관리의 삭제(`deleteBackupOpert`)·상세조회(`selectBackupOpert`)는 이미 `@RequireAdmin`으로 관리자만 접근 가능한데, 등록(`addBackupOpert.do`)·수정(`updateBackupOpert.do`)에는 이 애노테이션이 없었습니다.

## 변경 내용

형제 메서드와 똑같이 두 메서드에 `@RequireAdmin`을 추가했습니다.

```java
@PostMapping("/sym/sym/bak/addBackupOpert.do")
@RequireAdmin
public String insertBackupOpert(...)
```

## 영향 범위

`EgovBackupOpertController`의 `insertBackupOpert`·`updateBackupOpert`에 애노테이션만 추가했습니다. 이 두 메서드는 관리자 콘솔 화면(`EgovBackupOpertRegist.jsp`·`EgovBackupOpertUpdt.jsp`)에서만 호출됩니다.

## 테스트 방법

### 재현 (수정 전)

로그인만 한 일반 사용자가 등록·수정 URL을 직접 호출하면 관리자 여부와 무관하게 처리됩니다.

### 확인 (수정 후)

관리자가 아니면 차단됩니다(`@RequireAdmin` AOP가 형제 메서드와 동일하게 처리).

### 단위 테스트

`EgovBackupOpertControllerAdminCheckTest`를 추가했습니다. `@RequireAdmin`은 Spring AOP로 위빙되는 방식이라 컨트롤러를 직접 호출해서는 실제 차단이 재현되지 않습니다. 그래서 애노테이션이 붙어 있는지를 리플렉션으로 확인합니다.

```
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
```

애노테이션 2개를 모두 제거하면:

```
Tests run: 2, Failures: 2, Errors: 0, Skipped: 0
  insertRequiresAdmin: 백업작업 등록은 관리자만 가능해야 한다. ==> expected: <true> but was: <false>
  updateRequiresAdmin: 백업작업 수정은 관리자만 가능해야 한다. ==> expected: <true> but was: <false>
```
