### PR TITLE
fix: 게시물 삭제 시 첨부파일이 미사용 처리되지 않는 문제 수정

### DIFF
--- a/src/main/java/egovframework/com/cop/bbs/web/EgovArticleController.java
+++ b/src/main/java/egovframework/com/cop/bbs/web/EgovArticleController.java
@@ -715,6 +715,10 @@ public class EgovArticleController {
 
 		if (isAuthenticated) {
 			board.setLastUpdusrId((user == null || user.getUniqId() == null) ? "" : user.getUniqId());
+			// 삭제 폼(EgovArticleDetail.jsp의 formDelete)은 atchFileId를 전송하지 않아 요청 바인딩 값이
+			// 비어 있다. 그대로 넘기면 deleteArticle의 첨부그룹 정리 분기가 실행되지 않으므로,
+			// updateBoardArticle과 동일하게 조회·권한검증을 마친 원본(vo)의 값을 사용한다.
+			board.setAtchFileId(vo.getAtchFileId());
 
 			egovArticleService.deleteArticle(board);
 		}

--- a/src/test/java/egovframework/com/cop/bbs/web/EgovArticleControllerDeleteFileTest.java
+++ b/src/test/java/egovframework/com/cop/bbs/web/EgovArticleControllerDeleteFileTest.java
@@ -1,0 +1,193 @@
+package egovframework.com.cop.bbs.web;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.lang.reflect.Field;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.ui.ModelMap;
+
+import egovframework.com.cmm.LoginVO;
+import egovframework.com.cmm.service.EgovUserDetailsService;
+import egovframework.com.cmm.util.EgovUserDetailsHelper;
+import egovframework.com.cop.bbs.service.Board;
+import egovframework.com.cop.bbs.service.BoardMaster;
+import egovframework.com.cop.bbs.service.BoardVO;
+import egovframework.com.cop.bbs.service.EgovArticleService;
+
+/**
+ * 게시물 삭제 시 첨부파일 정리 회귀 테스트.
+ *
+ * deleteArticle(Board)는 board.getAtchFileId()로 첨부그룹을 미사용 처리한다. 그런데 삭제 폼
+ * (EgovArticleDetail.jsp의 formDelete)은 atchFileId를 전송하지 않아 요청 바인딩 값이 비어 있고,
+ * 그대로 넘기면 서비스의 파일 정리 분기가 실행되지 않는다. 같은 컨트롤러의 updateBoardArticle은
+ * 이미 "클라이언트가 전달한 atchFileId를 신뢰하지 않고 조회본의 값을 쓴다"로 조치돼 있다.
+ */
+class EgovArticleControllerDeleteFileTest {
+
+	private static final String OWNER_UNIQ_ID = "USRCNFRM_00000000001";
+	private static final String STORED_ATCH_FILE_ID = "FILE_000000000000123";
+
+	/** deleteArticle에 실제로 전달된 Board를 기록하는 스텁. */
+	private static final class StubService implements EgovArticleService {
+		private final BoardVO stored;
+		private Board deletedArg;
+
+		StubService(String atchFileId) {
+			this.stored = new BoardVO();
+			this.stored.setFrstRegisterId(OWNER_UNIQ_ID);
+			this.stored.setNtcrId("writer");
+			this.stored.setAtchFileId(atchFileId);
+		}
+
+		@Override
+		public BoardVO selectArticleDetail(BoardVO boardVO) {
+			return stored;
+		}
+
+		@Override
+		public void deleteArticle(Board board) {
+			deletedArg = board;
+		}
+
+		@Override
+		public java.util.Map<String, Object> selectArticleList(BoardVO boardVO) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public void insertArticleAndFiles(Board board,
+				List<org.springframework.web.multipart.MultipartFile> files) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public void updateArticle(Board board) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public void updateArticleAndFiles(Board board,
+				List<org.springframework.web.multipart.MultipartFile> files, String atchFileId) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public List<BoardVO> selectNoticeArticleList(BoardVO boardVO) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public java.util.Map<String, Object> selectGuestArticleList(BoardVO vo) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public BoardVO selectArticleCnOne(BoardVO boardVO) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public List<BoardVO> selectBlogNmList(BoardVO boardVO) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public java.util.Map<String, Object> selectBlogListManager(BoardVO boardVO) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public List<BoardVO> selectArticleDetailDefault(BoardVO boardVO) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public int selectArticleDetailDefaultCnt(BoardVO boardVO) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public List<BoardVO> selectArticleDetailCn(BoardVO boardVO) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public int selectLoginUser(BoardVO boardVO) {
+			throw new UnsupportedOperationException();
+		}
+	}
+
+	private static void bindLoginUser(String uniqId) {
+		LoginVO login = new LoginVO();
+		login.setUniqId(uniqId);
+		login.setId(uniqId);
+		EgovUserDetailsService stub = new EgovUserDetailsService() {
+			@Override
+			public Object getAuthenticatedUser() {
+				return login;
+			}
+
+			@Override
+			public List<String> getAuthorities() {
+				return List.of();
+			}
+
+			@Override
+			public Boolean isAuthenticated() {
+				return Boolean.TRUE;
+			}
+		};
+		new EgovUserDetailsHelper().setEgovUserDetailsService(stub);
+	}
+
+	private static EgovArticleController controllerWith(StubService service) throws Exception {
+		EgovArticleController controller = new EgovArticleController();
+		Field f = EgovArticleController.class.getDeclaredField("egovArticleService");
+		f.setAccessible(true);
+		f.set(controller, service);
+		return controller;
+	}
+
+	private static BoardVO searchVO() {
+		BoardVO boardVO = new BoardVO();
+		boardVO.setNttId(1L);
+		boardVO.setBbsId("BBSMSTR_000000000001");
+		boardVO.setBlogAt("");
+		return boardVO;
+	}
+
+	@Test
+	void deleteBoardArticleCleansUpTheAttachmentGroupRecordedOnTheServer() throws Exception {
+		StubService service = new StubService(STORED_ATCH_FILE_ID);
+		EgovArticleController controller = controllerWith(service);
+		bindLoginUser(OWNER_UNIQ_ID);
+
+		// 삭제 폼은 atchFileId를 전송하지 않으므로 요청 바인딩 값은 비어 있다.
+		Board board = new Board();
+		board.setNttId(1L);
+		board.setBbsId("BBSMSTR_000000000001");
+
+		controller.deleteBoardArticle(null, searchVO(), board, new BoardMaster(), new ModelMap());
+
+		assertEquals(STORED_ATCH_FILE_ID, service.deletedArg.getAtchFileId(),
+				"삭제 시 첨부그룹 정리는 폼이 보내지 않는 요청값이 아니라 서버에 저장된 atchFileId로 이뤄져야 한다.");
+	}
+
+	@Test
+	void deleteBoardArticleLeavesTheAttachmentIdEmptyWhenThePostHasNoAttachment() throws Exception {
+		StubService service = new StubService("");
+		EgovArticleController controller = controllerWith(service);
+		bindLoginUser(OWNER_UNIQ_ID);
+
+		Board board = new Board();
+		board.setNttId(1L);
+		board.setBbsId("BBSMSTR_000000000001");
+
+		controller.deleteBoardArticle(null, searchVO(), board, new BoardMaster(), new ModelMap());
+
+		assertEquals("", service.deletedArg.getAtchFileId(),
+				"첨부가 없는 게시물은 빈 값이 그대로 넘어가 서비스의 정리 분기를 건너뛰어야 한다.");
+	}
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`EgovArticleServiceImpl.deleteArticle(Board)`는 `board.getAtchFileId()`로 첨부그룹을 미사용 처리합니다.

```java
public void deleteArticle(Board board) throws Exception {
	FileVO fvo = new FileVO();
	fvo.setAtchFileId(board.getAtchFileId());
	...
	if (fvo.getAtchFileId() != null && !"".equals(fvo.getAtchFileId())) {
		fileService.deleteAllFileInf(fvo);
	}
}
```

그런데 삭제 폼은 `atchFileId`를 보내지 않습니다. `EgovArticleDetail.jsp`의 `formDelete`는 `nttId`·`bbsId`와 검색조건만 싣고(`EgovArticleBlogDetail.jsp`도 같습니다), 첨부파일을 보여주는 `<c:import url="/cmm/fms/selectFileInfs.do">`는 상세 표 안에 있어 그 폼 바깥입니다. 그래서 요청에 바인딩된 `board`의 `atchFileId`가 항상 비어 있고 위 정리 분기는 어느 호출 경로에서도 실행되지 않습니다. 게시물을 지워도 첨부그룹이 `COMTNFILE`에 `USE_AT='Y'`로 남습니다.

같은 컨트롤러의 `updateBoardArticle`은 이미 저장본의 값을 쓰도록 조치돼 있습니다.

```java
// IDOR 조치: 클라이언트가 전달한 atchFileId(boardVO.getAtchFileId())를 그대로 신뢰하지 않고,
String atchFileId = vo.getAtchFileId();
```

삭제 경로도 같은 출처를 쓰도록 맞췄습니다.

AS-IS

```java
if (isAuthenticated) {
	board.setLastUpdusrId((user == null || user.getUniqId() == null) ? "" : user.getUniqId());

	egovArticleService.deleteArticle(board);
}
```

TO-BE

```java
if (isAuthenticated) {
	board.setLastUpdusrId((user == null || user.getUniqId() == null) ? "" : user.getUniqId());
	// 삭제 폼(EgovArticleDetail.jsp의 formDelete)은 atchFileId를 전송하지 않아 요청 바인딩 값이
	// 비어 있다. 그대로 넘기면 deleteArticle의 첨부그룹 정리 분기가 실행되지 않으므로,
	// updateBoardArticle과 동일하게 조회·권한검증을 마친 원본(vo)의 값을 사용한다.
	board.setAtchFileId(vo.getAtchFileId());

	egovArticleService.deleteArticle(board);
}
```

`vo`는 같은 메서드가 앞서 조회해 `EgovXssChecker.checkerUserXss(request, vo.getFrstRegisterId())`로 작성자 검증까지 마친 저장본입니다. 요청 파라미터가 아니라서 다른 게시물의 첨부를 가리킬 수 없습니다.

### 영향 범위

`deleteAllFileInf`는 `UPDATE COMTNFILE SET USE_AT = 'N'`입니다. `COMTNFILEDETAIL` 행과 디스크 파일은 그대로 두고 사용 여부만 바꿉니다.

매퍼 `deleteArticle`은 `atchFileId`를 참조하지 않아 SQL 변경은 없습니다.

첨부가 없는 게시물은 저장본의 값도 비어 있어 서비스의 기존 가드에 걸리고 지금과 동작이 같습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

컨트롤러를 직접 생성하고 서비스 자리에 스텁을 넣어 삭제 경로만 확인했습니다. `deleteArticle`에 실제로 전달된 `Board`의 `atchFileId`를 기록해 대조합니다.

수정 전

```
[ERROR] Tests run: 2, Failures: 1, Errors: 0, Skipped: 0
[ERROR]   EgovArticleControllerDeleteFileTest.deleteBoardArticleCleansUpTheAttachmentGroupRecordedOnTheServer:174
          삭제 시 첨부그룹 정리는 폼이 보내지 않는 요청값이 아니라 서버에 저장된 atchFileId로 이뤄져야 한다.
          ==> expected: <FILE_000000000000123> but was: <>
```

수정 후

```
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

첨부가 없는 게시물에서 빈 값이 그대로 넘어가는지도 함께 확인합니다.
