### PR TITLE
fix: 당직관리 단건조회가 해당 행이 없을 때 NPE를 내는 문제 수정

### DIFF
--- a/src/main/java/egovframework/com/uss/ion/bnt/service/impl/EgovBndtManageServiceImpl.java
+++ b/src/main/java/egovframework/com/uss/ion/bnt/service/impl/EgovBndtManageServiceImpl.java
@@ -111,6 +111,13 @@ public class EgovBndtManageServiceImpl extends EgovAbstractServiceImpl implement
 		bndtManageVO.setBndtDe(EgovStringUtil.removeMinusChar(bndtManageVO.getBndtDe()));
 		BndtManageVO bndtManageVOTemp = new BndtManageVO();
 		bndtManageVOTemp = bndtManageDAO.selectBndtManage(bndtManageVO);
+
+		// 해당 당직 행이 없으면 조회 결과가 없다. 같은 클래스의 엑셀 일괄등록 경로와 동일하게
+		// 결과를 확인한 뒤 사용한다.
+		if (bndtManageVOTemp == null) {
+			return null;
+		}
+
 		bndtManageVOTemp.setBndtDe(EgovDateUtil.formatDate(bndtManageVOTemp.getBndtDe(), "-"));
 
 		return bndtManageVOTemp;

--- a/src/test/java/egovframework/com/uss/ion/bnt/service/impl/EgovBndtManageServiceImplDetailTest.java
+++ b/src/test/java/egovframework/com/uss/ion/bnt/service/impl/EgovBndtManageServiceImplDetailTest.java
@@ -1,0 +1,65 @@
+package egovframework.com.uss.ion.bnt.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import egovframework.com.uss.ion.bnt.service.BndtManageVO;
+
+/**
+ * 당직관리 단건조회가 해당 행이 없을 때 NPE를 내지 않는지 확인한다.
+ *
+ * <p>조회 매퍼는 {@code BNDT_ID}와 {@code BNDT_DE} 조합으로 한 건을 찾으므로 해당 행이 없으면
+ * {@code null}을 돌려준다. 그런데 서비스가 그 결과를 확인 없이 바로 역참조해
+ * {@code NullPointerException}이 났다. 같은 클래스의 엑셀 일괄등록 경로는 같은 DAO 결과를
+ * {@code == null}로 확인한 뒤 사용한다.</p>
+ */
+class EgovBndtManageServiceImplDetailTest {
+
+	/** 지정한 결과만 돌려주는 DAO 스텁. */
+	private static final class StubDAO extends BndtManageDAO {
+		private final BndtManageVO result;
+
+		StubDAO(BndtManageVO result) {
+			this.result = result;
+		}
+
+		@Override
+		public BndtManageVO selectBndtManage(BndtManageVO bndtManageVO) {
+			return result;
+		}
+	}
+
+	private static EgovBndtManageServiceImpl serviceWith(BndtManageVO daoResult) {
+		EgovBndtManageServiceImpl service = new EgovBndtManageServiceImpl();
+		ReflectionTestUtils.setField(service, "bndtManageDAO", new StubDAO(daoResult));
+		return service;
+	}
+
+	@Test
+	void detailLookupReturnsNullInsteadOfThrowingWhenTheRecordIsGone() throws Exception {
+		BndtManageVO request = new BndtManageVO();
+		request.setBndtId("USRCNFRM_00000000001");
+		request.setBndtDe("2026-08-27");
+
+		assertNull(serviceWith(null).selectBndtManage(request),
+				"해당 당직 행이 없으면 예외 대신 결과 없음이 돌아와야 한다.");
+	}
+
+	@Test
+	void detailLookupStillFormatsTheDutyDateWhenTheRecordExists() throws Exception {
+		BndtManageVO stored = new BndtManageVO();
+		stored.setBndtDe("20260827");
+
+		BndtManageVO request = new BndtManageVO();
+		request.setBndtId("USRCNFRM_00000000001");
+		request.setBndtDe("2026-08-27");
+
+		BndtManageVO result = serviceWith(stored).selectBndtManage(request);
+
+		assertEquals("2026-08-27", result.getBndtDe(),
+				"조회에 성공하면 기존과 같이 당직일자가 구분자 포함 형식으로 돌아와야 한다.");
+	}
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`selectBndtManage`는 DAO 조회 결과를 확인 없이 역참조합니다.

```java
bndtManageVOTemp = bndtManageDAO.selectBndtManage(bndtManageVO);
bndtManageVOTemp.setBndtDe(EgovDateUtil.formatDate(bndtManageVOTemp.getBndtDe(), "-"));
```

조회 매퍼는 `BNDT_ID`와 `BNDT_DE` 조합으로 한 건을 찾습니다.

```xml
FROM   COMTNBNDTMANAGE ans, COMVNUSERMASTER mst
WHERE  BNDT_ID   = #{bndtId}
  AND  BNDT_DE   = #{bndtDe}
  AND  ans.BNDT_ID = mst.ESNTL_ID
```

해당 행이 없으면 `null`이 돌아오므로 이미 지워졌거나 없는 당직 정보로 상세·수정 화면에 들어가면 `NullPointerException`이 납니다. 이 서비스 메서드는 상세 화면(`EgovBndtManageDetail.do`)과 삭제 실패 후 재표시 경로 두 곳에서 부릅니다.

같은 클래스의 엑셀 일괄등록 경로는 같은 DAO 결과를 확인한 뒤 사용합니다.

```java
bndtManageVO = bndtManageDAO.selectBndtManageBnde(checkBndtManageVO);
if (bndtManageVO == null) {
	bndtManageVO = new BndtManageVO();
	BeanUtils.copyProperties(checkBndtManageVO, bndtManageVO);
}
```

단건조회에도 같은 확인을 넣었습니다.

TO-BE

```java
bndtManageVOTemp = bndtManageDAO.selectBndtManage(bndtManageVO);

// 해당 당직 행이 없으면 조회 결과가 없다. 같은 클래스의 엑셀 일괄등록 경로와 동일하게
// 결과를 확인한 뒤 사용한다.
if (bndtManageVOTemp == null) {
	return null;
}

bndtManageVOTemp.setBndtDe(EgovDateUtil.formatDate(bndtManageVOTemp.getBndtDe(), "-"));
```

### 영향 범위

조회에 성공하는 기존 흐름은 동작이 같습니다. 해당 행이 없을 때만 예외 대신 결과 없음이 돌아갑니다.

DAO와 매퍼는 변경하지 않았습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

`src/test/java/egovframework/com/uss/ion/bnt/service/impl/EgovBndtManageServiceImplDetailTest.java`를 추가했습니다. DAO가 구상 클래스라 익명 서브클래스로 결과를 지정하고 조회 결과가 없을 때와 있을 때를 각각 확인합니다.

수정 전

```
[ERROR] Tests run: 2, Failures: 0, Errors: 1, Skipped: 0
[ERROR]   EgovBndtManageServiceImplDetailTest.detailLookupReturnsNullInsteadOfThrowingWhenTheRecordIsGone:47
          » NullPointer Cannot invoke "...BndtManageVO.getBndtDe()" because "bndtManageVOTemp" is null
```

수정 후

```
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

조회에 성공하는 경우 당직일자가 기존과 같은 형식으로 돌아오는지도 함께 확인합니다.

`pom.xml`의 surefire 설정이 `skipTests=true`라 기본 빌드에서는 실행되지 않습니다. 확인할 때는 그 값을 잠시 `false`로 두고 돌렸습니다.
