### PR TITLE
fix: 예약이 있는 회의실을 지울 때 그 예약이 정리되지 않는 문제 수정

### DIFF
--- a/src/main/java/egovframework/com/uss/ion/mtg/service/EgovMtgPlaceManageService.java
+++ b/src/main/java/egovframework/com/uss/ion/mtg/service/EgovMtgPlaceManageService.java
@@ -76,6 +76,11 @@ public interface EgovMtgPlaceManageService {
 	public void deleteMtgPlaceResve(MtgPlaceResveVO mtgPlaceResveVO) throws Exception;
 
 	/**
+	 * 회의실에 등록된 예약 건수를 조회한다.
+	 */
+	public int selectMtgPlaceResveCnt(MtgPlaceManageVO mtgPlaceManageVO) throws Exception;
+
+	/**
 	 * 회의실 중복여부 체크.
 	 */
 	public int mtgPlaceResveDplactCeck(MtgPlaceManageVO mtgPlaceManageVO) throws Exception;

--- a/src/main/java/egovframework/com/uss/ion/mtg/service/impl/EgovMtgPlaceManageServiceImpl.java
+++ b/src/main/java/egovframework/com/uss/ion/mtg/service/impl/EgovMtgPlaceManageServiceImpl.java
@@ -169,6 +169,16 @@ public class EgovMtgPlaceManageServiceImpl extends EgovAbstractServiceImpl imple
 
 
 	/**
+	 * 회의실에 등록된 예약 건수를 조회한다.
+	 * @param mtgPlaceManageVO - 회의실관리 VO
+	 * @return int - 예약건수
+	 */
+	@Override
+	public int selectMtgPlaceResveCnt(MtgPlaceManageVO mtgPlaceManageVO) throws Exception {
+		return mtgPlaceManageDAO.selectMtgPlaceResveCnt(mtgPlaceManageVO);
+	}
+
+	/**
 	 * 회의실 중복여부 체크.
 	 * @param mtgPlaceManageVO - 회의실관리 VO
 	 * @return int - 중복건수

--- a/src/main/java/egovframework/com/uss/ion/mtg/service/impl/MtgPlaceManageDAO.java
+++ b/src/main/java/egovframework/com/uss/ion/mtg/service/impl/MtgPlaceManageDAO.java
@@ -132,6 +132,15 @@ public class MtgPlaceManageDAO extends EgovComAbstractDAO {
 	
 	
 	/**
+	 * 회의실에 등록된 예약 건수를 조회한다.
+	 * @param mtgPlaceManageVO - 회의실관리 VO
+	 * @return int - 예약건수
+	 */
+	public int selectMtgPlaceResveCnt(MtgPlaceManageVO mtgPlaceManageVO) {
+		return (Integer)selectOne("mtgPlaceManageDAO.selectMtgPlaceResveCnt", mtgPlaceManageVO);
+	}
+
+	/**
 	 * 회의실 중복여부 체크.
 	 * @param mtgPlaceManageVO - 회의실관리 VO
 	 * @return int - 중복건수

--- a/src/main/java/egovframework/com/uss/ion/mtg/web/EgovMtgPlaceManageController.java
+++ b/src/main/java/egovframework/com/uss/ion/mtg/web/EgovMtgPlaceManageController.java
@@ -262,6 +262,13 @@ public class EgovMtgPlaceManageController {
 	@PostMapping("/uss/ion/mtg/deleteMtgPlaceManage.do")
 	public String deleteMtgPlaceManage(@ModelAttribute("mtgPlaceManageVO") MtgPlaceManageVO mtgPlaceManageVO,
 			SessionStatus status, ModelMap model) throws Exception {
+		// 예약이 남아 있으면 회의실을 삭제하지 않는다.
+		// 예약 조회는 회의실을 기준 테이블로 삼으므로 회의실이 없어지면 그 예약은 목록에도 상세에도 나오지 않는다.
+		if (egovMtgPlaceManageService.selectMtgPlaceResveCnt(mtgPlaceManageVO) > 0) {
+			model.addAttribute("mtgPlaceResveExist", "true");
+			return "forward:/uss/ion/mtg/selectMtgPlaceManageList.do";
+		}
+
 		String atchFileId = mtgPlaceManageVO.getAtchFileId();
 
 		egovMtgPlaceManageService.deleteMtgPlaceManage(mtgPlaceManageVO);

--- a/src/main/resources/egovframework/mapper/com/uss/ion/mtg/EgovMtgPlaceManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/mtg/EgovMtgPlaceManage_SQL_altibase.xml
@@ -366,4 +366,11 @@
 		 </if>	       
     </select>
 
+    <select id="selectMtgPlaceResveCnt" parameterType="egovframework.com.uss.ion.mtg.service.MtgPlaceManageVO" resultType="int">
+        
+			SELECT count(resve_id) from COMTNMTGPLACERESVE
+			WHERE  MTGRUM_ID  = #{mtgPlaceId}
+        
+    </select>
+
 </mapper>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/mtg/EgovMtgPlaceManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/mtg/EgovMtgPlaceManage_SQL_cubrid.xml
@@ -366,4 +366,11 @@
 		 </if>	       
     </select>
 
+    <select id="selectMtgPlaceResveCnt" parameterType="egovframework.com.uss.ion.mtg.service.MtgPlaceManageVO" resultType="int">
+        
+			SELECT count(resve_id) from COMTNMTGPLACERESVE
+			WHERE  MTGRUM_ID  = #{mtgPlaceId}
+        
+    </select>
+
 </mapper>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/mtg/EgovMtgPlaceManage_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/mtg/EgovMtgPlaceManage_SQL_goldilocks.xml
@@ -366,4 +366,11 @@
 		 </if>	       
     </select>
 
+    <select id="selectMtgPlaceResveCnt" parameterType="egovframework.com.uss.ion.mtg.service.MtgPlaceManageVO" resultType="int">
+        
+			SELECT count(resve_id) from COMTNMTGPLACERESVE
+			WHERE  MTGRUM_ID  = #{mtgPlaceId}
+        
+    </select>
+
 </mapper>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/mtg/EgovMtgPlaceManage_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/mtg/EgovMtgPlaceManage_SQL_maria.xml
@@ -361,4 +361,11 @@
 		 </if>	       
     </select>
 
+    <select id="selectMtgPlaceResveCnt" parameterType="egovframework.com.uss.ion.mtg.service.MtgPlaceManageVO" resultType="int">
+        
+			SELECT count(resve_id) from COMTNMTGPLACERESVE
+			WHERE  MTGRUM_ID  = #{mtgPlaceId}
+        
+    </select>
+
 </mapper>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/mtg/EgovMtgPlaceManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/mtg/EgovMtgPlaceManage_SQL_mysql.xml
@@ -361,4 +361,11 @@
 		 </if>	       
     </select>
 
+    <select id="selectMtgPlaceResveCnt" parameterType="egovframework.com.uss.ion.mtg.service.MtgPlaceManageVO" resultType="int">
+        
+			SELECT count(resve_id) from COMTNMTGPLACERESVE
+			WHERE  MTGRUM_ID  = #{mtgPlaceId}
+        
+    </select>
+
 </mapper>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/mtg/EgovMtgPlaceManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/mtg/EgovMtgPlaceManage_SQL_oracle.xml
@@ -366,4 +366,11 @@
 		 </if>	       
     </select>
 
+    <select id="selectMtgPlaceResveCnt" parameterType="egovframework.com.uss.ion.mtg.service.MtgPlaceManageVO" resultType="int">
+        
+			SELECT count(resve_id) from COMTNMTGPLACERESVE
+			WHERE  MTGRUM_ID  = #{mtgPlaceId}
+        
+    </select>
+
 </mapper>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/mtg/EgovMtgPlaceManage_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/mtg/EgovMtgPlaceManage_SQL_postgres.xml
@@ -358,4 +358,11 @@
 		  RESVE_ID <> #{resveId}    ]]>
 		 </if>	       
     </select>
+    <select id="selectMtgPlaceResveCnt" parameterType="egovframework.com.uss.ion.mtg.service.MtgPlaceManageVO" resultType="int">
+        
+			SELECT count(resve_id) from COMTNMTGPLACERESVE
+			WHERE  MTGRUM_ID  = #{mtgPlaceId}
+        
+    </select>
+
 </mapper>

--- a/src/main/resources/egovframework/mapper/com/uss/ion/mtg/EgovMtgPlaceManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/mtg/EgovMtgPlaceManage_SQL_tibero.xml
@@ -367,4 +367,11 @@
 		 </if>	       
     </select>
 
+    <select id="selectMtgPlaceResveCnt" parameterType="egovframework.com.uss.ion.mtg.service.MtgPlaceManageVO" resultType="int">
+        
+			SELECT count(resve_id) from COMTNMTGPLACERESVE
+			WHERE  MTGRUM_ID  = #{mtgPlaceId}
+        
+    </select>
+
 </mapper>

--- a/src/main/resources/egovframework/message/com/uss/ion/mtg/message_en.properties
+++ b/src/main/resources/egovframework/message/com/uss/ion/mtg/message_en.properties
@@ -9,6 +9,7 @@ comUssIonMtg.mtgPlaceManageList.location=Location
 comUssIonMtg.mtgPlaceManageList.searchUser=Search By User
 comUssIonMtg.mtgPlaceManageList.meetingManagementList=MeetingRoom Management List
 comUssIonMtg.mtgPlaceManageList.persons=Persons
+comUssIonMtg.mtgPlaceManageList.resveExist=Cannot delete the meeting room because it still has reservations.
 
 #EgovMtgPlaceRegist.jsp
 comUssIonMtg.mtgPlaceRegist.title=Meeting Room Registration

--- a/src/main/resources/egovframework/message/com/uss/ion/mtg/message_ko.properties
+++ b/src/main/resources/egovframework/message/com/uss/ion/mtg/message_ko.properties
@@ -9,6 +9,7 @@ comUssIonMtg.mtgPlaceManageList.location=\uc704\uce58
 comUssIonMtg.mtgPlaceManageList.searchUser=\uc0ac\uc6a9\uc790\uba85\uac80\uc0c9
 comUssIonMtg.mtgPlaceManageList.meetingManagementList=\ud68c\uc758\uc2e4 \uad00\ub9ac \ubaa9\ucc28
 comUssIonMtg.mtgPlaceManageList.persons=\uba85
+comUssIonMtg.mtgPlaceManageList.resveExist=\uc608\uc57d\uc774 \ub0a8\uc544 \uc788\uc5b4 \ud68c\uc758\uc2e4\uc744 \uc0ad\uc81c\ud560 \uc218 \uc5c6\uc2b5\ub2c8\ub2e4.
 
 #EgovMtgPlaceRegist.jsp
 comUssIonMtg.mtgPlaceRegist.title=\ud68c\uc758\uc2e4 \ub4f1\ub85d

--- a/src/main/webapp/WEB-INF/jsp/egovframework/com/uss/ion/mtg/EgovMtgPlaceManageList.jsp
+++ b/src/main/webapp/WEB-INF/jsp/egovframework/com/uss/ion/mtg/EgovMtgPlaceManageList.jsp
@@ -72,6 +72,7 @@ function press() {
 }
 
 -->
+<c:if test="${!empty mtgPlaceResveExist}">alert("<spring:message code="comUssIonMtg.mtgPlaceManageList.resveExist" />");/* 예약이 남아 있어 회의실을 삭제할 수 없습니다. */</c:if>
 </script>
 </head>
 

--- a/src/test/java/egovframework/com/uss/ion/mtg/web/EgovMtgPlaceManageControllerDeleteTest.java
+++ b/src/test/java/egovframework/com/uss/ion/mtg/web/EgovMtgPlaceManageControllerDeleteTest.java
@@ -1,0 +1,95 @@
+package egovframework.com.uss.ion.mtg.web;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Proxy;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.support.ReloadableResourceBundleMessageSource;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.bind.support.SimpleSessionStatus;
+import org.springframework.ui.ModelMap;
+
+import egovframework.com.cmm.EgovMessageSource;
+import egovframework.com.cmm.service.EgovFileMngService;
+import egovframework.com.uss.ion.mtg.service.EgovMtgPlaceManageService;
+import egovframework.com.uss.ion.mtg.service.MtgPlaceManageVO;
+
+/**
+ * 회의실 삭제가 그 회의실의 예약을 남겨두지 않는지 확인한다.
+ *
+ * <p>예약 조회는 회의실을 기준 테이블로 삼고(EgovMtgPlaceManage_SQL_mysql.xml 매퍼의
+ * selectMtgPlaceResveManageList), 예약 삭제 SQL 은 예약ID 를 반드시 요구한다. 회의실이 먼저 없어지면
+ * 그 예약은 목록에도 상세에도 나오지 않아 화면에서 지울 방법이 없다.</p>
+ */
+class EgovMtgPlaceManageControllerDeleteTest {
+
+	private EgovMtgPlaceManageController controller;
+	private final AtomicBoolean deleted = new AtomicBoolean(false);
+	private int resveCnt;
+
+	@BeforeEach
+	void setUp() {
+		deleted.set(false);
+
+		EgovMtgPlaceManageService service = (EgovMtgPlaceManageService) Proxy.newProxyInstance(
+				getClass().getClassLoader(), new Class<?>[] { EgovMtgPlaceManageService.class },
+				(proxy, method, args) -> {
+					switch (method.getName()) {
+					case "selectMtgPlaceResveCnt":
+						return Integer.valueOf(resveCnt);
+					case "deleteMtgPlaceManage":
+						deleted.set(true);
+						return null;
+					default:
+						return null;
+					}
+				});
+
+		EgovFileMngService fileMngService = (EgovFileMngService) Proxy.newProxyInstance(
+				getClass().getClassLoader(), new Class<?>[] { EgovFileMngService.class },
+				(proxy, method, args) -> null);
+
+		EgovMessageSource messageSource = new EgovMessageSource();
+		ReloadableResourceBundleMessageSource messages = new ReloadableResourceBundleMessageSource();
+		messages.setUseCodeAsDefaultMessage(true);
+		messageSource.setReloadableResourceBundleMessageSource(messages);
+
+		controller = new EgovMtgPlaceManageController();
+		ReflectionTestUtils.setField(controller, "egovMtgPlaceManageService", service);
+		ReflectionTestUtils.setField(controller, "fileMngService", fileMngService);
+		ReflectionTestUtils.setField(controller, "egovMessageSource", messageSource);
+	}
+
+	@Test
+	void deleteMtgPlaceIsRefusedWhenRoomStillHasReservation() throws Exception {
+		resveCnt = 1;
+		ModelMap model = new ModelMap();
+
+		controller.deleteMtgPlaceManage(mtgPlace(), new SimpleSessionStatus(), model);
+
+		assertFalse(deleted.get(), "예약이 남아 있으면 회의실을 지우지 않아야 한다");
+		assertEquals("true", model.get("mtgPlaceResveExist"), "화면에 알릴 표시가 있어야 한다");
+	}
+
+	@Test
+	void deleteMtgPlaceProceedsWhenRoomHasNoReservation() throws Exception {
+		resveCnt = 0;
+		ModelMap model = new ModelMap();
+
+		controller.deleteMtgPlaceManage(mtgPlace(), new SimpleSessionStatus(), model);
+
+		assertTrue(deleted.get(), "예약이 없는 회의실은 지울 수 있어야 한다");
+	}
+
+	private MtgPlaceManageVO mtgPlace() {
+		MtgPlaceManageVO mtgPlaceManageVO = new MtgPlaceManageVO();
+		mtgPlaceManageVO.setMtgPlaceId("MTGRUM_00000000000001");
+		mtgPlaceManageVO.setAtchFileId("MTG_0000000000000001");
+		return mtgPlaceManageVO;
+	}
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

회의실을 지워도 사라지는 것은 방 한 행뿐입니다. 같은 핸들러가 첨부파일은 정리하는데 예약만 정리하지 않습니다. 정리 책임을 이미 지고 있으면서 한쪽만 빠진 셈입니다.

매퍼 여덟 방언의 예약 삭제문은 예약 아이디를 요구하므로 방 아이디로 예약을 지우는 SQL 자체가 없습니다.

**배포한 DDL이 무엇이냐에 따라 결과가 달라집니다.**

| 참조 무결성 | 지금 일어나는 일 |
|---|---|
| 걸려 있는 방언 | 삭제 자체가 실패해 사용자가 오류 화면을 봅니다 |
| 걸려 있지 않은 방언 | 예약이 남습니다. 예약 조회가 회의실을 기준 테이블로 삼으므로 화면에서는 보이지 않습니다 |

어느 쪽으로 가든 바람직하지 않습니다.

AS-IS

```java
egovMtgPlaceManageService.deleteMtgPlaceManage(mtgPlaceManageVO);
return "forward:/uss/ion/mtg/selectMtgPlaceManageList.do";
```

TO-BE

```java
// 예약이 남아 있으면 회의실을 삭제하지 않는다.
if (egovMtgPlaceManageService.selectMtgPlaceResveCnt(mtgPlaceManageVO) > 0) {
    model.addAttribute("mtgPlaceResveExist", "true");
    return "forward:/uss/ion/mtg/selectMtgPlaceManageList.do";
}

egovMtgPlaceManageService.deleteMtgPlaceManage(mtgPlaceManageVO);
return "forward:/uss/ion/mtg/selectMtgPlaceManageList.do";
```

### 영향 범위

예약이 없는 회의실은 종전과 똑같이 지워집니다. 예약이 남아 있는 회의실을 지우려 할 때만 동작이 달라집니다. 그때는 오류 화면이나 조용한 잔존 대신 안내가 뜹니다.

방 아이디로 예약 건수를 세는 조회가 없어 여덟 방언에 같은 문장을 하나씩 넣었습니다.

```xml
<select id="selectMtgPlaceResveCnt" parameterType="egovframework.com.uss.ion.mtg.service.MtgPlaceManageVO" resultType="int">
    SELECT count(resve_id) from COMTNMTGPLACERESVE WHERE MTGRUM_ID = #{mtgPlaceId}
</select>
```

방언 문법 차이가 없어 여덟 파일이 같은 내용이고 각 파일 끝에 붙여 기존 문장과 줄이 겹치지 않습니다. DAO·서비스 배관은 같은 클래스의 기존 중복확인 조회와 같은 모양으로 맞췄습니다.

**연쇄 삭제라는 선택지도 있습니다.** 되돌릴 수 없는 삭제여서 이쪽을 골랐습니다. 메인테이너께서 연쇄 삭제를 원하신다면 그 방향으로 다시 내겠습니다.

한글·영문 메시지 키를 하나씩 추가했고 목록 화면에는 알림을 넣었습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`EgovMtgPlaceManageControllerDeleteTest` 2건을 추가했습니다. 서비스와 파일 서비스를 `Proxy`로 세우고 예약 건수를 달리하며 예약이 있을 때는 삭제가 호출되지 않고 없을 때는 호출되는지 확인합니다. 스프링 컨텍스트나 DB 없이 돌아갑니다.

수정 전(RED, 가드만 되돌려 실행)

```
[ERROR] Tests run: 2, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.133 s <<< FAILURE! -- in egovframework.com.uss.ion.mtg.web.EgovMtgPlaceManageControllerDeleteTest
[ERROR]   EgovMtgPlaceManageControllerDeleteTest.deleteMtgPlaceIsRefusedWhenRoomStillHasReservation:75 예약이 남아 있으면 회의실을 지우지 않아야 한다 ==> expected: <false> but was: <true>
```

수정 후(GREEN)

```
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.127 s -- in egovframework.com.uss.ion.mtg.web.EgovMtgPlaceManageControllerDeleteTest
[INFO] BUILD SUCCESS
```

커밋에 pom 변경은 넣지 않았습니다. `<skipTests>true</skipTests>`를 잠시 풀고 받은 출력입니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음
