### PR TITLE
fix(mgt): 직원검색 팝업 목록의 100행 상한이 postgres 매퍼에만 없음

### DIFF
--- a/src/main/resources/egovframework/mapper/com/uss/olp/mgt/EgovMeetingManage_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/olp/mgt/EgovMeetingManage_SQL_postgres.xml
@@ -103,6 +103,9 @@
 	 		</if>
 	 	
 	 </if>
+	 <if test="searchKeyword == null or searchKeyword == ''">
+	  LIMIT 100
+	 </if>
 	</select>
 
      <!-- 회의관리::삭제  -->

--- a/src/test/java/egovframework/com/uss/olp/mgt/service/impl/EgovMeetingManageEmpLyrPopupRowLimitTest.java
+++ b/src/test/java/egovframework/com/uss/olp/mgt/service/impl/EgovMeetingManageEmpLyrPopupRowLimitTest.java
@@ -1,0 +1,61 @@
+package egovframework.com.uss.olp.mgt.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.InputStream;
+import java.util.regex.Pattern;
+
+import org.apache.ibatis.builder.xml.XMLMapperBuilder;
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.mapping.MappedStatement;
+import org.apache.ibatis.session.Configuration;
+import org.egovframe.rte.psl.dataaccess.util.EgovMap;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import egovframework.com.cmm.ComDefaultVO;
+
+/**
+ * 직원검색 팝업 목록이 8개 DB 방언 모두에서 100행 상한을 거는지 검증한다.
+ *
+ * <p>{@link MeetingManageDao#egovMeetingManageLisEmpLyrPopup} 이 호출하는 목록은 팝업 JSP 가
+ * 페이징 없이 {@code c:forEach} 로 전부 렌더한다. 그래서 매퍼가 상한을 걸지 않으면 그 방언으로
+ * 기동했을 때만 직원 테이블 전체가 응답에 실린다.</p>
+ *
+ * <p>{@code context-mapper.xml} 의 {@code mapperLocations} 가
+ * {@code classpath:/egovframework/mapper/com/**}{@code /*_${Globals.DbType}.xml} 이라 런타임에는
+ * 방언 매퍼가 하나만 로드된다. 방언별로 매퍼를 직접 파싱해 DB 연결 없이 검증한다.</p>
+ */
+class EgovMeetingManageEmpLyrPopupRowLimitTest {
+
+	private static final String STATEMENT_ID = "MeetingManage.EgovMeetingManageLisEmpLyrPopup";
+
+	/** 방언마다 표기가 다른 100행 상한. */
+	private static final Pattern ROW_LIMIT = Pattern.compile(
+			"LIMIT\\s+(?:0\\s*,\\s*)?100\\b|R(?:OW)?NUM\\s*<=\\s*100\\b", Pattern.CASE_INSENSITIVE);
+
+	private Configuration loadMapper(String dialect) throws Exception {
+		String resource = "egovframework/mapper/com/uss/olp/mgt/EgovMeetingManage_SQL_" + dialect + ".xml";
+		Configuration configuration = new Configuration();
+		configuration.getTypeAliasRegistry().registerAlias("comDefaultVO", ComDefaultVO.class);
+		configuration.getTypeAliasRegistry().registerAlias("egovMap", EgovMap.class);
+		try (InputStream inputStream = Resources.getResourceAsStream(resource)) {
+			new XMLMapperBuilder(inputStream, configuration, resource, configuration.getSqlFragments()).parse();
+		}
+		return configuration;
+	}
+
+	@ParameterizedTest(name = "{0}")
+	@ValueSource(strings = { "mysql", "maria", "oracle", "postgres", "tibero", "altibase", "cubrid", "goldilocks" })
+	@DisplayName("검색어 없이 연 직원검색 팝업 목록은 방언과 무관하게 100행 상한을 건다")
+	void empLyrPopupListCapsRowsWhenSearchKeywordIsEmpty(String dialect) throws Exception {
+		MappedStatement statement = loadMapper(dialect).getMappedStatement(STATEMENT_ID);
+
+		// ComDefaultVO 의 searchKeyword 기본값이 빈 문자열이다. 팝업을 막 열었을 때와 같다.
+		String sql = statement.getBoundSql(new ComDefaultVO()).getSql();
+
+		assertTrue(ROW_LIMIT.matcher(sql).find(), dialect + " 매퍼에 100행 상한이 없다: " + sql);
+	}
+
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

직원검색 팝업 목록 `MeetingManage.EgovMeetingManageLisEmpLyrPopup`이 검색어 없이 열렸을 때 거는 100행 상한이 postgres 변종에만 없습니다.

```
EgovMeetingManage_SQL_mysql.xml:106        LIMIT 0,  100
EgovMeetingManage_SQL_maria.xml:106        LIMIT 0,  100
EgovMeetingManage_SQL_oracle.xml:109       WHERE RNUM <= 100
EgovMeetingManage_SQL_tibero.xml:109       WHERE RNUM <= 100
EgovMeetingManage_SQL_altibase.xml:109     WHERE RNUM <= 100
EgovMeetingManage_SQL_cubrid.xml:109       WHERE RNUM <= 100
EgovMeetingManage_SQL_goldilocks.xml:109   WHERE RNUM <= 100
EgovMeetingManage_SQL_postgres.xml         없음
```

이 목록을 받는 팝업 화면에는 페이징이 없습니다. `EgovMeetingManageLisEmpLyrPopup.jsp:160`의 `c:forEach`가 `resultList`를 전부 렌더하고 `paginationInfo`도 `ui:pagination`도 쓰지 않습니다. 같은 JSP의 `linkPage`(:36)는 정의만 있고 호출부가 없으며 그 정의마저 `EgovMeetingManageList.do`를 가리킵니다. 컨트롤러(`EgovMeetingManageController.java:129`)도 받은 목록을 자르지 않고 그대로 `resultList`에 담습니다. 매퍼가 자르지 않으면 자르는 곳이 없습니다.

검색어 없이 이 팝업을 열면 postgres로 기동한 인스턴스만 `COMTNEMPLYRINFO` 전체를 응답에 싣습니다.

나머지 일곱 변종과 같은 자리에 같은 조건으로 상한을 넣었습니다.

```xml
<if test="searchKeyword == null or searchKeyword == ''">
 LIMIT 100
</if>
```

`LIMIT 100` 표기는 같은 직원검색 팝업의 부서일정 모듈판인 `EgovDeptSchdulManage_SQL_postgres.xml:92`와 같습니다. `ORDER BY`는 넣지 않았습니다. 일곱 변종도 정렬 없이 자릅니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

매퍼 변종이 렌더하는 SQL에 100행 상한이 있는지 검사하는 테스트를 넣었습니다. 검색어를 비운 파라미터로 여덟 변종을 모두 확인합니다. `XMLMapperBuilder`와 `getBoundSql`만 쓰므로 데이터베이스 연결이 필요하지 않습니다.

수정 전

```
[ERROR] EgovMeetingManageEmpLyrPopupRowLimitTest.empLyrPopupListCapsRowsWhenSearchKeywordIsEmpty:58
        postgres 매퍼에 100행 상한이 없다: SELECT ...
[ERROR] Tests run: 8, Failures: 1, Errors: 0, Skipped: 0
```

수정 후

```
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0
```

`pom.xml`의 surefire 설정이 `<skipTests>true</skipTests>`로 고정돼 있어 이 값을 잠시 해제하고 실행한 결과입니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

브라우저 테스트는 하지 않았습니다. 매퍼가 렌더하는 SQL로 확인했습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

위 테스트 출력으로 대신합니다.
