### PR TITLE
fix: 시스템이력 삭제 시 첨부파일이 미사용 처리되지 않는 문제 수정

### DIFF
--- a/src/main/java/egovframework/com/sym/log/slg/web/EgovSysHistoryController.java
+++ b/src/main/java/egovframework/com/sym/log/slg/web/EgovSysHistoryController.java
@@ -217,7 +217,19 @@ public class EgovSysHistoryController {
 		LoginVO loginVO = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();
 
 		if (loginVO != null) {
+			// 첨부파일 ID는 삭제 폼에 실려오지 않으므로 저장본에서 가져온다.
+			SysHistoryVO searchVO = new SysHistoryVO();
+			searchVO.setHistId(history.getHistId());
+			SysHistoryVO storedHistory = sysHistoryService.selectSysHistory(searchVO);
+			String atchFileId = storedHistory == null ? "" : storedHistory.getAtchFileId();
+
 			sysHistoryService.deleteSysHistory(history);
+
+			// 첨부파일을 삭제하기 위한 Vo
+			FileVO fvo = new FileVO();
+			fvo.setAtchFileId(atchFileId);
+
+			fileMngService.deleteAllFileInf(fvo);
 		}
 
 		status.setComplete();

--- a/src/test/java/egovframework/com/sym/log/slg/web/EgovSysHistoryDeleteFileTest.java
+++ b/src/test/java/egovframework/com/sym/log/slg/web/EgovSysHistoryDeleteFileTest.java
@@ -1,0 +1,86 @@
+package egovframework.com.sym.log.slg.web;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.ui.ModelMap;
+import org.springframework.web.bind.support.SessionStatus;
+import org.springframework.web.bind.support.SimpleSessionStatus;
+
+import egovframework.com.cmm.LoginVO;
+import egovframework.com.cmm.service.EgovFileMngService;
+import egovframework.com.cmm.service.EgovUserDetailsService;
+import egovframework.com.cmm.service.FileVO;
+import egovframework.com.cmm.util.EgovUserDetailsHelper;
+import egovframework.com.sym.log.slg.service.EgovSysHistoryService;
+import egovframework.com.sym.log.slg.service.SysHistory;
+import egovframework.com.sym.log.slg.service.SysHistoryVO;
+
+/**
+ * 시스템이력을 삭제할 때 첨부파일도 미사용 처리하는지 검증.
+ *
+ * <p>회의실·포상·상담·FAQ 등은 도메인을 지운 뒤 deleteAllFileInf로 첨부를 정리하는데
+ * 시스템이력만 빠져 있었다. 삭제 폼이 첨부파일 ID를 실어보내지 않으므로 저장본을
+ * 조회해서 가져와야 한다.</p>
+ *
+ * <p>Spring 컨텍스트·DB 없이 동적 프록시 페이크와 ReflectionTestUtils 필드 주입으로
+ * 삭제 경로만 검증한다.</p>
+ */
+public class EgovSysHistoryDeleteFileTest {
+
+	private static final String ATCH_FILE_ID = "FILE_000000000000001";
+
+	private EgovUserDetailsService originalUserDetailsService;
+
+	@AfterEach
+	public void restoreUserDetailsService() {
+		new EgovUserDetailsHelper().setEgovUserDetailsService(originalUserDetailsService);
+	}
+
+	@Test
+	public void deleteRemovesAttachedFiles() throws Exception {
+		List<String> deletedFileIds = new ArrayList<>();
+
+		SysHistoryVO stored = new SysHistoryVO();
+		stored.setAtchFileId(ATCH_FILE_ID);
+
+		EgovUserDetailsHelper helper = new EgovUserDetailsHelper();
+		originalUserDetailsService = helper.getEgovUserDetailsService();
+		helper.setEgovUserDetailsService(stub(EgovUserDetailsService.class, (method, args) ->
+				"getAuthenticatedUser".equals(method.getName()) ? new LoginVO() : null));
+
+		EgovSysHistoryController controller = new EgovSysHistoryController();
+		ReflectionTestUtils.setField(controller, "sysHistoryService", stub(EgovSysHistoryService.class,
+				(method, args) -> "selectSysHistory".equals(method.getName()) ? stored : null));
+		ReflectionTestUtils.setField(controller, "fileMngService", stub(EgovFileMngService.class, (method, args) -> {
+			if ("deleteAllFileInf".equals(method.getName())) {
+				deletedFileIds.add(((FileVO) args[0]).getAtchFileId());
+			}
+			return null;
+		}));
+
+		SessionStatus status = new SimpleSessionStatus();
+		controller.deleteSysHistory(new SysHistory(), status, new ModelMap());
+
+		assertFalse(deletedFileIds.isEmpty(), "시스템이력을 지우면 첨부파일도 정리해야 한다.");
+		assertEquals(ATCH_FILE_ID, deletedFileIds.get(0), "저장된 첨부파일 ID로 정리해야 한다.");
+	}
+
+	private interface Handler {
+		Object handle(java.lang.reflect.Method method, Object[] args) throws Throwable;
+	}
+
+	@SuppressWarnings("unchecked")
+	private static <T> T stub(Class<T> type, Handler handler) {
+		return (T) Proxy.newProxyInstance(type.getClassLoader(), new Class<?>[] { type },
+				(proxy, method, args) -> handler.handle(method, args));
+	}
+
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

시스템이력은 등록·수정에서 `fileMngService.insertFileInfs`로 첨부파일을 만들고 `atchFileId`를 함께 저장합니다(`"SHF_"` 접두어). 그런데 삭제할 때는 `COMTHSYSHIST` 행만 지웁니다. 지워진 이력의 첨부는 `COMTNFILE`에 계속 사용중(`USE_AT='Y'`)으로 남습니다.

같은 저장소의 회의실(`EgovMtgPlaceManageController`)·포상(`EgovRwardManageController`)·상담(`EgovCnsltManageController`)·FAQ(`EgovFaqController`)는 도메인을 지운 뒤 `fileMngService.deleteAllFileInf`로 첨부를 정리합니다. 시스템이력만 그 단계가 없습니다.

AS-IS

```java
if (loginVO != null) {
	sysHistoryService.deleteSysHistory(history);
}
```

TO-BE

```java
if (loginVO != null) {
	// 첨부파일 ID는 삭제 폼에 실려오지 않으므로 저장본에서 가져온다.
	SysHistoryVO searchVO = new SysHistoryVO();
	searchVO.setHistId(history.getHistId());
	SysHistoryVO storedHistory = sysHistoryService.selectSysHistory(searchVO);
	String atchFileId = storedHistory == null ? "" : storedHistory.getAtchFileId();

	sysHistoryService.deleteSysHistory(history);

	// 첨부파일을 삭제하기 위한 Vo
	FileVO fvo = new FileVO();
	fvo.setAtchFileId(atchFileId);

	fileMngService.deleteAllFileInf(fvo);
}
```

삭제 폼(`EgovSysHistInqire.jsp`)이 `histId`만 보내기 때문에 첨부파일 ID를 저장본에서 다시 읽습니다. 요청 파라미터가 아니라 저장본에서 가져오므로 다른 이력의 첨부를 가리킬 수 없습니다.

### 영향 범위

`deleteAllFileInf`는 `UPDATE COMTNFILE SET USE_AT = 'N'`입니다. `COMTNFILEDETAIL` 행과 디스크 파일은 그대로 두고 사용 여부만 바꿉니다. 여덟 개 DB 방언 매퍼가 모두 같습니다.

`selectSysHistory`는 사용자·공통코드와 이너 조인이라 등록자가 사라진 이력은 조회되지 않습니다. 그때는 `atchFileId`가 비어 갱신되는 행이 없고 지금과 같은 상태로 남습니다. 삭제 자체는 조회 결과와 무관하게 그대로 수행됩니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

컨트롤러를 직접 생성하고 서비스 자리에 동적 프록시를 넣어 삭제 경로만 확인했습니다. 필드 주입은 이미 병합된 `EgovArticleServiceImplTest_deleteArticleGuard`와 같이 `ReflectionTestUtils.setField`를 썼습니다.

수정 전

```
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
[ERROR]   EgovSysHistoryDeleteFileTest.deleteRemovesAttachedFiles:72
          시스템이력을 지우면 첨부파일도 정리해야 한다. ==> expected: <false> but was: <true>
```

수정 후

```
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

`pom.xml`의 surefire 설정이 `skipTests=true`라 기본 빌드에서는 실행되지 않습니다. 확인할 때는 그 값을 잠시 `false`로 두고 돌렸습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

화면 출력이 달라지는 변경이 아니라 첨부하지 않았습니다.
