### PR TITLE
fix: 테스트 설정의 mysql 접속 주소가 특정 개발 장비를 가리키는 문제 수정

### DIFF
--- a/src/test/java/egovframework/com/cmm/TestGlobalsDatasourceUrlTest.java
+++ b/src/test/java/egovframework/com/cmm/TestGlobalsDatasourceUrlTest.java
@@ -1,0 +1,51 @@
+package egovframework.com.cmm;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * 테스트 설정의 데이터베이스 접속 주소가 로컬을 가리키는지 확인한다.
+ *
+ * <p>이 파일은 테스트 클래스패스에서 같은 이름의 main 리소스를 덮어쓴다. 여기에 특정 개발 장비의
+ * 주소가 남으면 로컬에 DB 를 세워도 테스트가 그 주소로 접속을 시도하고, 연결 거부가 아니라
+ * TCP 타임아웃으로 끝나 원인을 찾기 어렵다.</p>
+ */
+class TestGlobalsDatasourceUrlTest {
+
+	private static final String GLOBALS = "/egovframework/egovProps/globals.properties";
+
+	@Test
+	void everyDatasourceUrlPointsToLoopback() throws IOException {
+		Properties globals = new Properties();
+		try (InputStream in = getClass().getResourceAsStream(GLOBALS)) {
+			assertTrue(in != null, GLOBALS + " 을 클래스패스에서 찾지 못했습니다.");
+			globals.load(in);
+		}
+
+		List<String> urls = new ArrayList<>();
+		List<String> remote = new ArrayList<>();
+		for (Map.Entry<Object, Object> entry : globals.entrySet()) {
+			String key = String.valueOf(entry.getKey());
+			if (!key.startsWith("Globals.") || !key.endsWith(".Url")) {
+				continue;
+			}
+			String url = String.valueOf(entry.getValue());
+			urls.add(key);
+			if (!url.contains("127.0.0.1") && !url.contains("localhost")) {
+				remote.add(key + " = " + url);
+			}
+		}
+
+		assertFalse(urls.isEmpty(), GLOBALS + " 에서 접속 주소를 찾지 못했습니다.");
+		assertTrue(remote.isEmpty(), "로컬이 아닌 접속 주소가 있습니다 : " + remote);
+	}
+}

--- a/src/test/resources/egovframework/egovProps/globals.properties
+++ b/src/test/resources/egovframework/egovProps/globals.properties
@@ -37,7 +37,7 @@ Globals.MainPage  = /EgovContent.do
 #mysql
 Globals.mysql.DriverClassName=net.sf.log4jdbc.DriverSpy
 #Globals.mysql.Url=jdbc:log4jdbc:mysql://127.0.0.1:3306/comall
-Globals.mysql.Url=jdbc:log4jdbc:mysql://192.168.100.82:3306/com
+Globals.mysql.Url=jdbc:log4jdbc:mysql://127.0.0.1:3306/com
 Globals.mysql.UserName = com
 Globals.mysql.Password = xz4fmrSdr1vGGl6UtwPLwA%3D%3D
 


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

테스트 클래스패스의 `globals.properties`가 mysql 접속 주소로 사설 IP를 씁니다. 같은 파일의 나머지 일곱 개 DB는 전부 `127.0.0.1`이고 main 리소스의 같은 항목도 `127.0.0.1`입니다. mysql 하나만 다릅니다.

| 항목 | main 리소스 | 테스트 리소스 |
|---|---|---|
| `Globals.mysql.Url` | `127.0.0.1:3306` | **`192.168.100.82:3306`** |
| `Globals.oracle.Url` | `127.0.0.1:1521` | `127.0.0.1:1521` |
| `Globals.altibase.Url` | `127.0.0.1:20300` | `127.0.0.1:20300` |
| `Globals.tibero.Url` | `127.0.0.1:8629` | `127.0.0.1:8629` |
| `Globals.cubrid.Url` | `127.0.0.1:33000` | `127.0.0.1:33000` |
| `Globals.maria.Url` | `127.0.0.1:3336` | `127.0.0.1:3336` |
| `Globals.postgres.Url` | `127.0.0.1:5432` | `127.0.0.1:5432` |
| `Globals.goldilocks.Url` | `127.0.0.1:22581` | `127.0.0.1:22581` |

이 파일은 테스트 클래스패스에서 같은 이름의 main 리소스를 덮어씁니다. 그래서 안내대로 로컬에 MySQL을 세워도 DAO 테스트는 `192.168.100.82`로 접속을 시도합니다.

증상이 조용한 것이 특히 곤란합니다. 그 주소에 아무것도 없으면 연결 거부가 아니라 **TCP 타임아웃**으로 끝나므로 원인이 설정에 있다는 사실이 드러나지 않습니다. 저는 이 주소를 찾기 전까지 컨테이너 포트 매핑과 IPv6 바인딩을 의심했습니다.

`1e764b1b`("egovframe-common-components 5.0.0")에서 들어왔습니다.

AS-IS

```properties
Globals.mysql.Url=jdbc:log4jdbc:mysql://192.168.100.82:3306/com
```

TO-BE

```properties
Globals.mysql.Url=jdbc:log4jdbc:mysql://127.0.0.1:3306/com
```

### 영향 범위

테스트 설정 한 줄입니다. 운영 설정(main 리소스)은 이미 `127.0.0.1`이라 바뀌는 것이 없습니다.

`<skipTests>true</skipTests>`가 켜져 있어 기본 빌드에서는 이 값이 쓰이지 않습니다. 그래서 지금 무언가 깨지고 있다는 이야기가 아니라, DAO 테스트를 돌리려는 사람이 반드시 걸린다는 이야기입니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`TestGlobalsDatasourceUrlTest` 1건을 추가했습니다. 테스트 클래스패스에서 `globals.properties`를 읽어 `Globals.*.Url` 전부가 루프백을 가리키는지 봅니다. 정규식이 아무것도 못 잡아 무의미하게 통과하는 것을 막으려고 항목이 비어 있지 않은지 먼저 단언합니다.

수정 전(RED)

```
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.016 s <<< FAILURE! -- in egovframework.com.cmm.TestGlobalsDatasourceUrlTest
[ERROR]   TestGlobalsDatasourceUrlTest.everyDatasourceUrlPointsToLoopback:49 로컬이 아닌 접속 주소가 있습니다 : [Globals.mysql.Url = jdbc:log4jdbc:mysql://192.168.100.82:3306/com] ==> expected: <true> but was: <false>
```

수정 후(GREEN)

```
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.013 s -- in egovframework.com.cmm.TestGlobalsDatasourceUrlTest
[INFO] BUILD SUCCESS
```

`<skipTests>true</skipTests>`를 임시로 풀고 받은 출력입니다. pom 변경은 커밋에 넣지 않았습니다.

참고로 이 수정 뒤 로컬 MySQL에 DDL과 DML을 적재하고 `DeptJobDAOTest`를 돌리면 25건 중 24건이 통과합니다. 지금은 컨텍스트 적재 단계에서 전부 실패합니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음 (테스트 설정)

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음
