### PR TITLE
fix: 업무사용자 등록 검증 실패 재표시가 폼 객체를 다른 이름으로 담아 화면이 뜨지 않는 문제 수정

### DIFF
--- a/src/main/java/egovframework/com/uss/umt/web/EgovEmplyrManageController.java
+++ b/src/main/java/egovframework/com/uss/umt/web/EgovEmplyrManageController.java
@@ -192,7 +192,7 @@ public class EgovEmplyrManageController {
 	 */
 	@PostMapping("/uss/umt/EgovEmplyrInsert.do")
 	@RequireAdmin
-	public String insertUser(@Valid @ModelAttribute("userManageVO") EmplyrManageInsertVO emplyrManageInsertVO, 
+	public String insertUser(@Valid @ModelAttribute("emplyrManageVO") EmplyrManageInsertVO emplyrManageInsertVO, 
 			BindingResult bindingResult,
 			Model model) throws Exception {
 
@@ -203,6 +203,35 @@ public class EgovEmplyrManageController {
 		}
 
 		if (bindingResult.hasErrors()) {
+
+			ComDefaultCodeVO comDefaultCodeVO = new ComDefaultCodeVO();
+
+			// 패스워드힌트목록을 코드정보로부터 조회
+			comDefaultCodeVO.setCodeId("COM022");
+			List<CmmnDetailCode> passwordHintResult = cmmUseService.selectCmmCodeDetail(comDefaultCodeVO);
+			// 성별구분코드를 코드정보로부터 조회
+			comDefaultCodeVO.setCodeId("COM014");
+			List<CmmnDetailCode> sexdstnCodeResult = cmmUseService.selectCmmCodeDetail(comDefaultCodeVO);
+			// 사용자상태코드를 코드정보로부터 조회
+			comDefaultCodeVO.setCodeId("COM013");
+			List<CmmnDetailCode> emplyrSttusCodeResult = cmmUseService.selectCmmCodeDetail(comDefaultCodeVO);
+			// 소속기관코드를 코드정보로부터 조회 - COM025
+			comDefaultCodeVO.setCodeId("COM025");
+			List<CmmnDetailCode> insttCodeResult = cmmUseService.selectCmmCodeDetail(comDefaultCodeVO);
+			// 조직정보를 조회 - ORGNZT_ID정보
+			comDefaultCodeVO.setTableNm("COMTNORGNZTINFO");
+			List<CmmnDetailCode> orgnztIdResult = cmmUseService.selectOgrnztIdDetail(comDefaultCodeVO);
+			// 그룹정보를 조회 - GROUP_ID정보
+			comDefaultCodeVO.setTableNm("COMTNORGNZTINFO");
+			List<CmmnDetailCode> groupIdResult = cmmUseService.selectGroupIdDetail(comDefaultCodeVO);
+
+			model.addAttribute("passwordHint_result", passwordHintResult); // 패스워트힌트목록
+			model.addAttribute("sexdstnCode_result", sexdstnCodeResult); // 성별구분코드목록
+			model.addAttribute("emplyrSttusCode_result", emplyrSttusCodeResult);// 사용자상태코드목록
+			model.addAttribute("insttCode_result", insttCodeResult); // 소속기관코드목록
+			model.addAttribute("orgnztId_result", orgnztIdResult); // 조직정보 목록
+			model.addAttribute("groupId_result", groupIdResult); // 그룹정보 목록
+
 			return "egovframework/com/uss/umt/EgovEmplyrInsert";
 		} else {
 			if ("".equals(emplyrManageInsertVO.getOrgnztId())) {// KISA 보안약점 조치 (2018-10-29, 윤창원)

--- a/src/test/java/egovframework/com/uss/umt/web/EgovEmplyrManageControllerTest.java
+++ b/src/test/java/egovframework/com/uss/umt/web/EgovEmplyrManageControllerTest.java
@@ -1,19 +1,45 @@
 package egovframework.com.uss.umt.web;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.ui.ExtendedModelMap;
 import org.springframework.ui.Model;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.ModelAttribute;
+
+import egovframework.com.cmm.ComDefaultCodeVO;
+import egovframework.com.cmm.service.CmmnDetailCode;
+import egovframework.com.cmm.service.EgovCmmUseService;
+import egovframework.com.cmm.service.EgovUserDetailsService;
+import egovframework.com.cmm.util.EgovUserDetailsHelper;
+import egovframework.com.uss.umt.service.EmplyrManageInsertVO;
 
 class EgovEmplyrManageControllerTest {
 
 	private static final String ERROR_VIEW = "egovframework/com/cmm/error/egovError";
+
+	private static final String INSERT_VIEW = "egovframework/com/uss/umt/EgovEmplyrInsert";
+
+	/** EgovEmplyrInsert.jsp의 form:form modelAttribute 값 */
+	private static final String FORM_OBJECT_NAME = "emplyrManageVO";
+
+	/** EgovEmplyrInsert.jsp의 form:options items 목록 */
+	private static final List<String> CODE_LIST_ATTRIBUTES = Arrays.asList("passwordHint_result", "sexdstnCode_result",
+			"emplyrSttusCode_result", "insttCode_result", "orgnztId_result", "groupId_result");
 
 	private EgovEmplyrManageController controller;
 
@@ -21,6 +47,11 @@ class EgovEmplyrManageControllerTest {
 	void setUp() {
 		controller = new EgovEmplyrManageController();
 		controller.nextUrlWhitelist = Arrays.asList("/uss/umt/EgovMberSbscrbView.do");
+	}
+
+	@AfterEach
+	void tearDown() {
+		new EgovUserDetailsHelper().setEgovUserDetailsService(null);
 	}
 
 	@Test
@@ -31,6 +62,94 @@ class EgovEmplyrManageControllerTest {
 	@Test
 	void rlnmCnfirmRejectsOutOfRangeNextUrlIndex() throws Exception {
 		assertEquals(ERROR_VIEW, controller.rlnmCnfirm(model(), commandMap(), 1));
+	}
+
+	@Test
+	void insertUserUsesSameFormObjectNameAsInsertUserView() throws Exception {
+		assertEquals(FORM_OBJECT_NAME, formObjectName("insertUserView"));
+		assertEquals(FORM_OBJECT_NAME, formObjectName("insertUser"));
+	}
+
+	@Test
+	void insertUserRestoresCodeListsWhenValidationFails() throws Exception {
+		authenticate();
+		setField("cmmUseService", cmmUseService());
+
+		EmplyrManageInsertVO emplyrManageInsertVO = new EmplyrManageInsertVO();
+		BindingResult bindingResult = new BeanPropertyBindingResult(emplyrManageInsertVO, FORM_OBJECT_NAME);
+		bindingResult.rejectValue("emplyrId", "validation.egov.error.emplyrId");
+		Model model = model();
+
+		assertEquals(INSERT_VIEW, controller.insertUser(emplyrManageInsertVO, bindingResult, model));
+		for (String attribute : CODE_LIST_ATTRIBUTES) {
+			assertNotNull(model.asMap().get(attribute), attribute);
+		}
+	}
+
+	/** 핸들러 파라미터에 선언된 @ModelAttribute 이름을 읽는다. */
+	private String formObjectName(String methodName) {
+		for (Method method : EgovEmplyrManageController.class.getDeclaredMethods()) {
+			if (!methodName.equals(method.getName())) {
+				continue;
+			}
+			for (Parameter parameter : method.getParameters()) {
+				if (EmplyrManageInsertVO.class.equals(parameter.getType())) {
+					return parameter.getAnnotation(ModelAttribute.class).value();
+				}
+			}
+		}
+		throw new IllegalStateException(methodName);
+	}
+
+	private void authenticate() {
+		new EgovUserDetailsHelper().setEgovUserDetailsService(new EgovUserDetailsService() {
+
+			@Override
+			public Object getAuthenticatedUser() {
+				return null;
+			}
+
+			@Override
+			public List<String> getAuthorities() {
+				return Collections.emptyList();
+			}
+
+			@Override
+			public Boolean isAuthenticated() {
+				return Boolean.TRUE;
+			}
+		});
+	}
+
+	private EgovCmmUseService cmmUseService() {
+		return new EgovCmmUseService() {
+
+			@Override
+			public List<CmmnDetailCode> selectCmmCodeDetail(ComDefaultCodeVO comDefaultCodeVO) {
+				return Collections.singletonList(new CmmnDetailCode());
+			}
+
+			@Override
+			public Map<String, List<CmmnDetailCode>> selectCmmCodeDetails(List<ComDefaultCodeVO> comDefaultCodeVOs) {
+				return new HashMap<>();
+			}
+
+			@Override
+			public List<CmmnDetailCode> selectOgrnztIdDetail(ComDefaultCodeVO comDefaultCodeVO) {
+				return Collections.singletonList(new CmmnDetailCode());
+			}
+
+			@Override
+			public List<CmmnDetailCode> selectGroupIdDetail(ComDefaultCodeVO comDefaultCodeVO) {
+				return Collections.singletonList(new CmmnDetailCode());
+			}
+		};
+	}
+
+	private void setField(String fieldName, Object value) throws Exception {
+		Field field = EgovEmplyrManageController.class.getDeclaredField(fieldName);
+		field.setAccessible(true);
+		field.set(controller, value);
 	}
 
 	private Model model() {


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

업무사용자 등록 화면은 진입과 재표시가 같은 JSP를 쓰는데, 폼 객체를 서로 다른 이름으로 담습니다.

| 경로 | 폼 객체 이름 | 코드목록 |
|---|---|---|
| `insertUserView`(`:142`) 진입 | `emplyrManageVO` | 6종 담음 |
| `insertUser`(`:193`) 검증 실패 재표시 | `userManageVO` | 담지 않음 |

JSP는 `modelAttribute="emplyrManageVO"`를 기대합니다(`EgovEmplyrInsert.jsp:217`). 그 이름이 모델에도 `BindingResult`에도 없으면 첫 `form:input`이 `BindStatus`를 만들지 못합니다.

**증상은 둘로 나뉩니다.**

- **폼 객체 이름 불일치** — 화면 자체가 뜨지 않습니다. 실행으로 관측하지는 않았고, 스프링의 `BindStatus` 계약에서 나오는 결론입니다.
- **코드목록 6종 누락** — 이쪽은 별개입니다. `form:options`는 items가 null이면 아무것도 그리지 않으므로 화면이 뜨더라도 필수 선택상자 여섯 개가 빈 채로 나옵니다.

형제 화면들은 두 경로가 같은 이름을 씁니다. `EgovMberManageController`는 `mberManageVO`로, `EgovEntrprsManageController`는 `entrprsManageVO`로 진입과 POST가 일치합니다. `EgovMberManageController.insertMber`는 검증 실패 분기에서 코드목록을 다시 조회해 담습니다.

`1e764b1b`("egovframe-common-components 5.0.0")가 JSP와 `insertUserView`만 `emplyrManageVO`로 바꾸고 `insertUser`를 빠뜨렸습니다. 같은 커밋이 `@Valid`도 새로 붙여(이전에는 수동 검증 호출) 실패 분기가 실제로 도달 가능해졌습니다.

AS-IS

```java
public String insertUser(@Valid @ModelAttribute("userManageVO") EmplyrManageInsertVO emplyrManageInsertVO,
        BindingResult bindingResult, Model model) throws Exception {
    ...
    if (bindingResult.hasErrors()) {
        return "egovframework/com/uss/umt/EgovEmplyrInsert";
```

TO-BE

```java
public String insertUser(@Valid @ModelAttribute("emplyrManageVO") EmplyrManageInsertVO emplyrManageInsertVO,
        BindingResult bindingResult, Model model) throws Exception {
    ...
    if (bindingResult.hasErrors()) {
        // 진입 경로와 같은 코드목록 6종을 다시 담는다
        ...
        return "egovframework/com/uss/umt/EgovEmplyrInsert";
```

코드목록 복원은 형제 `EgovMberManageController.insertMber`와 같은 인라인 형태로 맞췄습니다.

### 영향 범위

요청 모델의 키가 `userManageVO`에서 `emplyrManageVO`로 바뀝니다. 저장소 전체를 확인했을 때 이 엔드포인트의 모델을 `userManageVO`로 읽는 JSP나 자바는 없습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

기존 `EgovEmplyrManageControllerTest`에 2건을 더했습니다. 진입 경로와 실패 경로가 같은 폼 객체 이름을 쓰는지, 실패 경로가 코드목록을 담는지를 따로 봅니다. 스프링 컨텍스트와 DB 없이 돌아갑니다.

수정 전(RED, 컨트롤러만 되돌려 실행)

```
[ERROR] Tests run: 4, Failures: 2, Errors: 0, Skipped: 0, Time elapsed: 0.141 s <<< FAILURE! -- in egovframework.com.uss.umt.web.EgovEmplyrManageControllerTest
[ERROR]   EgovEmplyrManageControllerTest.insertUserRestoresCodeListsWhenValidationFails:85 passwordHint_result ==> expected: not <null>
[ERROR]   EgovEmplyrManageControllerTest.insertUserUsesSameFormObjectNameAsInsertUserView:70 expected: <emplyrManageVO> but was: <userManageVO>
```

수정 후(GREEN)

```
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.132 s -- in egovframework.com.uss.umt.web.EgovEmplyrManageControllerTest
[INFO] BUILD SUCCESS
```

pom의 `<skipTests>true</skipTests>`를 임시로 풀고 받은 출력입니다. pom 변경은 커밋에 넣지 않았습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음 (화면 렌더링은 관측하지 않았습니다)

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음
