### PR TITLE
fix(EgovStringUtil): getTimeStamp 12시간제(hh)→24시간제(HH) — 고유값 오전/오후 충돌 수정 + 회귀 테스트

### DIFF
--- a/src/main/java/egovframework/com/utl/fcc/service/EgovStringUtil.java
+++ b/src/main/java/egovframework/com/utl/fcc/service/EgovStringUtil.java
@@ -863,14 +863,25 @@ public class EgovStringUtil {
 	 * @see
 	 */
 	public static String getTimeStamp() {
+		return getTimeStamp(System.currentTimeMillis());
+	}
+
+	/**
+	 * 지정한 시각(epoch millis)에 대한 17자리 TIMESTAMP 값을 구하는 기능 (테스트 가능하도록 분리)
+	 *
+	 * @param epochMillis 기준 시각(밀리초)
+	 * @return Timestamp 값
+	 */
+	static String getTimeStamp(long epochMillis) {
 
 		String rtnStr = null;
 
-		// 문자열로 변환하기 위한 패턴 설정(연도-월-일 시:분:초:초(자정이후 초))
-		String pattern = "yyyyMMddhhmmssSSS";
+		// 문자열로 변환하기 위한 패턴 설정(연도-월-일 시(24시간제):분:초:밀리초)
+		// 고유값 보장을 위해 24시간제(HH)를 사용한다. 12시간제(hh)는 오전/오후 값이 충돌한다.
+		String pattern = "yyyyMMddHHmmssSSS";
 
 		SimpleDateFormat sdfCurrent = new SimpleDateFormat(pattern, Locale.KOREA);
-		Timestamp ts = new Timestamp(System.currentTimeMillis());
+		Timestamp ts = new Timestamp(epochMillis);
 
 		rtnStr = sdfCurrent.format(ts.getTime());
 

--- a/src/test/java/egovframework/com/utl/fcc/service/EgovStringUtilTimeStampTest.java
+++ b/src/test/java/egovframework/com/utl/fcc/service/EgovStringUtilTimeStampTest.java
@@ -1,0 +1,57 @@
+package egovframework.com.utl.fcc.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import java.util.Calendar;
+import java.util.Locale;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * egovframework.com.utl.fcc.service.EgovStringUtilTimeStampTest
+ * <p>
+ * Regression test for EgovStringUtil.getTimeStamp().
+ * <p>
+ * getTimeStamp() is documented as a source of unique values and is used to build
+ * history IDs (EgovSysHistoryServiceImpl) and file names (EgovPdfCnvr). It used the
+ * 12-hour pattern "hh", so a value produced at 14:30 rendered the hour as "02" -- the
+ * same as 02:30 -- causing morning/afternoon collisions of supposedly unique values.
+ * The pattern must be 24-hour "HH".
+ *
+ * The assertions are timezone-independent: the Calendar uses the JVM default time zone,
+ * which is the same zone SimpleDateFormat formats in, so the local wall-clock hour is
+ * what gets rendered regardless of where the test runs.
+ *
+ * @author EricSeokgon
+ * @version 1.0
+ */
+class EgovStringUtilTimeStampTest {
+
+    private static long millisAt(int year, int month, int day, int hour, int minute, int second, int milli) {
+        Calendar cal = Calendar.getInstance(Locale.KOREA); // default time zone
+        cal.clear();
+        cal.set(year, month, day, hour, minute, second);
+        cal.set(Calendar.MILLISECOND, milli);
+        return cal.getTimeInMillis();
+    }
+
+    @Test
+    @DisplayName("getTimeStamp uses a 24-hour clock so afternoon does not collide with morning")
+    void getTimeStamp_uses24HourClock() {
+        long afternoon = millisAt(2026, Calendar.JANUARY, 2, 14, 30, 5, 123);
+        long morning = millisAt(2026, Calendar.JANUARY, 2, 2, 30, 5, 123);
+
+        String tsPm = EgovStringUtil.getTimeStamp(afternoon);
+        String tsAm = EgovStringUtil.getTimeStamp(morning);
+
+        assertEquals(17, tsPm.length(), "timestamp should be 17 digits");
+        assertEquals("20260102", tsPm.substring(0, 8), "date part");
+        assertEquals("14", tsPm.substring(8, 10),
+                "14:30 must render the hour as 24-hour '14', not 12-hour '02'");
+        assertEquals("02", tsAm.substring(8, 10));
+        assertNotEquals(tsAm, tsPm,
+                "afternoon and morning timestamps must not collide (getTimeStamp is a unique-value source)");
+    }
+}


### PR DESCRIPTION
## 문제

`EgovStringUtil.getTimeStamp()`은 "고유값을 사용하기 위해" 17자리 TIMESTAMP를 만든다고 문서화돼 있으나, 12시간제 패턴 `"yyyyMMddhhmmssSSS"`를 사용합니다.

```java
String pattern = "yyyyMMddhhmmssSSS"; // hh = 12시간제(01~12)
```

그 결과 **오후 시각의 시(hour)가 오전과 같은 값으로 찍혀 고유값이 충돌**합니다. 예: 14:30:05 → `...023005...`(02시로 표기) = 02:30:05 와 동일. 이 값은 실제로 고유 식별자·파일명 생성에 쓰입니다:

- `EgovSysHistoryServiceImpl`: `String histId = "HT_" + EgovStringUtil.getTimeStamp();` — **이력 ID 중복** 위험
- `EgovPdfCnvr`: `newName = EgovStringUtil.getTimeStamp();` — **파일명 충돌 → 덮어쓰기** 위험

## 변경

- 패턴을 24시간제 `"yyyyMMddHHmmssSSS"`(HH)로 수정.
- 테스트 가능하도록 시각을 주입받는 package-private 오버로드 `getTimeStamp(long epochMillis)`를 분리하고, 기존 `getTimeStamp()`는 이를 위임 호출(동작·시그니처 불변).

## 검증 (TDD)

회귀 테스트 `EgovStringUtilTimeStampTest`를 추가했습니다(타임존 독립: Calendar·SimpleDateFormat 모두 기본 TZ 사용).

- 수정 전: 테스트 **실패** — `14:30 must render the hour as 24-hour '14', not 12-hour '02' ==> expected: <14> but was: <02>`
- 수정 후: 테스트 **통과** — `mvn test -DskipTests=false -Dtest=EgovStringUtilTimeStampTest`, Tests run: 1, Failures: 0
- TDD 토글로 판별력 확인(수정 되돌리면 다시 실패)

> 참고: 이 저장소는 surefire `<skipTests>true</skipTests>`가 기본이라 일반 빌드에서는 테스트가 실행되지 않습니다. 위 검증은 `-DskipTests=false`로 실행했습니다.

## 관련(이 PR 범위 외)

- `EgovFileMngUtil`(private getTimeStamp, 444행)·`EgovNumberUtil`(파싱 전용)에도 유사한 `hh` 패턴이 있습니다. 리뷰 범위를 좁히기 위해 가장 널리 쓰이는 `EgovStringUtil.getTimeStamp`만 다뤘고, 원하시면 후속 PR로 정리하겠습니다.