### PR TITLE
fix(bbs): unscript()가 </embed>·</form> 닫는 태그를 여는 태그로 변조하는 문제 수정

### DIFF
--- a/src/main/java/egovframework/com/cop/bbs/web/EgovArticleController.java
+++ b/src/main/java/egovframework/com/cop/bbs/web/EgovArticleController.java
@@ -129,10 +129,10 @@ public class EgovArticleController {
 		ret = ret.replaceAll("</(A|a)(P|p)(P|p)(L|l)(E|e)(T|t)", "&lt;/applet");
 
 		ret = ret.replaceAll("<(E|e)(M|m)(B|b)(E|e)(D|d)", "&lt;embed");
-		ret = ret.replaceAll("</(E|e)(M|m)(B|b)(E|e)(D|d)", "&lt;embed");
+		ret = ret.replaceAll("</(E|e)(M|m)(B|b)(E|e)(D|d)", "&lt;/embed");
 
 		ret = ret.replaceAll("<(F|f)(O|o)(R|r)(M|m)", "&lt;form");
-		ret = ret.replaceAll("</(F|f)(O|o)(R|r)(M|m)", "&lt;form");
+		ret = ret.replaceAll("</(F|f)(O|o)(R|r)(M|m)", "&lt;/form");
 
 		return ret;
 	}


### PR DESCRIPTION
## 수정 사유 (Reason for modification)
- [x] 버그수정 (Bug fixes)

## 문제
`EgovArticleController.unscript()` 는 게시글 본문의 위험 태그를 `&lt;` 로 무력화합니다. 그런데 **닫는 태그 규칙 5개 중 2개**(`embed`, `form`)의 대체 문자열에 슬래시가 빠져 있어, 닫는 태그가 **여는 태그로 바뀐 채** 저장됩니다.

```java
ret = ret.replaceAll("</(S|s)(C|c)(R|r)(I|i)(P|p)(T|t)", "&lt;/script");   // 정상
ret = ret.replaceAll("</(O|o)(B|b)(J|j)(E|e)(C|c)(T|t)", "&lt;/object");   // 정상
ret = ret.replaceAll("</(A|a)(P|p)(P|p)(L|l)(E|e)(T|t)", "&lt;/applet");   // 정상
ret = ret.replaceAll("</(E|e)(M|m)(B|b)(E|e)(D|d)", "&lt;embed");          // 슬래시 누락
ret = ret.replaceAll("</(F|f)(O|o)(R|r)(M|m)", "&lt;form");                // 슬래시 누락
```

정규식이 매치한 `/` 가 대체 문자열에 없으므로 그대로 사라집니다. 결과는 게시글 저장 시점에 본문에 그대로 반영되어 되돌릴 수 없습니다.

| 입력 | 현재 | 기대 |
|---|---|---|
| `</embed>` | `&lt;embed>` | `&lt;/embed>` |
| `</form>` | `&lt;form>` | `&lt;/form>` |
| `<form action=x></form>` | `&lt;form action=x>&lt;form>` | `&lt;form action=x>&lt;/form>` |

사용자가 닫는 태그를 적었는데 **여는 태그가 하나 더 생긴 것처럼** 표시됩니다.

## 수정 내용
같은 메서드의 나머지 3종(script·object·applet)과 동일하게 대체 문자열에 슬래시를 넣었습니다. **2개 문자만 추가**되며, 여는 태그 규칙 5개는 건드리지 않았습니다.

```diff
-ret = ret.replaceAll("</(E|e)(M|m)(B|b)(E|e)(D|d)", "&lt;embed");
+ret = ret.replaceAll("</(E|e)(M|m)(B|b)(E|e)(D|d)", "&lt;/embed");

-ret = ret.replaceAll("</(F|f)(O|o)(R|r)(M|m)", "&lt;form");
+ret = ret.replaceAll("</(F|f)(O|o)(R|r)(M|m)", "&lt;/form");
```

## 검증 (실측)
메서드 본문을 그대로 옮긴 standalone 하네스로 수정 전/후를 비교했습니다.

| 시나리오 | 수정 전 | 수정 후 |
|---|---|---|
| `</embed>` | `&lt;embed>` | `&lt;/embed>` |
| `</form>` | `&lt;form>` | `&lt;/form>` |
| `<form action=x></form>` | `&lt;form action=x>&lt;form>` | `&lt;form action=x>&lt;/form>` |
| 회귀: `</script>` · `</object>` · `</applet>` | 정상 | **전후 동일** |
| 회귀: `<script>alert(1)</script>` · 일반 텍스트 | 정상 | **전후 동일** |

이미 올바르게 동작하던 경로는 결과가 완전히 같고, 잘못 변조되던 2종만 바로잡힙니다.

## 영향 범위
`unscript()` 는 같은 컨트롤러의 `insertArticle()`·`insertArticleReply()`·`updateArticle()` 3곳에서 `// XSS 방지` 주석과 함께 호출됩니다. 무력화 동작(위험 태그를 `&lt;` 로 바꿈) 자체는 그대로이며, 이번 변경은 **닫는 태그의 슬래시 보존**에 한정됩니다.