### PR TITLE
fix: 메인이미지 관리에 관리자 검증 추가

### DIFF
--- a/src/main/java/egovframework/com/uss/ion/msi/web/EgovMainImageController.java
+++ b/src/main/java/egovframework/com/uss/ion/msi/web/EgovMainImageController.java
@@ -21,6 +21,7 @@ import org.springframework.web.multipart.MultipartHttpServletRequest;
 import egovframework.com.cmm.EgovMessageSource;
 import egovframework.com.cmm.LoginVO;
 import egovframework.com.cmm.annotation.IncludedInfo;
+import egovframework.com.cmm.annotation.RequireAdmin;
 import egovframework.com.cmm.service.EgovFileMngService;
 import egovframework.com.cmm.service.EgovFileMngUtil;
 import egovframework.com.cmm.service.FileVO;
@@ -81,6 +82,7 @@ public class EgovMainImageController {
 	/**
 	 * 등록된 메인이미지의 상세정보를 조회한다.
 	 */
+	@RequireAdmin
 	@PostMapping("/uss/ion/msi/getMainImage.do")
 	public String selectMainImage(@RequestParam("imageId") String imageId,
 			@ModelAttribute("mainImageVO") MainImageVO mainImageVO, ModelMap model) throws Exception {
@@ -103,6 +105,7 @@ public class EgovMainImageController {
 	 * 메인이미지정보를 신규로 등록한다.
 	 */
 	@SuppressWarnings("unused")
+	@RequireAdmin
 	@PostMapping("/uss/ion/msi/addMainImage.do")
 	public String insertMainImage(final MultipartHttpServletRequest multiRequest,
 			@Valid @ModelAttribute("mainImageVO") MainImageVO mainImageVO, BindingResult bindingResult,
@@ -148,6 +151,7 @@ public class EgovMainImageController {
 	 * 기 등록된 메인이미지정보를 수정한다.
 	 */
 	@SuppressWarnings("unused")
+	@RequireAdmin
 	@PostMapping("/uss/ion/msi/updtMainImage.do")
 	public String updateMainImage(final MultipartHttpServletRequest multiRequest,
 			@Valid @ModelAttribute("mainImageVO") MainImageVO mainImageVO, BindingResult bindingResult,
@@ -196,6 +200,7 @@ public class EgovMainImageController {
 	/**
 	 * 기 등록된 메인이미지정보를 삭제한다.
 	 */
+	@RequireAdmin
 	@PostMapping("/uss/ion/msi/removeMainImage.do")
 	public String deleteMainImage(@RequestParam("imageId") String imageId,
 			@ModelAttribute("mainImageVO") MainImageVO mainImageVO, SessionStatus status, ModelMap model) throws Exception {
@@ -209,6 +214,7 @@ public class EgovMainImageController {
 	/**
 	 * 기 등록된 메인이미지정보 목록을 일괄 삭제한다.
 	 */
+	@RequireAdmin
 	@PostMapping("/uss/ion/msi/removeMainImageList.do")
 	public String deleteMainImageList(@RequestParam("imageIds") String imageIds,
 			@ModelAttribute("mainImageVO") MainImageVO mainImageVO, SessionStatus status, ModelMap model) throws Exception {

--- a/src/test/java/egovframework/com/uss/ion/msi/web/EgovMainImageControllerAdminCheckTest.java
+++ b/src/test/java/egovframework/com/uss/ion/msi/web/EgovMainImageControllerAdminCheckTest.java
@@ -1,0 +1,69 @@
+package egovframework.com.uss.ion.msi.web;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.ui.ModelMap;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.support.SessionStatus;
+import org.springframework.web.multipart.MultipartHttpServletRequest;
+
+import egovframework.com.cmm.annotation.RequireAdmin;
+import egovframework.com.uss.ion.msi.service.MainImageVO;
+
+/**
+ * 메인이미지 관리의 수정화면·등록·수정·삭제·일괄삭제에 @RequireAdmin이 붙어있는지 확인한다.
+ *
+ * @RequireAdmin은 Spring AOP(`@annotation(RequireAdmin)` 포인트컷)로 위빙되므로 컨트롤러를
+ * 직접 new해서 부르는 단위 테스트로는 실제 차단 동작을 재현할 수 없다(프록시를 거치지 않음).
+ * 이 AOP 자체가 실제로 작동한다는 것은 형제 배너관리(EgovBannerController)가 같은 애노테이션으로
+ * 관리자 전용이 되는 것으로 확인된다. 이 테스트는 그 전제 위에서 "애노테이션이 다섯 메서드에
+ * 실제로 붙어있는가"라는 구조적 사실만 고정한다 — 애노테이션이 실수로 빠지는 회귀를 잡기 위함이다.
+ */
+class EgovMainImageControllerAdminCheckTest {
+
+	private static Method method(String name, Class<?>... paramTypes) throws NoSuchMethodException {
+		return EgovMainImageController.class.getDeclaredMethod(name, paramTypes);
+	}
+
+	@Test
+	void selectMainImageRequiresAdmin() throws Exception {
+		Method m = method("selectMainImage", String.class, MainImageVO.class, ModelMap.class);
+		assertTrue(m.isAnnotationPresent(RequireAdmin.class),
+				"메인이미지 수정화면 진입은 관리자만 가능해야 한다.");
+	}
+
+	@Test
+	void insertMainImageRequiresAdmin() throws Exception {
+		Method m = method("insertMainImage", MultipartHttpServletRequest.class,
+				MainImageVO.class, BindingResult.class, SessionStatus.class, ModelMap.class);
+		assertTrue(m.isAnnotationPresent(RequireAdmin.class),
+				"메인이미지 등록은 관리자만 가능해야 한다.");
+	}
+
+	@Test
+	void updateMainImageRequiresAdmin() throws Exception {
+		Method m = method("updateMainImage", MultipartHttpServletRequest.class,
+				MainImageVO.class, BindingResult.class, SessionStatus.class, ModelMap.class);
+		assertTrue(m.isAnnotationPresent(RequireAdmin.class),
+				"메인이미지 수정은 관리자만 가능해야 한다.");
+	}
+
+	@Test
+	void deleteMainImageRequiresAdmin() throws Exception {
+		Method m = method("deleteMainImage", String.class,
+				MainImageVO.class, SessionStatus.class, ModelMap.class);
+		assertTrue(m.isAnnotationPresent(RequireAdmin.class),
+				"메인이미지 삭제는 관리자만 가능해야 한다.");
+	}
+
+	@Test
+	void deleteMainImageListRequiresAdmin() throws Exception {
+		Method m = method("deleteMainImageList", String.class,
+				MainImageVO.class, SessionStatus.class, ModelMap.class);
+		assertTrue(m.isAnnotationPresent(RequireAdmin.class),
+				"메인이미지 일괄삭제는 관리자만 가능해야 한다.");
+	}
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

메인이미지관리(`uss/ion/msi`)의 수정화면 진입·등록·수정·삭제·일괄삭제에 관리자 검증이 없습니다. 로그인만 하면 관리자가 아니어도 사이트 메인 이미지를 등록·교체·삭제할 수 있습니다.

같은 `uss/ion` 계열의 배너관리(`EgovBannerController`)는 동일한 다섯 경로가 모두 `@RequireAdmin`으로 관리자 전용입니다.

| 경로 | 배너관리 | 메인이미지관리 |
|---|---|---|
| 수정화면 진입 | `@RequireAdmin` | 없음 |
| 등록 | `@RequireAdmin` | 없음 |
| 수정 | `@RequireAdmin` | 없음 |
| 삭제 | `@RequireAdmin` | 없음 |
| 일괄삭제 | `@RequireAdmin` | 없음 |

### 누락으로 보는 근거

관리자 검증은 컨트롤러 단위로 점진 적용되어 왔습니다. 배너관리의 `@RequireAdmin` 개수 변화입니다.

```
2026-07-08  fb45f509^   0개
2026-07-14  fb45f509    3개   NCSC 보안점검 적용
2026-07-21  23d01889    5개   NCSC&NIA 보안점검 적용
```

메인이미지관리는 같은 시점에 모두 0개입니다.

현재 컨트롤러 164개 중 35개가 `@RequireAdmin`을 가지고 있습니다.

### 변경 내용

배너관리와 동일하게 다섯 메서드에 `@RequireAdmin`을 추가했습니다.

AS-IS
```java
@PostMapping("/uss/ion/msi/addMainImage.do")
public String insertMainImage(...)
```

TO-BE
```java
@RequireAdmin
@PostMapping("/uss/ion/msi/addMainImage.do")
public String insertMainImage(...)
```

### 영향 범위

`EgovMainImageController`에 애노테이션 5개와 import 1줄만 추가했습니다.

목록(`selectMainImageList`)과 등록 폼(`addViewMainImage`)에는 붙이지 않았습니다. 배너관리도 목록과 등록 폼은 열어두고 저장된 데이터가 오가는 경로만 막습니다.

이 다섯 경로를 호출하는 곳은 관리자 화면 JSP 세 곳(`EgovMainImageList.jsp`, `EgovMainImageRegist.jsp`, `EgovMainImageUpdt.jsp`)뿐이며 일반 사용자 화면에서 호출하는 곳은 없습니다.

메인 화면이 이미지를 소비하는 `getMainImageResult.do`는 별도 판단이 필요해 이번 범위에서 제외했습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`@RequireAdmin`은 `context-aspect.xml`의 `@annotation(egovframework.com.cmm.annotation.RequireAdmin)` 포인트컷으로 위빙됩니다. 이 포인트컷으로 두 컨트롤러를 평가하면 수정 전에는 배너만 걸립니다.

```
bnr.insertBanner                @RequireAdmin 걸림
bnr.updateBanner                @RequireAdmin 걸림
bnr.deleteBanner                @RequireAdmin 걸림
bnr.deleteBannerList            @RequireAdmin 걸림
msi.insertMainImage       게이트 없음
msi.updateMainImage       게이트 없음
msi.deleteMainImage       게이트 없음
msi.deleteMainImageList   게이트 없음
```

게이트에 걸렸을 때 `EgovAdminAuthorizationAspect.assertAdmin()`이 실제로 차단하는지도 확인했습니다.

```
일반 로그인(ROLE_USER) : 차단  redirect:/sec/ram/accessDenied.do
관리자(ROLE_ADMIN)     : 통과
비로그인               : 차단  redirect:/uat/uia/egovLoginUsr.do
```

수정 후에는 메인이미지의 다섯 경로가 모두 걸립니다.

`EgovMainImageControllerAdminCheckTest`를 추가했습니다. `@RequireAdmin`은 Spring AOP로 위빙되므로 컨트롤러를 직접 생성해 호출하는 단위 테스트로는 차단 동작을 재현할 수 없습니다. 다섯 메서드에 애노테이션이 붙어 있는지를 리플렉션으로 확인해, 나중에 실수로 빠지는 회귀를 잡습니다.

```
Tests run: 5, Failures: 0, Errors: 0, Skipped: 0
```

애노테이션을 제거하면 실패합니다.

```
Tests run: 5, Failures: 5, Errors: 0, Skipped: 0
  selectMainImageRequiresAdmin: 메인이미지 수정화면 진입은 관리자만 가능해야 한다. ==> expected: <true> but was: <false>
  insertMainImageRequiresAdmin: 메인이미지 등록은 관리자만 가능해야 한다. ==> expected: <true> but was: <false>
  updateMainImageRequiresAdmin: 메인이미지 수정은 관리자만 가능해야 한다. ==> expected: <true> but was: <false>
  deleteMainImageRequiresAdmin: 메인이미지 삭제는 관리자만 가능해야 한다. ==> expected: <true> but was: <false>
  deleteMainImageListRequiresAdmin: 메인이미지 일괄삭제는 관리자만 가능해야 한다. ==> expected: <true> but was: <false>
```

`pom.xml`의 surefire 설정이 `skipTests`를 `true`로 두고 있어 기본 빌드에서는 이 테스트가 실행되지 않습니다. 위 결과는 해당 값을 임시로 해제하고 확인한 것입니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [X] 기타 Others

화면 변경이 없어 브라우저 테스트는 해당하지 않습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음.

## 관련 PR

관리자 검증 누락 시리즈입니다. #1205 · #1209 · #1210 · #1211 · #1212 · #1213 · #1214 · #1215 · #1216 · #1217
