### PR TITLE
fix(ncm): 명함사용정보 수정 쿼리가 mysql 매퍼에만 있어 다른 DB 에서 실패

### DIFF
--- a/src/main/resources/egovframework/mapper/com/cop/ncm/EgovNcrd_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/ncm/EgovNcrd_SQL_altibase.xml
@@ -274,4 +274,12 @@
 	</select>	
 	
 	
+	<update id="updateNcrdUseInf" parameterType="egovframework.com.cop.ncm.service.NameCardUser">
+            UPDATE COMTNNCRDUSER
+            SET REGIST_SE_CODE = #{registSeCode}
+            WHERE
+                EMPLYR_ID = #{emplyrId}
+                AND NCRD_ID = #{ncrdId}
+    </update>
+	
 </mapper>

--- a/src/main/resources/egovframework/mapper/com/cop/ncm/EgovNcrd_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/ncm/EgovNcrd_SQL_cubrid.xml
@@ -274,4 +274,12 @@
 	</select>	
 	
 	
+	<update id="updateNcrdUseInf" parameterType="egovframework.com.cop.ncm.service.NameCardUser">
+            UPDATE COMTNNCRDUSER
+            SET REGIST_SE_CODE = #{registSeCode}
+            WHERE
+                EMPLYR_ID = #{emplyrId}
+                AND NCRD_ID = #{ncrdId}
+    </update>
+	
 </mapper>

--- a/src/main/resources/egovframework/mapper/com/cop/ncm/EgovNcrd_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/ncm/EgovNcrd_SQL_goldilocks.xml
@@ -274,4 +274,12 @@
 	</select>	
 	
 	
+	<update id="updateNcrdUseInf" parameterType="egovframework.com.cop.ncm.service.NameCardUser">
+            UPDATE COMTNNCRDUSER
+            SET REGIST_SE_CODE = #{registSeCode}
+            WHERE
+                EMPLYR_ID = #{emplyrId}
+                AND NCRD_ID = #{ncrdId}
+    </update>
+	
 </mapper>

--- a/src/main/resources/egovframework/mapper/com/cop/ncm/EgovNcrd_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/ncm/EgovNcrd_SQL_maria.xml
@@ -271,4 +271,12 @@
 	</select>	
 	
 	
+	<update id="updateNcrdUseInf" parameterType="egovframework.com.cop.ncm.service.NameCardUser">
+            UPDATE COMTNNCRDUSER
+            SET REGIST_SE_CODE = #{registSeCode}
+            WHERE
+                EMPLYR_ID = #{emplyrId}
+                AND NCRD_ID = #{ncrdId}
+    </update>
+	
 </mapper>

--- a/src/main/resources/egovframework/mapper/com/cop/ncm/EgovNcrd_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/ncm/EgovNcrd_SQL_oracle.xml
@@ -274,4 +274,12 @@
 	</select>	
 	
 	
+	<update id="updateNcrdUseInf" parameterType="egovframework.com.cop.ncm.service.NameCardUser">
+            UPDATE COMTNNCRDUSER
+            SET REGIST_SE_CODE = #{registSeCode}
+            WHERE
+                EMPLYR_ID = #{emplyrId}
+                AND NCRD_ID = #{ncrdId}
+    </update>
+	
 </mapper>

--- a/src/main/resources/egovframework/mapper/com/cop/ncm/EgovNcrd_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/ncm/EgovNcrd_SQL_postgres.xml
@@ -271,4 +271,12 @@
 	</select>	
 	
 	
+	<update id="updateNcrdUseInf" parameterType="egovframework.com.cop.ncm.service.NameCardUser">
+            UPDATE COMTNNCRDUSER
+            SET REGIST_SE_CODE = #{registSeCode}
+            WHERE
+                EMPLYR_ID = #{emplyrId}
+                AND NCRD_ID = #{ncrdId}
+    </update>
+	
 </mapper>

--- a/src/main/resources/egovframework/mapper/com/cop/ncm/EgovNcrd_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/ncm/EgovNcrd_SQL_tibero.xml
@@ -274,4 +274,12 @@
 	</select>	
 	
 	
+	<update id="updateNcrdUseInf" parameterType="egovframework.com.cop.ncm.service.NameCardUser">
+            UPDATE COMTNNCRDUSER
+            SET REGIST_SE_CODE = #{registSeCode}
+            WHERE
+                EMPLYR_ID = #{emplyrId}
+                AND NCRD_ID = #{ncrdId}
+    </update>
+	
 </mapper>

--- a/src/test/java/egovframework/com/cmm/EgovMapperVariantTest.java
+++ b/src/test/java/egovframework/com/cmm/EgovMapperVariantTest.java
@@ -1,0 +1,97 @@
+package egovframework.com.cmm;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * 같은 매퍼의 데이터베이스별 변종은 같은 쿼리 아이디 집합을 선언해야 한다.
+ *
+ * 한 변종에만 쿼리가 빠지면 그 데이터베이스로 기동했을 때만 실패한다.
+ *
+ * @author 최완택
+ * @since 2026-08-31
+ */
+@DisplayName("매퍼 변종")
+class EgovMapperVariantTest {
+
+	private static final Path MAPPER_ROOT = Paths.get("src/main/resources/egovframework/mapper");
+
+	private static final Pattern FILE_NAME = Pattern
+			.compile("(.+)_SQL_(mysql|maria|oracle|postgres|cubrid|tibero|altibase|goldilocks)\\.xml$");
+
+	private static final Pattern NAMESPACE = Pattern.compile("<mapper\\s+namespace=\"([^\"]+)\"");
+
+	private static final Pattern STATEMENT_ID = Pattern
+			.compile("<(?:select|insert|update|delete)\\s[^>]*id=\"([^\"]+)\"");
+
+	@Test
+	@DisplayName("데이터베이스별 변종이 같은 쿼리 아이디를 선언한다")
+	void mapperVariantsDeclareSameStatementIds() throws IOException {
+		Map<String, Map<String, Set<String>>> groups = new LinkedHashMap<>();
+
+		try (Stream<Path> paths = Files.walk(MAPPER_ROOT)) {
+			for (Path path : paths.filter(Files::isRegularFile).toList()) {
+				Matcher fileName = FILE_NAME.matcher(path.getFileName().toString());
+				if (!fileName.matches()) {
+					continue;
+				}
+				groups.computeIfAbsent(fileName.group(1), key -> new LinkedHashMap<>())
+						.put(fileName.group(2), statementIds(path));
+			}
+		}
+
+		List<String> missing = new ArrayList<>();
+
+		for (Map.Entry<String, Map<String, Set<String>>> group : groups.entrySet()) {
+			Set<String> union = new TreeSet<>();
+			group.getValue().values().forEach(union::addAll);
+
+			for (Map.Entry<String, Set<String>> variant : group.getValue().entrySet()) {
+				Set<String> gap = new TreeSet<>(union);
+				gap.removeAll(variant.getValue());
+				if (!gap.isEmpty()) {
+					missing.add(group.getKey() + "_SQL_" + variant.getKey() + ".xml " + gap);
+				}
+			}
+		}
+
+		assertTrue(missing.isEmpty(), "변종에 빠진 쿼리: " + missing);
+	}
+
+	/**
+	 * 아이디에 네임스페이스 접두어를 붙인 변종과 붙이지 않은 변종이 섞여 있다.
+	 * MyBatis 는 두 형태를 모두 등록하므로 접두어 유무는 동작 차이가 아니다. 벗겨서 비교한다.
+	 */
+	private Set<String> statementIds(Path path) throws IOException {
+		String source = Files.readString(path, StandardCharsets.UTF_8);
+
+		Matcher namespace = NAMESPACE.matcher(source);
+		String prefix = namespace.find() ? namespace.group(1) + "." : "";
+
+		Set<String> ids = new TreeSet<>();
+		Matcher statement = STATEMENT_ID.matcher(source);
+		while (statement.find()) {
+			String id = statement.group(1);
+			ids.add(id.startsWith(prefix) ? id.substring(prefix.length()) : id);
+		}
+		return ids;
+	}
+
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`updateNcrdUseInf`가 `EgovNcrd_SQL_mysql.xml`에만 있습니다. 나머지 일곱 변종에는 없습니다.

`NcrdManageDAO`는 조건 없이 이 쿼리를 부릅니다.

```java
// NcrdManageDAO.java:128
return update("NcrdManageDAO.updateNcrdUseInf", nameCardUser);
```

호출 경로는 `POST /cop/ncm/updateNcrdUseInf.do` → `EgovNcrdManageServiceImpl.updateNcrdUseInf` → DAO입니다. mysql이 아닌 데이터베이스로 기동하면 이 경로가 `Mapped Statements collection does not contain value`로 실패합니다.

같은 매퍼의 `insertNcrdUseInf`·`selectNcrdUseInfs`·`selectNcrdUseInfsCnt`는 여덟 변종에 모두 있습니다. `updateNcrdUseInf`만 빠져 있습니다.

mysql의 구문을 나머지 일곱에 그대로 넣었습니다. 표준 UPDATE라 방언 차이가 없습니다.

```sql
UPDATE COMTNNCRDUSER
SET REGIST_SE_CODE = #{registSeCode}
WHERE EMPLYR_ID = #{emplyrId} AND NCRD_ID = #{ncrdId}
```

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

매퍼의 데이터베이스별 변종이 같은 쿼리 아이디를 선언하는지 검사하는 테스트를 넣었습니다. 아이디에 네임스페이스 접두어를 붙인 변종과 붙이지 않은 변종이 섞여 있어 접두어를 벗기고 비교합니다.

수정 전

```
[ERROR] EgovMapperVariantTest.mapperVariantsDeclareSameStatementIds:75
        변종에 빠진 쿼리: [EgovNcrd_SQL_oracle.xml [updateNcrdUseInf],
        EgovNcrd_SQL_altibase.xml [updateNcrdUseInf], EgovNcrd_SQL_cubrid.xml [updateNcrdUseInf],
        EgovNcrd_SQL_postgres.xml [updateNcrdUseInf], EgovNcrd_SQL_tibero.xml [updateNcrdUseInf],
        EgovNcrd_SQL_maria.xml [updateNcrdUseInf], EgovNcrd_SQL_goldilocks.xml [updateNcrdUseInf]]
```

수정 후

```
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
```

`pom.xml`의 surefire 설정이 `<skipTests>true</skipTests>`로 고정돼 있어 이 값을 잠시 해제하고 실행한 결과입니다.

수동으로는 `Globals.DbType`을 `maria`로 두고 앱을 띄운 뒤 해당 경로를 호출했습니다.

수정 전

```
Caused by: java.lang.IllegalArgumentException: Mapped Statements collection
  does not contain value for NcrdManageDAO.updateNcrdUseInf
    at egovframework.com.cop.ncm.web.EgovNcrdManageController.updateNcrdUseInf(EgovNcrdManageController.java:364)
```

수정 후

```
[jdbc.sqlonly] UPDATE COMTNNCRDUSER SET REGIST_SE_CODE = 'REGC01'
               WHERE EMPLYR_ID = 'USRCNFRM_00000000001'
```

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

로컬에 띄운 인스턴스에 HTTP 요청을 보냈습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

위 로그로 대신합니다.
