### PR TITLE
fix: 기업회원 가입신청 검증 실패 재표시가 코드목록을 다시 담지 않아 선택상자가 비는 문제 수정

### DIFF
--- a/src/main/java/egovframework/com/uss/umt/web/EgovEntrprsManageController.java
+++ b/src/main/java/egovframework/com/uss/umt/web/EgovEntrprsManageController.java
@@ -378,21 +378,7 @@ public class EgovEntrprsManageController {
 			@ModelAttribute("entrprsManageVO") EntrprsManageInsertVO entrprsManageInsertVO,
 			@RequestParam Map<String, Object> commandMap, Model model) throws Exception {
 
-		ComDefaultCodeVO comDefaultCodeVO = new ComDefaultCodeVO();
-
-		comDefaultCodeVO.setCodeId("COM022");
-		List<CmmnDetailCode> passwordHintResult = cmmUseService.selectCmmCodeDetail(comDefaultCodeVO);
-		comDefaultCodeVO.setCodeId("COM014");
-		List<CmmnDetailCode> sexdstnCodeResult = cmmUseService.selectCmmCodeDetail(comDefaultCodeVO);
-		comDefaultCodeVO.setCodeId("COM026");
-		List<CmmnDetailCode> entrprsSeCodeResult = cmmUseService.selectCmmCodeDetail(comDefaultCodeVO);
-		comDefaultCodeVO.setCodeId("COM027");
-		List<CmmnDetailCode> indutyCodeResult = cmmUseService.selectCmmCodeDetail(comDefaultCodeVO);
-
-		model.addAttribute("passwordHint_result", passwordHintResult);
-		model.addAttribute("sexdstnCode_result", sexdstnCodeResult);
-		model.addAttribute("entrprsSeCode_result", entrprsSeCodeResult);
-		model.addAttribute("indutyCode_result", indutyCodeResult);
+		addEntrprsSbscrbCodeListToModel(model);
 
 		if (!"".equals(commandMap.get("realname"))) {
 			model.addAttribute("applcntNm", commandMap.get("realname"));
@@ -411,15 +397,17 @@ public class EgovEntrprsManageController {
 	 * 
 	 * @param entrprsManageInsertVO 기업회원가입신청정보 (비밀번호 검증 포함)
 	 * @param bindingResult         입력값검증용 bindingResult
+	 * @param model                 화면모델
 	 * @return forward:/uat/uia/egovLoginUsr.do
 	 * @throws Exception
 	 */
 	@RequestMapping(value = "/uss/umt/EgovEntrprsSbscrb.do", method = RequestMethod.POST)
 	public String sbscrbEntrprsMber(@Valid @ModelAttribute("entrprsManageVO") EntrprsManageInsertVO entrprsManageInsertVO,
-			BindingResult bindingResult)
+			BindingResult bindingResult, Model model)
 			throws Exception {
 
 		if (bindingResult.hasErrors()) {
+			addEntrprsSbscrbCodeListToModel(model);
 			return "egovframework/com/uss/umt/EgovEntrprsSbscrb";
 		}
 
@@ -534,6 +522,24 @@ public class EgovEntrprsManageController {
 		model.addAttribute("entrprsPasswordManageVO", entrprsPasswordManageVO);
 		model.addAttribute("userSearchVO", userSearchVO);
 		return "egovframework/com/uss/umt/EgovEntrprsPasswordUpdt";
+	}
+
+	private void addEntrprsSbscrbCodeListToModel(Model model) {
+		ComDefaultCodeVO comDefaultCodeVO = new ComDefaultCodeVO();
+
+		comDefaultCodeVO.setCodeId("COM022");
+		List<CmmnDetailCode> passwordHintResult = cmmUseService.selectCmmCodeDetail(comDefaultCodeVO);
+		comDefaultCodeVO.setCodeId("COM014");
+		List<CmmnDetailCode> sexdstnCodeResult = cmmUseService.selectCmmCodeDetail(comDefaultCodeVO);
+		comDefaultCodeVO.setCodeId("COM026");
+		List<CmmnDetailCode> entrprsSeCodeResult = cmmUseService.selectCmmCodeDetail(comDefaultCodeVO);
+		comDefaultCodeVO.setCodeId("COM027");
+		List<CmmnDetailCode> indutyCodeResult = cmmUseService.selectCmmCodeDetail(comDefaultCodeVO);
+
+		model.addAttribute("passwordHint_result", passwordHintResult);
+		model.addAttribute("sexdstnCode_result", sexdstnCodeResult);
+		model.addAttribute("entrprsSeCode_result", entrprsSeCodeResult);
+		model.addAttribute("indutyCode_result", indutyCodeResult);
 	}
 
 	private void addEntrprsCodeListToModel(Model model) throws Exception {

--- a/src/test/java/egovframework/com/uss/umt/web/EgovEntrprsManageControllerTest.java
+++ b/src/test/java/egovframework/com/uss/umt/web/EgovEntrprsManageControllerTest.java
@@ -1,0 +1,134 @@
+package egovframework.com.uss.umt.web;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.ui.ExtendedModelMap;
+import org.springframework.ui.Model;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.BindingResult;
+
+import egovframework.com.cmm.ComDefaultCodeVO;
+import egovframework.com.cmm.service.CmmnDetailCode;
+import egovframework.com.cmm.service.EgovCmmUseService;
+import egovframework.com.uss.umt.service.EntrprsManageInsertVO;
+import egovframework.com.uss.umt.service.UserDefaultVO;
+
+/**
+ * 기업회원 가입신청 화면의 코드목록 복원 검증.
+ *
+ * <p>입력값 검증에 실패하면 가입신청 화면(EgovEntrprsSbscrb.jsp)을 그대로 다시 그리는데,
+ * 이때 화면이 form:options로 참조하는 코드목록을 모델에 다시 담지 않아
+ * 비밀번호힌트·업종코드·기업구분코드 선택상자가 빈 채로 표시되던 문제에 대한 회귀 방지 테스트.</p>
+ *
+ * <p>Spring 컨텍스트·DB 없이 EgovCmmUseService 동적 프록시와 ReflectionTestUtils 필드 주입으로
+ * 검증 실패 분기만 확인한다.</p>
+ */
+class EgovEntrprsManageControllerTest {
+
+	private static final String SBSCRB_VIEW = "egovframework/com/uss/umt/EgovEntrprsSbscrb";
+
+	private EgovEntrprsManageController controller;
+
+	@BeforeEach
+	void setUp() {
+		controller = new EgovEntrprsManageController();
+		ReflectionTestUtils.setField(controller, "cmmUseService", stubCmmUseService());
+	}
+
+	@Test
+	void sbscrbEntrprsMberRestoresCodeListWhenValidationFails() throws Exception {
+		Model model = new ExtendedModelMap();
+
+		assertEquals(SBSCRB_VIEW, invokeSbscrbEntrprsMber(model));
+
+		// EgovEntrprsSbscrb.jsp가 form:options로 참조하는 코드목록
+		assertNotNull(model.getAttribute("passwordHint_result"), "비밀번호힌트 코드목록이 있어야 한다");
+		assertNotNull(model.getAttribute("indutyCode_result"), "업종코드 목록이 있어야 한다");
+		assertNotNull(model.getAttribute("entrprsSeCode_result"), "기업구분코드 목록이 있어야 한다");
+	}
+
+	@Test
+	void sbscrbEntrprsMberKeepsSameCodeListAsSbscrbView() throws Exception {
+		Model viewModel = new ExtendedModelMap();
+		controller.sbscrbEntrprsMberView(new UserDefaultVO(), insertVO(), new HashMap<>(), viewModel);
+
+		Model errorModel = new ExtendedModelMap();
+		invokeSbscrbEntrprsMber(errorModel);
+
+		assertEquals(codeListNames(viewModel), codeListNames(errorModel),
+				"가입신청 화면 진입 경로와 검증 실패 재표시 경로의 코드목록이 같아야 한다");
+	}
+
+	/**
+	 * 검증 실패를 처리하는 sbscrbEntrprsMber 를 리플렉션으로 호출한다.
+	 *
+	 * <p>수정 전에는 Model 파라미터가 없으므로, 직접 호출하면 테스트가 수정 전 소스에서
+	 * 컴파일되지 않아 RED 를 실패가 아니라 컴파일 오류로 만든다. 두 시그니처를 모두 받아
+	 * 같은 테스트가 수정 전후 양쪽에서 돌아가게 한다.</p>
+	 */
+	private String invokeSbscrbEntrprsMber(Model model) throws Exception {
+		Method withModel = null;
+		Method withoutModel = null;
+		for (Method method : EgovEntrprsManageController.class.getDeclaredMethods()) {
+			if (!"sbscrbEntrprsMber".equals(method.getName())) {
+				continue;
+			}
+			Class<?>[] types = method.getParameterTypes();
+			if (types.length == 3 && Model.class.isAssignableFrom(types[2])) {
+				withModel = method;
+			} else if (types.length == 2 && BindingResult.class.isAssignableFrom(types[1])) {
+				withoutModel = method;
+			}
+		}
+		if (withModel != null) {
+			return (String) withModel.invoke(controller, insertVO(), rejectedBindingResult(), model);
+		}
+		assertNotNull(withoutModel, "검증 실패를 처리하는 sbscrbEntrprsMber 를 찾지 못했다");
+		return (String) withoutModel.invoke(controller, insertVO(), rejectedBindingResult());
+	}
+
+	private EntrprsManageInsertVO insertVO() {
+		return new EntrprsManageInsertVO();
+	}
+
+	private BindingResult rejectedBindingResult() {
+		BindingResult bindingResult = new BeanPropertyBindingResult(insertVO(), "entrprsManageVO");
+		bindingResult.rejectValue("passwordHint", "errors.required");
+		return bindingResult;
+	}
+
+	private Set<String> codeListNames(Model model) {
+		return model.asMap().keySet().stream().filter(name -> name.endsWith("_result"))
+				.collect(Collectors.toCollection(TreeSet::new));
+	}
+
+	/** 요청한 코드ID를 그대로 되돌려주는 EgovCmmUseService 페이크 생성. */
+	private EgovCmmUseService stubCmmUseService() {
+		return (EgovCmmUseService) Proxy.newProxyInstance(
+				getClass().getClassLoader(),
+				new Class<?>[] { EgovCmmUseService.class },
+				(proxy, method, args) -> {
+					if (method.getReturnType() != List.class) {
+						return null;
+					}
+					CmmnDetailCode detailCode = new CmmnDetailCode();
+					detailCode.setCode(((ComDefaultCodeVO) args[0]).getCodeId());
+					detailCode.setCodeNm("stub");
+					return Collections.singletonList(detailCode);
+				});
+	}
+
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

같은 컨트롤러 안에서 두 경로가 검증 실패를 다르게 처리합니다. 관리자 등록 `insertEntrprsMber`는 실패 분기에서 코드목록을 다시 조회해 모델에 담고 같은 화면으로 돌아갑니다. 공개 가입 `sbscrbEntrprsMber`는 같은 분기에서 아무것도 담지 않습니다.

`EgovEntrprsSbscrb.jsp`가 `form:options`로 참조하는 목록 넷(비밀번호힌트·성별구분·기업구분·업종)이 비어서 필수 선택상자가 빈 채로 나옵니다. 가입을 완주할 수 없습니다.

`sbscrbEntrprsMber`에는 `Model` 파라미터가 아예 없어 파라미터 추가도 수정에 함께 들어갑니다. 진입 경로와 실패 경로가 같은 코드를 쓰도록 private 헬퍼로 묶었습니다.

AS-IS

```java
public String sbscrbEntrprsMber(@Valid @ModelAttribute("entrprsManageVO") EntrprsManageInsertVO entrprsManageVO,
        BindingResult bindingResult) throws Exception {
    ...
    if (bindingResult.hasErrors()) {
        return "egovframework/com/uss/umt/EgovEntrprsSbscrb";
```

TO-BE

```java
public String sbscrbEntrprsMber(@Valid @ModelAttribute("entrprsManageVO") EntrprsManageInsertVO entrprsManageVO,
        BindingResult bindingResult, Model model) throws Exception {
    ...
    if (bindingResult.hasErrors()) {
        addEntrprsSbscrbCodeListToModel(model);
        return "egovframework/com/uss/umt/EgovEntrprsSbscrb";
```

진입 경로에 있던 인라인 조회를 같은 헬퍼로 옮겨 두 경로가 한 코드를 쓰게 했습니다.

### 영향 범위

가입 화면의 검증 실패 재표시에만 닿습니다. 정상 가입 흐름과 관리자 등록 경로는 그대로입니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`EgovEntrprsManageControllerTest` 2건을 추가했습니다. 실패 재표시가 코드목록을 담는지, 그 목록이 진입 경로와 같은지를 봅니다. `EgovCmmUseService`는 동적 프록시로 세워 스프링 컨텍스트와 DB 없이 돌아갑니다.

수정이 메서드 시그니처를 바꿉니다. 테스트가 새 시그니처를 직접 부르면 수정 전 소스에서 컴파일이 되지 않아 RED가 실패가 아니라 컴파일 오류로 납니다. 리플렉션으로 두 시그니처를 모두 받게 해서 같은 테스트가 양쪽에서 돌아가도록 했습니다.

수정 전(RED, 컨트롤러만 되돌려 실행)

```
[ERROR] Tests run: 2, Failures: 2, Errors: 0, Skipped: 0, Time elapsed: 0.139 s <<< FAILURE! -- in egovframework.com.uss.umt.web.EgovEntrprsManageControllerTest
[ERROR]   EgovEntrprsManageControllerTest.sbscrbEntrprsMberKeepsSameCodeListAsSbscrbView:71 가입신청 화면 진입 경로와 검증 실패 재표시 경로의 코드목록이 같아야 한다 ==> expected: <[entrprsSeCode_result, indutyCode_result, passwordHint_result, sexdstnCode_result]> but was: <[]>
[ERROR]   EgovEntrprsManageControllerTest.sbscrbEntrprsMberRestoresCodeListWhenValidationFails:58 비밀번호힌트 코드목록이 있어야 한다 ==> expected: not <null>
```

수정 후(GREEN)

```
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.143 s -- in egovframework.com.uss.umt.web.EgovEntrprsManageControllerTest
[INFO] BUILD SUCCESS
```

pom의 `<skipTests>true</skipTests>`를 임시로 풀고 받은 출력입니다. pom 변경은 커밋에 넣지 않았습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음
