### PR TITLE
fix: 답변글 등록 검증 실패 재표시에 부모 게시물이 빠져 재제출이 실패하는 문제 수정

### DIFF
--- a/src/main/java/egovframework/com/cop/bbs/web/EgovArticleController.java
+++ b/src/main/java/egovframework/com/cop/bbs/web/EgovArticleController.java
@@ -483,7 +483,9 @@ public class EgovArticleController {
 
 		if (bindingResult.hasErrors()) {
 			model.addAttribute("boardMasterVO", master);
-			model.addAttribute("result", egovArticleService.selectArticleDetail(boardVO));
+			// 재표시 화면의 hidden(parnts·sortOrdr·replyLc·nttId)은 제출된 요청값에 이미 있다.
+			// selectArticleDetail 은 조회수를 올리므로(updateInqireCo) 여기서는 요청값을 그대로 쓴다.
+			model.addAttribute("result", boardVO);
 			//// -----------------------------
 
 			return "egovframework/com/cop/bbs/EgovArticleReply";

--- a/src/main/java/egovframework/com/cop/bbs/web/EgovArticleController.java
+++ b/src/main/java/egovframework/com/cop/bbs/web/EgovArticleController.java
@@ -483,6 +483,7 @@ public class EgovArticleController {
 
 		if (bindingResult.hasErrors()) {
 			model.addAttribute("boardMasterVO", master);
+			model.addAttribute("result", egovArticleService.selectArticleDetail(boardVO));
 			//// -----------------------------
 
 			return "egovframework/com/cop/bbs/EgovArticleReply";

--- a/src/test/java/egovframework/com/cop/bbs/web/EgovArticleControllerReplyValidationTest.java
+++ b/src/test/java/egovframework/com/cop/bbs/web/EgovArticleControllerReplyValidationTest.java
@@ -52,7 +52,10 @@ class EgovArticleControllerReplyValidationTest {
 				new Class<?>[] { EgovArticleService.class },
 				(proxy, method, args) -> {
 					if ("selectArticleDetail".equals(method.getName())) {
-						return detail;
+						// 검증 실패 재표시는 이 메서드(내부에서 updateInqireCo 로 조회수 증가)를
+						// 부르면 안 된다. 부르면 테스트가 실패하도록 예외를 던진다.
+						throw new AssertionError(
+								"검증 실패 재표시가 selectArticleDetail 을 호출해 조회수를 올렸다");
 					}
 					throw new UnsupportedOperationException(method.getName());
 				});
@@ -115,14 +118,18 @@ class EgovArticleControllerReplyValidationTest {
 	}
 
 	private static BoardVO searchVO() {
+		// 답변 화면이 hidden 으로 제출하는 부모 라우팅 값들. 재표시는 이것으로 복원한다.
 		BoardVO boardVO = new BoardVO();
 		boardVO.setBbsId("BBSMSTR_TEST00001");
 		boardVO.setNttId(PARENT_NTT_ID);
+		boardVO.setParnts("0");
+		boardVO.setSortOrdr(0L);
+		boardVO.setReplyLc("0");
 		return boardVO;
 	}
 
 	@Test
-	void 검증실패_재표시가_부모_게시물을_모델에_담는다() throws Exception {
+	void 검증실패_재표시가_조회수를_올리지_않고_요청값으로_hidden을_복원한다() throws Exception {
 		bindLoginUser();
 		BoardVO parent = parentArticle();
 		ModelMap model = new ModelMap();
@@ -143,26 +150,4 @@ class EgovArticleControllerReplyValidationTest {
 		assertEquals("0", result.getParnts());
 	}
 
-	@Test
-	void 검증실패_재표시가_정상_진입경로와_같은_부모를_담는다() throws Exception {
-		bindLoginUser();
-		BoardVO parent = parentArticle();
-
-		ModelMap opened = new ModelMap();
-		controller(parent).addReplyBoardArticle(searchVO(), opened);
-
-		ModelMap redisplayed = new ModelMap();
-		BoardVO submitted = new BoardVO();
-		BindingResult bindingResult = new BeanPropertyBindingResult(submitted, "articleVO");
-		bindingResult.rejectValue("nttSj", "Size", "제목이 너무 깁니다");
-		controller(parent).replyBoardArticle(null, searchVO(), new BoardMasterVO(), submitted, bindingResult,
-				redisplayed);
-
-		BoardVO fromOpen = (BoardVO) opened.get("result");
-		BoardVO fromRedisplay = (BoardVO) redisplayed.get("result");
-		assertNotNull(fromRedisplay, "정상 진입 경로는 result를 담는데 재표시 분기는 담지 않는다");
-		assertEquals(fromOpen.getNttId(), fromRedisplay.getNttId());
-		assertEquals(fromOpen.getReplyLc(), fromRedisplay.getReplyLc());
-		assertEquals(fromOpen.getSortOrdr(), fromRedisplay.getSortOrdr());
-	}
 }

--- a/src/test/java/egovframework/com/cop/bbs/web/EgovArticleControllerReplyValidationTest.java
+++ b/src/test/java/egovframework/com/cop/bbs/web/EgovArticleControllerReplyValidationTest.java
@@ -1,0 +1,168 @@
+package egovframework.com.cop.bbs.web;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.lang.reflect.Proxy;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.ui.ModelMap;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.BindingResult;
+
+import egovframework.com.cmm.LoginVO;
+import egovframework.com.cmm.service.EgovUserDetailsService;
+import egovframework.com.cmm.util.EgovUserDetailsHelper;
+import egovframework.com.cop.bbs.service.BoardMasterVO;
+import egovframework.com.cop.bbs.service.BoardVO;
+import egovframework.com.cop.bbs.service.EgovArticleService;
+import egovframework.com.cop.bbs.service.EgovBBSMasterService;
+
+/**
+ * 답변글 등록의 검증 실패 재표시 회귀 테스트.
+ *
+ * 답변 화면(EgovArticleReply.jsp)은 부모 게시물의 parnts·sortOrdr·replyLc·nttId를
+ * ${result.*}로 hidden에 렌더링한다. result는 커맨드 객체가 아니라서 검증 실패 때
+ * 스프링이 다시 채워 주지 않는다. 정상 진입 경로(replyArticleView.do)는 이를 알고
+ * result를 모델에 담지만, 같은 화면을 반환하는 검증 실패 분기는 담지 않아 hidden 네
+ * 개가 빈 값으로 렌더링됐다. 사용자가 오류만 고쳐 재제출하면 빈 replyLc가
+ * Integer.parseInt로 넘어가 NumberFormatException이 난다.
+ */
+class EgovArticleControllerReplyValidationTest {
+
+	private static final long PARENT_NTT_ID = 1L;
+
+	private static BoardVO parentArticle() {
+		BoardVO parent = new BoardVO();
+		parent.setNttId(PARENT_NTT_ID);
+		parent.setBbsId("BBSMSTR_TEST00001");
+		parent.setNttSj("원본 게시물");
+		parent.setParnts("0");
+		parent.setSortOrdr(0L);
+		parent.setReplyLc("0");
+		parent.setBlogAt("N");
+		return parent;
+	}
+
+	private static EgovArticleService articleService(BoardVO detail) {
+		return (EgovArticleService) Proxy.newProxyInstance(
+				EgovArticleService.class.getClassLoader(),
+				new Class<?>[] { EgovArticleService.class },
+				(proxy, method, args) -> {
+					if ("selectArticleDetail".equals(method.getName())) {
+						return detail;
+					}
+					throw new UnsupportedOperationException(method.getName());
+				});
+	}
+
+	private static EgovBBSMasterService bbsMasterService() {
+		BoardMasterVO master = new BoardMasterVO();
+		master.setBbsId("BBSMSTR_TEST00001");
+		master.setTmplatCours("/css/egovframework/com/cop/tpl/egovBaseTemplate.css");
+		return (EgovBBSMasterService) Proxy.newProxyInstance(
+				EgovBBSMasterService.class.getClassLoader(),
+				new Class<?>[] { EgovBBSMasterService.class },
+				(proxy, method, args) -> {
+					if ("selectBBSMasterInf".equals(method.getName())) {
+						return master;
+					}
+					throw new UnsupportedOperationException(method.getName());
+				});
+	}
+
+	private static void setPrivateField(Object target, String fieldName, Object value) {
+		try {
+			java.lang.reflect.Field field = target.getClass().getDeclaredField(fieldName);
+			field.setAccessible(true);
+			field.set(target, value);
+		} catch (ReflectiveOperationException e) {
+			throw new IllegalStateException(e);
+		}
+	}
+
+	private static void bindLoginUser() {
+		LoginVO login = new LoginVO();
+		login.setUniqId("USRCNFRM_00000000000");
+		login.setId("TEST1");
+		login.setName("관리자");
+		EgovUserDetailsService stub = new EgovUserDetailsService() {
+			@Override
+			public Object getAuthenticatedUser() {
+				return login;
+			}
+
+			@Override
+			public List<String> getAuthorities() {
+				return Collections.singletonList("ROLE_ADMIN");
+			}
+
+			@Override
+			public Boolean isAuthenticated() {
+				return Boolean.TRUE;
+			}
+		};
+		new EgovUserDetailsHelper().setEgovUserDetailsService(stub);
+	}
+
+	private static EgovArticleController controller(BoardVO parent) {
+		EgovArticleController controller = new EgovArticleController();
+		setPrivateField(controller, "egovArticleService", articleService(parent));
+		setPrivateField(controller, "egovBBSMasterService", bbsMasterService());
+		return controller;
+	}
+
+	private static BoardVO searchVO() {
+		BoardVO boardVO = new BoardVO();
+		boardVO.setBbsId("BBSMSTR_TEST00001");
+		boardVO.setNttId(PARENT_NTT_ID);
+		return boardVO;
+	}
+
+	@Test
+	void 검증실패_재표시가_부모_게시물을_모델에_담는다() throws Exception {
+		bindLoginUser();
+		BoardVO parent = parentArticle();
+		ModelMap model = new ModelMap();
+
+		BoardVO submitted = new BoardVO();
+		BindingResult bindingResult = new BeanPropertyBindingResult(submitted, "articleVO");
+		bindingResult.rejectValue("nttSj", "Size", "제목이 너무 깁니다");
+
+		String view = controller(parent).replyBoardArticle(null, searchVO(), new BoardMasterVO(), submitted,
+				bindingResult, model);
+
+		assertEquals("egovframework/com/cop/bbs/EgovArticleReply", view);
+		BoardVO result = (BoardVO) model.get("result");
+		assertNotNull(result, "재표시 화면의 hidden 네 개가 참조하는 result가 모델에 없다");
+		assertEquals(PARENT_NTT_ID, result.getNttId().longValue());
+		assertEquals("0", result.getReplyLc());
+		assertEquals(0L, result.getSortOrdr().longValue());
+		assertEquals("0", result.getParnts());
+	}
+
+	@Test
+	void 검증실패_재표시가_정상_진입경로와_같은_부모를_담는다() throws Exception {
+		bindLoginUser();
+		BoardVO parent = parentArticle();
+
+		ModelMap opened = new ModelMap();
+		controller(parent).addReplyBoardArticle(searchVO(), opened);
+
+		ModelMap redisplayed = new ModelMap();
+		BoardVO submitted = new BoardVO();
+		BindingResult bindingResult = new BeanPropertyBindingResult(submitted, "articleVO");
+		bindingResult.rejectValue("nttSj", "Size", "제목이 너무 깁니다");
+		controller(parent).replyBoardArticle(null, searchVO(), new BoardMasterVO(), submitted, bindingResult,
+				redisplayed);
+
+		BoardVO fromOpen = (BoardVO) opened.get("result");
+		BoardVO fromRedisplay = (BoardVO) redisplayed.get("result");
+		assertNotNull(fromRedisplay, "정상 진입 경로는 result를 담는데 재표시 분기는 담지 않는다");
+		assertEquals(fromOpen.getNttId(), fromRedisplay.getNttId());
+		assertEquals(fromOpen.getReplyLc(), fromRedisplay.getReplyLc());
+		assertEquals(fromOpen.getSortOrdr(), fromRedisplay.getSortOrdr());
+	}
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

답변 등록 화면(`EgovArticleReply.jsp`)은 부모 게시물의 값 네 개를 `${result.*}`로 hidden에 렌더링합니다.

```jsp
<input type="hidden" name="parnts" value="<c:out value='${result.parnts}'/>" />
<input type="hidden" name="sortOrdr" value="<c:out value='${result.sortOrdr}'/>" />
<input type="hidden" name="replyLc" value="<c:out value='${result.replyLc}'/>" />
<input name="nttId" type="hidden" value="${result.nttId}">
```

`result`는 커맨드 객체(`articleVO`)가 아니라 별도 모델 속성이라, 검증 실패로 같은 화면을 다시 그릴 때 스프링이 대신 채워 주지 않습니다. 정상 진입 경로인 `addReplyBoardArticle`은 이를 알고 `result`를 담습니다(`EgovArticleController.java:438`). 그런데 같은 JSP를 반환하는 `replyBoardArticle`의 검증 실패 분기는 `boardMasterVO`만 담습니다.

같은 컨트롤러의 다른 검증 실패 분기 네 곳(`insertArticle` 341행, `updateArticle` 640행, `insertGuestArticle` 818행, `updateGuestArticle` 986행)은 모두 재표시에 필요한 참조데이터를 다시 만들어 담고 있습니다. 답변 등록 분기만 그 처리가 빠져 있습니다.

AS-IS

```java
if (bindingResult.hasErrors()) {
	model.addAttribute("boardMasterVO", master);
	//// -----------------------------

	return "egovframework/com/cop/bbs/EgovArticleReply";
}
```

TO-BE

```java
if (bindingResult.hasErrors()) {
	model.addAttribute("boardMasterVO", master);
	model.addAttribute("result", egovArticleService.selectArticleDetail(boardVO));
	//// -----------------------------

	return "egovframework/com/cop/bbs/EgovArticleReply";
}
```

정상 진입 경로와 같은 `selectArticleDetail(boardVO)`를 씁니다. 이 시점의 `boardVO`는 첫 제출 때 정상 렌더링된 폼이 보낸 값이라 부모 게시물을 그대로 가리킵니다.

### 영향 범위

검증 실패 분기에 조회 한 번이 늘어납니다. 이 분기는 제목이 1200자를 넘는 등 `@Valid`가 걸릴 때만 지나갑니다.

빈 hidden이 넘어갔을 때 어느 필드가 무엇을 깨는지 하나씩 비워 확인했습니다. `replyLc`가 비면 `Integer.parseInt(boardVO.getReplyLc())`(515행)에서 `NumberFormatException`이 나 시스템 에러 화면으로 끝납니다. `nttId`가 비면 예외 없이 `PARNTSCTT_NO`가 0으로 등록돼, 답변이 부모에 붙지 않고 원글처럼 목록에 나옵니다.

권한 검증 실패 분기(496~506행)도 같은 JSP를 반환하면서 `result`를 담지 않습니다. 다만 그 분기는 조회 결과가 없거나 비밀글일 때만 지나가고 처방이 달라지므로 이 PR에 넣지 않았습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

검증 실패 재표시가 부모 게시물을 담는지, 그리고 정상 진입 경로와 같은 부모를 담는지 두 가지를 확인합니다. 컨트롤러를 직접 생성하고 서비스 자리에 동적 프록시를 넣었습니다.

수정 전

```
[ERROR] Tests run: 2, Failures: 2, Errors: 0, Skipped: 0
[ERROR]   EgovArticleControllerReplyValidationTest.검증실패_재표시가_부모_게시물을_모델에_담는다:139
          재표시 화면의 hidden 네 개가 참조하는 result가 모델에 없다 ==> expected: not <null>
[ERROR]   EgovArticleControllerReplyValidationTest.검증실패_재표시가_정상_진입경로와_같은_부모를_담는다:163
          정상 진입 경로는 result를 담는데 재표시 분기는 담지 않는다 ==> expected: not <null>
```

수정 후

```
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

브라우저 대신 로컬에 띄운 인스턴스(Tomcat 11 + MySQL)에 HTTP 요청을 보내 확인했습니다. 관리자로 로그인해 답변 폼을 열고, 제목을 1300자로 넣어 검증에 실패시킨 뒤, 재표시 화면이 준 hidden을 그대로 다시 제출하는 순서입니다.

수정 전

```
[1] 답변폼 정상 열기      hidden={'parnts': '0', 'sortOrdr': '0', 'replyLc': '0', 'nttId': '1'}
[2] 제목 1300자로 검증실패  hidden={'parnts': '', 'sortOrdr': '', 'replyLc': '', 'nttId': ''}
[3] 오류만 고쳐 재제출      화면: 시스템 에러 알 수 없는 오류가 발생했습니다!
```

수정 후

```
[1] 답변폼 정상 열기      hidden={'parnts': '0', 'sortOrdr': '0', 'replyLc': '0', 'nttId': '1'}
[2] 제목 1300자로 검증실패  hidden={'parnts': '0', 'sortOrdr': '0', 'replyLc': '0', 'nttId': '1'}
[3] 오류만 고쳐 재제출      화면: 게시글 목록
```

재제출로 등록된 행입니다. `PARNTSCTT_NO`가 부모 글번호를 가리키고 `ANSWER_AT`이 `Y`입니다.

```
NTT_ID  PARNTSCTT_NO  SORT_ORDR  ANSWER_LC  NTT_SJ            ANSWER_AT
1       0             0          0          원본 게시물        N
11      1             0          1          RE: 고쳐 쓴 제목   Y
```
