### PR TITLE
fix(ion): 결재·등록 핸들러 네 곳의 검증 분기가 @Valid 누락으로 동작하지 않음

### DIFF
--- a/src/main/java/egovframework/com/uss/ion/ctn/web/EgovCtsnnManageController.java
+++ b/src/main/java/egovframework/com/uss/ion/ctn/web/EgovCtsnnManageController.java
@@ -340,7 +340,7 @@ public class EgovCtsnnManageController {
 	 * @return String - 리턴 Url
 	 */
 	 @PostMapping("/uss/ion/ctn/updtCtsnnConfm.do")
-	 public String updateCtsnnManageConfm(@ModelAttribute("ctsnnManageVO") CtsnnManageVO ctsnnManageVO,
+	 public String updateCtsnnManageConfm(@Valid @ModelAttribute("ctsnnManageVO") CtsnnManageVO ctsnnManageVO,
 			                               BindingResult bindingResult,
 			                               SessionStatus status,
 		                                   ModelMap model) throws Exception {

--- a/src/main/java/egovframework/com/uss/ion/rmm/web/EgovRoughMapController.java
+++ b/src/main/java/egovframework/com/uss/ion/rmm/web/EgovRoughMapController.java
@@ -154,7 +154,7 @@ public class EgovRoughMapController {
 	 * @throws Exception
 	 */
 	@PostMapping("/com/uss/ion/rmm/insertRoughMap.do")
-	public String insertRoughMap(@ModelAttribute("roughMap") RoughMapVO roughMap, BindingResult bindingResult)
+	public String insertRoughMap(@Valid @ModelAttribute("roughMap") RoughMapVO roughMap, BindingResult bindingResult)
 			throws Exception {
 
 		// 권한 체크

--- a/src/main/java/egovframework/com/uss/ion/rwd/web/EgovRwardManageController.java
+++ b/src/main/java/egovframework/com/uss/ion/rwd/web/EgovRwardManageController.java
@@ -435,7 +435,7 @@ public class EgovRwardManageController {
 	 * @return String - 리턴 Url
 	 */
 	@PostMapping("/uss/ion/rwd/updtRwardConfm.do")
-	public String updtRwardManageConfm(@ModelAttribute("rwardManage") RwardManage rwardManage,
+	public String updtRwardManageConfm(@Valid @ModelAttribute("rwardManage") RwardManage rwardManage,
 			BindingResult bindingResult, SessionStatus status, ModelMap model) throws Exception {
 
 		LoginVO user = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();
@@ -459,7 +459,7 @@ public class EgovRwardManageController {
 
 		if (bindingResult.hasErrors()) {
 			model.addAttribute("rwardManageVO", rwardManage);
-			return "egovframework/com/uss/ion/vct/EgovRwardConfm";
+			return "egovframework/com/uss/ion/rwd/EgovRwardConfm";
 		} else {
 
 			rwardManage.setSanctnerId((user == null || user.getUniqId() == null) ? "" : user.getUniqId());

--- a/src/main/java/egovframework/com/uss/ion/vct/web/EgovVcatnManageController.java
+++ b/src/main/java/egovframework/com/uss/ion/vct/web/EgovVcatnManageController.java
@@ -641,7 +641,7 @@ public class EgovVcatnManageController {
 	 * @return String - 리턴 Url
 	 */
 	@PostMapping("/uss/ion/vct/updtVcatnConfm.do")
-	public String updtVcatnManageConfm(@ModelAttribute("vcatnManageVO") VcatnManageVO vcatnManageVO, BindingResult bindingResult, SessionStatus status,
+	public String updtVcatnManageConfm(@Valid @ModelAttribute("vcatnManageVO") VcatnManageVO vcatnManageVO, BindingResult bindingResult, SessionStatus status,
 			ModelMap model) throws Exception {
 
 		vcatnManageVO.setBgnde(EgovStringUtil.removeMinusChar(vcatnManageVO.getBgnde()));


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

네 핸들러가 `BindingResult`를 받아 `bindingResult.hasErrors()` 분기를 두고 있으나 `@Valid`가 없습니다. `@Valid`가 없으면 제약이 적용되지 않아 `BindingResult`가 항상 비고 그 분기로 들어가지 못합니다.

| 핸들러 | VO | VO 의 제약 |
|---|---|---|
| `EgovCtsnnManageController.updateCtsnnManageConfm` | `CtsnnManageVO` | 12건 |
| `EgovRoughMapController.insertRoughMap` | `RoughMapVO` | 3건 |
| `EgovVcatnManageController.updtVcatnManageConfm` | `VcatnManageVO` | 8건 |
| `EgovRwardManageController.updtRwardManageConfm` | `RwardManage` | 10건 |

휴가결재를 예로 들면, 필수 키 항목인 `vcatnSe`·`bgnde`·`endde`는 승인 UPDATE 의 `WHERE` 에 그대로 쓰입니다.

```sql
UPDATE COMTNVCATNMANAGE
   SET CONFM_AT = #{confmAt}, SANCTN_DT = #{sanctnDt}, ...
 WHERE APPLCNT_ID = #{applcntId}
   AND VCATN_SE = #{vcatnSe} AND BGNDE = #{bgnde} AND ENDDE = #{endde}
```

이 중 하나가 비면 아무 행도 잡히지 않은 채 결재목록으로 넘어갑니다. 결재자 화면에는 처리된 것처럼 보이고 결재는 되지 않습니다. `@EgovNullCheck`가 붙어 있는 항목들이라 검증 분기가 원래 걸러야 하는 경우입니다.

`updtRwardManageConfm`의 오류 분기는 존재하지 않는 뷰를 가리키고 있어 함께 고쳤습니다. `uss/ion/vct/EgovRwardConfm`은 없고 실제 경로는 `uss/ion/rwd/EgovRwardConfm`입니다. 이 분기가 살아나면 그대로 실패하는 자리입니다.

각 화면이 제출하는 항목을 확인해 제약이 걸린 항목이 모두 폼에 있는지 대조했습니다(`disabled` 없음). 정상 요청이 새로 막히지 않습니다.

## JUnit 테스트 JUnit tests

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

앱을 띄우고 결재권자로 로그인해 휴가결재를 실행했습니다.

수정 전 — `bgnde`를 비운 요청

```
HTTP 200  <title>휴가승인 목록</title>
DB  CONFM_AT: A → A   (변화 없음)
```

수정 후 — 같은 요청

```
HTTP 200  <title>휴가승인</title>          결재 화면으로 되돌아옴
DB  CONFM_AT: A → A
```

수정 후 — 정상 요청

```
HTTP 200
DB  CONFM_AT: A → C,  LAST_UPDUSR_ID 기록됨
```

약도 등록도 같은 방식으로 확인했습니다.

```
정상 요청     COMTNROUGHMAP 0건 → 1건
제목 비운 요청 1건 → 1건,  <title>약도 등록</title>
```

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

로컬에 띄운 인스턴스에 HTTP 요청을 보냈습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

위 응답과 DB 값으로 대신합니다.
