### PR TITLE
fix(fbk,wed): LOGGER 두 곳이 다른 클래스로 잡혀 로그 카테고리와 레벨 조정이 어긋남

### DIFF
--- a/src/main/java/egovframework/com/uss/ion/fbk/web/EgovFacebookController.java
+++ b/src/main/java/egovframework/com/uss/ion/fbk/web/EgovFacebookController.java
@@ -29,7 +29,6 @@ import org.springframework.web.bind.annotation.RequestMethod;
 
 import egovframework.com.cmm.annotation.IncludedInfo;
 import egovframework.com.cmm.service.EgovProperties;
-import egovframework.com.uss.olp.qim.web.EgovQustnrItemManageController;
 
 /**
  * Facebook을 처리하는 Controller Class 구현
@@ -50,7 +49,7 @@ import egovframework.com.uss.olp.qim.web.EgovQustnrItemManageController;
 @Controller
 public class EgovFacebookController {
 	
-	private static final Logger LOGGER = LoggerFactory.getLogger(EgovQustnrItemManageController.class);	
+	private static final Logger LOGGER = LoggerFactory.getLogger(EgovFacebookController.class);	
 	/**
 	 * facebook 로그인 버튼을 보여준 후, 로그인이 완료되면 연동을 위한 목록을 보여준다.
 	 * @return String - 리턴 Url

--- a/src/main/java/egovframework/com/utl/wed/filter/DefaultFileSaveManager.java
+++ b/src/main/java/egovframework/com/utl/wed/filter/DefaultFileSaveManager.java
@@ -29,8 +29,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import egovframework.com.cmm.service.EgovProperties;
-
 /**
  * Created by guava on 1/20/14.
  *  이미지 저장 처리 클래스
@@ -51,7 +49,7 @@ import egovframework.com.cmm.service.EgovProperties;
  */
 public class DefaultFileSaveManager implements FileSaveManager {
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(EgovProperties.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(DefaultFileSaveManager.class);
 
 	@Override
 	public String saveFile(FileItem fileItem, String imageBaseDir) {

--- a/src/test/java/egovframework/com/cmm/EgovLoggerCategoryTest.java
+++ b/src/test/java/egovframework/com/cmm/EgovLoggerCategoryTest.java
@@ -1,0 +1,42 @@
+package egovframework.com.cmm;
+
+import java.lang.reflect.Field;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.slf4j.Logger;
+
+import egovframework.com.uss.ion.fbk.web.EgovFacebookController;
+import egovframework.com.utl.wed.filter.DefaultFileSaveManager;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * LOGGER 카테고리가 선언 클래스와 일치하는지 확인한다.
+ * log4j2.xml 의 PatternLayout 이 %c(카테고리)를 출력하고 패키지 단위로 로그 레벨을
+ * 조정하므로, 다른 클래스로 바인딩되면 로그 출처 표기와 레벨 조정이 모두 어긋난다.
+ * @author 표준프레임워크센터
+ * @since 2026.09.01
+ * @version 1.0
+ */
+public class EgovLoggerCategoryTest {
+
+	static Stream<Arguments> data() {
+		return Stream.of(
+			Arguments.of(EgovFacebookController.class),
+			Arguments.of(DefaultFileSaveManager.class)
+		);
+	}
+
+	@ParameterizedTest(name = "{index}: {0}")
+	@MethodSource("data")
+	void testLoggerBoundToDeclaringClass(Class<?> clazz) throws Exception {
+		Field field = clazz.getDeclaredField("LOGGER");
+		field.setAccessible(true);
+		Logger logger = (Logger) field.get(null);
+		assertEquals(clazz.getName(), logger.getName());
+	}
+
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

두 클래스의 `LOGGER`가 자기 자신이 아닌 다른 클래스로 잡혀 있습니다.

```java
// EgovFacebookController.java:53
private static final Logger LOGGER = LoggerFactory.getLogger(EgovQustnrItemManageController.class);

// DefaultFileSaveManager.java:54
private static final Logger LOGGER = LoggerFactory.getLogger(EgovProperties.class);
```

`EgovQustnrItemManageController`는 설문항목관리 Controller 이고 `EgovProperties`는 globals.properties 를 읽어들이는 클래스라 두 파일과 관계가 없습니다.

`src/main/resources/log4j2.xml`은 카테고리를 두 가지로 씁니다. PatternLayout `[log4j]%d %5p [%c] %m%n`이 매 줄에 카테고리를 찍고, `Loggers` 블록이 `egovframework`·`org.egovframe`·`org.springframework` 처럼 패키지 이름으로 레벨을 정합니다. 카테고리가 어긋나면 출처 표기와 패키지 단위 레벨 조정이 함께 어긋납니다.

`EgovFacebookController`의 `LOGGER.info`는 `:63` `:75` `:96` `:109` `:121`에 있고, `DefaultFileSaveManager`의 `LOGGER.debug`는 CKEditor 이미지 저장이 `IOException`으로 실패하는 자리(`:71`) 하나입니다.

로거 인자를 선언 클래스로 바꿨습니다. 그 인자가 유일한 사용처였던 import 두 줄도 함께 지웠습니다. 나머지 로거 선언은 모두 자기 클래스를 가리킵니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`src/test/java/egovframework/com/cmm/EgovLoggerCategoryTest.java`를 추가했습니다. 두 클래스의 `LOGGER` 필드를 읽어 `getName()`이 선언 클래스와 같은지 봅니다.

수정 전

```
[ERROR] EgovLoggerCategoryTest.testLoggerBoundToDeclaringClass:39 expected: <egovframework.com.uss.ion.fbk.web.EgovFacebookController> but was: <egovframework.com.uss.olp.qim.web.EgovQustnrItemManageController>
[ERROR] EgovLoggerCategoryTest.testLoggerBoundToDeclaringClass:39 expected: <egovframework.com.utl.wed.filter.DefaultFileSaveManager> but was: <egovframework.com.cmm.service.EgovProperties>
[ERROR] Tests run: 2, Failures: 2, Errors: 0, Skipped: 0
```

수정 후

```
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

`pom.xml`의 surefire 설정이 `skipTests=true`라 기본 빌드에서는 실행되지 않습니다. 확인할 때는 그 값을 잠시 `false`로 두고 돌렸습니다.

수동으로는 저장소의 `log4j2.xml`을 설정으로 주고 두 클래스의 `LOGGER`로 한 줄씩 찍었습니다.

수정 전

```
[log4j]2026-09-01 11:49:43,567  INFO [egovframework.com.uss.olp.qim.web.EgovQustnrItemManageController] ####페이스북 앱 아이디 불러옴 : 1234567890
[log4j]2026-09-01 11:49:43,568 DEBUG [egovframework.com.cmm.service.EgovProperties] File IO exceptionboom
```

수정 후

```
[log4j]2026-09-01 11:49:44,250  INFO [egovframework.com.uss.ion.fbk.web.EgovFacebookController] ####페이스북 앱 아이디 불러옴 : 1234567890
[log4j]2026-09-01 11:49:44,251 DEBUG [egovframework.com.utl.wed.filter.DefaultFileSaveManager] File IO exceptionboom
```

`Loggers`에 `<Logger name="egovframework.com.uss.ion.fbk" level="OFF" />`를 더해 페이스북 로그를 끄려는 설정으로도 돌려 봤습니다.

수정 전 (끄려 한 로그가 그대로 나옵니다)

```
[log4j]2026-09-01 11:49:43,805  INFO [egovframework.com.uss.olp.qim.web.EgovQustnrItemManageController] ####페이스북 앱 아이디 불러옴 : 1234567890
[log4j]2026-09-01 11:49:43,806 DEBUG [egovframework.com.cmm.service.EgovProperties] File IO exceptionboom
```

수정 후

```
[log4j]2026-09-01 11:49:44,458 DEBUG [egovframework.com.utl.wed.filter.DefaultFileSaveManager] File IO exceptionboom
```

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

브라우저 화면과 무관한 변경이라 선택하지 않았습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

위 로그로 대신합니다.
