### PR TITLE
fix: 업무사용자 화면의 스크립트가 존재하지 않는 폼을 참조하는 문제 수정

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/egovframework/com/uss/umt/EgovEmplyrInsert.jsp
+++ b/src/main/webapp/WEB-INF/jsp/egovframework/com/uss/umt/EgovEmplyrInsert.jsp
@@ -145,23 +145,23 @@ function fnIdCheck1(){
     var retVal;
     var url = "<c:url value='/uss/umt/EgovIdDplctCnfirmView.do'/>";
     var varParam = new Object();
-    varParam.checkId = document.userManageVO.emplyrId.value;
+    varParam.checkId = document.emplyrManageVO.emplyrId.value;
     var openParam = "dialogWidth:303px;dialogHeight:250px;scroll:no;status:no;center:yes;resizable:yes;";
     retVal = window.showModalDialog(url, varParam, openParam);
     if(retVal) {
-        document.userManageVO.emplyrId.value = retVal;
+        document.emplyrManageVO.emplyrId.value = retVal;
     }
 }
 
 function showModalDialogCallback(retVal) {
 	if(retVal) {
-	    document.userManageVO.emplyrId.value = retVal;
+	    document.emplyrManageVO.emplyrId.value = retVal;
 	}
 }
 
 function fnListPage(){
-    document.userManageVO.action = "<c:url value='/uss/umt/EgovEmplyrManage.do'/>";
-    document.userManageVO.submit();
+    document.emplyrManageVO.action = "<c:url value='/uss/umt/EgovEmplyrManage.do'/>";
+    document.emplyrManageVO.submit();
 }
 
 function fnInsert(form){
@@ -193,7 +193,7 @@ function fn_egov_inqire_cert() {
 }
 
 function fn_egov_dn_info_setting(dn) {
-	var frm = document.userManageVO;
+	var frm = document.emplyrManageVO;
 
 	frm.subDn.value = dn;
 }

--- a/src/main/webapp/WEB-INF/jsp/egovframework/com/uss/umt/EgovEmplyrSelectUpdt.jsp
+++ b/src/main/webapp/WEB-INF/jsp/egovframework/com/uss/umt/EgovEmplyrSelectUpdt.jsp
@@ -87,7 +87,7 @@ function fn_egov_inqire_cert() {
 }
 
 function fn_egov_dn_info_setting(dn) {
-	var frm = document.userManageVO;
+	var frm = document.emplyrManageVO;
 
 	frm.subDn.value = dn;
 }
@@ -363,7 +363,7 @@ function fn_egov_dn_info_setting(dn) {
 		<span class="btn_s"><a href="<c:url value='/uss/umt/EgovEmplyrManage.do' />"  title="<spring:message code="button.list" /> <spring:message code="input.button" />"><spring:message code="button.list" /></a></span>
 		<button class="btn_s2" onClick="fnPasswordMove(); return false;" title="<spring:message code="comUssUmt.userManageModifyBtn.passwordChange" /> <spring:message code="input.button" />"><spring:message code="comUssUmt.userManageModifyBtn.passwordChange" /></button>
 		<button class="btn_s2" onClick="fnLockIncorrect(); return false;" title="<spring:message code="comUssUmt.common.lockAtBtn" /> <spring:message code="input.button" />"><spring:message code="comUssUmt.common.lockAtBtn" /></button>
-		<button class="btn_s2" onClick="document.userManageVO.reset(); return false;" title="<spring:message code="button.reset" /> <spring:message code="input.button" />"><spring:message code="button.reset" /></button>
+		<button class="btn_s2" onClick="document.emplyrManageVO.reset(); return false;" title="<spring:message code="button.reset" /> <spring:message code="input.button" />"><spring:message code="button.reset" /></button>
 	</div><div style="clear:both;"></div>
 
 </div>

--- a/src/test/java/egovframework/com/uss/umt/web/EgovEmplyrJspFormNameTest.java
+++ b/src/test/java/egovframework/com/uss/umt/web/EgovEmplyrJspFormNameTest.java
@@ -1,0 +1,68 @@
+package egovframework.com.uss.umt.web;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * 업무사용자 화면의 스크립트가 참조하는 폼 이름이 실제 폼 이름과 같은지 확인한다.
+ *
+ * <p>{@code document.이름} 으로 폼을 찾는데 그 이름이 틀리면 undefined 가 되고, 뒤이어 속성이나
+ * 메서드를 쓰는 순간 TypeError 로 끊긴다. 화면은 아무 반응이 없고 오류도 보이지 않는다.</p>
+ */
+class EgovEmplyrJspFormNameTest {
+
+	private static final String BASE = "src/main/webapp/WEB-INF/jsp/egovframework/com/uss/umt/";
+
+	private static final Pattern FORM_NAME = Pattern.compile("<form:form[^>]*\\sname=\"([^\"]+)\"");
+
+	private static final Pattern DOCUMENT_FORM = Pattern.compile("document\\.([A-Za-z_][A-Za-z0-9_]*VO)\\b");
+
+	private static final Pattern HTML_COMMENT = Pattern.compile("<!--.*?-->", Pattern.DOTALL);
+
+	@Test
+	void emplyrSelectUpdtScriptUsesItsOwnFormName() throws IOException {
+		assertScriptMatchesFormName("EgovEmplyrSelectUpdt.jsp");
+	}
+
+	@Test
+	void emplyrInsertScriptUsesItsOwnFormName() throws IOException {
+		assertScriptMatchesFormName("EgovEmplyrInsert.jsp");
+	}
+
+	/** 주석 안의 옛 코드는 실행되지 않으므로 검사 대상에서 뺀다. */
+	private String stripComments(String source) {
+		return HTML_COMMENT.matcher(source).replaceAll("");
+	}
+
+	private void assertScriptMatchesFormName(String jsp) throws IOException {
+		String source = stripComments(new String(Files.readAllBytes(Paths.get(BASE + jsp)), StandardCharsets.UTF_8));
+
+		Matcher form = FORM_NAME.matcher(source);
+		assertTrue(form.find(), jsp + " 에서 폼 이름을 찾지 못했습니다.");
+		String formName = form.group(1);
+
+		List<String> referenced = new ArrayList<>();
+		Matcher used = DOCUMENT_FORM.matcher(source);
+		while (used.find()) {
+			referenced.add(used.group(1));
+		}
+		assertFalse(referenced.isEmpty(), jsp + " 에서 폼 참조를 찾지 못했습니다.");
+
+		for (String name : referenced) {
+			assertEquals(formName, name,
+					jsp + " 의 스크립트가 존재하지 않는 폼을 참조합니다 : document." + name);
+		}
+	}
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

업무사용자 등록·수정 화면의 폼 이름은 `emplyrManageVO`인데, 스크립트는 여덟 곳에서 `document.userManageVO`를 씁니다. 그런 이름의 폼이 없으니 `undefined`가 되고, 뒤이어 속성이나 메서드를 쓰는 순간 `TypeError`로 끊깁니다. 화면은 아무 반응이 없고 오류도 보이지 않습니다.

형제 화면은 각자 자기 폼 이름을 씁니다.

| 화면 | 스크립트가 찾는 폼 | 실제 폼 이름 |
|---|---|---|
| `EgovMberSelectUpdt.jsp` | `document.mberManageVO` | `mberManageVO` |
| `EgovEntrprsSelectUpdt.jsp` | `document.entrprsManageVO` | `entrprsManageVO` |
| `EgovEmplyrSelectUpdt.jsp` | `document.userManageVO` | **`emplyrManageVO`** |
| `EgovEmplyrInsert.jsp` | `document.userManageVO` | **`emplyrManageVO`** |

`1e764b1b`("egovframe-common-components 5.0.0")가 `EgovUserManageController`를 `EgovEmplyrManageController`로 옮기며 폼 이름도 바꿨는데, 스크립트 쪽 참조는 따라가지 않았습니다.

**지금 눌리는 경로가 둘입니다.**

- 수정 화면의 초기화 버튼이 `onClick`에서 직접 `document.userManageVO.reset()`을 부릅니다. 누르면 아무 일도 일어나지 않습니다.
- 인증서 DN 설정 팝업에서 `opener.fn_egov_dn_info_setting(dn)`으로 부르는 함수도 같은 참조를 씁니다. 두 화면 모두 그렇습니다.

**나머지는 호출처가 없는 옛 경로입니다.** 아이디 중복확인은 모달로, 목록 이동은 링크로 바뀌었습니다. 같은 리네임 때 함께 남은 코드라 한 번에 정리했습니다.

AS-IS

```javascript
<button class="btn_s2" onClick="document.userManageVO.reset(); return false;" ...>
```

TO-BE

```javascript
<button class="btn_s2" onClick="document.emplyrManageVO.reset(); return false;" ...>
```

여덟 곳 모두 같은 형태입니다.

### 영향 범위

JSP 두 파일의 스크립트 참조만 바뀝니다. 폼 이름과 컨트롤러는 손대지 않았습니다.

주석 안에 남아 있는 `document.mberManageVO` 참조는 실행되지 않는 옛 코드라 그대로 두었습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`EgovEmplyrJspFormNameTest` 2건을 추가했습니다. 각 JSP에서 폼 이름과 `document.…VO` 참조를 뽑아 서로 같은지 봅니다. 주석 안의 코드는 실행되지 않으니 검사에서 뺐습니다. 참조가 하나도 안 잡히면 무의미하게 통과하므로 비어 있지 않은지 먼저 단언합니다.

수정 전(RED, JSP 두 개만 되돌려 실행)

```
[ERROR] Tests run: 2, Failures: 2, Errors: 0, Skipped: 0, Time elapsed: 0.020 s <<< FAILURE! -- in egovframework.com.uss.umt.web.EgovEmplyrJspFormNameTest
[ERROR]   EgovEmplyrJspFormNameTest.emplyrInsertScriptUsesItsOwnFormName:41->assertScriptMatchesFormName:64 EgovEmplyrInsert.jsp 의 스크립트가 존재하지 않는 폼을 참조합니다 : document.userManageVO ==> expected: <emplyrManageVO> but was: <userManageVO>
[ERROR]   EgovEmplyrJspFormNameTest.emplyrSelectUpdtScriptUsesItsOwnFormName:36->assertScriptMatchesFormName:64 EgovEmplyrSelectUpdt.jsp 의 스크립트가 존재하지 않는 폼을 참조합니다 : document.userManageVO ==> expected: <emplyrManageVO> but was: <userManageVO>
```

수정 후(GREEN)

```
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.017 s -- in egovframework.com.uss.umt.web.EgovEmplyrJspFormNameTest
[INFO] BUILD SUCCESS
```

`<skipTests>true</skipTests>`를 임시로 풀고 뽑은 출력입니다. pom 변경은 커밋에 넣지 않았습니다.

브라우저에서 초기화 버튼을 눌러 확인하지는 않았습니다. `document.emplyrManageVO`가 실제 폼을 가리킨다는 것까지가 테스트로 증명되는 범위입니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음 (브라우저 동작은 관측하지 않았습니다)

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음
