### PR TITLE
fix: 비밀번호 만료 팝업의 업무사용자 분기가 존재하지 않는 URL로 전송하는 문제 수정

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/egovframework/com/uat/uia/EgovExpirePwd.jsp
+++ b/src/main/webapp/WEB-INF/jsp/egovframework/com/uat/uia/EgovExpirePwd.jsp
@@ -44,7 +44,7 @@ function fnPasswordMoveMber(){
 }
 // 업무사용자 (TEST1/webmaster)
 function fnPasswordMoveUser(){
-	document.pwdManage.action = "<c:url value='/uss/umt/EgovUserPasswordUpdtView.do'/>";
+	document.pwdManage.action = "<c:url value='/uss/umt/EgovEmplyrPasswordUpdtView.do'/>";
     document.pwdManage.submit();
 }
 

--- a/src/test/java/egovframework/com/uat/uia/web/EgovExpirePwdTest.java
+++ b/src/test/java/egovframework/com/uat/uia/web/EgovExpirePwdTest.java
@@ -1,0 +1,76 @@
+package egovframework.com.uat.uia.web;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import egovframework.com.uss.umt.web.EgovEmplyrManageController;
+import egovframework.com.uss.umt.web.EgovEntrprsManageController;
+import egovframework.com.uss.umt.web.EgovMberManageController;
+
+class EgovExpirePwdTest {
+
+	private static final String EXPIRE_PWD_JSP = "src/main/webapp/WEB-INF/jsp/egovframework/com/uat/uia/EgovExpirePwd.jsp";
+
+	private static final Pattern FORM_ACTION = Pattern.compile("\\.action\\s*=\\s*\"<c:url\\s+value='([^']+)'\\s*/>\"");
+
+	/**
+	 * 비밀번호 만료 팝업은 사용자 구분(업무사용자/기업회원/일반회원)에 따라 비밀번호 변경화면으로 전송한다.
+	 * 세 구분 모두 실제 등록된 요청 URL로 전송하는지 확인한다.
+	 */
+	@Test
+	void everyPasswordUpdtViewActionHasHandler() throws IOException {
+		Set<String> mappings = mappingsOf(EgovEmplyrManageController.class, EgovEntrprsManageController.class,
+				EgovMberManageController.class);
+
+		List<String> actions = formActionsOf(EXPIRE_PWD_JSP);
+		assertFalse(actions.isEmpty(), EXPIRE_PWD_JSP + " 에서 전송 URL을 찾지 못했습니다.");
+
+		for (String action : actions) {
+			assertTrue(mappings.contains(action), "처리할 핸들러가 없는 전송 URL 입니다 : " + action);
+		}
+	}
+
+	private List<String> formActionsOf(String jsp) throws IOException {
+		List<String> actions = new ArrayList<>();
+		Matcher matcher = FORM_ACTION.matcher(new String(Files.readAllBytes(Paths.get(jsp)), StandardCharsets.UTF_8));
+		while (matcher.find()) {
+			actions.add(matcher.group(1));
+		}
+		return actions;
+	}
+
+	private Set<String> mappingsOf(Class<?>... controllers) {
+		Set<String> mappings = new HashSet<>();
+		for (Class<?> controller : controllers) {
+			for (Method method : controller.getDeclaredMethods()) {
+				PostMapping postMapping = method.getAnnotation(PostMapping.class);
+				if (postMapping != null) {
+					mappings.addAll(Arrays.asList(postMapping.value()));
+				}
+				RequestMapping requestMapping = method.getAnnotation(RequestMapping.class);
+				if (requestMapping != null) {
+					mappings.addAll(Arrays.asList(requestMapping.value()));
+				}
+			}
+		}
+		return mappings;
+	}
+
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

비밀번호 만료 팝업은 로그인 구분에 따라 세 갈래로 전송합니다. 그중 업무사용자 분기만 존재하지 않는 URL로 보냅니다.

| 구분 | 전송 URL | 핸들러 |
|---|---|---|
| 기업회원 | `/uss/umt/EgovEntrprsPasswordUpdtView.do` | `EgovEntrprsManageController:520` |
| 일반회원 | `/uss/umt/EgovMberPasswordUpdtView.do` | `EgovMberManageController:591` |
| 업무사용자 | `/uss/umt/EgovUserPasswordUpdtView.do` | **없음** |

저장소 전체에서 `EgovUserPasswordUpdtView.do`를 찾으면 이 JSP와 `EgovEmplyrManageController`의 javadoc 문구뿐입니다. 매핑 선언은 한 건도 없습니다. 업무사용자용 실제 핸들러는 `EgovEmplyrManageController:547`의 `/uss/umt/EgovEmplyrPasswordUpdtView.do`입니다.

`1e764b1b`("egovframe-common-components 5.0.0")가 `EgovUserManageController`를 지우고 `EgovEmplyrManageController`로 옮기면서 이 URL이 사라졌습니다. 같은 커밋이 `uss/umt` 아래 JSP는 새 이름으로 함께 고쳤지만 `uat/uia`에 있는 이 팝업은 변경 목록에 들어 있지 않습니다.

AS-IS (`EgovExpirePwd.jsp:47`)

```jsp
document.pwdManage.action = "<c:url value='/uss/umt/EgovUserPasswordUpdtView.do'/>";
```

TO-BE

```jsp
document.pwdManage.action = "<c:url value='/uss/umt/EgovEmplyrPasswordUpdtView.do'/>";
```

### 영향 범위

한 줄만 바뀝니다. 폼이 보내는 hidden 필드는 이미 새 핸들러와 맞습니다. `emplyrId`(`:127`)와 `uniqId`(`:122`)가 `EmplyrPasswordManageVO`에 그대로 바인딩되고 그 VO가 `:547` 핸들러의 `@ModelAttribute` 타입입니다.

팝업이 뜨는 시점에 사용자는 이미 인증돼 있습니다. `EgovLoginController:632`가 인증된 사용자를 모델에 담아 이 화면을 반환하므로 대상 핸들러의 미인증 차단에 걸리지 않습니다. 그 핸들러에는 `@RequireAdmin`도 붙어 있지 않아 본인 비밀번호 변경이 관리자 권한에 막히지 않습니다.

핸들러가 없을 때 무엇이 보이는지는 실행으로 확인하지 않았습니다. `web.xml:33~36`의 error-page 설정상 404가 `/code404.jsp`로 매핑되고 폼이 `target="_parent"`라 부모 프레임이 그 화면으로 바뀝니다.

같은 리네임이 남긴 javadoc 문구(`EgovEmplyrManageController:485`, `:544`)도 옛 이름이지만 동작과 무관해 손대지 않았습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`EgovExpirePwdTest` 1건을 추가했습니다. JSP 원문에서 전송 URL 세 개를 뽑고 세 컨트롤러의 요청 매핑을 리플렉션으로 모아 모두 처리 가능한지 확인합니다. 정규식이 아무것도 못 잡아 무의미하게 통과하는 일을 막으려고 추출 목록이 비어 있지 않은지 먼저 단언합니다.

수정 전(RED, JSP 토큰만 되돌려 실행)

```
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.020 s <<< FAILURE! -- in egovframework.com.uat.uia.web.EgovExpirePwdTest
[ERROR]   EgovExpirePwdTest.everyPasswordUpdtViewActionHasHandler:46 처리할 핸들러가 없는 전송 URL 입니다 : /uss/umt/EgovUserPasswordUpdtView.do ==> expected: <true> but was: <false>
```

수정 후(GREEN)

```
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.018 s -- in egovframework.com.uat.uia.web.EgovExpirePwdTest
[INFO] BUILD SUCCESS
```

pom의 `<skipTests>true</skipTests>`를 임시로 풀고 받은 출력입니다. pom 변경은 커밋에 넣지 않았습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음 (전송 URL 문자열 수정)

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음
