### PR TITLE
fix: 일지 삭제 시 첨부파일이 미사용 처리되지 않는 문제 수정

### DIFF
--- a/src/main/java/egovframework/com/cop/smt/dsm/web/EgovDiaryManageController.java
+++ b/src/main/java/egovframework/com/cop/smt/dsm/web/EgovDiaryManageController.java
@@ -180,6 +180,20 @@ public class EgovDiaryManageController {
 		String sCmd = commandMap.get("cmd") == null ? "" : (String) commandMap.get("cmd");
 
 		if (sCmd.equals("del")) {
+			// 첨부파일 삭제 start....
+			// 삭제 폼은 atchFileId를 전송하지 않으므로, 소유권 검증을 위해 이미 조회해 둔 원본의
+			// 첨부파일ID를 사용한다. 형제 핸들러(mrm·wmr·djm)와 동일하게 레코드를 지우기 전에
+			// 첨부그룹을 미사용 처리한다.
+			String atchFileId = existingDiary.getAtchFileId();
+
+			if (atchFileId != null && !atchFileId.isEmpty()) {
+				FileVO fvo = new FileVO();
+				fvo.setAtchFileId(atchFileId);
+
+				fileMngService.deleteAllFileInf(fvo);
+			}
+			// 첨부파일 삭제 End.............
+
 			egovDiaryManageService.deleteDiaryManage(diaryManageVO);
 			sLocationUrl = "redirect:/cop/smt/dsm/EgovDiaryManageList.do";
 		} else {

--- a/src/test/java/egovframework/com/cop/smt/dsm/web/EgovDiaryManageControllerDeleteFileTest.java
+++ b/src/test/java/egovframework/com/cop/smt/dsm/web/EgovDiaryManageControllerDeleteFileTest.java
@@ -1,0 +1,148 @@
+package egovframework.com.cop.smt.dsm.web;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.ui.ModelMap;
+
+import egovframework.com.cmm.ComDefaultVO;
+import egovframework.com.cmm.LoginVO;
+import egovframework.com.cmm.service.EgovFileMngService;
+import egovframework.com.cmm.service.EgovUserDetailsService;
+import egovframework.com.cmm.service.FileVO;
+import egovframework.com.cmm.util.EgovUserDetailsHelper;
+import egovframework.com.cop.smt.dsm.service.DiaryManageVO;
+import egovframework.com.cop.smt.dsm.service.EgovDiaryManageService;
+
+/**
+ * 일지 삭제 시 첨부파일 정리 회귀 테스트.
+ *
+ * <p>같은 cop/smt 패키지의 형제 삭제 핸들러(mrm·wmr·djm)는 레코드를 지우기 전에
+ * {@code fileMngService.deleteAllFileInf}로 첨부그룹을 미사용 처리한다. 일지 삭제 경로만 그
+ * 호출이 없어, 등록·수정에서 만든 {@code DIARY_} 첨부그룹이 COMTNFILE에 USE_AT='Y'로 남는다.</p>
+ *
+ * <p>삭제 폼은 atchFileId를 전송하지 않으므로, 정리에 쓰는 값은 요청 VO가 아니라 소유권 검증을
+ * 위해 이미 조회해 둔 원본이어야 한다. 하드닝된 형제 djm이 같은 방식이다.</p>
+ */
+class EgovDiaryManageControllerDeleteFileTest {
+
+	private static final String LOGIN_UNIQ_ID = "USRCNFRM_TEST";
+	private static final String STORED_ATCH_FILE_ID = "FILE_000000000000123";
+
+	private final InvocationHandler authStub = (proxy, method, args) -> {
+		switch (method.getName()) {
+		case "isAuthenticated":
+			return Boolean.TRUE;
+		case "getAuthenticatedUser":
+			LoginVO loginVO = new LoginVO();
+			loginVO.setUniqId(LOGIN_UNIQ_ID);
+			return loginVO;
+		case "getAuthorities":
+			return Collections.emptyList();
+		default:
+			return null;
+		}
+	};
+
+	@BeforeEach
+	void bindAuthenticatedUser() {
+		EgovUserDetailsService stub = (EgovUserDetailsService) Proxy.newProxyInstance(
+				EgovUserDetailsService.class.getClassLoader(),
+				new Class<?>[] { EgovUserDetailsService.class }, authStub);
+		new EgovUserDetailsHelper().setEgovUserDetailsService(stub);
+	}
+
+	@AfterEach
+	void clearAuthenticatedUser() {
+		new EgovUserDetailsHelper().setEgovUserDetailsService(null);
+	}
+
+	/** 삭제된 첨부그룹ID를 기록하는 파일 서비스 스텁. */
+	private final List<String> deletedAtchFileIds = new ArrayList<>();
+
+	private EgovFileMngService fileServiceStub() {
+		return (EgovFileMngService) Proxy.newProxyInstance(
+				EgovFileMngService.class.getClassLoader(),
+				new Class<?>[] { EgovFileMngService.class },
+				(proxy, method, args) -> {
+					if ("deleteAllFileInf".equals(method.getName())) {
+						deletedAtchFileIds.add(((FileVO) args[0]).getAtchFileId());
+						return null;
+					}
+					return null;
+				});
+	}
+
+	private EgovDiaryManageService diaryServiceStub(String storedAtchFileId, List<String> deletedDiaryIds) {
+		DiaryManageVO stored = new DiaryManageVO();
+		stored.setFrstRegisterId(LOGIN_UNIQ_ID);
+		stored.setDiaryId("DIARY_00000000000001");
+		stored.setAtchFileId(storedAtchFileId);
+
+		return (EgovDiaryManageService) Proxy.newProxyInstance(
+				EgovDiaryManageService.class.getClassLoader(),
+				new Class<?>[] { EgovDiaryManageService.class },
+				(proxy, method, args) -> {
+					switch (method.getName()) {
+					case "selectDiaryManageDetail":
+						return stored;
+					case "deleteDiaryManage":
+						deletedDiaryIds.add(((DiaryManageVO) args[0]).getDiaryId());
+						return null;
+					default:
+						return null;
+					}
+				});
+	}
+
+	private String callDelete(String storedAtchFileId, List<String> deletedDiaryIds) throws Exception {
+		EgovDiaryManageController controller = new EgovDiaryManageController();
+		ReflectionTestUtils.setField(controller, "egovDiaryManageService",
+				diaryServiceStub(storedAtchFileId, deletedDiaryIds));
+		ReflectionTestUtils.setField(controller, "fileMngService", fileServiceStub());
+
+		// 삭제 폼은 atchFileId를 전송하지 않으므로 요청 VO의 값은 비어 있다.
+		DiaryManageVO requestVO = new DiaryManageVO();
+		requestVO.setDiaryId("DIARY_00000000000001");
+
+		Map<String, String> commandMap = new HashMap<>();
+		commandMap.put("cmd", "del");
+
+		return controller.egovDiaryManageDetail(new ComDefaultVO(), requestVO, commandMap, new ModelMap());
+	}
+
+	@Test
+	void deletingADiaryReleasesTheAttachmentGroupRecordedOnTheServer() throws Exception {
+		List<String> deletedDiaryIds = new ArrayList<>();
+
+		String view = callDelete(STORED_ATCH_FILE_ID, deletedDiaryIds);
+
+		assertEquals(List.of(STORED_ATCH_FILE_ID), deletedAtchFileIds,
+				"일지를 삭제하면 서버에 저장된 첨부그룹이 미사용 처리돼야 한다. 형제(mrm·wmr·djm)는 모두 이렇게 한다.");
+		assertTrue(deletedDiaryIds.contains("DIARY_00000000000001"), "일지 자체도 삭제돼야 한다.");
+		assertEquals("redirect:/cop/smt/dsm/EgovDiaryManageList.do", view);
+	}
+
+	@Test
+	void deletingADiaryWithoutAttachmentsDoesNotCallTheFileService() throws Exception {
+		List<String> deletedDiaryIds = new ArrayList<>();
+
+		callDelete("", deletedDiaryIds);
+
+		assertTrue(deletedAtchFileIds.isEmpty(),
+				"첨부가 없는 일지는 파일 서비스를 부르지 않아야 한다.");
+		assertTrue(deletedDiaryIds.contains("DIARY_00000000000001"), "일지 자체는 삭제돼야 한다.");
+	}
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

일지관리는 등록·수정에서 `fileUtil.parseFileInf(files, "DIARY_", ...)` 와 `fileMngService.insertFileInfs` 로 첨부파일을 만들고 `atchFileId` 를 함께 저장합니다. 그런데 삭제할 때는 `COMTNDIARYINFO` 행만 지웁니다. 지워진 일지의 첨부는 `COMTNFILE` 에 계속 사용중(`USE_AT='Y'`)으로 남습니다.

같은 `cop/smt` 패키지의 형제 삭제 핸들러는 모두 레코드를 지우기 전에 첨부그룹을 정리합니다.

- `EgovMemoReprtController` 468행
- `EgovWikMnthngReprtController` 440행
- `EgovDeptJobController` 764행

일지 삭제 경로만 그 단계가 없습니다.

AS-IS

```java
if (sCmd.equals("del")) {
	egovDiaryManageService.deleteDiaryManage(diaryManageVO);
	sLocationUrl = "redirect:/cop/smt/dsm/EgovDiaryManageList.do";
}
```

TO-BE

```java
if (sCmd.equals("del")) {
	// 첨부파일 삭제 start....
	// 삭제 폼은 atchFileId를 전송하지 않으므로, 소유권 검증을 위해 이미 조회해 둔 원본의
	// 첨부파일ID를 사용한다. 형제 핸들러(mrm·wmr·djm)와 동일하게 레코드를 지우기 전에
	// 첨부그룹을 미사용 처리한다.
	String atchFileId = existingDiary.getAtchFileId();

	if (atchFileId != null && !atchFileId.isEmpty()) {
		FileVO fvo = new FileVO();
		fvo.setAtchFileId(atchFileId);

		fileMngService.deleteAllFileInf(fvo);
	}
	// 첨부파일 삭제 End.............

	egovDiaryManageService.deleteDiaryManage(diaryManageVO);
	sLocationUrl = "redirect:/cop/smt/dsm/EgovDiaryManageList.do";
}
```

`existingDiary` 는 같은 메서드가 앞서 조회해 작성자 본인 또는 관리자만 통과시키는 소유권 검증에 쓴 저장본입니다. 요청 파라미터가 아니라서 다른 일지의 첨부를 가리킬 수 없습니다. 클라이언트가 보낸 값을 쓰지 않는 것은 `EgovDeptJobController` 의 기존 조치와 같은 형태입니다.

`FileVO` 와 `EgovFileMngService` 는 이 컨트롤러가 이미 주입·import 하고 있어 추가 의존성이 없습니다.

### 영향 범위

`deleteAllFileInf` 는 `UPDATE COMTNFILE SET USE_AT = 'N'` 입니다. `COMTNFILEDETAIL` 행과 디스크 파일은 그대로 두고 사용 여부만 바꿉니다.

첨부가 없는 일지는 `atchFileId` 가 비어 파일 서비스를 부르지 않고 지금과 동작이 같습니다.

서비스·DAO·매퍼는 변경하지 않았습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

컨트롤러를 직접 생성하고 서비스 자리에 동적 프록시를 넣어 삭제 경로만 확인했습니다. 필드 주입은 이미 병합된 `EgovDiaryManageControllerFileUploadRestoreTest` 와 같이 `ReflectionTestUtils.setField` 를 썼습니다.

수정 전

```
[ERROR] Tests run: 2, Failures: 1, Errors: 0, Skipped: 0
[ERROR]   EgovDiaryManageControllerDeleteFileTest.deletingADiaryReleasesTheAttachmentGroupRecordedOnTheServer:132
          일지를 삭제하면 서버에 저장된 첨부그룹이 미사용 처리돼야 한다. 형제(mrm·wmr·djm)는 모두 이렇게 한다.
          ==> expected: <[FILE_000000000000123]> but was: <[]>
```

수정 후

```
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

첨부가 없는 일지에서 파일 서비스를 부르지 않는지도 함께 확인합니다.
