### PR TITLE
fix: 기념일 조회가 결과 없음에서 NPE를 내 호출자의 null 검사가 실행되지 못하는 문제 수정

### DIFF
--- a/src/main/java/egovframework/com/uss/ion/ans/service/impl/EgovAnnvrsryManageServiceImpl.java
+++ b/src/main/java/egovframework/com/uss/ion/ans/service/impl/EgovAnnvrsryManageServiceImpl.java
@@ -104,6 +104,9 @@ public class EgovAnnvrsryManageServiceImpl extends EgovAbstractServiceImpl imple
 	public AnnvrsryManageVO selectAnnvrsryManage(AnnvrsryManageVO annvrsryManageVO) throws Exception {
 		annvrsryManageVO.setAnnvrsryDe(EgovStringUtil.removeMinusChar(annvrsryManageVO.getAnnvrsryDe()));
 		AnnvrsryManageVO annvrsryManageVOTemp = annvrsryManageDAO.selectAnnvrsryManage(annvrsryManageVO);
+		if (annvrsryManageVOTemp == null) {
+			return null;
+		}
 		annvrsryManageVOTemp.setAnnvrsryDe(EgovDateUtil.formatDate(annvrsryManageVOTemp.getAnnvrsryDe(), "-"));
 		return annvrsryManageVOTemp;
 	}

--- a/src/main/java/egovframework/com/uss/ion/ans/web/EgovAnnvrsryManageController.java
+++ b/src/main/java/egovframework/com/uss/ion/ans/web/EgovAnnvrsryManageController.java
@@ -432,6 +432,9 @@ public class EgovAnnvrsryManageController {
 		 * annvrsryManageVO.setAnnvrsryDe(sAnnvrsryDe_Temp); }
 		 */
 		AnnvrsryManageVO resultVO = egovAnnvrsryManageService.selectAnnvrsryManage(annvrsryManageVO);
+		if (resultVO == null) {
+			throw new IllegalStateException("권한이 없습니다.");
+		}
 		sAnnvrsryDe = EgovStringUtil.removeMinusChar(resultVO.getAnnvrsryDe());
 		if ("1".equals(resultVO.getCldrSe())) {
 			sTempCldrSe = egovMessageSource.getMessage("comUssIonAns.annvrsryGdcc.cldrSe1");// 양

--- a/src/test/java/egovframework/com/uss/ion/ans/service/impl/EgovAnnvrsryManageServiceImplTest.java
+++ b/src/test/java/egovframework/com/uss/ion/ans/service/impl/EgovAnnvrsryManageServiceImplTest.java
@@ -17,7 +17,9 @@ package egovframework.com.uss.ion.ans.service.impl;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 
 import org.junit.jupiter.api.Test;
@@ -77,5 +79,31 @@ class EgovAnnvrsryManageServiceImplTest {
         vo.setAnnvrsryDe(todayStr);
 
         assertEquals(0L, callGetDateCount(vo), "오늘 날짜(8자리) 기념일의 D-day는 0이어야 한다");
+    }
+
+    /** selectOne이 결과 0건에서 null을 돌려주는 상황(존재하지 않는 기념일 ID)을 재현한다. */
+    static class NullSelectOneAnnvrsryManageDAO extends AnnvrsryManageDAO {
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> T selectOne(String queryId, Object parameterObject) {
+            return null;
+        }
+    }
+
+    @Test
+    void selectAnnvrsryManage_missingRow_returnsNullInsteadOfNpe() throws Exception {
+        // 조회 결과가 없으면 null을 돌려주어야 한다. 수정 전에는 곧바로
+        // annvrsryManageVOTemp.setAnnvrsryDe(...)를 호출해 NullPointerException이 났고,
+        // 그 때문에 호출자들이 두고 있는 null 검사가 실행될 수 없었다.
+        EgovAnnvrsryManageServiceImpl service = new EgovAnnvrsryManageServiceImpl();
+        Field daoField = EgovAnnvrsryManageServiceImpl.class.getDeclaredField("annvrsryManageDAO");
+        daoField.setAccessible(true);
+        daoField.set(service, new NullSelectOneAnnvrsryManageDAO());
+
+        AnnvrsryManageVO annvrsryManageVO = new AnnvrsryManageVO();
+        annvrsryManageVO.setAnnId("nonexistent-id");
+
+        assertNull(service.selectAnnvrsryManage(annvrsryManageVO),
+                "존재하지 않는 기념일 ID는 NPE 없이 null이어야 한다");
     }
 }


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`EgovAnnvrsryManageServiceImpl.selectAnnvrsryManage`(:106)는 MyBatis `selectOne` 결과를 null 검사 없이 바로 쓰므로 해당 행이 없으면 NPE를 냅니다.

이 때문에 **호출자가 둔 null 검사가 실행되지 못합니다.** `EgovAnnvrsryManageController`는 세 곳에서 이 메서드를 부르는데, 두 곳에는 이미 null 검사가 있습니다.

```java
:164 if (resultVO == null) { throw new IllegalStateException("권한이 없습니다."); }
:352 if (resultVO == null) { throw new IllegalStateException("권한이 없습니다."); }
```

`fb45f509`(NCSC 보안점검 적용)가 넣은 검사입니다. 그런데 서비스가 `null`을 돌려주는 일이 없으므로 두 검사 모두 도달할 수 없고, 남의 기념일 ID를 넣으면 의도한 "권한이 없습니다" 대신 NPE가 납니다.

세 번째 호출 지점인 `selectAnnvrsryGdcc`(:434)에는 검사 자체가 없습니다.

AS-IS

```java
AnnvrsryManageVO annvrsryManageVOTemp = annvrsryManageDAO.selectAnnvrsryManage(annvrsryManageVO);
annvrsryManageVOTemp.setAnnvrsryDe(...);
return annvrsryManageVOTemp;
```

TO-BE

```java
AnnvrsryManageVO annvrsryManageVOTemp = annvrsryManageDAO.selectAnnvrsryManage(annvrsryManageVO);
if (annvrsryManageVOTemp == null) {
    return null;
}
annvrsryManageVOTemp.setAnnvrsryDe(...);
return annvrsryManageVOTemp;
```

`selectAnnvrsryGdcc`에는 형제 두 곳과 같은 형태의 검사를 더했습니다.

### 영향 범위

`selectAnnvrsryManage`의 반환 계약이 "없으면 null"로 바뀝니다. 호출자는 컨트롤러 세 곳뿐이고 세 곳 모두 null을 처리합니다. 조회 결과가 있으면 동작은 그대로입니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

기존 `EgovAnnvrsryManageServiceImplTest`에 케이스를 하나 더했습니다. `pom.xml:624`가 surefire `skipTests`를 `true`로 두고 있어 해제하고 실행했습니다.

수정 전

```
[ERROR] EgovAnnvrsryManageServiceImplTest.selectAnnvrsryManage_missingRow_returnsNullInsteadOfNpe:106
  » NullPointer Cannot invoke "AnnvrsryManageVO.getAnnvrsryDe()" because "annvrsryManageVOTemp" is null
[ERROR] Tests run: 4, Failures: 0, Errors: 1, Skipped: 0
```

수정 후

```
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```
