### PR TITLE
fix: Q&A 답변관리 수정·저장에 관리자 검증 추가

### DIFF
--- a/src/main/java/egovframework/com/uss/olh/qna/web/EgovQnaController.java
+++ b/src/main/java/egovframework/com/uss/olh/qna/web/EgovQnaController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import egovframework.com.cmm.ComDefaultCodeVO;
+import egovframework.com.cmm.annotation.RequireAdmin;
 import egovframework.com.cmm.EgovMessageSource;
 import egovframework.com.cmm.LoginVO;
 import egovframework.com.cmm.annotation.IncludedInfo;
@@ -422,6 +423,7 @@ public class EgovQnaController {
 	 * @return "/uss/olh/qna/EgovQnaAnswerUpdt"
 	 * @throws Exception
 	 */
+	@RequireAdmin
 	@PostMapping("/uss/olh/qna/updateQnaAnswerView.do")
 	public String updateQnaAnswerView(QnaVO qnaVO, @ModelAttribute("searchVO") QnaVO searchVO, ModelMap model)
 			throws Exception {
@@ -447,6 +449,7 @@ public class EgovQnaController {
 	 * @return "forward:/uss/olh/qnm/selectQnaAnswerList.do"
 	 * @throws Exception
 	 */
+	@RequireAdmin
 	@PostMapping("/uss/olh/qna/updateQnaAnswer.do")
 	public String updateQnaAnswer(@Valid QnaVO qnaVO, BindingResult bindingResult,
 			 @ModelAttribute("searchVO") QnaVO searchVO,

--- a/src/test/java/egovframework/com/uss/olh/qna/web/EgovQnaControllerAdminCheckTest.java
+++ b/src/test/java/egovframework/com/uss/olh/qna/web/EgovQnaControllerAdminCheckTest.java
@@ -1,0 +1,45 @@
+package egovframework.com.uss.olh.qna.web;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.Test;
+
+import egovframework.com.cmm.annotation.RequireAdmin;
+
+/**
+ * updateQnaAnswerView·updateQnaAnswer에 @RequireAdmin이 붙어있는지 확인한다.
+ *
+ * Q&A답변관리(@IncludedInfo gid=50)는 관리자가 사용자 문의에 공식 답변을 다는 화면이다.
+ * 같은 gid=50 메뉴군의 FAQ(EgovFaqController)는 등록/수정/삭제 다섯 메서드가 모두
+ * @RequireAdmin으로 보호되고 행정전문용어사전(EgovAdministrationWordController)도 마찬가지인데,
+ * Q&A답변관리는 답변 저장 경로에 관리자 확인이 없었다. 매퍼 updateQnaAnswer도
+ * WHERE QA_ID=#{qaId}뿐이라 대상 문의를 제한하지 않는다.
+ *
+ * @RequireAdmin은 Spring AOP(`@annotation(RequireAdmin)` 포인트컷)로 위빙되므로 컨트롤러를
+ * 직접 new해서 부르는 단위 테스트로는 실제 차단 동작을 재현할 수 없다(프록시를 거치지 않음).
+ * 이 테스트는 이미 병합된 다른 관리자 검증 테스트들과 같이 "애노테이션이 실제로 붙어있는가"라는
+ * 구조적 사실만 고정한다.
+ */
+class EgovQnaControllerAdminCheckTest {
+
+	private static Method method(String name, Class<?>... paramTypes) throws NoSuchMethodException {
+		return EgovQnaController.class.getDeclaredMethod(name, paramTypes);
+	}
+
+	@Test
+	void answerUpdateViewRequiresAdmin() throws Exception {
+		Method m = method("updateQnaAnswerView", egovframework.com.uss.olh.qna.service.QnaVO.class,
+				egovframework.com.uss.olh.qna.service.QnaVO.class, org.springframework.ui.ModelMap.class);
+		assertTrue(m.isAnnotationPresent(RequireAdmin.class), "Q&A 답변 수정화면은 관리자만 열 수 있어야 한다.");
+	}
+
+	@Test
+	void answerUpdateRequiresAdmin() throws Exception {
+		Method m = method("updateQnaAnswer", egovframework.com.uss.olh.qna.service.QnaVO.class,
+				org.springframework.validation.BindingResult.class,
+				egovframework.com.uss.olh.qna.service.QnaVO.class, org.springframework.ui.Model.class);
+		assertTrue(m.isAnnotationPresent(RequireAdmin.class), "Q&A 답변 저장은 관리자만 가능해야 한다.");
+	}
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

Q&A답변관리(`@IncludedInfo(name = "Q&A답변관리", order = 551, gid = 50)`)는 관리자가 사용자 문의에 공식 답변을 다는 화면입니다. 그런데 답변 수정화면(`updateQnaAnswerView`)과 답변 저장(`updateQnaAnswer`)에 관리자 확인이 없어, 로그인한 사용자면 누구나 임의의 문의에 답변과 처리상태를 저장할 수 있습니다.

매퍼도 대상 문의를 제한하지 않습니다.

```xml
<update id="updateQnaAnswer">
	UPDATE	COMTNQAINFO	SET
		  	QNA_PROCESS_STTUS_CODE=#{qnaProcessSttusCode}
		  , ANSWER_CN=#{answerCn}
		  ...
	WHERE  QA_ID=#{qaId}
</update>
```

같은 `gid = 50` 메뉴군의 형제 컨트롤러는 변경 경로를 모두 `@RequireAdmin`으로 보호합니다.

- `EgovFaqController` : `insertFaqView`·`insertFaq`·`updateFaqView`·`updateFaq`·`deleteFaq` 다섯 메서드
- `EgovAdministrationWordController` : 등록·수정·삭제 세 메서드

조회 목록·상세는 두 컨트롤러 모두 애노테이션이 없습니다. Q&A답변관리도 같은 기준으로 저장 경로 두 곳에만 맞췄습니다.

AS-IS

```java
	@PostMapping("/uss/olh/qna/updateQnaAnswerView.do")
	public String updateQnaAnswerView(QnaVO qnaVO, @ModelAttribute("searchVO") QnaVO searchVO, ModelMap model)

	@PostMapping("/uss/olh/qna/updateQnaAnswer.do")
	public String updateQnaAnswer(@Valid QnaVO qnaVO, BindingResult bindingResult,
```

TO-BE

```java
	@RequireAdmin
	@PostMapping("/uss/olh/qna/updateQnaAnswerView.do")
	public String updateQnaAnswerView(QnaVO qnaVO, @ModelAttribute("searchVO") QnaVO searchVO, ModelMap model)

	@RequireAdmin
	@PostMapping("/uss/olh/qna/updateQnaAnswer.do")
	public String updateQnaAnswer(@Valid QnaVO qnaVO, BindingResult bindingResult,
```

### 영향 범위

`@RequireAdmin`은 `egov-com-loginaop.xml`의 `@annotation(egovframework.com.cmm.annotation.RequireAdmin)` 포인트컷으로 `EgovAdminAuthorizationAspect.assertAdmin`이 위빙됩니다. 애노테이션을 붙이는 것 외에 설정 변경은 없습니다.

관리자의 기존 답변 작성 동작은 그대로입니다. 사용자용 문의 등록·수정·삭제(`insertQna`·`updateQna`·`deleteQna`)와 조회 경로는 변경하지 않았습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

애노테이션이 붙어 있는지 고정하는 테스트를 추가했습니다. `@RequireAdmin`은 AOP로 위빙되므로 컨트롤러를 직접 생성해 호출하는 단위 테스트로는 차단 동작을 재현할 수 없어, 이미 병합된 다른 관리자 검증 테스트들과 같은 방식으로 구조적 사실만 고정했습니다.

수정 전

```
[ERROR] Tests run: 2, Failures: 2, Errors: 0, Skipped: 0
[ERROR]   EgovQnaControllerAdminCheckTest.answerUpdateRequiresAdmin:43
          Q&A 답변 저장은 관리자만 가능해야 한다. ==> expected: <true> but was: <false>
[ERROR]   EgovQnaControllerAdminCheckTest.answerUpdateViewRequiresAdmin:35
          Q&A 답변 수정화면은 관리자만 열 수 있어야 한다. ==> expected: <true> but was: <false>
```

수정 후

```
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

`pom.xml`의 surefire 설정이 `skipTests=true`라 기본 빌드에서는 실행되지 않습니다. 확인할 때는 그 값을 잠시 `false`로 두고 돌렸습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

차단 동작은 실제로 톰캣에 올려 확인했습니다. MySQL에 문의 한 건을 넣고 일반회원(`ROLE_USER`)과 업무사용자(`ROLE_ADMIN`)로 각각 `POST /uss/olh/qna/updateQnaAnswer.do`를 보냈습니다.

수정 전, 일반회원이 다른 사람의 문의 답변을 덮어썼습니다.

```
QA_ID                  ANSWER_CN            QNA_PROCESS_STTUS_CODE  LAST_UPDUSR_ID
QA_00000000000000001   일반사용자가 덮어쓴 답변   2                       USRCNFRM_00000000001
```

수정 후, 같은 요청이 권한 오류로 끝나고 레코드는 그대로입니다.

```
QA_00000000000000001   관리자 원본 답변        1                       NULL
```

수정 후, 관리자는 그대로 저장됩니다.

```
QA_00000000000000001   관리자가 정상 작성한 답변  2                       USRCNFRM_00000000000
```
