### PR TITLE
fix: 메인화면이미지·배너·로그인화면이미지 삭제가 경로 구분자를 빠뜨려 파일을 지우지 못하는 문제 수정

### DIFF
--- a/src/main/java/egovframework/com/uss/ion/bnr/service/impl/EgovBannerServiceImpl.java
+++ b/src/main/java/egovframework/com/uss/ion/bnr/service/impl/EgovBannerServiceImpl.java
@@ -100,7 +100,7 @@ public class EgovBannerServiceImpl extends EgovAbstractServiceImpl implements Eg
 	@Override
 	public void deleteBannerFile(BannerVO bannerVO) throws Exception{
 		FileVO fileVO = bannerDAO.selectBannerFile(bannerVO);
-		File file = new File(fileVO.getFileStreCours()+fileVO.getStreFileNm());
+		File file = new File(fileVO.getFileStreCours(), fileVO.getStreFileNm());
 		//2017.02.08 	이정은 	시큐어코딩(ES)-부적절한 예외 처리[CWE-253, CWE-440, CWE-754]
 		if(file.delete()){
 			LOGGER.debug("[file.delete] file : File Deletion Success");

--- a/src/main/java/egovframework/com/uss/ion/lsi/service/impl/EgovLoginScrinImageServiceImpl.java
+++ b/src/main/java/egovframework/com/uss/ion/lsi/service/impl/EgovLoginScrinImageServiceImpl.java
@@ -102,7 +102,7 @@ public class EgovLoginScrinImageServiceImpl extends EgovAbstractServiceImpl impl
 	@Override
 	public void deleteLoginScrinImageFile(LoginScrinImageVO loginScrinImageVO) throws Exception {
 		FileVO fileVO = loginScrinImageDAO.selectLoginScrinImageFile(loginScrinImageVO);
-		File file = new File(fileVO.getFileStreCours()+fileVO.getStreFileNm());
+		File file = new File(fileVO.getFileStreCours(), fileVO.getStreFileNm());
 		//2017.02.08 	이정은 	시큐어코딩(ES)-부적절한 예외 처리[CWE-253, CWE-440, CWE-754]
 		if(file.delete()){
 			LOGGER.debug("[file.delete] file : File Deletion Success");

--- a/src/main/java/egovframework/com/uss/ion/msi/service/impl/EgovMainImageServiceImpl.java
+++ b/src/main/java/egovframework/com/uss/ion/msi/service/impl/EgovMainImageServiceImpl.java
@@ -98,7 +98,7 @@ public class EgovMainImageServiceImpl extends EgovAbstractServiceImpl implements
 	@Override
 	public void deleteMainImageFile(MainImageVO mainImageVO) throws Exception {
 		FileVO fileVO = mainImageDAO.selectMainImageFile(mainImageVO);
-		File file = new File(fileVO.getFileStreCours()+fileVO.getStreFileNm());
+		File file = new File(fileVO.getFileStreCours(), fileVO.getStreFileNm());
 		//2017.02.08 	이정은 	시큐어코딩(ES)-부적절한 예외 처리[CWE-253, CWE-440, CWE-754]
 		if(file.delete()){
 			LOGGER.debug("[file.delete] file : File Deletion Success");

--- a/src/test/java/egovframework/com/uss/ion/EgovImageFileDeletePathTest.java
+++ b/src/test/java/egovframework/com/uss/ion/EgovImageFileDeletePathTest.java
@@ -1,0 +1,102 @@
+package egovframework.com.uss.ion;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import egovframework.com.cmm.service.FileVO;
+import egovframework.com.uss.ion.bnr.service.BannerVO;
+import egovframework.com.uss.ion.bnr.service.impl.BannerDAO;
+import egovframework.com.uss.ion.bnr.service.impl.EgovBannerServiceImpl;
+import egovframework.com.uss.ion.lsi.service.LoginScrinImageVO;
+import egovframework.com.uss.ion.lsi.service.impl.EgovLoginScrinImageServiceImpl;
+import egovframework.com.uss.ion.lsi.service.impl.LoginScrinImageDAO;
+import egovframework.com.uss.ion.msi.service.MainImageVO;
+import egovframework.com.uss.ion.msi.service.impl.EgovMainImageServiceImpl;
+import egovframework.com.uss.ion.msi.service.impl.MainImageDAO;
+
+/**
+ * 메인화면이미지·배너·로그인화면이미지의 이미지파일 삭제 경로 검증.
+ *
+ * <p>EgovFileMngUtil.parseFileInf()는 파일을 {@code 저장경로 + File.separator + 저장파일명}에
+ * 기록하고 저장경로(FILE_STRE_COURS)와 저장파일명(STRE_FILE_NM)을 분리해 보관한다.
+ * 삭제 시 두 값을 구분자 없이 이어 붙이면 존재하지 않는 경로를 가리켜 파일이 남는다.</p>
+ *
+ * <p>Spring 컨텍스트·DB 없이 DAO 서브클래스와 ReflectionTestUtils 필드 주입으로
+ * 삭제 경로 계산만 검증한다.</p>
+ */
+class EgovImageFileDeletePathTest {
+
+	@TempDir
+	Path storeDir;
+
+	/** parseFileInf()가 저장한 형태 그대로(경로/파일명 분리) 실제 파일을 만든다. */
+	private FileVO storedFile(String streFileNm) throws Exception {
+		Files.write(storeDir.resolve(streFileNm), new byte[] {1, 2, 3});
+
+		FileVO fileVO = new FileVO();
+		fileVO.setFileStreCours(storeDir.toString());
+		fileVO.setStreFileNm(streFileNm);
+		return fileVO;
+	}
+
+	@Test
+	void deleteMainImageFileRemovesStoredFile() throws Exception {
+		final FileVO fileVO = storedFile("MSI_0");
+
+		EgovMainImageServiceImpl service = new EgovMainImageServiceImpl();
+		ReflectionTestUtils.setField(service, "mainImageDAO", new MainImageDAO() {
+			@Override
+			public FileVO selectMainImageFile(MainImageVO mainImageVO) {
+				return fileVO;
+			}
+		});
+
+		assertTrue(Files.exists(storeDir.resolve("MSI_0")));
+		service.deleteMainImageFile(new MainImageVO());
+
+		assertFalse(Files.exists(storeDir.resolve("MSI_0")), "메인화면이미지 파일이 디스크에서 삭제되어야 한다");
+	}
+
+	@Test
+	void deleteBannerFileRemovesStoredFile() throws Exception {
+		final FileVO fileVO = storedFile("BNR_0");
+
+		EgovBannerServiceImpl service = new EgovBannerServiceImpl();
+		ReflectionTestUtils.setField(service, "bannerDAO", new BannerDAO() {
+			@Override
+			public FileVO selectBannerFile(BannerVO bannerVO) {
+				return fileVO;
+			}
+		});
+
+		assertTrue(Files.exists(storeDir.resolve("BNR_0")));
+		service.deleteBannerFile(new BannerVO());
+
+		assertFalse(Files.exists(storeDir.resolve("BNR_0")), "배너 파일이 디스크에서 삭제되어야 한다");
+	}
+
+	@Test
+	void deleteLoginScrinImageFileRemovesStoredFile() throws Exception {
+		final FileVO fileVO = storedFile("LSI_0");
+
+		EgovLoginScrinImageServiceImpl service = new EgovLoginScrinImageServiceImpl();
+		ReflectionTestUtils.setField(service, "loginScrinImageDAO", new LoginScrinImageDAO() {
+			@Override
+			public FileVO selectLoginScrinImageFile(LoginScrinImageVO loginScrinImageVO) {
+				return fileVO;
+			}
+		});
+
+		assertTrue(Files.exists(storeDir.resolve("LSI_0")));
+		service.deleteLoginScrinImageFile(new LoginScrinImageVO());
+
+		assertFalse(Files.exists(storeDir.resolve("LSI_0")), "로그인화면이미지 파일이 디스크에서 삭제되어야 한다");
+	}
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

메인화면이미지·배너·로그인화면이미지 세 서비스는 파일을 지울 때 저장경로와 파일명을 구분자 없이 이어붙입니다. 그래서 존재하지 않는 경로가 만들어지고 `File.delete()`가 항상 `false`를 돌려줍니다. 로그에는 `File Deletion Fail`만 남고 파일은 디스크에 그대로 쌓입니다.

같은 저장소에서 파일을 읽는 코드는 이미 두 인자 생성자를 씁니다.

| 위치 | 형태 |
|---|---|
| `EgovFileDownloadController:125` | `new File(fvo.getFileStreCours(), fvo.getStreFileNm())` |
| `EgovSndngMailRegistServiceImpl:98` | `new File(fvo.getFileStreCours(), fvo.getStreFileNm())` |
| `EgovMainImageServiceImpl:101` (수정 전) | `new File(fileVO.getFileStreCours()+fileVO.getStreFileNm())` |
| `EgovBannerServiceImpl:103` (수정 전) | 같음 |
| `EgovLoginScrinImageServiceImpl:105` (수정 전) | 같음 |

같은 두 값을 두고 읽을 때는 구분자를 넣고 지울 때는 빼는 셈입니다.

AS-IS

```java
File file = new File(fileVO.getFileStreCours()+fileVO.getStreFileNm());
```

TO-BE

```java
File file = new File(fileVO.getFileStreCours(), fileVO.getStreFileNm());
```

세 파일에 각각 한 줄씩입니다.

### 영향 범위

삭제가 실제로 동작합니다. 이미 쌓여 있던 파일까지 이 수정이 소급해서 지워주지는 않습니다.

세 서비스 계층만 바꿨고 컨트롤러는 건드리지 않았습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`EgovImageFileDeletePathTest` 3건을 추가했습니다. DAO를 익명 서브클래스로 덮어 임시 디렉터리 경로를 돌려주게 하고 실제 파일을 만든 뒤 삭제 여부를 확인합니다. 스프링 컨텍스트와 DB 없이 돌아갑니다.

수정 전(RED, 세 파일의 해당 줄만 되돌려 실행)

```
[log4j] ERROR [egovframework.com.uss.ion.lsi.service.impl.EgovLoginScrinImageServiceImpl] [file.delete] file : File Deletion Fail
[log4j] ERROR [egovframework.com.uss.ion.msi.service.impl.EgovMainImageServiceImpl] [file.delete] file : File Deletion Fail
[ERROR] Tests run: 3, Failures: 3, Errors: 0, Skipped: 0, Time elapsed: 0.161 s <<< FAILURE! -- in egovframework.com.uss.ion.EgovImageFileDeletePathTest
[ERROR]   EgovImageFileDeletePathTest.deleteBannerFileRemovesStoredFile:82 배너 파일이 디스크에서 삭제되어야 한다 ==> expected: <false> but was: <true>
[ERROR]   EgovImageFileDeletePathTest.deleteLoginScrinImageFileRemovesStoredFile:100 로그인화면이미지 파일이 디스크에서 삭제되어야 한다 ==> expected: <false> but was: <true>
[ERROR]   EgovImageFileDeletePathTest.deleteMainImageFileRemovesStoredFile:64 메인화면이미지 파일이 디스크에서 삭제되어야 한다 ==> expected: <false> but was: <true>
```

수정 후(GREEN)

```
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.147 s -- in egovframework.com.uss.ion.EgovImageFileDeletePathTest
[INFO] BUILD SUCCESS
```

pom에 `<skipTests>true</skipTests>`가 있어 기본 빌드에서는 테스트가 돌지 않습니다. 위 출력은 그 줄을 임시로 풀고 받은 것입니다. pom 변경은 커밋에 넣지 않았습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음 (서버 측 파일 삭제 로직)

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음 (화면 변경 없음)
