### PR TITLE
fix: 프록시서비스 목록화면 진입에 관리자 검증 적용

### DIFF
--- a/src/main/java/egovframework/com/utl/sys/pxy/web/EgovProxySvcController.java
+++ b/src/main/java/egovframework/com/utl/sys/pxy/web/EgovProxySvcController.java
@@ -83,6 +83,7 @@ public class EgovProxySvcController {
 	 * @return String
 	 */
 	@RequestMapping(value = "/utl/sys/pxy/selectProxySvcListView.do")
+	@RequireAdmin
 	public String selectProxySvcListView() throws Exception {
 		return "egovframework/com/utl/sys/pxy/EgovProxySvcList";
 	}
@@ -250,6 +251,7 @@ public class EgovProxySvcController {
 	 * @return String
 	 */
 	@RequestMapping(value = "/utl/sys/pxy/selectProxyLogListView.do")
+	@RequireAdmin
 	public String selectProxyLogListView(@ModelAttribute("proxyLog") ProxyLog proxyLog, Model model) throws Exception {
 		proxyLog.setStrStartDate(EgovStringUtil.addMinusChar(EgovDateUtil.addMonth(EgovDateUtil.getToday(), -1)));
 		proxyLog.setStrEndDate(EgovStringUtil.addMinusChar(EgovDateUtil.getToday()));

--- a/src/test/java/egovframework/com/utl/sys/pxy/web/EgovProxySvcControllerAdminCheckTest.java
+++ b/src/test/java/egovframework/com/utl/sys/pxy/web/EgovProxySvcControllerAdminCheckTest.java
@@ -1,0 +1,39 @@
+package egovframework.com.utl.sys.pxy.web;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.Test;
+
+import egovframework.com.cmm.annotation.RequireAdmin;
+import egovframework.com.utl.sys.pxy.service.ProxyLog;
+
+/**
+ * 프록시서비스·프록시로그 목록화면 진입에 @RequireAdmin이 붙어있는지 검증.
+ *
+ * <p>같은 컨트롤러의 목록·상세·등록·수정·삭제는 모두 @RequireAdmin으로 막혀 있는데
+ * 목록화면 진입 둘만 빠져 있었다. 같은 utl/sys 네임스페이스의 서버자원모니터링은
+ * 구조가 같은 selectServerResrceMntrngListView에도 붙여둔다.</p>
+ *
+ * <p>@RequireAdmin은 Spring AOP(@annotation 포인트컷)로 위빙되므로 컨트롤러를 직접
+ * 생성해 호출하는 단위 테스트로는 차단 동작을 재현할 수 없다. 이 테스트는 애노테이션이
+ * 실제로 붙어있는지만 고정한다.</p>
+ */
+public class EgovProxySvcControllerAdminCheckTest {
+
+	@Test
+	public void proxySvcListViewRequiresAdmin() throws Exception {
+		Method method = EgovProxySvcController.class.getDeclaredMethod("selectProxySvcListView");
+		assertTrue(method.isAnnotationPresent(RequireAdmin.class),
+				"프록시서비스 목록화면은 관리자만 열 수 있어야 한다.");
+	}
+
+	@Test
+	public void proxyLogListViewRequiresAdmin() throws Exception {
+		Method method = EgovProxySvcController.class.getDeclaredMethod("selectProxyLogListView",
+				ProxyLog.class, org.springframework.ui.Model.class);
+		assertTrue(method.isAnnotationPresent(RequireAdmin.class),
+				"프록시로그 목록화면은 관리자만 열 수 있어야 한다.");
+	}
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`EgovProxySvcController`의 매핑 열 개 중 여덟 개는 `@RequireAdmin`으로 막혀 있는데, 목록화면으로 이동하는 두 개만 빠져 있습니다.

| 매핑 | `@RequireAdmin` |
| --- | --- |
| `selectProxySvcListView.do` | **없음** |
| `selectProxySvcList.do` | 있음 |
| `getProxySvc.do` | 있음 |
| `addViewProxySvc.do` · `addProxySvc.do` | 있음 |
| `updtViewProxySvc.do` · `updtProxySvc.do` | 있음 |
| `removeProxySvc.do` | 있음 |
| `selectProxyLogListView.do` | **없음** |
| `selectProxyLogList.do` | 있음 |

`23d01889`(NCSC&NIA 보안점검 적용)이 같은 `utl/sys` 네임스페이스를 정리하면서 프록시서비스에는 `selectProxySvcList.do` 한 곳만 붙였습니다. 같은 커밋이 서버자원모니터링에서는 구조가 같은 `selectServerResrceMntrngListView.do`에도 붙였습니다. 그 화면도 조회 없이 JSP만 반환하는 진입점입니다.

AS-IS

```java
@RequestMapping(value = "/utl/sys/pxy/selectProxySvcListView.do")
public String selectProxySvcListView() throws Exception {
	return "egovframework/com/utl/sys/pxy/EgovProxySvcList";
}
```

TO-BE

```java
@RequestMapping(value = "/utl/sys/pxy/selectProxySvcListView.do")
@RequireAdmin
public String selectProxySvcListView() throws Exception {
	return "egovframework/com/utl/sys/pxy/EgovProxySvcList";
}
```

`selectProxyLogListView.do`도 같습니다. 애노테이션 위치는 같은 파일의 기존 여덟 곳과 맞춰 매핑 아래에 두었습니다.

### 왜 이 컨트롤러만인지

같은 `utl/sys`의 동기화서버(`EgovSynchrnServerController`)에도 `selectSynchrnServerListView.do`가 열려 있지만 이번 수정에 넣지 않았습니다. 그쪽은 목록 조회인 `selectSynchrnServerList.do`도 함께 열려 있어 성격이 다릅니다. 프록시서비스는 데이터를 반환하는 경로가 이미 전부 막혀 있어 진입점 두 개만 남은 경우입니다.

### 영향 범위

두 URL은 저장소 안에서 호출하는 곳이 없습니다. JSP와 메뉴 초기 데이터 모두 `selectProxySvcList.do`·`selectProxyLogList.do`로 바로 갑니다. 관리자 화면 흐름은 그대로입니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

`@RequireAdmin`은 `egov-com-loginaop.xml`의 `@annotation` 포인트컷으로 위빙되므로, 컨트롤러를 직접 생성해 호출하는 단위 테스트로는 차단 동작을 재현할 수 없습니다. 애노테이션이 붙어 있는지만 고정했습니다.

수정 전

```
[ERROR] Tests run: 2, Failures: 2, Errors: 0, Skipped: 0
[ERROR]   EgovProxySvcControllerAdminCheckTest.proxySvcListViewRequiresAdmin:28
          프록시서비스 목록화면은 관리자만 열 수 있어야 한다. ==> expected: <true> but was: <false>
[ERROR]   EgovProxySvcControllerAdminCheckTest.proxyLogListViewRequiresAdmin:36
          프록시로그 목록화면은 관리자만 열 수 있어야 한다. ==> expected: <true> but was: <false>
```

수정 후

```
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

`pom.xml`의 surefire 설정이 `skipTests=true`라 기본 빌드에서는 실행되지 않습니다. 확인할 때는 그 값을 잠시 `false`로 두고 돌렸습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

화면 출력이 달라지는 변경이 아니라 첨부하지 않았습니다.
