### PR TITLE
fix: 권한그룹관리 목록의 form action이 다른 네임스페이스를 가리켜 검색어 Enter가 404가 되는 문제 수정

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/egovframework/com/sec/rgm/EgovAuthorGroupManage.jsp
+++ b/src/main/webapp/WEB-INF/jsp/egovframework/com/sec/rgm/EgovAuthorGroupManage.jsp
@@ -209,7 +209,7 @@ function press() {
 <body>
 <!-- javascript warning tag  -->
 <noscript class="noScriptTitle"><spring:message code="common.noScriptTitle.msg" /></noscript>
-<form:form name="listForm" action="${pageContext.request.contextPath}/sec/ram/EgovAuthorGroupList.do" method="post" modelAttribute="searchVO">
+<form:form name="listForm" action="${pageContext.request.contextPath}/sec/rgm/EgovAuthorGroupList.do" method="post" modelAttribute="searchVO">
 <div class="board">
 	<h1>${pageTitle} <spring:message code="title.list" /></h1><!-- 권한그룹관리 목록 -->
 	<!-- 검색영역 -->

--- a/src/test/java/egovframework/com/sec/rgm/web/EgovAuthorGroupManageJspTest.java
+++ b/src/test/java/egovframework/com/sec/rgm/web/EgovAuthorGroupManageJspTest.java
@@ -1,0 +1,82 @@
+package egovframework.com.sec.rgm.web;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+/**
+ * 권한그룹관리 목록 화면의 전송 URL이 실제 요청 매핑을 갖는지 확인한다.
+ *
+ * <p>이 화면에는 submit 버튼이 없고 검색어 입력칸 하나만 암묵적 제출을 막는 필드다.
+ * 그래서 검색어 칸에서 Enter를 치면 form 의 action 으로 그대로 POST 된다.
+ * JS 는 조회·등록·삭제·페이징마다 action 을 다시 지정하지만, 그 경로를 타지 않는 Enter 는
+ * form 에 적힌 action 을 그대로 쓴다.</p>
+ */
+class EgovAuthorGroupManageJspTest {
+
+	private static final String LIST_JSP =
+			"src/main/webapp/WEB-INF/jsp/egovframework/com/sec/rgm/EgovAuthorGroupManage.jsp";
+
+	private static final Pattern FORM_TAG_ACTION =
+			Pattern.compile("<form:form[^>]*action=\"\\$\\{pageContext\\.request\\.contextPath\\}([^\"]+)\"");
+
+	private static final Pattern SCRIPT_ACTION =
+			Pattern.compile("\\.action\\s*=\\s*\"<c:url\\s+value='([^']+)'\\s*/>\"");
+
+	@Test
+	void everyActionInListJspHasHandler() throws IOException {
+		Set<String> mappings = mappingsOf(EgovAuthorGroupController.class);
+
+		List<String> actions = actionsOf(LIST_JSP);
+		assertFalse(actions.isEmpty(), LIST_JSP + " 에서 전송 URL을 찾지 못했습니다.");
+
+		for (String action : actions) {
+			assertTrue(mappings.contains(action), "처리할 핸들러가 없는 전송 URL 입니다 : " + action);
+		}
+	}
+
+	private List<String> actionsOf(String jsp) throws IOException {
+		String source = new String(Files.readAllBytes(Paths.get(jsp)), StandardCharsets.UTF_8);
+		List<String> actions = new ArrayList<>();
+		for (Pattern pattern : Arrays.asList(FORM_TAG_ACTION, SCRIPT_ACTION)) {
+			Matcher matcher = pattern.matcher(source);
+			while (matcher.find()) {
+				actions.add(matcher.group(1));
+			}
+		}
+		return actions;
+	}
+
+	private Set<String> mappingsOf(Class<?>... controllers) {
+		Set<String> mappings = new HashSet<>();
+		for (Class<?> controller : controllers) {
+			for (Method method : controller.getDeclaredMethods()) {
+				PostMapping post = method.getAnnotation(PostMapping.class);
+				if (post != null) {
+					mappings.addAll(Arrays.asList(post.value()));
+				}
+				RequestMapping request = method.getAnnotation(RequestMapping.class);
+				if (request != null) {
+					mappings.addAll(Arrays.asList(request.value()));
+				}
+			}
+		}
+		return mappings;
+	}
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

권한그룹관리 목록 화면이 자기 자신과 어긋납니다. JS는 네 곳 모두 `/sec/rgm/`으로 action을 다시 지정하는데, `<form:form>` 태그에 적힌 action만 `/sec/ram/EgovAuthorGroupList.do`입니다.

| 위치 | 경로 |
|---|---|
| `EgovAuthorGroupManage.jsp:132` 조회 | `/sec/rgm/EgovAuthorGroupList.do` |
| `:142` 등록 | `/sec/rgm/EgovAuthorGroupInsert.do` |
| `:152` 삭제 | `/sec/rgm/EgovAuthorGroupDelete.do` |
| `:159` 페이징 | `/sec/rgm/EgovAuthorGroupList.do` |
| `:212` `<form:form>` action | `/sec/ram/EgovAuthorGroupList.do` |

`/sec/ram/EgovAuthorGroupList.do`에는 매핑이 없습니다. 매핑은 `EgovAuthorGroupController:79`에 `/sec/rgm/EgovAuthorGroupList.do`로 등록돼 있습니다.

**버튼을 누르면 문제가 없습니다.** 조회·등록·삭제·페이징은 모두 JS가 action을 덮어쓰기 때문입니다. 그런데 이 화면에는 submit 버튼이 하나도 없고, 암묵적 제출을 막는 필드는 검색어 입력칸(`searchKeyword`) 하나뿐입니다. 그래서 검색어 칸에서 Enter를 치면 JS를 거치지 않고 form의 action으로 그대로 POST됩니다.

형제 화면 `sec/ram/EgovAuthorManage.jsp:170`도 같은 자리에 `/sec/ram/EgovAuthorList.do`를 쓰는데 그쪽은 맞는 경로입니다(`EgovAuthorManageController:68`). 이 화면은 그 형제에서 파생되면서 JS 네 곳은 `rgm`으로 바뀌고 form action만 `ram`으로 남은 것으로 보입니다.

AS-IS (`:212`)

```jsp
<form:form name="listForm" action="${pageContext.request.contextPath}/sec/ram/EgovAuthorGroupList.do" method="post" modelAttribute="searchVO">
```

TO-BE

```jsp
<form:form name="listForm" action="${pageContext.request.contextPath}/sec/rgm/EgovAuthorGroupList.do" method="post" modelAttribute="searchVO">
```

### 영향 범위

한 토큰만 바뀝니다. JS가 action을 지정하는 네 경로는 그대로고 Enter로 제출할 때만 도착지가 달라집니다.

두 화면 모두 `press()` 함수를 정의해 두었지만(`:200`) 어느 요소에도 연결돼 있지 않아 실제로는 브라우저의 암묵적 제출이 동작합니다. 그 함수는 손대지 않았습니다.

404가 실제로 어떤 화면으로 보이는지는 실행으로 확인하지 않았습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`EgovAuthorGroupManageJspTest` 1건을 추가했습니다. JSP에서 `<form:form>` action과 JS가 지정하는 action을 모두 뽑아, 각각 컨트롤러에 매핑이 있는지 봅니다. 정규식이 아무것도 못 잡아 무의미하게 통과하는 것을 막으려고, 추출 목록이 비어 있지 않은지 먼저 단언합니다.

수정 전(RED, form action만 되돌려 실행)

```
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.020 s <<< FAILURE! -- in egovframework.com.sec.rgm.web.EgovAuthorGroupManageJspTest
[ERROR]   EgovAuthorGroupManageJspTest.everyActionInListJspHasHandler:50 처리할 핸들러가 없는 전송 URL 입니다 : /sec/ram/EgovAuthorGroupList.do ==> expected: <true> but was: <false>
```

수정 후(GREEN)

```
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.016 s -- in egovframework.com.sec.rgm.web.EgovAuthorGroupManageJspTest
[INFO] BUILD SUCCESS
```

pom의 `<skipTests>true</skipTests>`를 임시로 풀고 받은 출력입니다. pom 변경은 커밋에 넣지 않았습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음 (전송 URL 문자열 수정)

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음
