### PR TITLE
fix: 당직 엑셀 일괄등록의 당직자ID·당직자명이 조회 조건에 뒤바뀌어 들어가는 문제 수정

### DIFF
--- a/src/main/java/egovframework/com/uss/ion/bnt/service/impl/EgovBndtManageServiceImpl.java
+++ b/src/main/java/egovframework/com/uss/ion/bnt/service/impl/EgovBndtManageServiceImpl.java
@@ -456,8 +456,8 @@ public class EgovBndtManageServiceImpl extends EgovAbstractServiceImpl implement
 					sTempId = getCellValueAsString(cell);
 					cell = row.getCell(2); // 당직자명
 					sTempNm = getCellValueAsString(cell);
-					checkBndtManageVO.setTempBndtNm(sTempId); // 당직자ID
-					checkBndtManageVO.setTempBndtId(sTempNm); // 당직자명
+					checkBndtManageVO.setTempBndtId(sTempId); // 당직자ID
+					checkBndtManageVO.setTempBndtNm(sTempNm); // 당직자명
 
 					// 최두영 로직변경
 					bndtManageVO = bndtManageDAO.selectBndtManageBnde(checkBndtManageVO);
@@ -526,8 +526,8 @@ public class EgovBndtManageServiceImpl extends EgovAbstractServiceImpl implement
 							sTempId = getCellValueAsString(cell);
 							cell = row.getCell(2); // 당직자명
 							sTempNm = getCellValueAsString(cell);
-							checkBndtManageVO.setTempBndtNm(sTempId); // 당직자ID
-							checkBndtManageVO.setTempBndtId(sTempNm); // 당직자명
+							checkBndtManageVO.setTempBndtId(sTempId); // 당직자ID
+							checkBndtManageVO.setTempBndtNm(sTempNm); // 당직자명
 
 							// 최두영 로직변경
 							bndtManageVO = bndtManageDAO.selectBndtManageBnde(checkBndtManageVO);

--- a/src/test/java/egovframework/com/uss/ion/bnt/service/impl/EgovBndtManageServiceImplBndeTest.java
+++ b/src/test/java/egovframework/com/uss/ion/bnt/service/impl/EgovBndtManageServiceImplBndeTest.java
@@ -1,0 +1,93 @@
+package egovframework.com.uss.ion.bnt.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.poi.hssf.usermodel.HSSFRow;
+import org.apache.poi.hssf.usermodel.HSSFSheet;
+import org.apache.poi.hssf.usermodel.HSSFWorkbook;
+import org.egovframe.rte.fdl.excel.EgovExcelService;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import egovframework.com.uss.ion.bnt.service.BndtManageVO;
+
+/**
+ * 당직 엑셀 일괄등록의 조회 조건 매핑 회귀 테스트.
+ *
+ * <p>매퍼 selectBndtManageBnde 는 {@code WHERE ESNTL_ID = #{tempBndtId} AND USER_NM = #{tempBndtNm}}
+ * 로 두 필드의 의미를 못박는다(여덟 개 DB 매퍼가 모두 같다). 그런데 조회용 VO 를 채우는 곳만
+ * 당직자ID 를 tempBndtNm 에, 당직자명을 tempBndtId 에 넣어 서로 뒤바뀌어 있었다. 같은 메서드
+ * 11줄 아래에서 결과 VO 를 채울 때는 {@code setTempBndtNm(sTempNm)} 으로 올바르게 넣는다.</p>
+ *
+ * <p>그 결과 조회가 항상 빈 결과를 돌려주고, 소속명(tempOrgnztNm)·동명이인 수(tempCount)가
+ * 채워지지 않은 채 확인 화면이 그려진다.</p>
+ */
+class EgovBndtManageServiceImplBndeTest {
+
+	private static final String BNDT_ID = "USRCNFRM_00000000001";
+	private static final String BNDT_NM = "홍길동";
+
+	/** selectBndtManageBnde 에 실제로 전달된 조회 조건을 기록하는 DAO 스텁. */
+	private static final class RecordingDAO extends BndtManageDAO {
+		private BndtManageVO lastQuery;
+
+		@Override
+		public BndtManageVO selectBndtManageBnde(BndtManageVO bndtManageVO) {
+			lastQuery = bndtManageVO;
+			return null;
+		}
+	}
+
+	private static InputStream oneRowWorkbook() throws Exception {
+		HSSFWorkbook wb = new HSSFWorkbook();
+		HSSFSheet sheet = wb.createSheet("당직자");
+		HSSFRow header = sheet.createRow(0);
+		header.createCell(0).setCellValue("당직일자");
+		header.createCell(1).setCellValue("당직자ID");
+		header.createCell(2).setCellValue("당직자명");
+		HSSFRow row = sheet.createRow(1);
+		row.createCell(0).setCellValue("20260827");
+		row.createCell(1).setCellValue(BNDT_ID);
+		row.createCell(2).setCellValue(BNDT_NM);
+
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+		wb.write(out);
+		wb.close();
+		return new ByteArrayInputStream(out.toByteArray());
+	}
+
+	private static EgovExcelService excelServiceStub(InputStream source) throws Exception {
+		final HSSFWorkbook wb = new HSSFWorkbook(source);
+		return (EgovExcelService) Proxy.newProxyInstance(
+				EgovExcelService.class.getClassLoader(),
+				new Class<?>[] { EgovExcelService.class },
+				(proxy, method, args) -> "loadWorkbook".equals(method.getName()) ? wb : null);
+	}
+
+	@Test
+	void bulkUploadLooksUpTheDutyOfficerWithIdAndNameInTheOrderTheMapperExpects() throws Exception {
+		EgovBndtManageServiceImpl service = new EgovBndtManageServiceImpl();
+		RecordingDAO dao = new RecordingDAO();
+		ReflectionTestUtils.setField(service, "bndtManageDAO", dao);
+		ReflectionTestUtils.setField(service, "excelZipService", excelServiceStub(oneRowWorkbook()));
+
+		List<BndtManageVO> result = service.selectBndtManageBnde(new ByteArrayInputStream(new byte[0]));
+
+		assertNotNull(dao.lastQuery, "조회가 호출돼야 한다.");
+		assertEquals(BNDT_ID, dao.lastQuery.getTempBndtId(),
+				"tempBndtId 는 매퍼의 ESNTL_ID 조건에 쓰이므로 당직자ID 여야 한다.");
+		assertEquals(BNDT_NM, dao.lastQuery.getTempBndtNm(),
+				"tempBndtNm 은 매퍼의 USER_NM 조건에 쓰이므로 당직자명이어야 한다.");
+		assertEquals(1, result.size());
+	}
+
+	private static final List<String> UNUSED = new ArrayList<>();
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

당직 엑셀 일괄등록은 업로드한 행마다 당직자를 조회해 소속명과 동명이인 수를 채웁니다. 그 조회 매퍼 `selectBndtManageBnde`는 두 필드의 의미를 못박고 있습니다.

```xml
select A.ESNTL_ID as bndtId ,
       A.USER_NM as tempBndtNm ,
      (select info.ORGNZT_NM from COMTNORGNZTINFO info where info.ORGNZT_ID = A.ORGNZT_ID) AS tempOrgnztNm,
      (select count(user_nm) from COMVNUSERMASTER where user_nm = A.USER_NM) tempCount
from COMVNUSERMASTER A
WHERE  ESNTL_ID   = #{tempBndtId}
AND    USER_NM   = #{tempBndtNm}
```

`tempBndtId`는 `ESNTL_ID`(당직자ID), `tempBndtNm`은 `USER_NM`(당직자명)입니다. 여덟 개 DB 매퍼가 모두 같고 결과 매핑도 `USER_NM`을 `tempBndtNm`으로 돌려줍니다.

그런데 조회용 VO를 채우는 곳만 두 값이 서로 뒤바뀌어 있습니다. 주석은 각각 당직자ID·당직자명으로 올바르게 적혀 있어 코드와 어긋납니다.

AS-IS

```java
cell = row.getCell(1); // 당직자ID
sTempId = getCellValueAsString(cell);
cell = row.getCell(2); // 당직자명
sTempNm = getCellValueAsString(cell);
checkBndtManageVO.setTempBndtNm(sTempId); // 당직자ID
checkBndtManageVO.setTempBndtId(sTempNm); // 당직자명
```

TO-BE

```java
checkBndtManageVO.setTempBndtId(sTempId); // 당직자ID
checkBndtManageVO.setTempBndtNm(sTempNm); // 당직자명
```

같은 메서드 11줄 아래에서 결과 VO를 채울 때는 `bndtManageVO.setTempBndtNm(sTempNm)`으로 올바르게 넣습니다.

### 영향 범위

이 조회는 `ESNTL_ID`를 당직자명과, `USER_NM`을 당직자ID와 비교하게 되어 항상 빈 결과를 돌려줍니다. 조회가 `null`이면 호출부가 `BeanUtils.copyProperties`로 입력값만 복사하므로, 소속명(`tempOrgnztNm`)과 동명이인 수(`tempCount`)가 채워지지 않은 채 확인 화면이 그려집니다.

xls(HSSF)와 xlsx(XSSF) 두 경로에 같은 코드가 있어 함께 수정했습니다. 조회 조건만 바로잡았고 결과 VO를 채우는 부분과 매퍼는 변경하지 않았습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

`src/test/java/egovframework/com/uss/ion/bnt/service/impl/EgovBndtManageServiceImplBndeTest.java`를 추가했습니다. 한 행짜리 워크북을 코드로 만들어 서비스에 넣고 DAO에 실제로 전달된 조회 조건을 기록해 대조합니다. DAO는 구상 클래스라 익명 서브클래스로, `EgovExcelService`는 인터페이스라 동적 프록시로 대체했습니다.

수정 전

```
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
[ERROR]   EgovBndtManageServiceImplBndeTest.bulkUploadLooksUpTheDutyOfficerWithIdAndNameInTheOrderTheMapperExpects:85
          tempBndtId 는 매퍼의 ESNTL_ID 조건에 쓰이므로 당직자ID 여야 한다.
          ==> expected: <USRCNFRM_00000000001> but was: <홍길동>
```

수정 후

```
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

`pom.xml`의 surefire 설정이 `skipTests=true`라 기본 빌드에서는 실행되지 않습니다. 확인할 때는 그 값을 잠시 `false`로 두고 돌렸습니다.
