### PR TITLE
fix(sim·sdm): 주간일정 조회의 week 인덱스 범위 검증 누락으로 발생하는 IndexOutOfBoundsException 수정

### DIFF
--- a/src/main/java/egovframework/com/cop/smt/sdm/web/EgovDeptSchdulManageController.java
+++ b/src/main/java/egovframework/com/cop/smt/sdm/web/EgovDeptSchdulManageController.java
@@ -408,6 +408,12 @@ public class EgovDeptSchdulManageController {
 
 		model.addAttribute("listWeekGrop", listWeekGrop);
 
+		// 2026.09.01 인덱스 사용 전 범위 검증(IndexOutOfBoundsException 방지)
+		if (iNowWeek < 0 || iNowWeek >= listWeekGrop.size()) {
+			iNowWeek = 0;
+			model.addAttribute("week", iNowWeek);
+		}
+
 		List<String> listWeek = listWeekGrop.get(iNowWeek);
 		commandMap.put("searchMode", "WEEK");
 		commandMap.put("schdulBgnde", listWeek.get(0));

--- a/src/main/java/egovframework/com/cop/smt/sim/web/EgovIndvdlSchdulManageController.java
+++ b/src/main/java/egovframework/com/cop/smt/sim/web/EgovIndvdlSchdulManageController.java
@@ -339,6 +339,12 @@ public class EgovIndvdlSchdulManageController {
 
 		model.addAttribute("listWeekGrop", listWeekGrop);
 
+		// 2026.09.01 인덱스 사용 전 범위 검증(IndexOutOfBoundsException 방지)
+		if (iNowWeek < 0 || iNowWeek >= listWeekGrop.size()) {
+			iNowWeek = 0;
+			model.addAttribute("week", iNowWeek);
+		}
+
 		List listWeek = (List) listWeekGrop.get(iNowWeek);
 		commandMap.put("searchMode", "WEEK");
 		commandMap.put("schdulBgnde", listWeek.get(0));


### PR DESCRIPTION
## 수정 사유 (Reason for modification)
- [x] 버그수정 (Bug fixes)

## 문제
개인일정(`sim`)·부서일정(`sdm`) 주간 조회는 `week` 요청 파라미터를 **검증 없이 주별 그룹 리스트의 인덱스로 사용**합니다.

```java
List listWeek = (List) listWeekGrop.get(iNowWeek);   // 범위 검증 없음
```

그런데 `listWeekGrop` 의 크기는 **연·월에 따라 5개 또는 6개로 달라집니다**. 그룹이 더 적은 연·월로 이동하면 인덱스가 범위를 벗어나 **IndexOutOfBoundsException** 이 발생합니다.

재현 경로는 화면의 평범한 조작입니다 — 주별 그룹이 6개인 달(예: 2026-01)에서 마지막 주(week=5)를 보다가 **연도 이전/다음 화살표**를 누르면 `week` 값이 그대로 유지된 채 그룹이 5개인 달(2025-01)로 이동합니다.

| 연·월 | 주별 그룹 수 |
|---|---|
| 2026-01 | 6 |
| 2025-01 | 5 |
| 2026-08 | 6 |
| 2027-08 | 5 |

## 수정 내용
같은 기능을 수행하는 **`EgovLeaderSchdulController`(기관장일정)에 이미 적용되어 있는 범위 검증**을 두 컨트롤러에 동일하게 추가했습니다.

```java
// 인덱스 사용 전 범위 검증(IndexOutOfBoundsException 방지)
if (iNowWeek < 0 || iNowWeek >= listWeekGrop.size()) {
    iNowWeek = 0;
    model.addAttribute("week", iNowWeek);
}
```

범위를 벗어나면 해당 월의 첫 주로 보정하고, 화면에 표시되는 `week` 값도 함께 맞춥니다. 2개 파일에 각각 5줄 추가이며 기존 로직은 변경하지 않았습니다.

## 검증 (실측)
주별 그룹 생성 로직을 동일 구조로 옮긴 standalone 하네스로 확인했습니다.

| 시나리오 | 수정 전 | 수정 후 |
|---|---|---|
| 2026-01 week=5 (그룹 6개) | 정상 | **동일하게 정상** |
| 2025-01 week=5 (그룹 5개) | **IndexOutOfBoundsException** | 첫 주로 보정 후 정상 |
| 회귀: 2026-01 week=0 | 정상 | **전후 동일** |
| 회귀: 2026-01 week=4 | 정상 | **전후 동일** |

정상 범위 인덱스는 가드 유무와 결과가 완전히 같고, 예외가 나던 경우만 보정됩니다.