### PR TITLE
chore(VcatnManage): 디버그용 System.out.println 제거 — 입력값을 기록하지 않는 형태로 재작성 (#1097 리뷰 반영)

### DIFF
--- a/src/main/java/egovframework/com/uss/ion/vct/web/EgovVcatnManageController.java
+++ b/src/main/java/egovframework/com/uss/ion/vct/web/EgovVcatnManageController.java
@@ -453,9 +453,6 @@ public class EgovVcatnManageController {
 		}
 
 		if (bindingResult.hasErrors()) {
-			System.out.println("#########################");
-			System.out.println("#########################");
-			System.out.println("#########################");
 
 			vcatnManageVO.setBgnde(EgovStringUtil.removeMinusChar(vcatnManageVO.getBgnde()));
 			vcatnManageVO.setEndde(EgovStringUtil.removeMinusChar(vcatnManageVO.getEndde()));


### PR DESCRIPTION
## 수정 사유 (Reason for modification)
- [x] 기타 (Others) — 디버그용 콘솔 출력 정리

## 관련 PR
#1097 (리뷰 후 종료) — 리뷰 의견을 반영해 **현재 main 기준으로 다시 작성**한 PR 입니다.

## 리뷰 의견과 조치
@mochoping 님께서 #1097 에 대해 다음과 같이 지적해 주셨습니다.

> 기존 출력은 구분선 문자열만 찍고 있어 데이터를 남기지 않았으나, 이번 변경은 그 자리에서 `bindingResult.getAllErrors()` 를 함께 기록합니다. FieldError 문자열에는 거절된 입력값이 포함되고 egovframework 로거의 기본 레벨이 DEBUG 라, 기본 설정에서 휴가 사유 등 입력값이 그대로 로그에 남습니다.

지적하신 내용에 동의합니다. 기존 출력이 데이터를 남기지 않았는데 정리 과정에서 오히려 입력값이 기록되도록 만든 것은 제 판단 착오였습니다. 이번 PR 은 **로거로 대체하지 않고 디버그용 출력만 제거**하여, 기록되는 데이터가 전혀 없도록 했습니다.

## 변경 내용
`EgovVcatnManageController.updtVcatnManage()` 의 입력값 검증 실패 블록에 남아 있던 디버그용 출력 3줄을 제거했습니다. 로그 호출은 추가하지 않았습니다.

```diff
 if (bindingResult.hasErrors()) {
-    System.out.println("#########################");
-    System.out.println("#########################");
-    System.out.println("#########################");

     vcatnManageVO.setBgnde(EgovStringUtil.removeMinusChar(vcatnManageVO.getBgnde()));
```

1개 파일, 3줄 삭제 / 0줄 추가.

## 같은 클래스와의 일관성
같은 컨트롤러의 다른 검증 실패 블록도 아무것도 기록하지 않습니다. 이번 변경으로 세 메서드의 처리 방식이 같아집니다.

- `insertVcatnManage()` — `if (bindingResult.hasErrors())` 블록에 로그 없음
- `updtVcatnManageConfm()` — `if (bindingResult.hasErrors())` 블록에 로그 없음
- `updtVcatnManage()` — 이번 변경으로 로그 없음

## 확인
- 변경 후 이 파일에 `System.out.println` 은 남아 있지 않으며, `getAllErrors()` 호출도 추가하지 않았습니다.
- 검증 실패 시 동작(입력값 재설정 후 수정 화면 반환)은 그대로입니다.

#1097 은 이 PR 로 대체되므로 닫힌 상태로 두겠습니다. 다시 검토해 주시면 감사하겠습니다.