### PR TITLE
fix: 개인연차 미등록 사용자의 휴가 신청·수정이 NullPointerException으로 실패

### DIFF
--- a/src/main/java/egovframework/com/uss/ion/vct/service/impl/EgovVcatnManageServiceImpl.java
+++ b/src/main/java/egovframework/com/uss/ion/vct/service/impl/EgovVcatnManageServiceImpl.java
@@ -154,6 +154,9 @@ public class EgovVcatnManageServiceImpl extends EgovAbstractServiceImpl implemen
 		// vcatnManageVO);
 		vcatnManageVO.setInfrmlSanctnId(infrmlSanctn.getInfrmlSanctnId());
 		VcatnManageVO vcatnManageVO1 = selectIndvdlYrycManage(uniqId);
+		if (vcatnManageVO1 == null) {
+			vcatnManageVO1 = new VcatnManageVO();
+		}
 		double iUseYrycCo = vcatnManageVO1.getUseYrycCo(); // 연차테이블의 사용 연차개수
 		double iRemndrYrycCo = vcatnManageVO1.getRemndrYrycCo(); // 연차테이블의 잔여 연차개수
 		double iCountYryc = 0.0;
@@ -314,6 +317,9 @@ public class EgovVcatnManageServiceImpl extends EgovAbstractServiceImpl implemen
 
 		// 개인연차조회
 		VcatnManageVO vcatnManageVO1 = selectIndvdlYrycManage(vcatnManageVO.getApplcntId());
+		if (vcatnManageVO1 == null) {
+			vcatnManageVO1 = new VcatnManageVO();
+		}
 		double iUseYrycCo = vcatnManageVO1.getUseYrycCo(); // 연차테이블의 사용 연차개수
 		double iRemndrYrycCo = vcatnManageVO1.getRemndrYrycCo(); // 연차테이블의 잔여 연차개수
 		double iCountYryc = 0.0;
@@ -432,6 +438,9 @@ public class EgovVcatnManageServiceImpl extends EgovAbstractServiceImpl implemen
 			// 연차 반환처리
 			// 개인연차조회
 			VcatnManageVO vcatnManageVO1 = selectIndvdlYrycManage(vcatnManageVO.getApplcntId());
+			if (vcatnManageVO1 == null) {
+				vcatnManageVO1 = new VcatnManageVO();
+			}
 			double iUseYrycCo = vcatnManageVO1.getUseYrycCo(); // 연차테이블의 사용 연차개수
 			double iRemndrYrycCo = vcatnManageVO1.getRemndrYrycCo(); // 연차테이블의 잔여 연차개수
 			double iCountYryc = 0.0;

--- a/src/main/java/egovframework/com/uss/ion/vct/web/EgovVcatnManageController.java
+++ b/src/main/java/egovframework/com/uss/ion/vct/web/EgovVcatnManageController.java
@@ -395,6 +395,9 @@ public class EgovVcatnManageController {
 					model.addAttribute("errorMessage", sTempMessage);
 
 					VcatnManageVO vcatnManageVO1 = egovVcatnManageService.selectIndvdlYrycManage(user.getUniqId());
+					if (vcatnManageVO1 == null) {
+						vcatnManageVO1 = new VcatnManageVO();
+					}
 					vcatnManageVO1.setApplcntId(user.getUniqId());
 					vcatnManageVO1.setApplcntNm(user.getName());
 					vcatnManageVO1.setOrgnztNm(user.getOrgnztNm());
@@ -416,6 +419,9 @@ public class EgovVcatnManageController {
 
 				VcatnManageVO vcatnManageVO1 = egovVcatnManageService
 						.selectIndvdlYrycManage(user == null ? "" : EgovStringUtil.isNullToString(user.getUniqId()));
+				if (vcatnManageVO1 == null) {
+					vcatnManageVO1 = new VcatnManageVO();
+				}
 				vcatnManageVO1.setApplcntId(user == null ? "" : EgovStringUtil.isNullToString(user.getUniqId()));
 				vcatnManageVO1.setApplcntNm(user == null ? "" : EgovStringUtil.isNullToString(user.getName()));
 				vcatnManageVO1.setOrgnztNm(user == null ? "" : EgovStringUtil.isNullToString(user.getOrgnztNm()));
@@ -508,6 +514,9 @@ public class EgovVcatnManageController {
 				model.addAttribute("errorMessage", sTempMessage);
 
 				VcatnManageVO vcatnManageVO1 = egovVcatnManageService.selectIndvdlYrycManage(user.getUniqId());
+				if (vcatnManageVO1 == null) {
+					vcatnManageVO1 = new VcatnManageVO();
+				}
 				vcatnManageVO1.setApplcntId(user.getUniqId());
 				vcatnManageVO1.setApplcntNm(user.getName());
 				vcatnManageVO1.setOrgnztNm(user.getOrgnztNm());

--- a/src/test/java/egovframework/com/uss/ion/vct/service/impl/EgovVcatnManageServiceImplTest.java
+++ b/src/test/java/egovframework/com/uss/ion/vct/service/impl/EgovVcatnManageServiceImplTest.java
@@ -1,0 +1,104 @@
+package egovframework.com.uss.ion.vct.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Proxy;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import egovframework.com.cmm.LoginVO;
+import egovframework.com.cmm.service.EgovUserDetailsService;
+import egovframework.com.cmm.util.EgovUserDetailsHelper;
+import egovframework.com.uss.ion.ism.service.EgovInfrmlSanctnService;
+import egovframework.com.uss.ion.ism.service.InfrmlSanctn;
+import egovframework.com.uss.ion.vct.service.VcatnManageVO;
+
+/**
+ * 개인연차 정보가 없는 사용자의 휴가신청 회귀 테스트.
+ *
+ * selectIndvdlYrycManage는 (발생연도, 사용자ID)로 한 건을 조회하므로 개인연차가 등록되지 않은
+ * 사용자에게는 null을 돌려준다. 목록 화면은 이 상태를 정상으로 보고 개인연차관리로 안내하는데,
+ * 신청 처리는 결과를 그대로 역참조해 NullPointerException을 냈다.
+ */
+class EgovVcatnManageServiceImplTest {
+
+	/** 개인연차가 등록되지 않아 selectIndvdlYrycManage가 null을 돌려주는 상황을 재현한다. */
+	static class NullIndvdlYrycVcatnManageDAO extends VcatnManageDAO {
+		private VcatnManageVO insertedVO;
+
+		@Override
+		public VcatnManageVO selectIndvdlYrycManage(VcatnManageVO vcatnManageVO) {
+			return null;
+		}
+
+		@Override
+		public void insertVcatnManage(VcatnManageVO vcatnManageVO) {
+			insertedVO = vcatnManageVO;
+		}
+	}
+
+	private static EgovInfrmlSanctnService stubSanctnService() {
+		return (EgovInfrmlSanctnService) Proxy.newProxyInstance(
+				EgovInfrmlSanctnService.class.getClassLoader(),
+				new Class<?>[] { EgovInfrmlSanctnService.class },
+				(proxy, method, args) -> {
+					if ("insertInfrmlSanctn".equals(method.getName())) {
+						InfrmlSanctn infrmlSanctn = new InfrmlSanctn();
+						infrmlSanctn.setInfrmlSanctnId("SANCTN_0000000000001");
+						return infrmlSanctn;
+					}
+					return null;
+				});
+	}
+
+	@Test
+	void insertVcatnManage_withoutIndvdlYryc_registersInsteadOfNpe() throws Exception {
+		// 무급휴가(03)는 연차를 차감하지 않으므로 개인연차가 없어도 등록되어야 한다.
+		// 수정 전에는 연차 차감 여부를 가리기 전에 조회 결과를 역참조해 NullPointerException이 났다.
+		bindLoginUser("USRCNFRM_00000000001");
+		EgovVcatnManageServiceImpl service = new EgovVcatnManageServiceImpl();
+		NullIndvdlYrycVcatnManageDAO dao = new NullIndvdlYrycVcatnManageDAO();
+		setField(service, "vcatnManageDAO", dao);
+		setField(service, "infrmlSanctnService", stubSanctnService());
+
+		VcatnManageVO vcatnManageVO = new VcatnManageVO();
+		vcatnManageVO.setVcatnSe("03");
+		vcatnManageVO.setBgnde("20260901");
+		vcatnManageVO.setEndde("20260901");
+
+		assertEquals("01", service.insertVcatnManage(vcatnManageVO),
+				"개인연차가 없어도 무급휴가는 NPE 없이 등록되어야 한다");
+		assertEquals("SANCTN_0000000000001", dao.insertedVO.getInfrmlSanctnId(),
+				"등록된 휴가에 결재 식별자가 그대로 실려야 한다");
+	}
+
+	private static void bindLoginUser(String uniqId) {
+		LoginVO login = new LoginVO();
+		login.setUniqId(uniqId);
+		EgovUserDetailsService stub = new EgovUserDetailsService() {
+			@Override
+			public Object getAuthenticatedUser() {
+				return login;
+			}
+
+			@Override
+			public List<String> getAuthorities() {
+				return List.of();
+			}
+
+			@Override
+			public Boolean isAuthenticated() {
+				return Boolean.TRUE;
+			}
+		};
+		new EgovUserDetailsHelper().setEgovUserDetailsService(stub);
+	}
+
+	private static void setField(Object target, String name, Object value) throws Exception {
+		Field field = EgovVcatnManageServiceImpl.class.getDeclaredField(name);
+		field.setAccessible(true);
+		field.set(target, value);
+	}
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`EgovVcatnManageServiceImpl.selectIndvdlYrycManage`(:479)는 `(발생연도, 사용자ID)`로 개인연차 한 건을 조회하므로, 개인연차가 등록되지 않은 사용자에게는 `null`을 돌려줍니다.

코드는 이 상태를 이미 정상으로 다룹니다. 휴가관리 목록(`EgovVcatnManageController` :108)은 `null`이면 "개인연차 등록을 위해 개인연차관리 콤포넌트로 이동" 안내를 띄우고, 휴가신청 화면(:207)은 `null`이면 빈 VO로 바꿔 진입을 허용합니다.

그런데 신청·수정 처리는 같은 조회 결과를 검사 없이 그대로 역참조합니다.

AS-IS

```java
VcatnManageVO vcatnManageVO1 = selectIndvdlYrycManage(uniqId);
double iUseYrycCo = vcatnManageVO1.getUseYrycCo();      // 연차테이블의 사용 연차개수
double iRemndrYrycCo = vcatnManageVO1.getRemndrYrycCo(); // 연차테이블의 잔여 연차개수
```

TO-BE

```java
VcatnManageVO vcatnManageVO1 = selectIndvdlYrycManage(uniqId);
if (vcatnManageVO1 == null) {
	vcatnManageVO1 = new VcatnManageVO();
}
double iUseYrycCo = vcatnManageVO1.getUseYrycCo();      // 연차테이블의 사용 연차개수
double iRemndrYrycCo = vcatnManageVO1.getRemndrYrycCo(); // 연차테이블의 잔여 연차개수
```

이 메서드를 부르는 곳은 열 곳이고 그중 네 곳(`EgovVcatnManageController` :108 :207 :285, `EgovVcatnManageServiceImpl` :110)에는 이미 `null` 검사가 있습니다. 검사가 없는 여섯 곳을 :207과 같은 방식(빈 VO로 대체)으로 맞췄습니다.

연차·반차 신청은 잔여 0으로 계산되어 기존 "연차휴가 등록실패(잔여연차 부족)" 메시지로 거절됩니다. 연차를 차감하지 않는 휴가구분(무급·유급·대체·기타)은 정상 등록됩니다.

개인연차 갱신 쿼리 `updateIndvdlYrycManage`는 `(발생연도, 사용자ID)`를 조건으로 하는 UPDATE라, 행이 없는 이 상황에서는 0행이 갱신됩니다. 빈 VO로 계산한 값이 개인연차 테이블에 기록되지는 않습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`EgovVcatnManageServiceImplTest`를 추가했습니다. 개인연차 조회가 `null`을 돌려주는 DAO로 무급휴가(03) 신청을 태워, 수정 전에는 `NullPointerException`이 나고 수정 후에는 `"01"`(등록 성공)이 나오는지 확인합니다.

수동 테스트는 `main`(88fe3636)과 이 브랜치를 각각 톰캣에 올려 같은 요청을 보냈습니다. `com_DML_mysql.sql`을 그대로 적재하면 `COMTNINDVDLYRYCMANAGE`가 0건이라 별도 조작 없이 재현됩니다.

`POST /uss/ion/vct/insertVcatnManage.do` (`vcatnSe=01`)

수정 전: 화면에 "시스템 에러 - 알 수 없는 오류가 발생했습니다!"

```
java.lang.NullPointerException: Cannot invoke "egovframework.com.uss.ion.vct.service.VcatnManageVO.getUseYrycCo()" because "vcatnManageVO1" is null
	at egovframework.com.uss.ion.vct.service.impl.EgovVcatnManageServiceImpl.insertVcatnManage(EgovVcatnManageServiceImpl.java:157)
```

수정 후: 휴가신청 화면이 다시 뜨고 `alert("연차휴가 등록실패(잔여연차 부족)")`

`POST /uss/ion/vct/updtVcatnManage.do`도 같습니다. 수정 전에는 `EgovVcatnManageServiceImpl.java:317`에서 같은 예외가 나고, 수정 후에는 같은 안내로 끝납니다.

개인연차 행이 있는 정상 흐름은 두 빌드가 동일했습니다. 15일 중 1일 신청 후 `USE_YRYC_CO=1.0`, `REMNDR_YRYC_CO=14.0`으로 같았습니다.
