### PR TITLE
fix: 로그인화면이미지 관리에 관리자 검증 추가

### DIFF
--- a/src/main/java/egovframework/com/uss/ion/lsi/web/EgovLoginScrinImageController.java
+++ b/src/main/java/egovframework/com/uss/ion/lsi/web/EgovLoginScrinImageController.java
@@ -42,6 +42,7 @@ import org.springframework.web.multipart.MultipartHttpServletRequest;
 import egovframework.com.cmm.EgovMessageSource;
 import egovframework.com.cmm.LoginVO;
 import egovframework.com.cmm.annotation.IncludedInfo;
+import egovframework.com.cmm.annotation.RequireAdmin;
 import egovframework.com.cmm.service.EgovFileMngService;
 import egovframework.com.cmm.service.EgovFileMngUtil;
 import egovframework.com.cmm.service.FileVO;
@@ -121,6 +122,7 @@ public class EgovLoginScrinImageController {
 	 * @param loginScrinImageVO - 로그인화면이미지 VO
 	 * @return String - 리턴 Url
 	 */
+    @RequireAdmin
     @PostMapping("/uss/ion/lsi/getLoginScrinImage.do")
 	public String selectLoginScrinImage(@RequestParam("imageId") String imageId,
 			                            @ModelAttribute("loginScrinImageVO") LoginScrinImageVO loginScrinImageVO,
@@ -151,6 +153,7 @@ public class EgovLoginScrinImageController {
 	 * @return String - 리턴 Url
 	 */
     @SuppressWarnings("unused")
+	@RequireAdmin
 	@PostMapping("/uss/ion/lsi/addLoginScrinImage.do")
 	public String insertLoginScrinImage(final MultipartHttpServletRequest multiRequest,
 			                            @Valid @ModelAttribute("loginScrinImageVO") LoginScrinImageVO loginScrinImageVO,
@@ -235,6 +238,7 @@ public class EgovLoginScrinImageController {
 	 * @return String - 리턴 Url
 	 */
 	@SuppressWarnings("unused")
+	@RequireAdmin
 	@PostMapping("/uss/ion/lsi/updtLoginScrinImage.do")
 	public String updateLoginScrinImage(final MultipartHttpServletRequest multiRequest,
 			                            @Valid @ModelAttribute("loginScrinImageVO") LoginScrinImageVO loginScrinImageVO,
@@ -311,6 +315,7 @@ public class EgovLoginScrinImageController {
 	 * @param loginScrinImageVO - 로그인화면이미지 VO
 	 * @return String - 리턴 Url
 	 */
+    @RequireAdmin
     @PostMapping("/uss/ion/lsi/removeLoginScrinImage.do")
 	public String deleteLoginScrinImage(@RequestParam("imageId") String imageId,
 			                            @ModelAttribute("loginScrinImageVO") LoginScrinImageVO loginScrinImageVO,
@@ -332,6 +337,7 @@ public class EgovLoginScrinImageController {
 	 * @return String
 	 * @exception Exception
 	 */
+    @RequireAdmin
     @PostMapping("/uss/ion/lsi/removeLoginScrinImageList.do")
 	public String deleteLoginScrinImageList(@RequestParam("imageIds") String imageIds,
 			                                @ModelAttribute("loginScrinImageVO") LoginScrinImageVO loginScrinImageVO,

--- a/src/test/java/egovframework/com/uss/ion/lsi/web/EgovLoginScrinImageControllerAdminCheckTest.java
+++ b/src/test/java/egovframework/com/uss/ion/lsi/web/EgovLoginScrinImageControllerAdminCheckTest.java
@@ -1,0 +1,70 @@
+package egovframework.com.uss.ion.lsi.web;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.ui.ModelMap;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.support.SessionStatus;
+import org.springframework.web.multipart.MultipartHttpServletRequest;
+
+import egovframework.com.cmm.annotation.RequireAdmin;
+import egovframework.com.uss.ion.lsi.service.LoginScrinImageVO;
+
+/**
+ * 로그인화면이미지 관리의 수정화면·등록·수정·삭제·일괄삭제에 @RequireAdmin이 붙어있는지 확인한다.
+ *
+ * @RequireAdmin은 Spring AOP(`@annotation(RequireAdmin)` 포인트컷)로 위빙되므로 컨트롤러를
+ * 직접 new해서 부르는 단위 테스트로는 실제 차단 동작을 재현할 수 없다(프록시를 거치지 않음).
+ * 이 AOP 자체가 실제로 작동한다는 것은 형제 배너관리(EgovBannerController)가 같은 애노테이션으로
+ * 관리자 전용이 되는 것으로 이미 확인된다. 이 테스트는 그 전제 위에서 "애노테이션이 다섯 메서드에
+ * 실제로 붙어있는가"라는 구조적 사실만 고정한다 — 애노테이션이 실수로 빠지거나 지워지는 회귀를 잡기 위함이다.
+ */
+class EgovLoginScrinImageControllerAdminCheckTest {
+
+	private static Method method(String name, Class<?>... paramTypes) throws NoSuchMethodException {
+		return EgovLoginScrinImageController.class.getDeclaredMethod(name, paramTypes);
+	}
+
+	@Test
+	void selectLoginScrinImageRequiresAdmin() throws Exception {
+		Method m = method("selectLoginScrinImage", String.class,
+				LoginScrinImageVO.class, ModelMap.class);
+		assertTrue(m.isAnnotationPresent(RequireAdmin.class),
+				"로그인화면이미지 수정화면 진입은 관리자만 가능해야 한다.");
+	}
+
+	@Test
+	void insertLoginScrinImageRequiresAdmin() throws Exception {
+		Method m = method("insertLoginScrinImage", MultipartHttpServletRequest.class,
+				LoginScrinImageVO.class, BindingResult.class, SessionStatus.class, ModelMap.class);
+		assertTrue(m.isAnnotationPresent(RequireAdmin.class),
+				"로그인화면이미지 등록은 관리자만 가능해야 한다.");
+	}
+
+	@Test
+	void updateLoginScrinImageRequiresAdmin() throws Exception {
+		Method m = method("updateLoginScrinImage", MultipartHttpServletRequest.class,
+				LoginScrinImageVO.class, BindingResult.class, SessionStatus.class, ModelMap.class);
+		assertTrue(m.isAnnotationPresent(RequireAdmin.class),
+				"로그인화면이미지 수정은 관리자만 가능해야 한다.");
+	}
+
+	@Test
+	void deleteLoginScrinImageRequiresAdmin() throws Exception {
+		Method m = method("deleteLoginScrinImage", String.class,
+				LoginScrinImageVO.class, SessionStatus.class, ModelMap.class);
+		assertTrue(m.isAnnotationPresent(RequireAdmin.class),
+				"로그인화면이미지 삭제는 관리자만 가능해야 한다.");
+	}
+
+	@Test
+	void deleteLoginScrinImageListRequiresAdmin() throws Exception {
+		Method m = method("deleteLoginScrinImageList", String.class,
+				LoginScrinImageVO.class, SessionStatus.class, ModelMap.class);
+		assertTrue(m.isAnnotationPresent(RequireAdmin.class),
+				"로그인화면이미지 일괄삭제는 관리자만 가능해야 한다.");
+	}
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

로그인화면이미지관리(`uss/ion/lsi`)의 수정화면 진입·등록·수정·삭제·일괄삭제에 관리자 검증이 없습니다. 로그인만 하면 관리자가 아니어도 사이트 로그인 화면에 노출되는 이미지를 등록·교체·삭제할 수 있습니다.

같은 `uss/ion` 계열의 배너관리(`EgovBannerController`)는 동일한 다섯 경로가 모두 `@RequireAdmin`으로 관리자 전용입니다.

| 경로 | 배너관리 | 로그인화면이미지관리 |
|---|---|---|
| 수정화면 진입 | `@RequireAdmin` | 없음 |
| 등록 | `@RequireAdmin` | 없음 |
| 수정 | `@RequireAdmin` | 없음 |
| 삭제 | `@RequireAdmin` | 없음 |
| 일괄삭제 | `@RequireAdmin` | 없음 |

### 누락으로 보는 근거

관리자 검증은 컨트롤러 단위로 점진 적용되어 왔습니다. 배너관리의 `@RequireAdmin` 개수 변화입니다.

```
2026-07-08  fb45f509^   0개
2026-07-14  fb45f509    3개   NCSC 보안점검 적용
2026-07-21  23d01889    5개   NCSC&NIA 보안점검 적용
```

로그인화면이미지관리는 같은 시점에 모두 0개입니다. `fb45f509`는 이 파일도 함께 수정했지만 `@RequestMapping`을 `@PostMapping`으로 바꾸는 데 그쳤습니다. 두 파일의 변경 규모가 다릅니다.

```
EgovBannerController.java            +47 -7
EgovLoginScrinImageController.java    +7 -6
```

현재 컨트롤러 164개 중 35개가 `@RequireAdmin`을 가지고 있습니다.

### 변경 내용

배너관리와 동일하게 다섯 메서드에 `@RequireAdmin`을 추가했습니다.

AS-IS
```java
@PostMapping("/uss/ion/lsi/addLoginScrinImage.do")
public String insertLoginScrinImage(...)
```

TO-BE
```java
@RequireAdmin
@PostMapping("/uss/ion/lsi/addLoginScrinImage.do")
public String insertLoginScrinImage(...)
```

### 영향 범위

`EgovLoginScrinImageController`에 애노테이션 5개와 import 1줄만 추가했습니다.

목록(`selectLoginScrinImageList`)과 등록 폼(`addViewLoginScrinImage`)에는 붙이지 않았습니다. 배너관리도 목록과 등록 폼은 열어두고 저장된 데이터가 오가는 경로만 막습니다.

이 다섯 경로를 호출하는 곳은 관리자 화면 JSP 세 곳(`EgovLoginScrinImageList.jsp`, `EgovLoginScrinImageRegist.jsp`, `EgovLoginScrinImageUpdt.jsp`)뿐이며 일반 사용자 화면에서 호출하는 곳은 없습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`@RequireAdmin`은 `context-aspect.xml`의 `@annotation(egovframework.com.cmm.annotation.RequireAdmin)` 포인트컷으로 위빙됩니다. 이 포인트컷으로 두 컨트롤러를 평가하면 수정 전에는 배너만 걸립니다.

```
bnr.insertBanner                @RequireAdmin 걸림
bnr.updateBanner                @RequireAdmin 걸림
bnr.deleteBanner                @RequireAdmin 걸림
bnr.deleteBannerList            @RequireAdmin 걸림
lsi.insertLoginScrinImage       게이트 없음
lsi.updateLoginScrinImage       게이트 없음
lsi.deleteLoginScrinImage       게이트 없음
lsi.deleteLoginScrinImageList   게이트 없음
```

게이트에 걸렸을 때 `EgovAdminAuthorizationAspect.assertAdmin()`이 실제로 차단하는지도 확인했습니다.

```
일반 로그인(ROLE_USER) : 차단  redirect:/sec/ram/accessDenied.do
관리자(ROLE_ADMIN)     : 통과
비로그인               : 차단  redirect:/uat/uia/egovLoginUsr.do
```

수정 후에는 로그인화면이미지의 다섯 경로가 모두 걸립니다.

`EgovLoginScrinImageControllerAdminCheckTest`를 추가했습니다. `@RequireAdmin`은 Spring AOP로 위빙되므로 컨트롤러를 직접 생성해 호출하는 단위 테스트로는 차단 동작을 재현할 수 없습니다. 다섯 메서드에 애노테이션이 붙어 있는지를 리플렉션으로 확인해, 나중에 실수로 빠지는 회귀를 잡습니다.

```
Tests run: 5, Failures: 0, Errors: 0, Skipped: 0
```

애노테이션을 제거하면 실패합니다.

```
Tests run: 5, Failures: 3, Errors: 0, Skipped: 0
  selectLoginScrinImageRequiresAdmin: 로그인화면이미지 수정화면 진입은 관리자만 가능해야 한다. ==> expected: <true> but was: <false>
  deleteLoginScrinImageRequiresAdmin: 로그인화면이미지 삭제는 관리자만 가능해야 한다. ==> expected: <true> but was: <false>
  deleteLoginScrinImageListRequiresAdmin: 로그인화면이미지 일괄삭제는 관리자만 가능해야 한다. ==> expected: <true> but was: <false>
```

`pom.xml`의 surefire 설정이 `skipTests`를 `true`로 두고 있어 기본 빌드에서는 이 테스트가 실행되지 않습니다. 위 결과는 해당 값을 임시로 해제하고 확인한 것입니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [X] 기타 Others

화면 변경이 없어 브라우저 테스트는 해당하지 않습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음.

## 관련 PR

관리자 검증 누락 시리즈입니다. #1205 · #1209 · #1210 · #1211 · #1212 · #1213 · #1214 · #1215 · #1216 · #1217
