### PR TITLE
[2026 컨트리뷰션] 버그 수정

### DIFF
--- a/src/main/java/egovframework/com/cmm/service/EgovFileMngUtil.java
+++ b/src/main/java/egovframework/com/cmm/service/EgovFileMngUtil.java
@@ -54,7 +54,7 @@ import egovframework.com.cmm.EgovWebUtil;
  *   2022.11.11  김혜준          시큐어코딩 처리
  *   2024.12.04  신용호          downFile() KISA 시큐어코딩 처리
  *   2025.05.26  이백행          PMD로 소프트웨어 보안약점 진단하고 제거하기-FormalParameterNamingConventions(공식 매개변수 명명 규칙), CloseResource(리소스 닫기), LocalVariableNamingConventions(지역 변수 명명 규칙), AssignmentInOperand(피연산자의 할당)
- *   2026.08.14  content_j      downFile() orgFileName 조회 속성키 오타 수정(orginFile→orgFileName, NullPointerException 가능성 제거)
+ *   2026.08.14  content_j      downFile() orgFileName 조회 속성키 오타 수정(orginFile → orgFileName, NullPointerException 가능성 제거)
  *
  *      </pre>
  */

--- a/src/main/java/egovframework/com/cmm/service/EgovFileMngUtil.java
+++ b/src/main/java/egovframework/com/cmm/service/EgovFileMngUtil.java
@@ -36,12 +36,12 @@ import egovframework.com.cmm.EgovWebUtil;
 
 /**
  * 파일 관리 유틸리티
- * 
+ *
  * @author 공통 서비스 개발팀 이삼섭
  * @since 2009. 02. 13
  * @version 1.0
  * @see
- * 
+ *
  *      <pre>
  *  == 개정이력(Modification Information) ==
  *
@@ -54,7 +54,8 @@ import egovframework.com.cmm.EgovWebUtil;
  *   2022.11.11  김혜준          시큐어코딩 처리
  *   2024.12.04  신용호          downFile() KISA 시큐어코딩 처리
  *   2025.05.26  이백행          PMD로 소프트웨어 보안약점 진단하고 제거하기-FormalParameterNamingConventions(공식 매개변수 명명 규칙), CloseResource(리소스 닫기), LocalVariableNamingConventions(지역 변수 명명 규칙), AssignmentInOperand(피연산자의 할당)
- * 
+ *   2026.08.14  content_j      downFile() orgFileName 조회 속성키 오타 수정(orginFile→orgFileName, NullPointerException 가능성 제거)
+ *
  *      </pre>
  */
 @Component("EgovFileMngUtil")
@@ -74,7 +75,7 @@ public class EgovFileMngUtil {
 	 * @throws Exception
 	 */
 	public List<FileVO> parseFileInf(Map<String, MultipartFile> files, String keyStr, int fileKeyParam,
-			String atchFileId, String storePath) throws Exception {
+	                                 String atchFileId, String storePath) throws Exception {
 		int fileKey = fileKeyParam;
 
 		String storePathString = "";
@@ -147,7 +148,7 @@ public class EgovFileMngUtil {
 	 * @throws Exception
 	 */
 	public List<FileVO> parseFileInf(List<MultipartFile> files, String keyStr, int fileKeyParam, String atchFileId,
-			String storePath) throws Exception {
+	                                 String storePath) throws Exception {
 		int fileKey = fileKeyParam;
 
 		String storePathString = "";
@@ -253,11 +254,11 @@ public class EgovFileMngUtil {
 		} else {
 			downFileName = (String) request.getAttribute("downFile");
 		}
-
+		// 2026-08-14 content_j downFile() orgFileName 조회 속성키 오타 수정(orginFile → orgFileName, NullPointerException 가능성 제거)
 		if ((String) request.getAttribute("orgFileName") == null) {
 			orgFileName = "";
 		} else {
-			orgFileName = (String) request.getAttribute("orginFile");
+			orgFileName = (String) request.getAttribute("orgFileName");
 		}
 
 		orgFileName = orgFileName.replaceAll("\r", "").replaceAll("\n", "");
@@ -281,7 +282,7 @@ public class EgovFileMngUtil {
 		response.setHeader("Expires", "0");
 
 		try (BufferedInputStream fin = new BufferedInputStream(new FileInputStream(file));
-				BufferedOutputStream outs = new BufferedOutputStream(response.getOutputStream());) {
+		     BufferedOutputStream outs = new BufferedOutputStream(response.getOutputStream());) {
 			FileCopyUtils.copy(fin, outs);
 		}
 	}
@@ -338,8 +339,8 @@ public class EgovFileMngUtil {
 		}
 
 		try (InputStream stream = file.getInputStream();
-				OutputStream bos = new FileOutputStream(EgovWebUtil
-						.filePathBlackList(FILE_STORE_PATH + File.separator + FilenameUtils.getName(newName)));) {
+		     OutputStream bos = new FileOutputStream(EgovWebUtil
+					 .filePathBlackList(FILE_STORE_PATH + File.separator + FilenameUtils.getName(newName)));) {
 
 			FileCopyUtils.copy(stream, bos);
 		}
@@ -389,19 +390,19 @@ public class EgovFileMngUtil {
 
 		/*
 		 * String uploadPath = propertiesService.getString("fileDir");
-		 * 
+		 *
 		 * File uFile = new File(uploadPath, requestedFile); int fSize = (int)
 		 * uFile.length();
-		 * 
+		 *
 		 * if (fSize > 0) { BufferedInputStream in = new BufferedInputStream(new
 		 * FileInputStream(uFile));
-		 * 
+		 *
 		 * String mimetype = "text/html";
-		 * 
+		 *
 		 * //response.setBufferSize(fSize); response.setContentType(mimetype);
 		 * response.setHeader("Content-Disposition", "attachment; filename=\"" +
 		 * requestedFile + "\""); response.setContentLength(fSize);
-		 * 
+		 *
 		 * FileCopyUtils.copy(in, response.getOutputStream()); in.close();
 		 * response.getOutputStream().flush(); response.getOutputStream().close(); }
 		 * else { response.setContentType("text/html"); PrintWriter printwriter =
@@ -420,15 +421,15 @@ public class EgovFileMngUtil {
 		 * String(orgFileName.getBytes(),"UTF-8" ));
 		 * response.setHeader("Content-Transfer-Encoding","binary");
 		 * response.setHeader("Pragma","no-cache"); response.setHeader("Expires","0");
-		 * 
+		 *
 		 * BufferedInputStream fin = new BufferedInputStream(new FileInputStream(file));
 		 * BufferedOutputStream outs = new
 		 * BufferedOutputStream(response.getOutputStream()); int read = 0;
-		 * 
+		 *
 		 * while ((read = fin.read(b)) != -1) { outs.write(b,0,read); }
 		 * log.debug(this.getClass().getName()
 		 * +" BufferedOutputStream Write Complete!!! ");
-		 * 
+		 *
 		 * outs.close(); fin.close(); //
 		 */
 	}

--- a/src/main/java/egovframework/com/cmm/service/EgovFileMngUtil.java
+++ b/src/main/java/egovframework/com/cmm/service/EgovFileMngUtil.java
@@ -75,7 +75,7 @@ public class EgovFileMngUtil {
 	 * @throws Exception
 	 */
 	public List<FileVO> parseFileInf(Map<String, MultipartFile> files, String keyStr, int fileKeyParam,
-	                                 String atchFileId, String storePath) throws Exception {
+			String atchFileId, String storePath) throws Exception {
 		int fileKey = fileKeyParam;
 
 		String storePathString = "";
@@ -148,7 +148,7 @@ public class EgovFileMngUtil {
 	 * @throws Exception
 	 */
 	public List<FileVO> parseFileInf(List<MultipartFile> files, String keyStr, int fileKeyParam, String atchFileId,
-	                                 String storePath) throws Exception {
+			String storePath) throws Exception {
 		int fileKey = fileKeyParam;
 
 		String storePathString = "";
@@ -254,7 +254,8 @@ public class EgovFileMngUtil {
 		} else {
 			downFileName = (String) request.getAttribute("downFile");
 		}
-		// 2026-08-14 content_j downFile() orgFileName 조회 속성키 오타 수정(orginFile → orgFileName, NullPointerException 가능성 제거)
+
+		// 2026-08-14 content_j downFile() orgFileName 조회 속성키 오타 수정(orginFile→orgFileName, NullPointerException 가능성 제거)
 		if ((String) request.getAttribute("orgFileName") == null) {
 			orgFileName = "";
 		} else {
@@ -282,7 +283,7 @@ public class EgovFileMngUtil {
 		response.setHeader("Expires", "0");
 
 		try (BufferedInputStream fin = new BufferedInputStream(new FileInputStream(file));
-		     BufferedOutputStream outs = new BufferedOutputStream(response.getOutputStream());) {
+				BufferedOutputStream outs = new BufferedOutputStream(response.getOutputStream());) {
 			FileCopyUtils.copy(fin, outs);
 		}
 	}
@@ -339,8 +340,8 @@ public class EgovFileMngUtil {
 		}
 
 		try (InputStream stream = file.getInputStream();
-		     OutputStream bos = new FileOutputStream(EgovWebUtil
-					 .filePathBlackList(FILE_STORE_PATH + File.separator + FilenameUtils.getName(newName)));) {
+				OutputStream bos = new FileOutputStream(EgovWebUtil
+						.filePathBlackList(FILE_STORE_PATH + File.separator + FilenameUtils.getName(newName)));) {
 
 			FileCopyUtils.copy(stream, bos);
 		}

--- a/src/main/java/egovframework/com/cmm/service/EgovFileMngUtil.java
+++ b/src/main/java/egovframework/com/cmm/service/EgovFileMngUtil.java
@@ -36,12 +36,12 @@ import egovframework.com.cmm.EgovWebUtil;
 
 /**
  * 파일 관리 유틸리티
- *
+ * 
  * @author 공통 서비스 개발팀 이삼섭
  * @since 2009. 02. 13
  * @version 1.0
  * @see
- *
+ * 
  *      <pre>
  *  == 개정이력(Modification Information) ==
  *
@@ -54,8 +54,7 @@ import egovframework.com.cmm.EgovWebUtil;
  *   2022.11.11  김혜준          시큐어코딩 처리
  *   2024.12.04  신용호          downFile() KISA 시큐어코딩 처리
  *   2025.05.26  이백행          PMD로 소프트웨어 보안약점 진단하고 제거하기-FormalParameterNamingConventions(공식 매개변수 명명 규칙), CloseResource(리소스 닫기), LocalVariableNamingConventions(지역 변수 명명 규칙), AssignmentInOperand(피연산자의 할당)
- *   2026.08.14  content_j      downFile() orgFileName 조회 속성키 오타 수정(orginFile → orgFileName, NullPointerException 가능성 제거)
- *
+ * 
  *      </pre>
  */
 @Component("EgovFileMngUtil")
@@ -255,11 +254,10 @@ public class EgovFileMngUtil {
 			downFileName = (String) request.getAttribute("downFile");
 		}
 
-		// 2026-08-14 content_j downFile() orgFileName 조회 속성키 오타 수정(orginFile→orgFileName, NullPointerException 가능성 제거)
 		if ((String) request.getAttribute("orgFileName") == null) {
 			orgFileName = "";
 		} else {
-			orgFileName = (String) request.getAttribute("orgFileName");
+			orgFileName = (String) request.getAttribute("orginFile");
 		}
 
 		orgFileName = orgFileName.replaceAll("\r", "").replaceAll("\n", "");
@@ -391,19 +389,19 @@ public class EgovFileMngUtil {
 
 		/*
 		 * String uploadPath = propertiesService.getString("fileDir");
-		 *
+		 * 
 		 * File uFile = new File(uploadPath, requestedFile); int fSize = (int)
 		 * uFile.length();
-		 *
+		 * 
 		 * if (fSize > 0) { BufferedInputStream in = new BufferedInputStream(new
 		 * FileInputStream(uFile));
-		 *
+		 * 
 		 * String mimetype = "text/html";
-		 *
+		 * 
 		 * //response.setBufferSize(fSize); response.setContentType(mimetype);
 		 * response.setHeader("Content-Disposition", "attachment; filename=\"" +
 		 * requestedFile + "\""); response.setContentLength(fSize);
-		 *
+		 * 
 		 * FileCopyUtils.copy(in, response.getOutputStream()); in.close();
 		 * response.getOutputStream().flush(); response.getOutputStream().close(); }
 		 * else { response.setContentType("text/html"); PrintWriter printwriter =
@@ -422,15 +420,15 @@ public class EgovFileMngUtil {
 		 * String(orgFileName.getBytes(),"UTF-8" ));
 		 * response.setHeader("Content-Transfer-Encoding","binary");
 		 * response.setHeader("Pragma","no-cache"); response.setHeader("Expires","0");
-		 *
+		 * 
 		 * BufferedInputStream fin = new BufferedInputStream(new FileInputStream(file));
 		 * BufferedOutputStream outs = new
 		 * BufferedOutputStream(response.getOutputStream()); int read = 0;
-		 *
+		 * 
 		 * while ((read = fin.read(b)) != -1) { outs.write(b,0,read); }
 		 * log.debug(this.getClass().getName()
 		 * +" BufferedOutputStream Write Complete!!! ");
-		 *
+		 * 
 		 * outs.close(); fin.close(); //
 		 */
 	}

--- a/src/main/java/egovframework/com/utl/fcc/service/EgovStringUtil.java
+++ b/src/main/java/egovframework/com/utl/fcc/service/EgovStringUtil.java
@@ -8,6 +8,7 @@
  *   2009.01.13     박정규          최초 생성
  *   2009.02.13     이삼섭          내용 추가
  *   2024.10.29		Chung10Kr		명사에 맞는 조사 반환 기능 개발
+ *   2026.08.14     content_j      split() 구분자 2글자 이상 사용 시 필드에 잔여문자가 남는 오류 수정(index+1 → index + separator.length())
  *
  * @author 공통 서비스 개발팀 박정규
  * @since 2009. 01. 13
@@ -558,17 +559,18 @@ public class EgovStringUtil {
 
 		int index = source.indexOf(separator);
 		int index0 = 0;
+		// 2026-08-14 content_j split() 구분자 2글자 이상 사용 시 필드에 잔여문자가 남는 오류 수정(index+1 → index + separator.length())
 		while (index >= 0) {
 			cnt++;
-			index = source.indexOf(separator, index + 1);
+			index = source.indexOf(separator, index + separator.length());
 		}
 		returnVal = new String[cnt];
 		cnt = 0;
 		index = source.indexOf(separator);
 		while (index >= 0) {
 			returnVal[cnt] = source.substring(index0, index);
-			index0 = index + 1;
-			index = source.indexOf(separator, index + 1);
+			index0 = index + separator.length();
+			index = source.indexOf(separator, index + separator.length());
 			cnt++;
 		}
 		returnVal[cnt] = source.substring(index0);
@@ -733,11 +735,12 @@ public class EgovStringUtil {
 		String[] returnVal = new String[arraylength];
 		int cnt = 0;
 		int index0 = 0;
+		// 2026-08-14 content_j split() 구분자 2글자 이상 사용 시 필드에 잔여문자가 남는 오류 수정(index+1 → index + separator.length())
 		int index = source.indexOf(separator);
 		while (index >= 0 && cnt < (arraylength - 1)) {
 			returnVal[cnt] = source.substring(index0, index);
-			index0 = index + 1;
-			index = source.indexOf(separator, index + 1);
+			index0 = index + separator.length();
+			index = source.indexOf(separator, index + separator.length());
 			cnt++;
 		}
 		returnVal[cnt] = source.substring(index0);

--- a/src/test/java/egovframework/com/utl/fcc/service/EgovStringUtilTest.java
+++ b/src/test/java/egovframework/com/utl/fcc/service/EgovStringUtilTest.java
@@ -95,5 +95,50 @@ public class EgovStringUtilTest {
         Assertions.assertEquals(EgovStringUtil.getAuxiliaryParticle(""), "는");
     }
 
+    // === split(String, String): 구분자 길이별 동작 검증 ===
+
+    // 한글자 구분자: 기존 동작 유지 확인(회귀 방지)
+    @Test
+    void splitWithSingleCharSeparator(){
+        String[] result = EgovStringUtil.split("a,b,c", ",");
+        Assertions.assertArrayEquals(new String[]{"a", "b", "c"}, result);
+    }
+
+    // 수정 전엔 index+1로 이동해 구분자의 두번째 글자가 다음 필드에 남았음
+    @Test
+    void splitWithTwoCharSeparator_noResidualChar(){
+        String[] result = EgovStringUtil.split("a::b::c", "::");
+        Assertions.assertArrayEquals(new String[]{"a", "b", "c"}, result);
+    }
+
+    // 동일한 수정을 3글자 구분자로도 검증
+    @Test
+    void splitWithThreeCharSeparator_noResidualChar(){
+        String[] result = EgovStringUtil.split("a###b###c", "###");
+        Assertions.assertArrayEquals(new String[]{"a", "b", "c"}, result);
+    }
+
+    // 구분자가 없으면 원본 문자열이 단일 요소로 반환되어야 함
+    @Test
+    void splitReturnsWholeStringWhenSeparatorNotFound(){
+        String[] result = EgovStringUtil.split("abc", "::");
+        Assertions.assertArrayEquals(new String[]{"abc"}, result);
+    }
+
+    // === split(String, String, int): 구분자 길이별 동작 검증 ===
+
+    // 다중글자 구분자 + 배열 길이가 전체 필드 수와 정확히 일치하는 경우
+    @Test
+    void splitWithLimit_twoCharSeparator(){
+        String[] result = EgovStringUtil.split("a::b::c", "::", 3);
+        Assertions.assertArrayEquals(new String[]{"a", "b", "c"}, result);
+    }
+
+    // 배열 길이를 초과하는 나머지는 구분자를 포함한 채 마지막 필드에 남아야 함
+    @Test
+    void splitWithLimit_remainderKeptInLastField(){
+        String[] result = EgovStringUtil.split("a::b::c::d", "::", 2);
+        Assertions.assertArrayEquals(new String[]{"a", "b::c::d"}, result);
+    }
 
 }


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

ㅇ EgovFileMngUtil.java
- downFile() 메소드
- null 체크는 "orgFileName" 속성으로 하면서(수정 전 258라인), 실제 값은 다른 키인 "orginFile"에서 읽어오는(수정 전 261라인) 오타를 발견
- 두 속성명이 미묘하게 달라(orgFileName ↔ orginFile) 컴파일 에러 없이 통과되며 "orginFile"이라는 키는 애초에 존재하지 않으므로 orgFileName 변수가 결국 null이 됨
- rgFileName.replaceAll("\r", "").replaceAll("\n", "") 호출 시 NullPointerException이 발생할 수 있었음
- 테스트 방법
  1. HttpServletRequest에 request.setAttribute("orgFileName", "테스트파일.txt")만 설정하고 downFile() 호출
     - 수정 전 : orginFile 키가 없어 orgFileName이 null이 되고 replaceAll() 호출에서 NullPointerException 발생
     - 수정 후 : orginFile 값이 정상적으로 "테스트파일.txt"로 채워져 NullPointerException 발생하지 않음

ㅇ EgovStringUtil.java
- split() 메소드
- 구분자를 찾은 뒤 다음 탐색 위치를 index + 1로 지정하고 있음을 발견
- 구분자가 1글자일 때는 우연히 정상 동작하지만, "TAB"·"::"처럼 2글자 이상인 구분자를 쓰면 index + 1이 구분자를 1글자만 건너뛰어, 첫 번째 필드를 제외한 나머지가 모든 필드 앞에 구분자의 잔여 문자가 그대로 남는 오류가 있음
- (예: split("a::b::c", "::") 호출 시 ["a", "b", "c"]가 아니라 ["a", ":b", ":c"]가 반환됨)
- 같은 파일의 EgovNumberUtil.getNumberCnvr()는 동일한 find-and-advance 로직을 index+subject.length()로 정확히 구현하고 있음 split()의 "+1" 은 실수임을 뒷받침함
- 테스트 방법
   1. EgovStringUtil.split("a::b::c", "::") 호출
      - 수정 전: ["a", ":b", ":c"] (오류)
      - 수정 후 : ["a", "b", "c"](정상)
 

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [x] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.
