### PR TITLE
fix: 지식맵 수정이 최종수정자 감사 컬럼을 채우지 않아 NULL이 박히는 문제 수정

### DIFF
--- a/src/main/java/egovframework/com/dam/map/mat/web/EgovMapMaterialController.java
+++ b/src/main/java/egovframework/com/dam/map/mat/web/EgovMapMaterialController.java
@@ -210,6 +210,7 @@ public class EgovMapMaterialController {
 		}
 
 		mapMaterial.setFrstRegisterId(loginVO.getUniqId());
+		mapMaterial.setLastUpdusrId(loginVO.getUniqId());
 		mapMaterialService.updateMapMaterial(mapMaterial);
 		return "forward:/dam/map/mat/EgovComDamMapMaterialList.do";
 	}

--- a/src/main/java/egovframework/com/dam/map/tea/web/EgovMapTeamController.java
+++ b/src/main/java/egovframework/com/dam/map/tea/web/EgovMapTeamController.java
@@ -175,6 +175,7 @@ public class EgovMapTeamController {
 		}
 
 		mapTeam.setFrstRegisterId(loginVO.getUniqId());
+		mapTeam.setLastUpdusrId(loginVO.getUniqId());
 		mapTeamService.updateMapTeam(mapTeam);
 		return "forward:/dam/map/tea/EgovComDamMapTeamList.do";
 	}

--- a/src/test/java/egovframework/com/dam/map/mat/web/EgovMapMaterialControllerTest.java
+++ b/src/test/java/egovframework/com/dam/map/mat/web/EgovMapMaterialControllerTest.java
@@ -1,0 +1,53 @@
+package egovframework.com.dam.map.mat.web;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.lang.reflect.Proxy;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.ui.ModelMap;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.BindingResult;
+
+import egovframework.com.cmm.LoginVO;
+import egovframework.com.dam.map.mat.service.EgovMapMaterialService;
+import egovframework.com.dam.map.mat.service.MapMaterial;
+import egovframework.com.dam.map.mat.service.MapMaterialVO;
+
+class EgovMapMaterialControllerTest {
+
+	private static final String UNIQ_ID = "USRCNFRM_00000000000";
+
+	@Test
+	void updateMapMaterialSetsLastUpdusrIdBoundByUpdateStatement() throws Exception {
+		AtomicReference<MapMaterial> updated = new AtomicReference<>();
+
+		EgovMapMaterialController controller = new EgovMapMaterialController();
+		ReflectionTestUtils.setField(controller, "mapMaterialService", mapMaterialServiceCapturingUpdate(updated));
+
+		LoginVO loginVO = new LoginVO();
+		loginVO.setUniqId(UNIQ_ID);
+
+		MapMaterial mapMaterial = new MapMaterial();
+		mapMaterial.setKnoTypeCd("KNWLDG_TY_0000000001");
+		BindingResult bindingResult = new BeanPropertyBindingResult(mapMaterial, "mapMaterial");
+
+		controller.updateMapMaterial(loginVO, new MapMaterialVO(), mapMaterial, bindingResult, new ModelMap());
+
+		assertEquals(UNIQ_ID, updated.get().getLastUpdusrId());
+	}
+
+	private EgovMapMaterialService mapMaterialServiceCapturingUpdate(AtomicReference<MapMaterial> updated) {
+		return (EgovMapMaterialService) Proxy.newProxyInstance(EgovMapMaterialService.class.getClassLoader(),
+				new Class<?>[] { EgovMapMaterialService.class }, (proxy, method, args) -> {
+					if ("updateMapMaterial".equals(method.getName())) {
+						updated.set((MapMaterial) args[0]);
+						return null;
+					}
+
+					throw new UnsupportedOperationException(method.toString());
+				});
+	}
+}

--- a/src/test/java/egovframework/com/dam/map/tea/web/EgovMapTeamControllerTest.java
+++ b/src/test/java/egovframework/com/dam/map/tea/web/EgovMapTeamControllerTest.java
@@ -1,0 +1,52 @@
+package egovframework.com.dam.map.tea.web;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.lang.reflect.Proxy;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.ui.ModelMap;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.BindingResult;
+
+import egovframework.com.cmm.LoginVO;
+import egovframework.com.dam.map.tea.service.EgovMapTeamService;
+import egovframework.com.dam.map.tea.service.MapTeam;
+
+class EgovMapTeamControllerTest {
+
+	private static final String UNIQ_ID = "USRCNFRM_00000000000";
+
+	@Test
+	void updateMapTeamSetsLastUpdusrIdBoundByUpdateStatement() throws Exception {
+		AtomicReference<MapTeam> updated = new AtomicReference<>();
+
+		EgovMapTeamController controller = new EgovMapTeamController();
+		ReflectionTestUtils.setField(controller, "mapTeamService", mapTeamServiceCapturingUpdate(updated));
+
+		LoginVO loginVO = new LoginVO();
+		loginVO.setUniqId(UNIQ_ID);
+
+		MapTeam mapTeam = new MapTeam();
+		mapTeam.setOrgnztId("ORGNZT_0000000000001");
+		BindingResult bindingResult = new BeanPropertyBindingResult(mapTeam, "mapTeam");
+
+		controller.updateMapTeam(loginVO, mapTeam, bindingResult, new ModelMap());
+
+		assertEquals(UNIQ_ID, updated.get().getLastUpdusrId());
+	}
+
+	private EgovMapTeamService mapTeamServiceCapturingUpdate(AtomicReference<MapTeam> updated) {
+		return (EgovMapTeamService) Proxy.newProxyInstance(EgovMapTeamService.class.getClassLoader(),
+				new Class<?>[] { EgovMapTeamService.class }, (proxy, method, args) -> {
+					if ("updateMapTeam".equals(method.getName())) {
+						updated.set((MapTeam) args[0]);
+						return null;
+					}
+
+					throw new UnsupportedOperationException(method.toString());
+				});
+	}
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

조직별·지식유형 두 지식맵의 수정 경로가 `setFrstRegisterId`만 호출합니다. 그런데 `updateMapTeam`과 `updateMapMaterial` 매퍼는 `LAST_UPDUSR_ID = #{lastUpdusrId}`를 바인딩하므로 감사 컬럼에 NULL이 들어갑니다.

등록 매퍼는 `LAST_UPDUSR_ID`에 `#{frstRegisterId}`를 바인딩해 값을 넣습니다. **즉 수정이 이미 들어있던 값을 지웁니다.** `COMTNDAMMAPTEAM`에는 `FRST_REGISTER_ID` 컬럼 자체가 없어 `LAST_UPDUSR_ID`가 유일한 감사 컬럼입니다.

형제 컴포넌트 `dam/spe`의 `EgovKnoSpecialistController`는 같은 상황에서 두 setter를 나란히 호출합니다.

AS-IS

```java
mapTeam.setFrstRegisterId(loginVO.getUniqId());
mapTeamService.updateMapTeam(mapTeam);
```

TO-BE

```java
mapTeam.setFrstRegisterId(loginVO.getUniqId());
mapTeam.setLastUpdusrId(loginVO.getUniqId());
mapTeamService.updateMapTeam(mapTeam);
```

지식유형 쪽도 같은 한 줄입니다.

### 영향 범위

컨트롤러 두 파일에 한 줄씩입니다. 기존 `setFrstRegisterId`는 그대로 뒀습니다.

컨트롤러에서 고치면 여덟 개 DB 방언 매퍼를 손대지 않아도 됩니다. 두 도메인의 매퍼 열여섯 개가 모두 같은 바인딩을 쓰는 것을 확인했습니다.

`dam/map` 한 도메인만 담았습니다. 같은 성격이 다른 컴포넌트에도 있지만 도메인별로 나누는 편이 리뷰가 쉽다고 봤습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`EgovMapTeamControllerTest`와 `EgovMapMaterialControllerTest` 각 1건을 추가했습니다. 서비스를 `Proxy`로 세워 수정 경로가 전달한 VO를 잡고 `getLastUpdusrId()`를 봅니다. 스프링 컨텍스트와 DB 없이 돌아갑니다.

수정 전(RED, 컨트롤러 두 줄만 되돌려 실행)

```
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.133 s <<< FAILURE! -- in egovframework.com.dam.map.mat.web.EgovMapMaterialControllerTest
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.003 s <<< FAILURE! -- in egovframework.com.dam.map.tea.web.EgovMapTeamControllerTest
[ERROR]   EgovMapMaterialControllerTest.updateMapMaterialSetsLastUpdusrIdBoundByUpdateStatement:39 expected: <USRCNFRM_00000000000> but was: <>
[ERROR]   EgovMapTeamControllerTest.updateMapTeamSetsLastUpdusrIdBoundByUpdateStatement:38 expected: <USRCNFRM_00000000000> but was: <null>
```

수정 후(GREEN)

```
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

pom의 `<skipTests>true</skipTests>`를 임시로 풀고 받은 출력이며 pom 변경은 커밋에 넣지 않았습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음 (서버 측 감사 컬럼)

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음 (화면 변경 없음)
