### PR TITLE
fix: 주소록 수정화면이 존재하지 않는 주소록에 NPE를 내는 문제 수정

### DIFF
--- a/src/main/java/egovframework/com/cop/adb/web/EgovAddressBookController.java
+++ b/src/main/java/egovframework/com/cop/adb/web/EgovAddressBookController.java
@@ -415,6 +415,12 @@ public class EgovAddressBookController {
 
         AddressBookVO tempAdbkVO = adbkService.selectAdressBook(adbkVO);
 
+        // 서비스가 조회 결과 없음을 그대로 돌려주므로(EgovAddressBookServiceImpl 의 null 검사)
+        // 확인한 뒤 사용한다. 없는 주소록이면 목록으로 돌려보낸다.
+        if (tempAdbkVO == null) {
+            return "forward:/cop/adb/selectAdbkList.do";
+        }
+
         AddressBookUserVO adbkUserVO = new AddressBookUserVO();
 
         boolean writer = false;

--- a/src/test/java/egovframework/com/cop/adb/web/EgovAddressBookControllerUpdateNullTest.java
+++ b/src/test/java/egovframework/com/cop/adb/web/EgovAddressBookControllerUpdateNullTest.java
@@ -1,0 +1,72 @@
+package egovframework.com.cop.adb.web;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.lang.reflect.Proxy;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.ui.ModelMap;
+
+import egovframework.com.cmm.LoginVO;
+import egovframework.com.cmm.service.EgovUserDetailsService;
+import egovframework.com.cmm.util.EgovUserDetailsHelper;
+import egovframework.com.cop.adb.service.AddressBookVO;
+import egovframework.com.cop.adb.service.EgovAddressBookService;
+
+/**
+ * 주소록 수정화면이 존재하지 않는 주소록을 받았을 때 처리를 확인한다.
+ *
+ * <p>{@code EgovAddressBookServiceImpl.selectAdressBook}은 {@code if(adbkVO != null)}로
+ * 조회 결과가 없을 수 있음을 스스로 밝히고 그대로 돌려준다. 그런데 수정화면은 그 결과를
+ * 확인 없이 바로 역참조해 {@code NullPointerException}이 났다.</p>
+ */
+class EgovAddressBookControllerUpdateNullTest {
+
+	private EgovAddressBookController controller;
+
+	@BeforeEach
+	void setUp() {
+		EgovUserDetailsService auth = (EgovUserDetailsService) Proxy.newProxyInstance(
+				getClass().getClassLoader(), new Class<?>[] { EgovUserDetailsService.class },
+				(proxy, method, args) -> {
+					if ("isAuthenticated".equals(method.getName())) {
+						return Boolean.TRUE;
+					}
+					if ("getAuthenticatedUser".equals(method.getName())) {
+						LoginVO user = new LoginVO();
+						user.setId("USER");
+						return user;
+					}
+					return null;
+				});
+		ReflectionTestUtils.setField(EgovUserDetailsHelper.class, "egovUserDetailsService", auth);
+
+		// 없는 주소록을 조회한 상황.
+		EgovAddressBookService service = (EgovAddressBookService) Proxy.newProxyInstance(
+				getClass().getClassLoader(), new Class<?>[] { EgovAddressBookService.class },
+				(proxy, method, args) -> null);
+
+		controller = new EgovAddressBookController();
+		ReflectionTestUtils.setField(controller, "adbkService", service);
+	}
+
+	@AfterEach
+	void tearDown() {
+		ReflectionTestUtils.setField(EgovUserDetailsHelper.class, "egovUserDetailsService", null);
+	}
+
+	@Test
+	void addressBookUpdateViewFallsBackToTheListWhenTheRecordIsGone() throws Exception {
+		AddressBookVO vo = new AddressBookVO();
+		vo.setAdbkId("ADBK_00000000000000");
+
+		String view = controller.updateAdbkInf(vo, new ModelMap());
+
+		assertNotNull(view, "없는 주소록으로 수정화면을 열면 예외 대신 화면 이동이 나와야 한다.");
+		assertEquals("forward:/cop/adb/selectAdbkList.do", view);
+	}
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`updateAdbkInf`는 주소록 조회 결과를 확인 없이 역참조합니다.

```java
AddressBookVO tempAdbkVO = adbkService.selectAdressBook(adbkVO);

AddressBookUserVO adbkUserVO = new AddressBookUserVO();
...
for (AddressBookUser element : tempAdbkVO.getAdbkMan()) {
```

그런데 서비스는 조회 결과가 없을 수 있음을 스스로 밝히고 그대로 돌려줍니다.

```java
AddressBookVO adbkVO = adbkDAO.selectAdressBook(addressBookVO);

if(adbkVO != null) {
	adbkVO.setAdbkMan(adbkDAO.selectUserList(adbkVO));
}
```

그래서 이미 지워졌거나 없는 주소록으로 수정화면을 열면 `NullPointerException`이 납니다.

TO-BE

```java
AddressBookVO tempAdbkVO = adbkService.selectAdressBook(adbkVO);

// 서비스가 조회 결과 없음을 그대로 돌려주므로(EgovAddressBookServiceImpl 의 null 검사)
// 확인한 뒤 사용한다. 없는 주소록이면 목록으로 돌려보낸다.
if (tempAdbkVO == null) {
    return "forward:/cop/adb/selectAdbkList.do";
}
```

### 영향 범위

조회에 성공하는 기존 흐름은 동작이 같습니다. 조회 결과가 없을 때만 예외 대신 목록으로 돌아갑니다. 돌아가는 목록은 같은 컨트롤러의 삭제 경로가 쓰는 화면입니다.

작성자 여부(`writer`)를 화면에 넘기는 기존 처리는 그대로입니다. 서비스·DAO·매퍼는 변경하지 않았습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

`src/test/java/egovframework/com/cop/adb/web/EgovAddressBookControllerUpdateNullTest.java`를 추가했습니다. 조회가 `null`을 돌려주는 상황을 동적 프록시로 만들고 수정화면을 호출합니다.

수정 전

```
[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0
[ERROR]   EgovAddressBookControllerUpdateNullTest.addressBookUpdateViewFallsBackToTheListWhenTheRecordIsGone:67
          » NullPointer Cannot invoke "...AddressBookVO.getAdbkMan()" because "tempAdbkVO" is null
```

수정 후

```
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

`pom.xml`의 surefire 설정이 `skipTests=true`라 기본 빌드에서는 실행되지 않습니다. 확인할 때는 그 값을 잠시 `false`로 두고 돌렸습니다.
