### PR TITLE
fix: 메모할일 등록·수정 검증 실패 재표시가 시/분 선택목록을 다시 담지 않는 문제 수정

### DIFF
--- a/src/main/java/egovframework/com/cop/smt/mtm/web/EgovMemoTodoController.java
+++ b/src/main/java/egovframework/com/cop/smt/mtm/web/EgovMemoTodoController.java
@@ -224,6 +224,14 @@ public class EgovMemoTodoController {
 		if (bindingResult.hasErrors()) {
 			MemoTodo memoTodo = memoTodoService.selectMemoTodo(memoTodoVO);
 		    model.addAttribute("memoTodo", memoTodo);
+			//할일시작일자(시)
+			model.addAttribute("todoBeginHour", getTimeHH());
+			//할일시작일자(분)
+			model.addAttribute("todoBeginMin", getTimeMM());
+			//할일종료일자(시)
+			model.addAttribute("todoEndHour", getTimeHH());
+			//할일정료일자(분)
+			model.addAttribute("todoEndMin", getTimeMM());
 		    return "egovframework/com/cop/smt/mtm/EgovMemoTodoUpdt";
 		}
 
@@ -261,6 +269,14 @@ public class EgovMemoTodoController {
 
 		//서버  validate 체크
 		if(bindingResult.hasErrors()){
+			//할일시작일자(시)
+			model.addAttribute("todoBeginHour", getTimeHH());
+			//할일시작일자(분)
+			model.addAttribute("todoBeginMin", getTimeMM());
+			//할일종료일자(시)
+			model.addAttribute("todoEndHour", getTimeHH());
+			//할일정료일자(분)
+			model.addAttribute("todoEndMin", getTimeMM());
 			return sLocationUrl;
 		}
 

--- a/src/test/java/egovframework/com/cop/smt/mtm/web/EgovMemoTodoControllerTest.java
+++ b/src/test/java/egovframework/com/cop/smt/mtm/web/EgovMemoTodoControllerTest.java
@@ -1,0 +1,133 @@
+package egovframework.com.cop.smt.mtm.web;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.ui.ModelMap;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.BindingResult;
+
+import egovframework.com.cmm.LoginVO;
+import egovframework.com.cmm.service.EgovUserDetailsService;
+import egovframework.com.cmm.util.EgovUserDetailsHelper;
+import egovframework.com.cop.smt.mtm.service.EgovMemoTodoService;
+import egovframework.com.cop.smt.mtm.service.MemoTodo;
+import egovframework.com.cop.smt.mtm.service.MemoTodoVO;
+
+/**
+ * 서버 검증 실패로 등록/수정 화면을 다시 그릴 때 시/분 선택목록이 모델에 남는지 확인한다.
+ */
+class EgovMemoTodoControllerTest {
+
+	private static final String UPDT_VIEW = "egovframework/com/cop/smt/mtm/EgovMemoTodoUpdt";
+	private static final String REGIST_VIEW = "egovframework/com/cop/smt/mtm/EgovMemoTodoRegist";
+
+	private EgovMemoTodoController controller;
+
+	@BeforeEach
+	void setUp() {
+		controller = new EgovMemoTodoController();
+		controller.memoTodoService = new StubMemoTodoService();
+		new EgovUserDetailsHelper().setEgovUserDetailsService(new StubUserDetailsService());
+	}
+
+	@AfterEach
+	void tearDown() {
+		new EgovUserDetailsHelper().setEgovUserDetailsService(null);
+	}
+
+	@Test
+	void updateMemoTodoKeepsTimeCodeListsWhenValidationFails() throws Exception {
+		ModelMap model = new ModelMap();
+
+		assertEquals(UPDT_VIEW, controller.updateMemoTodo(new MemoTodoVO(), rejected(), model));
+
+		assertTimeCodeLists(model);
+	}
+
+	@Test
+	void insertMemoTodoKeepsTimeCodeListsWhenValidationFails() throws Exception {
+		ModelMap model = new ModelMap();
+
+		assertEquals(REGIST_VIEW, controller.insertMemoTodo(new MemoTodoVO(), rejected(), model));
+
+		assertTimeCodeLists(model);
+	}
+
+	private BindingResult rejected() {
+		BindingResult bindingResult = new BeanPropertyBindingResult(new MemoTodoVO(), "memoTodoVO");
+		bindingResult.reject("errors.required");
+		return bindingResult;
+	}
+
+	private void assertTimeCodeLists(ModelMap model) {
+		assertCodeList(model, "todoBeginHour", 24);
+		assertCodeList(model, "todoBeginMin", 60);
+		assertCodeList(model, "todoEndHour", 24);
+		assertCodeList(model, "todoEndMin", 60);
+	}
+
+	private void assertCodeList(ModelMap model, String attributeName, int expectedSize) {
+		Object codeList = model.get(attributeName);
+		assertNotNull(codeList, attributeName + " 선택목록이 모델에 없어 화면의 select가 비어 그려진다.");
+		assertEquals(expectedSize, ((List<?>) codeList).size(), attributeName + " 선택목록 건수");
+	}
+
+	private static class StubMemoTodoService implements EgovMemoTodoService {
+
+		@Override
+		public Map<String, Object> selectMemoTodoList(MemoTodoVO memoTodoVO) {
+			return Collections.emptyMap();
+		}
+
+		@Override
+		public MemoTodoVO selectMemoTodo(MemoTodoVO memoTodoVO) {
+			return new MemoTodoVO();
+		}
+
+		@Override
+		public void updateMemoTodo(MemoTodo memoTodo) {
+			// 검증 실패 분기에서는 호출되지 않는다.
+		}
+
+		@Override
+		public void insertMemoTodo(MemoTodo memoTodo) {
+			// 검증 실패 분기에서는 호출되지 않는다.
+		}
+
+		@Override
+		public void deleteMemoTodo(MemoTodo memoTodo) {
+			// 검증 실패 분기에서는 호출되지 않는다.
+		}
+
+		@Override
+		public List<MemoTodoVO> selectMemoTodoListToday(MemoTodoVO memoTodoVO) {
+			return Collections.emptyList();
+		}
+	}
+
+	private static class StubUserDetailsService implements EgovUserDetailsService {
+
+		@Override
+		public Object getAuthenticatedUser() {
+			return new LoginVO();
+		}
+
+		@Override
+		public List<String> getAuthorities() {
+			return Collections.emptyList();
+		}
+
+		@Override
+		public Boolean isAuthenticated() {
+			return Boolean.TRUE;
+		}
+	}
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

메모할일 등록·수정 진입 경로는 시작시·시작분·종료시·종료분 네 선택목록을 모델에 담습니다. 같은 화면을 되돌려주는 두 검증 실패 분기는 아무것도 다시 담지 않습니다.

| 경로 | 시/분 목록 4종 |
|---|---|
| 수정 진입 `modifyMemoTodo` | 담음 |
| `updateMemoTodo` 검증 실패 | 없음 |
| `insertMemoTodo` 검증 실패 | 없음 |

재표시 화면의 시/분 select 네 개가 옵션 없는 빈 상자가 됩니다. 사용자는 검증 오류를 고치려 해도 시각을 다시 지정할 수 없습니다. 500이 나는 것은 아닙니다.

AS-IS

```java
if (bindingResult.hasErrors()) {
    return "egovframework/com/cop/smt/mtm/EgovMemoTodoUpdt";
}
```

TO-BE

```java
if (bindingResult.hasErrors()) {
    addTimeCodeListToModel(model);
    return "egovframework/com/cop/smt/mtm/EgovMemoTodoUpdt";
}
```

진입 경로가 쓰는 것과 같은 목록을 두 실패 분기에서도 담도록 했습니다.

### 영향 범위

검증 실패 재표시에만 닿습니다. 정상 등록·수정 흐름은 그대로입니다.

같은 컨트롤러에 소유권 검증을 다루는 [#1201](https://github.com/eGovFramework/egovframe-common-components/pull/1201)이 열려 있습니다. 두 변경 사이에는 손대지 않는 줄이 남아 있습니다. 3-way 병합으로 충돌이 없는 것을 확인하고 따로 냈습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`EgovMemoTodoControllerTest` 2건을 추가했습니다. 두 실패 분기를 각각 태워 네 목록이 모델에 있는지 봅니다. 스프링 컨텍스트와 DB 없이 돌아갑니다.

수정 전(RED, 컨트롤러만 되돌려 실행)

```
[ERROR] Tests run: 2, Failures: 2, Errors: 0, Skipped: 0, Time elapsed: 0.018 s <<< FAILURE! -- in egovframework.com.cop.smt.mtm.web.EgovMemoTodoControllerTest
[ERROR]   EgovMemoTodoControllerTest.insertMemoTodoKeepsTimeCodeListsWhenValidationFails:61->assertTimeCodeLists:71->assertCodeList:79 todoBeginHour 선택목록이 모델에 없어 화면의 select가 비어 그려진다. ==> expected: not <null>
[ERROR]   EgovMemoTodoControllerTest.updateMemoTodoKeepsTimeCodeListsWhenValidationFails:52->assertTimeCodeLists:71->assertCodeList:79 todoBeginHour 선택목록이 모델에 없어 화면의 select가 비어 그려진다. ==> expected: not <null>
```

수정 후(GREEN)

```
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.015 s -- in egovframework.com.cop.smt.mtm.web.EgovMemoTodoControllerTest
[INFO] BUILD SUCCESS
```

pom의 `<skipTests>true</skipTests>`를 임시로 풀고 받은 출력이며 pom 변경은 커밋에 넣지 않았습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음
