### PR TITLE
docs(ion): 인터넷서비스안내·사용자부재 Javadoc 의 @param 이름이 메인이미지 VO 로 적힌 4곳 수정

### DIFF
--- a/src/main/java/egovframework/com/uss/ion/isg/service/EgovIntnetSvcGuidanceService.java
+++ b/src/main/java/egovframework/com/uss/ion/isg/service/EgovIntnetSvcGuidanceService.java
@@ -25,7 +25,7 @@ public interface EgovIntnetSvcGuidanceService {
 
 	/**
 	 * 인터넷서비스안내목록 총 개수를 조회한다.
-	 * @param mainImageVO - 인터넷서비스안내 VO
+	 * @param intnetSvcGuidanceVO - 인터넷서비스안내 VO
 	 * @return int
 	 */
 	public int selectIntnetSvcGuidanceListTotCnt(IntnetSvcGuidanceVO intnetSvcGuidanceVO) throws Exception;

--- a/src/main/java/egovframework/com/uss/ion/isg/service/impl/EgovIntnetSvcGuidanceServiceImpl.java
+++ b/src/main/java/egovframework/com/uss/ion/isg/service/impl/EgovIntnetSvcGuidanceServiceImpl.java
@@ -39,7 +39,7 @@ public class EgovIntnetSvcGuidanceServiceImpl extends EgovAbstractServiceImpl im
 
 	/**
 	 * 인터넷서비스안내목록 총 개수를 조회한다.
-	 * @param mainImageVO - 인터넷서비스안내 VO
+	 * @param intnetSvcGuidanceVO - 인터넷서비스안내 VO
 	 * @return int
 	 */
 	@Override

--- a/src/main/java/egovframework/com/uss/ion/isg/service/impl/IntnetSvcGuidanceDAO.java
+++ b/src/main/java/egovframework/com/uss/ion/isg/service/impl/IntnetSvcGuidanceDAO.java
@@ -33,7 +33,7 @@ public class IntnetSvcGuidanceDAO extends EgovComAbstractDAO {
 
     /**
 	 * 인터넷서비스안내목록 총 개수를 조회한다.
-	 * @param mainImageVO - 인터넷서비스안내 VO
+	 * @param intnetSvcGuidanceVO - 인터넷서비스안내 VO
 	 * @return int
 	 */
     public int selectIntnetSvcGuidanceListTotCnt(IntnetSvcGuidanceVO intnetSvcGuidanceVO) {

--- a/src/main/java/egovframework/com/uss/ion/uas/service/impl/UserAbsnceDAO.java
+++ b/src/main/java/egovframework/com/uss/ion/uas/service/impl/UserAbsnceDAO.java
@@ -33,7 +33,7 @@ public class UserAbsnceDAO extends EgovComAbstractDAO {
 
     /**
 	 * 사용자부재목록 총 개수를 조회한다.
-	 * @param mainImageVO - 사용자부재 VO
+	 * @param userAbsnceVO - 사용자부재 VO
 	 * @return int
 	 */
     public int selectUserAbsnceListTotCnt(UserAbsnceVO userAbsnceVO) {


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [X] 기타 Others

## 수정된 소스 내용 Modified source

인터넷서비스안내(`uss/ion/isg`)와 사용자부재(`uss/ion/uas`)의 `select…ListTotCnt` Javadoc 네 줄이 `@param mainImageVO` 를 문서화하고 있습니다. `mainImageVO` 는 메인이미지(`uss/ion/msi`)의 VO 이름이고, 두 모듈에는 그런 이름의 파라미터가 없습니다.

| 파일 | 줄 | 문서화된 이름 | 실제 파라미터 |
|---|---|---|---|
| `uss/ion/isg/service/EgovIntnetSvcGuidanceService.java` | 28 | `mainImageVO` | `intnetSvcGuidanceVO` |
| `uss/ion/isg/service/impl/EgovIntnetSvcGuidanceServiceImpl.java` | 42 | `mainImageVO` | `intnetSvcGuidanceVO` |
| `uss/ion/isg/service/impl/IntnetSvcGuidanceDAO.java` | 36 | `mainImageVO` | `intnetSvcGuidanceVO` |
| `uss/ion/uas/service/impl/UserAbsnceDAO.java` | 36 | `mainImageVO` | `userAbsnceVO` |

고칠 이름은 파일 자신이 정해 줍니다. 네 파일 모두 나머지 `@param` 은 실제 파라미터 이름을 그대로 쓰고 있어 어긋난 줄은 위 한 줄뿐이고, `mainImage` 라는 문자열도 두 모듈에서 이 네 줄 밖에는 나오지 않습니다.

`pom.xml` 의 maven-javadoc-plugin 설정이 `<doclint>none</doclint>` 이라 빌드에서는 드러나지 않습니다.

주석 4줄만 바꾸었고 코드와 시그니처는 그대로입니다(4파일, +4/-4).

### 검증

`javadoc -Xdoclint:all` 로 위 4개 파일을 대상으로 수정 전후를 비교했습니다(JDK 21, `-sourcepath src/main/java` 와 프로젝트 의존성 classpath 지정).

수정 전

```
.../isg/service/EgovIntnetSvcGuidanceService.java:28: error: @param name not found
.../isg/service/impl/EgovIntnetSvcGuidanceServiceImpl.java:42: error: @param name not found
.../isg/service/impl/IntnetSvcGuidanceDAO.java:36: error: @param name not found
.../uas/service/impl/UserAbsnceDAO.java:36: error: @param name not found
4 errors
```

수정 후

```
0 errors
```

이름이 어긋난 `@param` 이 실제 파라미터를 문서화하지 못해 함께 떠 있던 `no @param for intnetSvcGuidanceVO` / `no @param for userAbsnceVO` 경고 3건도 같이 사라집니다.

이 PR 은 `@param` 이름이 다른 모듈의 것으로 적힌 네 줄만 다룹니다. Javadoc 전반을 정리하는 변경이 아니며, 메인이미지 모듈 안에도 접미사가 빠진 `@param mainImage` 두 곳이 있으나 다른 모듈의 이름을 쓴 경우가 아니어서 넣지 않았습니다.

현재 열려 있는 PR 들의 변경 파일과 겹치지 않습니다.

## JUnit 테스트 JUnit tests

- [ ] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

주석만 바뀌어 바이트코드가 그대로이므로 단위 테스트는 해당 없습니다. 위 `javadoc` 실행으로 대신했습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음 (화면 영향 없음)

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

위 `javadoc` 출력으로 대신합니다.
