### PR TITLE
fix: 메뉴 수정 검증 실패 시 폼 재표시가 400 에러로 끊기는 문제

### DIFF
--- a/src/main/java/egovframework/com/sym/mnu/mpm/web/EgovMenuManageController.java
+++ b/src/main/java/egovframework/com/sym/mnu/mpm/web/EgovMenuManageController.java
@@ -259,7 +259,10 @@ public class EgovMenuManageController {
 		}
 
 		if (bindingResult.hasErrors()) {
-			sLocationUrl = "forward:/sym/mnu/mpm/EgovMenuManageListDetailSelect.do";
+			// 검증 실패 시 수정 폼을 다시 그린다. 입력값과 오류 메시지는 menuManageVO로 유지된다.
+			// 형제 핸들러(insertMenuManage)와 동일하게 뷰 이름을 직접 반환한다 —
+			// 재표시 forward 대상 selectMenuManage는 수정 폼이 보내지 않는 req_menuNo를 필수로 요구한다.
+			sLocationUrl = "egovframework/com/sym/mnu/mpm/EgovMenuDetailSelectUpdt";
 			return sLocationUrl;
 		}
 		ComDefaultVO searchVO = new ComDefaultVO();

--- a/src/test/java/egovframework/com/sym/mnu/mpm/web/EgovMenuManageControllerValidationTest.java
+++ b/src/test/java/egovframework/com/sym/mnu/mpm/web/EgovMenuManageControllerValidationTest.java
@@ -1,0 +1,64 @@
+package egovframework.com.sym.mnu.mpm.web;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.ui.ModelMap;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.BindingResult;
+
+import egovframework.com.cmm.LoginVO;
+import egovframework.com.cmm.service.EgovUserDetailsService;
+import egovframework.com.cmm.util.EgovUserDetailsHelper;
+import egovframework.com.sym.mnu.mpm.service.MenuManageVO;
+
+/**
+ * 메뉴 수정 검증 실패 시 폼 재표시 경로 회귀 테스트.
+ *
+ * updateMenuManage는 검증 실패 시 selectMenuManage로 forward했는데, 그 핸들러는 수정 폼이
+ * 보내지 않는 req_menuNo를 필수 파라미터로 요구한다. 그 결과 오류 재표시 대신
+ * MissingServletRequestParameterException(400)으로 끊겼다. 형제 핸들러들처럼 뷰 이름을 직접
+ * 반환하도록 바꿔, 파라미터 없이도 입력값·오류가 담긴 폼이 다시 그려지게 한다.
+ */
+class EgovMenuManageControllerValidationTest {
+
+	@Test
+	void updateMenuManage_validationFailure_returnsFormViewNotForward() throws Exception {
+		bindLoginUser("USRCNFRM_00000000001");
+
+		EgovMenuManageController controller = new EgovMenuManageController();
+
+		MenuManageVO menuManageVO = new MenuManageVO();
+		BindingResult bindingResult = new BeanPropertyBindingResult(menuManageVO, "menuManageVO");
+		bindingResult.rejectValue("menuNm", "Size", "메뉴명은 50자 이내여야 합니다.");
+
+		String view = controller.updateMenuManage(menuManageVO, bindingResult, new ModelMap());
+
+		assertEquals("egovframework/com/sym/mnu/mpm/EgovMenuDetailSelectUpdt", view,
+				"검증 실패 시 req_menuNo를 요구하는 forward가 아니라 수정 폼 뷰를 직접 반환해야 한다");
+	}
+
+	private static void bindLoginUser(String uniqId) {
+		LoginVO login = new LoginVO();
+		login.setUniqId(uniqId);
+		EgovUserDetailsService stub = new EgovUserDetailsService() {
+			@Override
+			public Object getAuthenticatedUser() {
+				return login;
+			}
+
+			@Override
+			public List<String> getAuthorities() {
+				return List.of();
+			}
+
+			@Override
+			public Boolean isAuthenticated() {
+				return Boolean.TRUE;
+			}
+		};
+		new EgovUserDetailsHelper().setEgovUserDetailsService(stub);
+	}
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`EgovMenuManageController.updateMenuManage`는 입력값 검증에 실패하면 `selectMenuManage`로 forward해 수정 폼을 다시 그리려 합니다.

```java
if (bindingResult.hasErrors()) {
    sLocationUrl = "forward:/sym/mnu/mpm/EgovMenuManageListDetailSelect.do";
    return sLocationUrl;
}
```

그런데 forward 대상 `selectMenuManage`는 `req_menuNo`를 필수 파라미터로 요구합니다.

```java
public String selectMenuManage(@RequestParam("req_menuNo") String searchKeyword, ...)
```

`req_menuNo`는 목록 화면(`EgovMenuManage.jsp`)의 hidden 필드에서만 채워지고, 수정 폼(`EgovMenuDetailSelectUpdt.jsp`)은 이 파라미터를 보내지 않습니다. 따라서 검증 실패 시 forward된 요청에 `req_menuNo`가 없어 `MissingServletRequestParameterException`이 나고, 폼 재표시 대신 400 에러로 끝납니다.

같은 클래스의 형제 핸들러들은 검증 실패 시 파라미터를 요구하지 않는 경로로 재표시합니다. `insertMenuManage`(:217)와 `insertMenuList`(:353)는 뷰 이름을 직접 반환합니다.

TO-BE

```java
if (bindingResult.hasErrors()) {
    // 검증 실패 시 수정 폼을 다시 그린다. 입력값과 오류 메시지는 menuManageVO로 유지된다.
    sLocationUrl = "egovframework/com/sym/mnu/mpm/EgovMenuDetailSelectUpdt";
    return sLocationUrl;
}
```

`EgovMenuDetailSelectUpdt.jsp`는 `menuManageVO`만 참조하고 그 값은 `@ModelAttribute`로 이미 모델에 있으므로 사용자가 입력한 값과 오류 메시지가 그대로 재표시됩니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`EgovMenuManageControllerValidationTest`를 추가했습니다. `menuNm`에 검증 오류를 심어 `updateMenuManage`를 호출하고 반환값이 forward가 아니라 수정 폼 뷰 이름인지 확인합니다.

수정 전

```
expected: <egovframework/com/sym/mnu/mpm/EgovMenuDetailSelectUpdt> but was: <forward:/sym/mnu/mpm/EgovMenuManageListDetailSelect.do>
```

수동 테스트는 `main`(88fe3636)과 이 브랜치를 각각 톰캣에 올려 `menuNm`에 51자를 넣어 요청했습니다.

`POST /sym/mnu/mpm/EgovMenuDetailSelectUpdt.do` (`menuNm` 51자)

- 수정 전: `HTTP Status 400 – Bad Request`

```
MissingServletRequestParameterException: Required request parameter 'req_menuNo' for method parameter type String is not present
```

- 수정 후: 수정 폼이 입력값·오류 메시지와 함께 다시 표시됨(HTTP 200)
