### PR TITLE
fix: 만족도 목록 페이징이 댓글 화면의 함수를 불러 동작하지 않는 문제 수정

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/egovframework/com/cop/stf/EgovSatisfactionList.jsp
+++ b/src/main/webapp/WEB-INF/jsp/egovframework/com/cop/stf/EgovSatisfactionList.jsp
@@ -182,7 +182,7 @@ function fn_egov_select_satisfactionList(pageNo) {
 	<!-- paging navigation -->
 		<div class="paging">
 			<ul>
-			<ui:pagination paginationInfo="${paginationInfo}" type="image" jsFunction="fn_egov_select_commentList"/>
+			<ui:pagination paginationInfo="${paginationInfo}" type="image" jsFunction="fn_egov_select_satisfactionList"/>
 			</ul>
 		</div>
 

--- a/src/test/java/egovframework/com/cop/stf/web/EgovSatisfactionListJspTest.java
+++ b/src/test/java/egovframework/com/cop/stf/web/EgovSatisfactionListJspTest.java
@@ -1,0 +1,60 @@
+package egovframework.com.cop.stf.web;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * 만족도 목록 화면의 페이징 태그가 이 화면이 정의한 페이징 함수를 가리키는지 확인한다.
+ *
+ * <p>만족도 화면은 자기 페이징 함수 fn_egov_select_satisfactionList 를 직접 정의하고,
+ * "만족도 초기화" 버튼도 그 함수를 부른다. 페이징 태그만 다른 화면의 함수를 가리키면
+ * 댓글을 끈 게시판(ANSWER_AT='N', STSFDG_AT='Y')에서 페이징이 동작하지 않는다.
+ * 그 화면에는 댓글 form 이 없어 함수가 참조할 대상이 사라지기 때문이다.</p>
+ */
+class EgovSatisfactionListJspTest {
+
+	private static final String SATISFACTION_JSP =
+			"src/main/webapp/WEB-INF/jsp/egovframework/com/cop/stf/EgovSatisfactionList.jsp";
+
+	private static final Pattern PAGINATION_JS_FUNCTION =
+			Pattern.compile("<ui:pagination[^>]*jsFunction=\"([^\"]+)\"");
+
+	private static final Pattern FUNCTION_DECLARATION =
+			Pattern.compile("function\\s+(\\w+)\\s*\\(");
+
+	@Test
+	void paginationCallsFunctionDeclaredInSameJsp() throws IOException {
+		String source = new String(Files.readAllBytes(Paths.get(SATISFACTION_JSP)), StandardCharsets.UTF_8);
+
+		List<String> jsFunctions = matches(PAGINATION_JS_FUNCTION, source);
+		assertEquals(1, jsFunctions.size(), SATISFACTION_JSP + " 의 페이징 태그를 찾지 못했습니다.");
+
+		Set<String> declared = new HashSet<>(matches(FUNCTION_DECLARATION, source));
+		String jsFunction = jsFunctions.get(0);
+
+		assertTrue(declared.contains(jsFunction),
+				"이 화면에 정의되지 않은 함수를 페이징 태그가 가리키고 있습니다 : " + jsFunction);
+	}
+
+	private List<String> matches(Pattern pattern, String source) {
+		List<String> found = new ArrayList<>();
+		Matcher matcher = pattern.matcher(source);
+		while (matcher.find()) {
+			found.add(matcher.group(1));
+		}
+		return found;
+	}
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

만족도 목록의 페이징 태그가 `jsFunction`으로 `fn_egov_select_commentList`를 가리킵니다. 그 함수는 댓글 화면 것입니다.

만족도 화면은 같은 파일 `:105`에서 자기 함수 `fn_egov_select_satisfactionList(pageNo)`를 정의합니다. 같은 파일 `:257`의 "만족도 초기화" 버튼은 이미 그 함수를 부릅니다. 페이징 태그 하나만 남의 함수를 가리키고 있습니다.

댓글 함수는 첫 줄에서 `document.getElementById("articleCommentVO")`로 댓글 폼을 찾습니다. 그 폼은 `EgovArticleCommentList.jsp:67`에만 있고 댓글 fragment는 `${useComment == 'true'}`일 때만 import됩니다. 댓글을 끄고 만족도만 켠 게시판에서는 폼이 없어 다음 줄에서 TypeError가 나고 요청이 나가지 않습니다. 페이지 번호를 눌러도 아무 반응이 없습니다.

**두 기능은 독립 설정입니다.**

- `COMTNBBSMASTEROPTN`이 `ANSWER_AT`과 `STSFDG_AT`을 별개 `NOT NULL` 컬럼으로 갖습니다.
- `EgovArticleController`가 `canUseComment`와 `canUseSatisfaction`을 각각 물어 두 값을 따로 담습니다. 그 위에 `2011.07.01 : 댓글, 만족도 조사 기능의 종속성 제거` 주석이 있습니다.

둘 다 켠 흔한 설정에서는 두 폼의 hidden 이름이 `subPageIndex`로 같아 어느 폼으로 제출하든 만족도 목록도 함께 넘어갑니다. 그래서 지금까지 드러나지 않았습니다.

AS-IS (`EgovSatisfactionList.jsp:185`)

```jsp
<ui:pagination paginationInfo="${paginationInfo}" type="image" jsFunction="fn_egov_select_commentList"/>
```

TO-BE

```jsp
<ui:pagination paginationInfo="${paginationInfo}" type="image" jsFunction="fn_egov_select_satisfactionList"/>
```

### 영향 범위

제출 URL은 바뀌지 않습니다. 두 함수 모두 `/cop/bbs/selectArticleDetail.do`로 제출합니다. 달라지는 것은 어느 폼이 요청을 싣느냐입니다.

댓글과 만족도가 `subPageIndex` 파라미터 이름을 공유하는 문제는 이 수정으로 없어지지 않습니다. 둘 다 켜면 여전히 두 목록이 함께 넘어갑니다. 별개 사안이라 손대지 않았습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`EgovSatisfactionListJspTest` 1건을 추가했습니다. JSP를 읽어 페이징 태그가 지목한 함수가 그 파일에 정의돼 있는지 봅니다.

`EgovArticleCommentList.jsp:63`도 같은 `jsFunction`을 쓰지만 거기서는 정상입니다. 그 fragment는 함수를 정의하는 페이지에서만 import되기 때문입니다. 그래서 테스트를 이 파일 하나로 좁혔습니다.

수정 전(RED, 태그 속성만 되돌려 실행)

```
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.016 s <<< FAILURE! -- in egovframework.com.cop.stf.web.EgovSatisfactionListJspTest
[ERROR]   EgovSatisfactionListJspTest.paginationCallsFunctionDeclaredInSameJsp:48 이 화면에 정의되지 않은 함수를 페이징 태그가 가리키고 있습니다 : fn_egov_select_commentList ==> expected: <true> but was: <false>
```

수정 후(GREEN)

```
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.014 s -- in egovframework.com.cop.stf.web.EgovSatisfactionListJspTest
[INFO] BUILD SUCCESS
```

pom의 `<skipTests>true</skipTests>`를 임시로 풀고 받은 출력이며 pom 변경은 커밋에 넣지 않았습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음 (브라우저 동작은 관측하지 않았습니다)

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음
