### PR TITLE
fix: 부서업무·부서업무함 수정화면이 존재하지 않는 식별자에 NPE를 내는 문제 수정

### DIFF
--- a/src/main/java/egovframework/com/cop/smt/djm/web/EgovDeptJobController.java
+++ b/src/main/java/egovframework/com/cop/smt/djm/web/EgovDeptJobController.java
@@ -345,6 +345,13 @@ public class EgovDeptJobController {
 		}
 
 		DeptJobBxVO resultVO = deptJobService.selectDeptJobBx(deptJobBxVO);
+
+		// 삭제 경로와 동일하게, 서버 조회 결과가 없으면 목록으로 돌려보낸다.
+		if (resultVO == null) {
+			model.addAttribute("message", egovMessageSource.getMessage("fail.common.select"));
+			return "forward:/cop/smt/djm/selectDeptJobBxList.do";
+		}
+
 		resultVO.setSearchCnd(deptJobBxVO.getSearchCnd());
 		resultVO.setSearchWrd(deptJobBxVO.getSearchWrd());
 		resultVO.setPageIndex(deptJobBxVO.getPageIndex());
@@ -580,6 +587,13 @@ public class EgovDeptJobController {
 		}
 
 		DeptJobVO resultVO = deptJobService.selectDeptJob(deptJobVO);
+
+		// 삭제 경로와 동일하게, 서버 조회 결과가 없으면 목록으로 돌려보낸다.
+		if (resultVO == null) {
+			model.addAttribute("message", egovMessageSource.getMessage("fail.common.select"));
+			return "forward:/cop/smt/djm/selectDeptJobList.do";
+		}
+
 		resultVO.setSearchCnd(deptJobVO.getSearchCnd());
 		resultVO.setSearchWrd(deptJobVO.getSearchWrd());
 		resultVO.setSearchDeptId(deptJobVO.getSearchDeptId());

--- a/src/test/java/egovframework/com/cop/smt/djm/web/EgovDeptJobControllerModifyNullTest.java
+++ b/src/test/java/egovframework/com/cop/smt/djm/web/EgovDeptJobControllerModifyNullTest.java
@@ -1,0 +1,92 @@
+package egovframework.com.cop.smt.djm.web;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.lang.reflect.Proxy;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.ui.ModelMap;
+
+import egovframework.com.cmm.EgovMessageSource;
+import egovframework.com.cmm.LoginVO;
+import egovframework.com.cmm.service.EgovUserDetailsService;
+import egovframework.com.cmm.util.EgovUserDetailsHelper;
+import egovframework.com.cop.smt.djm.service.DeptJobBxVO;
+import egovframework.com.cop.smt.djm.service.DeptJobVO;
+import egovframework.com.cop.smt.djm.service.EgovDeptJobService;
+
+/**
+ * 부서업무·부서업무함 수정화면이 존재하지 않는 식별자를 받았을 때 처리를 확인한다.
+ *
+ * <p>같은 컨트롤러의 삭제 경로는 서버에서 원본을 조회한 뒤 {@code if (originDeptJob == null)}로
+ * 존재 여부를 확인하고 목록으로 돌려보낸다. 그런데 수정화면 두 곳은 같은 단건 조회 결과를
+ * 확인 없이 바로 역참조해, 이미 지워졌거나 없는 식별자로 들어오면 NullPointerException이
+ * 나면서 화면이 뜨지 않는다.</p>
+ */
+class EgovDeptJobControllerModifyNullTest {
+
+	private EgovDeptJobController controller;
+
+	@BeforeEach
+	void setUp() {
+		EgovUserDetailsService auth = (EgovUserDetailsService) Proxy.newProxyInstance(
+				getClass().getClassLoader(), new Class<?>[] { EgovUserDetailsService.class },
+				(proxy, method, args) -> {
+					if ("isAuthenticated".equals(method.getName())) {
+						return Boolean.TRUE;
+					}
+					if ("getAuthenticatedUser".equals(method.getName())) {
+						return new LoginVO();
+					}
+					return null;
+				});
+		ReflectionTestUtils.setField(EgovUserDetailsHelper.class, "egovUserDetailsService", auth);
+
+		// 단건 조회가 없는 식별자에 대해 null 을 돌려주는 상황.
+		EgovDeptJobService service = (EgovDeptJobService) Proxy.newProxyInstance(
+				getClass().getClassLoader(), new Class<?>[] { EgovDeptJobService.class },
+				(proxy, method, args) -> null);
+
+		controller = new EgovDeptJobController();
+		ReflectionTestUtils.setField(controller, "deptJobService", service);
+		ReflectionTestUtils.setField(controller, "egovMessageSource", new EgovMessageSource() {
+			@Override
+			public String getMessage(String code) {
+				return code;
+			}
+		});
+	}
+
+	@AfterEach
+	void tearDown() {
+		ReflectionTestUtils.setField(EgovUserDetailsHelper.class, "egovUserDetailsService", null);
+	}
+
+	@Test
+	void deptJobBxModifyViewFallsBackToTheListWhenTheRecordIsGone() throws Exception {
+		DeptJobBxVO vo = new DeptJobBxVO();
+		vo.setDeptJobBxId("DEPTJOBBX_00000000000000");
+
+		ModelMap model = new ModelMap();
+		String view = controller.modifyDeptJobBx(vo, model);
+
+		assertNotNull(view, "없는 부서업무함으로 수정화면을 열면 예외 대신 화면 이동이 나와야 한다.");
+		assertEquals("forward:/cop/smt/djm/selectDeptJobBxList.do", view);
+	}
+
+	@Test
+	void deptJobModifyViewFallsBackToTheListWhenTheRecordIsGone() throws Exception {
+		DeptJobVO vo = new DeptJobVO();
+		vo.setDeptJobId("DEPTJOB_00000000000000");
+
+		ModelMap model = new ModelMap();
+		String view = controller.modifyDeptJob(vo, model);
+
+		assertNotNull(view, "없는 부서업무로 수정화면을 열면 예외 대신 화면 이동이 나와야 한다.");
+		assertEquals("forward:/cop/smt/djm/selectDeptJobList.do", view);
+	}
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`modifyDeptJob`과 `modifyDeptJobBx`는 수정화면을 그리기 전에 단건 조회를 하고 그 결과를 확인 없이 역참조합니다.

```java
DeptJobBxVO resultVO = deptJobService.selectDeptJobBx(deptJobBxVO);
resultVO.setSearchCnd(deptJobBxVO.getSearchCnd());
```

조회 매퍼는 식별자에 해당하는 행이 없으면 `null`을 돌려줍니다. 그래서 이미 지워졌거나 없는 식별자로 수정화면을 열면 `NullPointerException`이 나면서 화면이 뜨지 않습니다.

같은 컨트롤러의 삭제 경로는 이미 이 확인을 하고 있습니다.

```java
DeptJobVO originDeptJob = deptJobService.selectDeptJob(checkVO);

if (originDeptJob == null) {
	model.addAttribute("message", egovMessageSource.getMessage("fail.common.select"));
	return "forward:/cop/smt/djm/selectDeptJobList.do";
}
```

수정화면 두 곳도 같은 방식으로 맞췄습니다.

TO-BE

```java
DeptJobBxVO resultVO = deptJobService.selectDeptJobBx(deptJobBxVO);

// 삭제 경로와 동일하게, 서버 조회 결과가 없으면 목록으로 돌려보낸다.
if (resultVO == null) {
	model.addAttribute("message", egovMessageSource.getMessage("fail.common.select"));
	return "forward:/cop/smt/djm/selectDeptJobBxList.do";
}

resultVO.setSearchCnd(deptJobBxVO.getSearchCnd());
```

### 영향 범위

조회에 성공하는 기존 흐름은 동작이 같습니다. 조회 결과가 없을 때만 예외 대신 목록으로 돌아가고 안내 메시지가 표시됩니다. 돌아가는 목록은 각 핸들러가 원래 쓰는 목록 화면에 맞췄습니다.

서비스·DAO·매퍼는 변경하지 않았습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

`src/test/java/egovframework/com/cop/smt/djm/web/EgovDeptJobControllerModifyNullTest.java`를 추가했습니다. 단건 조회가 `null`을 돌려주는 상황을 동적 프록시로 만들고 두 수정화면을 호출합니다. 필드 주입은 이미 병합된 `EgovDeptJobControllerDeleteBxTest`와 같이 `ReflectionTestUtils.setField`를 썼습니다.

수정 전

```
[ERROR] Tests run: 2, Failures: 0, Errors: 2, Skipped: 0
[ERROR]   EgovDeptJobControllerModifyNullTest.deptJobBxModifyViewFallsBackToTheListWhenTheRecordIsGone:75
          » NullPointer Cannot invoke "...DeptJobBxVO.setSearchCnd(String)" because "resultVO" is null
[ERROR]   EgovDeptJobControllerModifyNullTest.deptJobModifyViewFallsBackToTheListWhenTheRecordIsGone:87
          » NullPointer Cannot invoke "...DeptJobVO.setSearchCnd(String)" because "resultVO" is null
```

수정 후

```
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

`pom.xml`의 surefire 설정이 `skipTests=true`라 기본 빌드에서는 실행되지 않습니다. 확인할 때는 그 값을 잠시 `false`로 두고 돌렸습니다.
