### PR TITLE
fix: 참가신청이 있는 행사를 지울 때 그 신청과 결재가 정리되지 않는 문제 수정

### DIFF
--- a/src/main/java/egovframework/com/uss/ion/evt/web/EgovEventManageController.java
+++ b/src/main/java/egovframework/com/uss/ion/evt/web/EgovEventManageController.java
@@ -255,6 +255,15 @@ public class EgovEventManageController {
 	public String deleteEventManage(@ModelAttribute("eventManage") EventManage eventManage, SessionStatus status,
 			ModelMap model) throws Exception {
 
+		// 참가신청이 있는 행사는 삭제하지 않는다.(EgovEventReqstDetail.jsp 의 삭제버튼 노출조건과 같은 값을 서버에서도 확인)
+		EventManageVO eventManageVO = new EventManageVO();
+		eventManageVO.setEventId(eventManage.getEventId());
+		EventManageVO eventManageVO1 = egovEventManageService.selectEventManage(eventManageVO);
+		if (eventManageVO1 != null && eventManageVO1.getEventAtdrnCount() > 0) {
+			model.addAttribute("eventAtdrnExist", "true");
+			return "forward:/uss/ion/evt/EgovEventReqstManageList.do";
+		}
+
 		egovEventManageService.deleteEventManage(eventManage);
 		status.setComplete();
 		model.addAttribute("message", egovMessageSource.getMessage("success.common.delete"));

--- a/src/main/resources/egovframework/message/com/uss/ion/evt/message_en.properties
+++ b/src/main/resources/egovframework/message/com/uss/ion/evt/message_en.properties
@@ -22,6 +22,7 @@ comUssIonEvt.eventAtdrn.validate.sanctnerId = Responder ID
 
 # EgovEventReqstManageList.jsp
 comUssIonEvt.eventReqstManageList.title = Event Management List
+comUssIonEvt.eventReqstManageList.eventAtdrnExist = Cannot delete the event because it already has participation requests.
 
 # EgovEventReqstRegist.jsp
 comUssIonEvt.eventReqstRegist.title = Registration

--- a/src/main/resources/egovframework/message/com/uss/ion/evt/message_ko.properties
+++ b/src/main/resources/egovframework/message/com/uss/ion/evt/message_ko.properties
@@ -22,6 +22,7 @@ comUssIonEvt.eventAtdrn.validate.sanctnerId=\uacb0\uc7ac\uc790ID
 
 #EgovEventReqstManageList.jsp
 comUssIonEvt.eventReqstManageList.title=\ud589\uc0ac\uc2e0\uccad\uad00\ub9ac \ubaa9\ub85d
+comUssIonEvt.eventReqstManageList.eventAtdrnExist=\ucc38\uac00\uc2e0\uccad\uc790\uac00 \uc788\ub294 \ud589\uc0ac\ub294 \uc0ad\uc81c\ud560 \uc218 \uc5c6\uc2b5\ub2c8\ub2e4.
 
 #EgovEventReqstRegist.jsp
 comUssIonEvt.eventReqstRegist.title=\ud589\uc0ac  \ub4f1\ub85d

--- a/src/main/webapp/WEB-INF/jsp/egovframework/com/uss/ion/evt/EgovEventReqstManageList.jsp
+++ b/src/main/webapp/WEB-INF/jsp/egovframework/com/uss/ion/evt/EgovEventReqstManageList.jsp
@@ -40,6 +40,15 @@
 <script type="text/javaScript" language="javascript">
 <!--
 /* ********************************************************
+ * 초기화 함수
+ ******************************************************** */
+function fn_egov_init_evt(){
+	if("${eventAtdrnExist}" == "true"){
+		alert("<spring:message code="comUssIonEvt.eventReqstManageList.eventAtdrnExist" />");/* 참가신청자가 있는 행사는 삭제할 수 없습니다. */
+	}
+}
+
+/* ********************************************************
  * 페이징 처리 함수
  ******************************************************** */
  /*설명 : 행사 목록 페이지 조회 */
@@ -111,7 +120,7 @@ function fncEventReqstAtdrnList(eventId){
 -->
 </script>
 </head>
-<body>
+<body onLoad="fn_egov_init_evt()">
 <noscript class="noScriptTitle"><spring:message code="common.noScriptTitle.msg" /></noscript><!-- 자바스크립트를 지원하지 않는 브라우저에서는 일부 기능을 사용하실 수 없습니다. -->
 
 <div class="board">

--- a/src/test/java/egovframework/com/uss/ion/evt/web/EgovEventManageControllerTest.java
+++ b/src/test/java/egovframework/com/uss/ion/evt/web/EgovEventManageControllerTest.java
@@ -1,0 +1,90 @@
+package egovframework.com.uss.ion.evt.web;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Proxy;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.ui.ModelMap;
+import org.springframework.web.bind.support.SimpleSessionStatus;
+
+import egovframework.com.cmm.EgovMessageSource;
+import egovframework.com.uss.ion.evt.service.EgovEventManageService;
+import egovframework.com.uss.ion.evt.service.EventManage;
+import egovframework.com.uss.ion.evt.service.EventManageVO;
+
+/**
+ * 행사 삭제가 그 행사의 참가신청을 뒤에 남기지 않는지 확인한다.
+ *
+ * <p>행사 삭제는 COMTNEVENTMANAGE 한 행만 지운다. 상세화면은 참가신청 건수가 0일 때만
+ * 삭제버튼을 노출하지만(EgovEventReqstDetail.jsp) 삭제 요청을 받는 쪽에는 같은 확인이 없어,
+ * 화면을 그린 뒤 신청이 들어오면 참가신청을 남긴 채 행사만 지우는 요청이 실행된다.</p>
+ */
+class EgovEventManageControllerTest {
+
+	private EgovEventManageController controller;
+	private final AtomicBoolean deleted = new AtomicBoolean(false);
+	private int eventAtdrnCount = 1;
+
+	@BeforeEach
+	void setUp() {
+		EgovEventManageService service = (EgovEventManageService) Proxy.newProxyInstance(
+				getClass().getClassLoader(), new Class<?>[] { EgovEventManageService.class },
+				(proxy, method, args) -> {
+					switch (method.getName()) {
+					case "selectEventManage":
+						EventManageVO found = new EventManageVO();
+						found.setEventId("EVT_000000000001");
+						found.setEventAtdrnCount(eventAtdrnCount);
+						return found;
+					case "deleteEventManage":
+						deleted.set(true);
+						return null;
+					default:
+						return null;
+					}
+				});
+
+		controller = new EgovEventManageController();
+		ReflectionTestUtils.setField(controller, "egovEventManageService", service);
+		ReflectionTestUtils.setField(controller, "egovMessageSource", new EgovMessageSource() {
+			@Override
+			public String getMessage(String code) {
+				return code;
+			}
+		});
+	}
+
+	@Test
+	void deleteEventManageIsRefusedWhenEventStillHasAtdrn() throws Exception {
+		eventAtdrnCount = 1;
+		ModelMap model = new ModelMap();
+
+		controller.deleteEventManage(event(), new SimpleSessionStatus(), model);
+
+		assertFalse(deleted.get(), "참가신청이 있으면 행사를 지우지 않아야 한다");
+		assertEquals("true", model.get("eventAtdrnExist"), "화면에 알릴 표시가 있어야 한다");
+	}
+
+	@Test
+	void deleteEventManageProceedsWhenEventHasNoAtdrn() throws Exception {
+		eventAtdrnCount = 0;
+		ModelMap model = new ModelMap();
+
+		controller.deleteEventManage(event(), new SimpleSessionStatus(), model);
+
+		assertTrue(deleted.get(), "참가신청이 없는 행사는 지울 수 있어야 한다");
+		assertFalse(model.containsAttribute("eventAtdrnExist"));
+	}
+
+	private EventManage event() {
+		EventManage eventManage = new EventManage();
+		eventManage.setEventId("EVT_000000000001");
+		return eventManage;
+	}
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

행사 삭제는 행사 한 행만 지웁니다. 참가신청과 그 약식결재는 아무도 정리하지 않습니다. 매퍼 여덟 방언 전부 `DELETE FROM COMTNEVENTMANAGE WHERE EVENT_ID = #{eventId}` 한 문장뿐이고 `COMTNEVENTATDRN`·`COMTNINFRMLSANCTN`을 건드리는 문장이 없습니다.

**결과는 배포한 DDL에 따라 갈립니다.**

| 참조 무결성 | 지금 일어나는 일 |
|---|---|
| 걸려 있는 방언 | 삭제 자체가 실패해 사용자가 오류 화면을 봅니다 |
| 걸려 있지 않은 방언 | 참가신청이 남습니다. 참가신청 조회가 행사를 기준 테이블로 삼으므로 화면에서는 보이지 않습니다 |

어느 쪽도 좋은 결과가 아닙니다. 화면은 참가자 수와 무관하게 삭제 버튼을 노출합니다.

같은 클래스의 참가신청 삭제는 약식결재를 먼저 지우고 신청을 지웁니다. 정리 책임 자체는 이 모듈이 이미 지고 있습니다. 다만 개인이 자기 신청을 취소하는 흐름이라 관리자가 행사를 지우는 흐름과 성격이 달라, 이 대조는 참고로만 적습니다.

AS-IS

```java
egovEventManageService.deleteEventManage(eventManage);
return "forward:/uss/ion/evt/EgovEventReqstManageList.do";
```

TO-BE

```java
// 참가신청이 있는 행사는 삭제하지 않는다.
EventManageVO eventManageVO = new EventManageVO();
eventManageVO.setEventId(eventManage.getEventId());
EventManageVO found = egovEventManageService.selectEventManage(eventManageVO);

if (found != null && found.getEventAtdrnCount() > 0) {
    model.addAttribute("eventAtdrnExist", "true");
    return "forward:/uss/ion/evt/EgovEventReqstManageList.do";
}

egovEventManageService.deleteEventManage(eventManage);
return "forward:/uss/ion/evt/EgovEventReqstManageList.do";
```

건수는 기존 `selectEventManage`가 이미 돌려주므로 새 조회를 만들지 않았습니다.

### 영향 범위

참가신청이 없는 행사는 지금처럼 지워집니다. 달라지는 것은 참가신청이 있는 행사를 지우려 할 때뿐이고 그때는 오류 화면이나 조용한 잔존 대신 안내가 뜹니다.

참가신청을 먼저 정리한 뒤 행사를 지우면 됩니다. 그 경로는 화면에 이미 있습니다.

**연쇄 삭제로 가는 방법도 있습니다.** 되돌릴 수 없는 삭제라 이쪽을 택했습니다. 메인테이너가 연쇄 삭제를 원하신다면 그쪽으로 다시 내겠습니다.

메시지 키를 한글·영문에 하나씩 추가했고 목록 화면에 알림을 넣었습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`EgovEventManageControllerTest` 2건을 추가했습니다. 서비스를 `Proxy`로 세워 참가신청 건수를 바꿔가며 신청이 있으면 삭제가 호출되지 않고 없으면 호출되는지 봅니다. 스프링 컨텍스트와 DB 없이 돌아갑니다.

수정 전(RED, 컨트롤러만 되돌려 실행)

```
[ERROR] Tests run: 2, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.131 s <<< FAILURE! -- in egovframework.com.uss.ion.evt.web.EgovEventManageControllerTest
[ERROR]   EgovEventManageControllerTest.deleteEventManageIsRefusedWhenEventStillHasAtdrn:70 참가신청이 있으면 행사를 지우지 않아야 한다 ==> expected: <false> but was: <true>
```

수정 후(GREEN)

```
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.128 s -- in egovframework.com.uss.ion.evt.web.EgovEventManageControllerTest
[INFO] BUILD SUCCESS
```

`<skipTests>true</skipTests>`를 임시로 풀고 받은 출력이며 pom 변경은 커밋에 넣지 않았습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음
