### PR TITLE
fix: 개인지식 삭제 시 첨부파일이 미사용 처리되지 않는 문제 수정

### DIFF
--- a/src/main/java/egovframework/com/dam/per/web/EgovKnoPersonalController.java
+++ b/src/main/java/egovframework/com/dam/per/web/EgovKnoPersonalController.java
@@ -403,7 +403,16 @@ public class EgovKnoPersonalController {
 			return "egovframework/com/cmm/error/accessDenied";
 		}
 
+		String atchFileId = existing.getAtchFileId();
+
 		knoPersonalService.deleteKnoPersonal(knoPersonal);
+
+		// 첨부파일을 삭제하기 위한 Vo
+		FileVO fvo = new FileVO();
+		fvo.setAtchFileId(atchFileId);
+
+		fileMngService.deleteAllFileInf(fvo);
+
 		return "forward:/dam/per/EgovComDamPersonalList.do";
 	}
 

--- a/src/test/java/egovframework/com/dam/per/web/EgovKnoPersonalDeleteFileTest.java
+++ b/src/test/java/egovframework/com/dam/per/web/EgovKnoPersonalDeleteFileTest.java
@@ -1,0 +1,95 @@
+package egovframework.com.dam.per.web;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import egovframework.com.cmm.LoginVO;
+import egovframework.com.cmm.service.EgovFileMngService;
+import egovframework.com.cmm.service.EgovUserDetailsService;
+import egovframework.com.cmm.service.FileVO;
+import egovframework.com.cmm.util.EgovUserDetailsHelper;
+import egovframework.com.dam.per.service.EgovKnoPersonalService;
+import egovframework.com.dam.per.service.KnoPersonal;
+
+/**
+ * 개인지식을 삭제할 때 딸린 첨부파일도 함께 정리하는지 확인한다.
+ *
+ * 회의실(EgovMtgPlaceManageController)·포상(EgovRwardManageController)·
+ * 상담(EgovCnsltManageController)·FAQ(EgovFaqController) 등은 도메인을 지운 뒤
+ * fileMngService.deleteAllFileInf로 첨부를 정리하는데 개인지식만 빠져 있었다.
+ */
+class EgovKnoPersonalDeleteFileTest {
+
+	private EgovUserDetailsService originalUserDetailsService;
+
+	@AfterEach
+	void restoreUserDetailsService() {
+		new EgovUserDetailsHelper().setEgovUserDetailsService(originalUserDetailsService);
+	}
+
+	private static final String OWNER = "USRCNFRM_00000000001";
+	private static final String ATCH_FILE_ID = "FILE_000000000000001";
+
+	@Test
+	void deleteRemovesAttachedFiles() throws Exception {
+		List<String> deletedFileIds = new ArrayList<>();
+
+		KnoPersonal stored = new KnoPersonal();
+		stored.setFrstRegisterId(OWNER);
+		stored.setAtchFileId(ATCH_FILE_ID);
+
+		LoginVO login = new LoginVO();
+		login.setUniqId(OWNER);
+
+		EgovUserDetailsHelper helper = new EgovUserDetailsHelper();
+		originalUserDetailsService = helper.getEgovUserDetailsService();
+		helper.setEgovUserDetailsService(stub(EgovUserDetailsService.class, (method, args) -> {
+			switch (method.getName()) {
+			case "isAuthenticated":
+				return Boolean.TRUE;
+			case "getAuthenticatedUser":
+				return login;
+			case "getAuthorities":
+				return Collections.<String>emptyList();
+			default:
+				return null;
+			}
+		}));
+
+		EgovKnoPersonalController controller = new EgovKnoPersonalController();
+		controller.knoPersonalService = stub(EgovKnoPersonalService.class,
+				(method, args) -> "selectKnoPersonal".equals(method.getName()) ? stored : null);
+		ReflectionTestUtils.setField(controller, "fileMngService", stub(EgovFileMngService.class, (method, args) -> {
+			if ("deleteAllFileInf".equals(method.getName())) {
+				deletedFileIds.add(((FileVO) args[0]).getAtchFileId());
+			}
+			return null;
+		}));
+
+		KnoPersonal request = new KnoPersonal();
+		controller.deleteKnoPersonal(request);
+
+		assertTrue(deletedFileIds.size() == 1, "개인지식을 지우면 첨부파일도 지워야 한다. 실제 호출: " + deletedFileIds);
+		assertEquals(ATCH_FILE_ID, deletedFileIds.get(0), "저장된 첨부파일 ID로 지워야 한다.");
+	}
+
+	private interface Handler {
+		Object handle(java.lang.reflect.Method method, Object[] args) throws Throwable;
+	}
+
+	@SuppressWarnings("unchecked")
+	private static <T> T stub(Class<T> type, Handler handler) {
+		return (T) Proxy.newProxyInstance(type.getClassLoader(), new Class<?>[] { type },
+				(proxy, method, args) -> handler.handle(method, args));
+	}
+
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

개인지식은 등록·수정에서 `fileMngService.insertFileInfs`로 첨부파일을 만들고 `atchFileId`를 함께 저장합니다. 그런데 삭제할 때는 개인지식 행만 지웁니다. 지워진 개인지식의 첨부는 `COMTNFILE`에 계속 사용중(`USE_AT='Y'`)으로 남습니다.

같은 저장소의 회의실(`EgovMtgPlaceManageController`)·포상(`EgovRwardManageController`)·상담(`EgovCnsltManageController`)·FAQ(`EgovFaqController`)는 도메인을 지운 뒤 `fileMngService.deleteAllFileInf`로 첨부를 정리합니다. 개인지식만 그 단계가 없습니다.

AS-IS

```java
knoPersonalService.deleteKnoPersonal(knoPersonal);
return "forward:/dam/per/EgovComDamPersonalList.do";
```

TO-BE

```java
String atchFileId = existing.getAtchFileId();

knoPersonalService.deleteKnoPersonal(knoPersonal);

// 첨부파일을 삭제하기 위한 Vo
FileVO fvo = new FileVO();
fvo.setAtchFileId(atchFileId);

fileMngService.deleteAllFileInf(fvo);

return "forward:/dam/per/EgovComDamPersonalList.do";
```

`existing`은 바로 위에서 소유권을 검증하려고 이미 조회해 둔 저장본입니다. 조회를 새로 하지 않았습니다. 첨부파일 ID도 요청 파라미터가 아니라 저장본에서 가져오므로 다른 사람의 첨부를 가리킬 수 없습니다.

### 영향 범위

`deleteAllFileInf`는 `UPDATE COMTNFILE SET USE_AT = 'N'`입니다. `COMTNFILEDETAIL` 행과 디스크 파일은 그대로 두고 사용 여부만 바꿉니다. 여덟 개 DB 방언 매퍼가 모두 같습니다.

첨부가 없는 개인지식을 지우면 빈 `atchFileId`로 호출되어 갱신되는 행이 없습니다. 형제 네 곳도 같은 형태입니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

컨트롤러를 직접 생성하고 서비스 자리에 동적 프록시를 넣어 삭제 경로만 확인했습니다. 필드 주입은 이미 병합된 `EgovArticleServiceImplTest_deleteArticleGuard`와 같이 `ReflectionTestUtils.setField`를 썼습니다.

수정 전

```
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
[ERROR]   EgovKnoPersonalDeleteFileTest.deleteRemovesAttachedFiles:81
          개인지식을 지우면 첨부파일도 지워야 한다. 실제 호출: [] ==> expected: <true> but was: <false>
```

`실제 호출: []`는 `deleteAllFileInf`가 한 번도 불리지 않았다는 뜻입니다.

수정 후

```
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

`pom.xml`의 surefire 설정이 `skipTests=true`라 기본 빌드에서는 실행되지 않습니다. 확인할 때는 그 값을 잠시 `false`로 두고 돌렸습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

화면 출력이 달라지는 변경이 아니라 첨부하지 않았습니다.
