### PR TITLE
fix: 기념일 수정 시 소유권 검증 추가

### DIFF
--- a/src/main/java/egovframework/com/uss/ion/ans/web/EgovAnnvrsryManageController.java
+++ b/src/main/java/egovframework/com/uss/ion/ans/web/EgovAnnvrsryManageController.java
@@ -306,6 +306,15 @@ public class EgovAnnvrsryManageController {
 			return "egovframework/com/uss/ion/ans/EgovAnnvrsryUpdt";
 		} else {
 
+			// 2026.07.13 KISA 보안취약점 조치 - 조회·삭제와 동일하게 소유자 또는 관리자만 수정할 수 있다.
+			AnnvrsryManageVO ownerVO = new AnnvrsryManageVO();
+			ownerVO.setAnnId(annvrsryManage.getAnnId());
+			AnnvrsryManageVO storedVO = egovAnnvrsryManageService.selectAnnvrsryManage(ownerVO);
+			if (storedVO == null) {
+				throw new IllegalStateException("권한이 없습니다.");
+			}
+			egovAssertAdminOrOwner(storedVO.getUsid());
+
 			LoginVO user = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();
 			status.setComplete();
 			annvrsryManage.setLastUpdusrId((user == null || user.getUniqId() == null) ? "" : user.getUniqId());


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

기념일관리(`uss/ion/ans`)의 수정 경로에 소유권 검증이 없습니다. 같은 컨트롤러의 상세조회와 삭제는 저장된 레코드의 `USID`를 로그인 사용자와 대조하는데, 수정만 요청으로 받은 `annId`를 그대로 갱신합니다.

| 경로 | 소유권 검증 |
|---|---|
| 상세조회 `selectAnnvrsryManage` | 있음 (`:169`) |
| 수정 `updateAnnvrsryManage` | **없음** |
| 삭제 `deleteAnnvrsryManage` | 있음 (`:357`) |

상세조회와 삭제는 동일한 형태입니다. 저장된 레코드를 조회해 `USID`가 다르면 `ROLE_ADMIN`을 요구하고, 아니면 `IllegalStateException("권한이 없습니다.")`을 던집니다.

DB 계층에도 방어가 없습니다.

```sql
UPDATE COMTNANNVRSRYMANAGE
   ...
 WHERE ANNVRSRY_ID = #{annId}
```

목록 조회는 `WHERE USER_ID = #{usid}`로 본인 것만 보여주므로, 이 데이터는 사용자별 소유 개념을 가집니다.

### 미사용 헬퍼

2026.07.13 KISA 보안취약점 조치가 이 파일에 소유자·관리자 판정 헬퍼를 추가했습니다.

```java
/**
 * 2026.07.13 KISA 보안취약점 조치 - 관리자 또는 소유자
 */
private void egovAssertAdminOrOwner(String ownerUniqId) {
```

그런데 저장소 전체에서 이 메서드를 호출하는 곳이 없습니다. 상세조회와 삭제는 같은 로직을 각자 인라인으로 갖고 있고, 수정에는 어느 쪽도 없습니다.

### 변경 내용

수정 경로에서 저장된 레코드를 조회한 뒤 이 헬퍼를 호출하도록 연결했습니다.

AS-IS
```java
} else {

    LoginVO user = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();
    status.setComplete();
```

TO-BE
```java
} else {

    // 2026.07.13 KISA 보안취약점 조치 - 조회·삭제와 동일하게 소유자 또는 관리자만 수정할 수 있다.
    AnnvrsryManageVO ownerVO = new AnnvrsryManageVO();
    ownerVO.setAnnId(annvrsryManage.getAnnId());
    AnnvrsryManageVO storedVO = egovAnnvrsryManageService.selectAnnvrsryManage(ownerVO);
    if (storedVO == null) {
        throw new IllegalStateException("권한이 없습니다.");
    }
    egovAssertAdminOrOwner(storedVO.getUsid());

    LoginVO user = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();
    status.setComplete();
```

소유자 판정은 요청값이 아니라 조회한 레코드의 `USID`를 씁니다. 삭제 경로가 쓰는 것과 같은 값입니다.

### 영향 범위

`EgovAnnvrsryManageController.updateAnnvrsryManage`에만 검증을 추가했습니다. 본인의 기념일을 수정하는 정상 경로와 관리자의 수정은 그대로 동작합니다.

검증 실패로 폼을 다시 그리는 분기(`bindingResult.hasErrors()`)에는 넣지 않았습니다. 그 분기는 저장하지 않고 화면만 반환합니다.

## JUnit 테스트 JUnit tests

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

세 경로의 소유권 대조 유무를 소스에서 확인했습니다.

수정 전
```
selectAnnvrsryManage     소유권 대조 1건
updateAnnvrsryManage     소유권 대조 0건
deleteAnnvrsryManage     소유권 대조 1건
```

수정 후
```
selectAnnvrsryManage     소유권 대조 1건
updateAnnvrsryManage     소유권 대조 1건
deleteAnnvrsryManage     소유권 대조 1건
```

재현 절차는 다음과 같습니다. 사용자 A로 기념일을 등록해 `annId`를 확인한 뒤 사용자 B로 로그인해 `POST /uss/ion/ans/updateAnnvrsryManage.do`에 그 `annId`와 임의의 값을 보냅니다. 수정 전에는 A의 기념일이 갱신되고 `success.common.update` 메시지가 나옵니다. 수정 후에는 `권한이 없습니다.`로 막힙니다. 같은 `annId`로 상세조회나 삭제를 호출하면 수정 전에도 `권한이 없습니다.`가 나오며, 이 차이가 세 경로의 불일치를 보여줍니다.

단위 테스트는 넣지 않았습니다. 이 검증은 서비스 조회 결과에 의존해 컨트롤러를 직접 생성하는 방식으로는 재현되지 않습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [X] 기타 Others

화면 변경이 없어 브라우저 테스트는 해당하지 않습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음.

## 관련 PR

소유권 검증 누락 시리즈입니다. #1197 · #1201 · #1202 · #1203 · #1204 · #1206 · #1207 · #1208

