### PR TITLE
fix: 게시판마스터 등록·수정 검증 실패 재표시가 추가 선택사항 표시 여부를 다시 담지 않는 문제 수정

### DIFF
--- a/src/main/java/egovframework/com/cop/bbs/web/EgovBBSMasterController.java
+++ b/src/main/java/egovframework/com/cop/bbs/web/EgovBBSMasterController.java
@@ -100,6 +100,21 @@ public class EgovBBSMasterController {
     }
 
     /**
+     * 추가 선택사항(댓글, 만족도조사) 컴포넌트의 설치 여부를 모델에 담는다.
+     * 2011.09.15 : 2단계 기능 추가 반영 방법 변경
+     *
+     * @param model
+     */
+    private void addAddedOptionsAttribute(ModelMap model) {
+        if (EgovComponentChecker.hasComponent("EgovArticleCommentService")) {
+            model.addAttribute("useComment", "true");
+        }
+        if (EgovComponentChecker.hasComponent("EgovBBSSatisfactionService")) {
+            model.addAttribute("useSatisfaction", "true");
+        }
+    }
+
+    /**
      * 신규 게시판 마스터 등록을 위한 등록페이지로 이동한다.
      *
      * @param boardMasterVO
@@ -118,17 +133,7 @@ public class EgovBBSMasterController {
 		model.addAttribute("boardMasterVO", boardMaster);
 
 
-		//---------------------------------
-		// 2011.09.15 : 2단계 기능 추가 반영 방법 변경
-		//---------------------------------
-
-
-		if(EgovComponentChecker.hasComponent("EgovArticleCommentService")){
-			model.addAttribute("useComment", "true");
-		}
-		if(EgovComponentChecker.hasComponent("EgovBBSSatisfactionService")){
-			model.addAttribute("useSatisfaction", "true");
-		}
+		addAddedOptionsAttribute(model);
 
 		return "egovframework/com/cop/bbs/EgovBBSMasterRegist";
     }
@@ -157,6 +162,7 @@ public class EgovBBSMasterController {
 		    vo.setCodeId("COM101");
 		    List<CmmnDetailCode> codeResult = cmmUseService.selectCmmCodeDetail(vo);
 		    model.addAttribute("bbsTyCode", codeResult);
+		    addAddedOptionsAttribute(model);
 
 		    return "egovframework/com/cop/bbs/EgovBBSMasterRegist";
 		}
@@ -404,16 +410,7 @@ public class EgovBBSMasterController {
 
         model.addAttribute("boardMasterVO", existingBoard);
 
-		//---------------------------------
-		// 2011.09.15 : 2단계 기능 추가 반영 방법 변경
-		//---------------------------------
-
-		if(EgovComponentChecker.hasComponent("EgovArticleCommentService")){
-			model.addAttribute("useComment", "true");
-		}
-		if(EgovComponentChecker.hasComponent("EgovBBSSatisfactionService")){
-			model.addAttribute("useSatisfaction", "true");
-		}
+		addAddedOptionsAttribute(model);
 
         return "egovframework/com/cop/bbs/EgovBBSMasterUpdt";
     }
@@ -449,6 +446,7 @@ public class EgovBBSMasterController {
 	        comVo.setCodeId("COM101");
 	        List<CmmnDetailCode> codeResult = cmmUseService.selectCmmCodeDetail(comVo);
 	        model.addAttribute("bbsTyCode", codeResult);
+		    addAddedOptionsAttribute(model);
 
 		    return "egovframework/com/cop/bbs/EgovBBSMasterUpdt";
 		}

--- a/src/test/java/egovframework/com/cop/bbs/web/EgovBBSMasterControllerTest.java
+++ b/src/test/java/egovframework/com/cop/bbs/web/EgovBBSMasterControllerTest.java
@@ -1,0 +1,152 @@
+package egovframework.com.cop.bbs.web;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Proxy;
+import java.util.Collections;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationContext;
+import org.springframework.ui.ModelMap;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.BindingResult;
+
+import egovframework.com.cmm.EgovComponentChecker;
+import egovframework.com.cmm.LoginVO;
+import egovframework.com.cmm.service.EgovCmmUseService;
+import egovframework.com.cmm.service.EgovUserDetailsService;
+import egovframework.com.cmm.util.EgovUserDetailsHelper;
+import egovframework.com.cop.bbs.service.BoardMaster;
+import egovframework.com.cop.bbs.service.BoardMasterVO;
+import egovframework.com.cop.bbs.service.EgovBBSMasterService;
+
+/**
+ * 게시판 마스터 등록/수정의 입력검증 실패 재표시 시, 등록/수정 폼 조회(GET)와 동일하게
+ * 추가 선택사항(댓글/만족도조사) 컴포넌트 설치 여부가 모델에 담기는지 확인한다.
+ */
+class EgovBBSMasterControllerTest {
+
+	private static final String REGIST_VIEW = "egovframework/com/cop/bbs/EgovBBSMasterRegist";
+	private static final String UPDT_VIEW = "egovframework/com/cop/bbs/EgovBBSMasterUpdt";
+	private static final String USER_ID = "USRCNFRM_00000000000";
+
+	private EgovBBSMasterController controller;
+	private ApplicationContext savedContext;
+	private Object savedUserDetailsService;
+
+	@BeforeEach
+	void setUp() throws Exception {
+		controller = new EgovBBSMasterController();
+		setField(controller, "cmmUseService",
+			proxy(EgovCmmUseService.class, (p, method, args) ->
+				"selectCmmCodeDetail".equals(method.getName()) ? Collections.emptyList() : null));
+		setField(controller, "egovBBSMasterService",
+			proxy(EgovBBSMasterService.class, (p, method, args) ->
+				"selectBBSMasterInf".equals(method.getName()) ? existingBoard() : null));
+
+		// 인증 스텁 : EgovUserDetailsHelper 의 static 필드는 package-private 이라 리플렉션으로 주입한다.
+		savedUserDetailsService = readStaticField(EgovUserDetailsHelper.class, "egovUserDetailsService");
+		setStaticField(EgovUserDetailsHelper.class, "egovUserDetailsService",
+			proxy(EgovUserDetailsService.class, (p, method, args) -> {
+				switch (method.getName()) {
+					case "getAuthenticatedUser":
+						return loginVO();
+					case "isAuthenticated":
+						return Boolean.TRUE;
+					case "getAuthorities":
+						return Collections.singletonList("ROLE_ADMIN");
+					default:
+						return null;
+				}
+			}));
+
+		// 댓글/만족도조사 컴포넌트가 모두 설치된 환경을 만든다.
+		savedContext = EgovComponentChecker.context;
+		EgovComponentChecker.context = proxy(ApplicationContext.class,
+			(p, method, args) -> "getBean".equals(method.getName()) ? new Object() : null);
+	}
+
+	@AfterEach
+	void tearDown() throws Exception {
+		EgovComponentChecker.context = savedContext;
+		setStaticField(EgovUserDetailsHelper.class, "egovUserDetailsService", savedUserDetailsService);
+	}
+
+	@Test
+	void insertBBSMasterKeepsAddedOptionsAttributesOnValidationError() throws Exception {
+		ModelMap model = new ModelMap();
+
+		assertEquals(REGIST_VIEW, controller.insertBBSMaster(new BoardMasterVO(), new BoardMaster(), errors(), model));
+
+		assertTrue(model.containsAttribute("useComment"), "useComment 가 모델에 없다");
+		assertTrue(model.containsAttribute("useSatisfaction"), "useSatisfaction 이 모델에 없다");
+	}
+
+	@Test
+	void updateBBSMasterKeepsAddedOptionsAttributesOnValidationError() throws Exception {
+		ModelMap model = new ModelMap();
+
+		assertEquals(UPDT_VIEW, controller.updateBBSMaster(new BoardMasterVO(), new BoardMaster(), errors(), model));
+
+		assertTrue(model.containsAttribute("useComment"), "useComment 가 모델에 없다");
+		assertTrue(model.containsAttribute("useSatisfaction"), "useSatisfaction 이 모델에 없다");
+	}
+
+	private BindingResult errors() {
+		BindingResult bindingResult = new BeanPropertyBindingResult(new BoardMaster(), "boardMasterVO");
+		bindingResult.reject("errors.required");
+		return bindingResult;
+	}
+
+	private LoginVO loginVO() {
+		LoginVO loginVO = new LoginVO();
+		loginVO.setUniqId(USER_ID);
+		return loginVO;
+	}
+
+	private BoardMasterVO existingBoard() {
+		BoardMasterVO boardMasterVO = new BoardMasterVO();
+		boardMasterVO.setFrstRegisterId(USER_ID);
+		return boardMasterVO;
+	}
+
+	@SuppressWarnings("unchecked")
+	private static <T> T proxy(Class<T> type, InvocationHandler handler) {
+		return (T) Proxy.newProxyInstance(type.getClassLoader(), new Class<?>[] { type },
+			(p, method, args) -> {
+				switch (method.getName()) {
+					case "hashCode":
+						return System.identityHashCode(p);
+					case "equals":
+						return p == args[0];
+					case "toString":
+						return type.getSimpleName() + "-stub";
+					default:
+						return handler.invoke(p, method, args);
+				}
+			});
+	}
+
+	private static void setField(Object target, String name, Object value) throws Exception {
+		Field field = target.getClass().getDeclaredField(name);
+		field.setAccessible(true);
+		field.set(target, value);
+	}
+
+	private static Object readStaticField(Class<?> type, String name) throws Exception {
+		Field field = type.getDeclaredField(name);
+		field.setAccessible(true);
+		return field.get(null);
+	}
+
+	private static void setStaticField(Class<?> type, String name, Object value) throws Exception {
+		Field field = type.getDeclaredField(name);
+		field.setAccessible(true);
+		field.set(null, value);
+	}
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

게시판마스터 등록·수정 폼 진입 경로는 `EgovComponentChecker.hasComponent` 결과를 `useComment`·`useSatisfaction`으로 담습니다. 같은 뷰를 되돌려주는 두 POST 오류 분기는 `bbsTyCode`만 담고 이 둘을 빠뜨립니다.

| 경로 | `useComment`·`useSatisfaction` |
|---|---|
| 등록 진입 `:126~131` | 담음 |
| 등록 검증 실패 `:153~162` | 없음 |
| 수정 진입 `:411~416` | 담음 |
| 수정 검증 실패 `:445~454` | 없음 |

**증상은 두 화면이 다릅니다.**

등록 화면은 `EgovBBSMasterRegist.jsp:214`의 `<c:if test="${useComment == 'true' || useSatisfaction == 'true'}">`가 추가 선택사항 `<tr>` 전체를 감쌉니다. 두 속성이 없으면 행이 통째로 사라지고 그 안의 `<form:select path="option">`도 같이 없어집니다. 재제출 시 `option`이 파라미터로 실리지 않으니 `BoardMaster.option`은 초기값 `""`로 남습니다. `EgovBBSMasterServiceImpl`은 `option`이 `comment`나 `stsfdg`일 때만 추가옵션을 저장하므로, 사용자가 고른 값은 오류 없이 버려집니다.

수정 화면은 `EgovBBSMasterUpdt.jsp:194~209`의 `<tr>`이 무조건 렌더되고 `<c:if>`는 `<option>` 두 개(`:200~205`)에만 걸립니다. 그래서 값이 유실되지는 않습니다. 현재 설정값이 목록에 없어 잘못 표시되는 선에서 그칩니다. 이 화면의 select는 `:197`에서 `option != 'na'`이면 disabled라 어차피 제출되지 않습니다.

화면 결과는 실행으로 확인하지 않았습니다. `<c:if>`가 `<tr>`을 감싸는 범위와 `<form:select>` 위치에서 나오는 결론입니다.

AS-IS

```java
if (bindingResult.hasErrors()) {
    ComDefaultCodeVO vo = new ComDefaultCodeVO();
    vo.setCodeId("COM004");
    model.addAttribute("bbsTyCode", cmmUseService.selectCmmCodeDetail(vo));
    return "egovframework/com/cop/bbs/EgovBBSMasterRegist";
}
```

TO-BE

```java
if (bindingResult.hasErrors()) {
    ComDefaultCodeVO vo = new ComDefaultCodeVO();
    vo.setCodeId("COM004");
    model.addAttribute("bbsTyCode", cmmUseService.selectCmmCodeDetail(vo));
    addAddedOptionsAttribute(model);
    return "egovframework/com/cop/bbs/EgovBBSMasterRegist";
}
```

중복돼 있던 `hasComponent` 블록을 `addAddedOptionsAttribute(ModelMap)` 헬퍼로 모아 진입 경로와 오류 재표시가 같은 코드를 쓰게 했습니다.

### 영향 범위

컨트롤러 한 파일입니다. JSP는 손대지 않았습니다. 조건부 렌더 자체는 의도된 설계입니다.

상세조회 `selectBBSMasterDetail`에도 같은 블록이 있지만 폼 재표시 흐름이 아니라 그대로 뒀습니다. 수정 오류 분기의 `model.addAttribute("result", ...)`는 JSP에서 참조되지 않는 죽은 코드입니다. 이번 건과 별개라 손대지 않았습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`EgovBBSMasterControllerTest` 2건을 추가했습니다. 스프링 컨텍스트 없이 컨트롤러를 만들고 협력 객체를 `Proxy`로 세웁니다. 검증 실패를 만들어 오류 분기를 태운 뒤 모델에 두 속성이 있는지 봅니다.

수정 전(RED, 컨트롤러만 되돌려 실행)

```
[ERROR] Tests run: 2, Failures: 2, Errors: 0, Skipped: 0, Time elapsed: 0.024 s <<< FAILURE! -- in egovframework.com.cop.bbs.web.EgovBBSMasterControllerTest
[ERROR]   EgovBBSMasterControllerTest.insertBBSMasterKeepsAddedOptionsAttributesOnValidationError:86 useComment 가 모델에 없다 ==> expected: <true> but was: <false>
[ERROR]   EgovBBSMasterControllerTest.updateBBSMasterKeepsAddedOptionsAttributesOnValidationError:96 useComment 가 모델에 없다 ==> expected: <true> but was: <false>
```

수정 후(GREEN)

```
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.021 s -- in egovframework.com.cop.bbs.web.EgovBBSMasterControllerTest
[INFO] BUILD SUCCESS
```

pom의 `<skipTests>true</skipTests>`를 임시로 풀고 받은 출력이며 pom 변경은 커밋에 넣지 않았습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음 (화면 렌더링은 관측하지 않았습니다)

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음
