### PR TITLE
fix: 존재하지 않는 게시물의 XSS 권한체크가 NullPointerException으로 실패

### DIFF
--- a/src/main/java/egovframework/com/cop/bbs/web/EgovArticleController.java
+++ b/src/main/java/egovframework/com/cop/bbs/web/EgovArticleController.java
@@ -626,7 +626,7 @@ public class EgovArticleController {
 		BoardVO vo = egovArticleService.selectArticleDetail(boardVO);
 
 		// step2 EgovXssChecker 공통모듈을 이용한 권한체크
-		EgovXssChecker.checkerUserXss(multiRequest, vo.getFrstRegisterId());
+		EgovXssChecker.checkerUserXss(multiRequest, vo == null ? null : vo.getFrstRegisterId());
 		LOGGER.debug("@ XSS 권한체크 END ------------------------------------------------");
 		// --------------------------------------------------------
 		// @ XSS 대응 권한체크 체크 END
@@ -699,7 +699,7 @@ public class EgovArticleController {
 		BoardVO vo = egovArticleService.selectArticleDetail(boardVO);
 
 		// step2 EgovXssChecker 공통모듈을 이용한 권한체크
-		EgovXssChecker.checkerUserXss(request, vo.getFrstRegisterId());
+		EgovXssChecker.checkerUserXss(request, vo == null ? null : vo.getFrstRegisterId());
 		LOGGER.debug("@ XSS 권한체크 END ------------------------------------------------");
 		// --------------------------------------------------------
 		// @ XSS 대응 권한체크 체크 END
@@ -889,7 +889,7 @@ public class EgovArticleController {
 
 		if (isAuthenticated) {
 			BoardVO vo = egovArticleService.selectArticleDetail(boardVO);
-			EgovXssChecker.checkerUserXss(request, vo.getFrstRegisterId());
+			EgovXssChecker.checkerUserXss(request, vo == null ? null : vo.getFrstRegisterId());
 
 			// 익명 게시글은 작성비밀번호가 유일한 인가 수단이므로 서버측에서 반드시 검증한다.
 			if (vo.getPassword() == null || board.getPassword() == null
@@ -928,7 +928,7 @@ public class EgovArticleController {
 		model.addAttribute("sessionUniqId", (user == null || user.getUniqId() == null) ? "" : user.getUniqId());
 
 		BoardVO vo = egovArticleService.selectArticleDetail(boardVO);
-		EgovXssChecker.checkerUserXss(request, vo.getFrstRegisterId());
+		EgovXssChecker.checkerUserXss(request, vo == null ? null : vo.getFrstRegisterId());
 
 		boardVO.setBbsId(boardVO.getBbsId());
 		boardVO.setBbsNm(boardVO.getBbsNm());
@@ -981,7 +981,7 @@ public class EgovArticleController {
 		}
 
 		BoardVO article = egovArticleService.selectArticleDetail(boardVO);
-		EgovXssChecker.checkerUserXss(request, article.getFrstRegisterId());
+		EgovXssChecker.checkerUserXss(request, article == null ? null : article.getFrstRegisterId());
 
 		if (bindingResult.hasErrors()) {
 

--- a/src/test/java/egovframework/com/cop/bbs/web/EgovArticleControllerXssCheckTest.java
+++ b/src/test/java/egovframework/com/cop/bbs/web/EgovArticleControllerXssCheckTest.java
@@ -1,0 +1,83 @@
+package egovframework.com.cop.bbs.web;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Proxy;
+import java.util.List;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.ui.ModelMap;
+
+import egovframework.com.cmm.LoginVO;
+import egovframework.com.cmm.exception.EgovXssException;
+import egovframework.com.cmm.service.EgovUserDetailsService;
+import egovframework.com.cmm.util.EgovUserDetailsHelper;
+import egovframework.com.cop.bbs.service.Board;
+import egovframework.com.cop.bbs.service.BoardMaster;
+import egovframework.com.cop.bbs.service.BoardVO;
+import egovframework.com.cop.bbs.service.EgovArticleService;
+
+/**
+ * 존재하지 않는 게시물에 대한 XSS 권한체크 회귀 테스트.
+ *
+ * EgovArticleServiceImpl.selectArticleDetail은 형제 서비스들과 달리 조회 결과가 없을 때 null을
+ * 그대로 돌려준다. 권한체크는 그 결과를 역참조해 EgovXssChecker에 넘기므로, 이미 삭제된 글 번호로
+ * 요청하면 XSS00001 대신 NullPointerException이 났다.
+ */
+class EgovArticleControllerXssCheckTest {
+
+	@Test
+	void deleteBoardArticle_missingArticle_throwsXssExceptionInsteadOfNpe() throws Exception {
+		bindLoginUser("USRCNFRM_00000000001");
+
+		EgovArticleController controller = new EgovArticleController();
+		setField(controller, "egovArticleService", nullReturningArticleService());
+
+		assertThrows(EgovXssException.class,
+				() -> controller.deleteBoardArticle(stubRequest(), new BoardVO(), new Board(), new BoardMaster(),
+						new ModelMap()),
+				"존재하지 않는 게시물은 NPE가 아니라 권한 오류로 끝나야 한다");
+	}
+
+	/** 조회 결과가 없어 selectArticleDetail이 null을 돌려주는 상황을 재현한다. */
+	private static EgovArticleService nullReturningArticleService() {
+		return (EgovArticleService) Proxy.newProxyInstance(EgovArticleService.class.getClassLoader(),
+				new Class<?>[] { EgovArticleService.class }, (proxy, method, args) -> null);
+	}
+
+	private static HttpServletRequest stubRequest() {
+		return (HttpServletRequest) Proxy.newProxyInstance(HttpServletRequest.class.getClassLoader(),
+				new Class<?>[] { HttpServletRequest.class }, (proxy, method, args) -> null);
+	}
+
+	private static void bindLoginUser(String uniqId) {
+		LoginVO login = new LoginVO();
+		login.setUniqId(uniqId);
+		EgovUserDetailsService stub = new EgovUserDetailsService() {
+			@Override
+			public Object getAuthenticatedUser() {
+				return login;
+			}
+
+			@Override
+			public List<String> getAuthorities() {
+				return List.of();
+			}
+
+			@Override
+			public Boolean isAuthenticated() {
+				return Boolean.TRUE;
+			}
+		};
+		new EgovUserDetailsHelper().setEgovUserDetailsService(stub);
+	}
+
+	private static void setField(Object target, String name, Object value) throws Exception {
+		Field field = EgovArticleController.class.getDeclaredField(name);
+		field.setAccessible(true);
+		field.set(target, value);
+	}
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`EgovArticleServiceImpl.selectArticleDetail`은 DAO 결과를 그대로 돌려주므로 이미 삭제됐거나 없는 글 번호로 요청하면 `null`이 됩니다. 같은 성격의 형제 서비스 세 곳은 이 경우 `processException("info.nodata.msg")`를 던집니다.

`EgovOnlineManualServiceImpl.selectOnlineManualDetail`, `EgovQnaServiceImpl.selectQnaDetail`, `EgovCnsltManageServiceImpl.selectCnsltListDetail`이 그렇습니다.

`EgovArticleController`의 XSS 권한체크는 그 결과를 검사 없이 역참조합니다.

AS-IS

```java
BoardVO vo = egovArticleService.selectArticleDetail(boardVO);

// step2 EgovXssChecker 공통모듈을 이용한 권한체크
EgovXssChecker.checkerUserXss(request, vo.getFrstRegisterId());
```

TO-BE

```java
BoardVO vo = egovArticleService.selectArticleDetail(boardVO);

// step2 EgovXssChecker 공통모듈을 이용한 권한체크
EgovXssChecker.checkerUserXss(request, vo == null ? null : vo.getFrstRegisterId());
```

`EgovXssChecker.checkerUserXss`는 `sUniqId`가 `null`이면 `XSS00001`을 던지도록 이미 만들어져 있고(:63), `EgovArticleCommentController`(:190 :288)는 같은 상황을 이 방식으로 넘기고 있습니다. 같은 파일에서 검사 없이 역참조하던 다섯 곳(:629 :702 :892 :931 :984)을 그 방식에 맞췄습니다.

권한체크에서 예외가 나므로 뒤따르는 조회·삭제 로직에는 도달하지 않습니다. 글이 있는 경우의 동작은 그대로입니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`EgovArticleControllerXssCheckTest`를 추가했습니다. 조회가 `null`을 돌려주는 서비스로 `deleteBoardArticle`을 호출해 수정 전에는 `NullPointerException`이 나고 수정 후에는 `EgovXssException`이 나오는지 확인합니다.

수정 전

```
expected: <egovframework.com.cmm.exception.EgovXssException> but was: <java.lang.NullPointerException>
```

수동 테스트는 `main`(88fe3636)과 이 브랜치를 각각 톰캣에 올려 같은 요청을 보냈습니다.

`POST /cop/bbs/deleteArticle.do` (없는 `nttId`)

- 수정 전: "시스템 에러 - 알 수 없는 오류가 발생했습니다!"
- 수정 후: "User authorization Error XSS00001 - 해당 기능에 대한 사용 및 처리 권한이 없습니다."

게시물이 있는 정상 삭제는 두 빌드가 같았습니다. `COMTNBBS.USE_AT`가 `N`으로 바뀌는 것까지 동일합니다.
