### PR TITLE
fix: 모니터링 메일 발송에 문자셋을 지정해 한글 제목·본문이 깨지지 않도록 수정

### DIFF
--- a/src/main/resources/egovframework/spring/com/context-mail.xml
+++ b/src/main/resources/egovframework/spring/com/context-mail.xml
@@ -42,7 +42,8 @@
         p:port="587"
         p:protocol="smtp"
         p:username="아이디" 
-        p:password="비밀번호">
+        p:password="비밀번호"
+        p:defaultEncoding="UTF-8">
         <property name="javaMailProperties"> 
             <props>
                 <prop key="mail.smtp.auth">true</prop> 


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`context-mail.xml`의 `mntrngMailSender`에 문자셋 설정이 없습니다.

```xml
:40 <bean id="mntrngMailSender" class="org.springframework.mail.javamail.JavaMailSenderImpl"
        p:username="아이디"
        p:password="비밀번호">
```

`JavaMailSenderImpl`에 `defaultEncoding`이 없으면 제목과 본문을 JVM 기본 문자셋으로 인코딩합니다. 기본 문자셋이 한글을 못 담는 환경, 이를테면 `LANG=C`·`POSIX`로 뜬 리눅스 서버나 컨테이너에서는 한글이 물음표로 바뀌고 되돌릴 수 없습니다.

이 sender로 나가는 메일은 전부 한글입니다. 같은 파일의 `mntrngMessage`는 제목이 `{모니터링종류} 상태통보.`이고 주입 지점은 여섯 곳입니다.

```
utl/sys/htm/service/HttpMntrngScheduling.java:43
utl/sys/trm/service/EgovTrsmrcvMntrngScheduling.java:39
utl/sys/prm/service/EgovProcessMonScheduling.java:43
utl/sys/dbm/service/EgovDbMntrngScheduling.java:42
utl/sys/srm/service/EgovServerResrceMntrngScheduling.java:68
utl/sys/nsm/service/EgovNtwrkSvcMntrngScheduling.java:73
```

AS-IS

```xml
p:password="비밀번호">
```

TO-BE

```xml
p:password="비밀번호"
p:defaultEncoding="UTF-8">
```

### 영향 범위

`mntrngMailSender` 한 곳에 속성 하나를 더합니다. 자바 코드는 그대로입니다.

## JUnit 테스트 JUnit tests

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

증상이 JVM 기본 문자셋에 달려 있어 실행 환경을 바꿔가며 대조했습니다. `mntrngMessage`와 같은 한글 제목을 넣고 `JavaMailSenderImpl`이 만든 MIME 헤더를 확인했습니다.

`LANG=C` 서버 모사 (`-Dfile.encoding=US-ASCII`), 수정 전

```
raw    : =?US-ASCII?B?SFRUUD8/PyA/Pz8/ID8/Pz8u?=
decoded: HTTP??? ???? ????.
원문복원: false
```

같은 환경, 수정 후

```
raw    : =?UTF-8?B?SFRUUOyEnOu5hOyKpCDrqqjri4jthLDrp4Eg7IOB7YOc7Ya167O0Lg==?=
decoded: HTTP서비스 모니터링 상태통보.
원문복원: true
```

기본 문자셋이 UTF-8인 환경에서는 수정 전후가 모두 `원문복원: true`로 같았습니다.
