### PR TITLE
fix(smt,cns): 화면이 거는 경로 두 곳이 매핑 없는 네임스페이스를 가리켜 404

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/egovframework/com/cop/smt/sdm/EgovDeptSchdulManageDetail.jsp
+++ b/src/main/webapp/WEB-INF/jsp/egovframework/com/cop/smt/sdm/EgovDeptSchdulManageDetail.jsp
@@ -68,7 +68,7 @@ function fn_egov_list_DeptSchdulManage(){
 
 	<%-- 전체일정목록 이동 --%>
 	<c:if test="${sLinkType eq 'asm'}">
-		location.href = "<c:url value='/cop/smt/asm/EgovAllSchdulManageList.do' />";
+		location.href = "<c:url value='/cop/smt/sam/EgovAllSchdulManageList.do' />";
 	</c:if>
 }
 /* ********************************************************

--- a/src/main/webapp/WEB-INF/jsp/egovframework/com/uss/olp/cns/EgovCnsltDtlsAnswerUpdt.jsp
+++ b/src/main/webapp/WEB-INF/jsp/egovframework/com/uss/olp/cns/EgovCnsltDtlsAnswerUpdt.jsp
@@ -85,7 +85,7 @@ function fn_egov_inqire_qnaanswerlist() {
  ******************************************************** */
 function fn_egov_pop_mailform() {
 
-	var url 	= "<c:url value='/ems/insertSndngMailView.do'/>";
+	var url 	= "<c:url value='/cop/ems/insertSndngMailView.do'/>";
 	var	status 	= "width=640,height=480,top=200,left=200";
 
 	window.open(url,'popup', status);


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

화면이 거는 경로 두 곳이 매핑 없는 네임스페이스를 가리켜 404가 납니다.

**1. 부서일정 상세의 목록 버튼** — `cop/smt/sdm/EgovDeptSchdulManageDetail.jsp:71`

전체일정관리 목록에서 부서일정을 누르면 `linkType=asm`을 달고 상세로 들어옵니다. 이때 목록 버튼은 `/cop/smt/asm/EgovAllSchdulManageList.do`로 갑니다. 매핑은 `/cop/smt/sam/`에 있습니다.

같은 목록에서 같은 `linkType=asm`으로 들어오는 개인일정 상세(`cop/smt/sim/EgovIndvdlSchdulManageDetail.jsp:70`)는 `/cop/smt/sam/`을 씁니다.

**2. 상담 답변 수정의 발송메일 등록 팝업** — `uss/olp/cns/EgovCnsltDtlsAnswerUpdt.jsp:88`

이메일답변여부가 `Y`이면 나타나는 버튼이 `/ems/insertSndngMailView.do`를 엽니다. 매핑은 `/cop/ems/`에 있고 이 화면을 여는 나머지 두 곳(`cop/ems/EgovMailDtls.jsp:57`, `ROLE_ADMIN_SiteMap.jsp:140`)도 `/cop/ems/`를 씁니다.

## JUnit 테스트 JUnit tests

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

앱을 띄우고 로그인해 확인했습니다.

수정 전

```
/cop/smt/sam/EgovAllSchdulManageList.do   200
/cop/smt/asm/EgovAllSchdulManageList.do   404
/cop/ems/insertSndngMailView.do           200
/ems/insertSndngMailView.do               404
```

전체일정목록에서 들어온 부서일정 상세가 실제로 내보내는 목록 이동 경로

```
location.href = "/egovframe-template-common-components/cop/smt/asm/EgovAllSchdulManageList.do"
```

수정 후 같은 화면

```
location.href = "/egovframe-template-common-components/cop/smt/sam/EgovAllSchdulManageList.do"   → 200
```

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

로컬에 띄운 인스턴스에 HTTP 요청을 보냈습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

위 응답 코드로 대신합니다.
