### PR TITLE
fix(cmm): @Size 에서만 사용자 지정 message 가 버려지고 공용 길이 메시지로 덮어써짐

### DIFF
--- a/src/main/java/egovframework/com/cmm/web/EgovValidationControllerAdvice.java
+++ b/src/main/java/egovframework/com/cmm/web/EgovValidationControllerAdvice.java
@@ -279,6 +279,12 @@ public class EgovValidationControllerAdvice {
 	 */
 	private String resolveSizeConstraintMessage(String defaultMessage, String fieldName, String annotationMessage, ConstraintViolation<Object> violation) {
 
+		// 사용자가 message 속성을 명시한 경우에는 공용 size 메시지로 덮어쓰지 않는다.
+		// null을 반환하면 resolveMessage()가 형제 제약과 동일하게 사용자 메시지를 처리한다.
+		if (annotationMessage != null) {
+			return null;
+		}
+
 		Integer max = getAnnotationValue(violation, "max");
 		Integer min = getAnnotationValue(violation, "min");
 		int valueLength = getValueLength(violation.getInvalidValue());

--- a/src/test/java/egovframework/com/cmm/web/EgovValidationControllerAdviceSizeMessageTest.java
+++ b/src/test/java/egovframework/com/cmm/web/EgovValidationControllerAdviceSizeMessageTest.java
@@ -1,0 +1,121 @@
+package egovframework.com.cmm.web;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.lang.reflect.Field;
+import java.util.Locale;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.support.ReloadableResourceBundleMessageSource;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.WebDataBinder;
+
+import egovframework.com.cmm.EgovMessageSource;
+import egovframework.com.uss.ion.noi.service.NotificationVO;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/**
+ * EgovValidationControllerAdvice가 사용자 지정 message를 어노테이션 종류와 무관하게 존중하는지 확인한다.
+ *
+ * resolveMessage()는 annotationMessage가 있으면 replaceMessageKeys()로 해석해 돌려주지만,
+ * @Size만 그 판단 앞에서 resolveSizeConstraintMessage()로 새어나가 공용 validation.size.min/max
+ * 메시지로 덮어쓴다. 아래 두 테스트는 동일한 message 속성을 @Size와 @NotBlank에 각각 붙여
+ * 그 비대칭을 드러낸다.
+ */
+class EgovValidationControllerAdviceSizeMessageTest {
+
+	private static final String CUSTOM_KEY = "ussIonNoi.notificationVO.bhNtfcIntrvlRequired";
+
+	private Locale savedLocale;
+	private ReloadableResourceBundleMessageSource bundle;
+	private EgovValidationControllerAdvice advice;
+
+	@BeforeEach
+	void setUp() throws Exception {
+		savedLocale = Locale.getDefault();
+		Locale.setDefault(Locale.KOREA);
+
+		bundle = new ReloadableResourceBundleMessageSource();
+		bundle.setBasenames("classpath:/egovframework/message/com/uss/ion/noi/message",
+				"classpath:/egovframework/message/com/message-validation");
+
+		EgovMessageSource egovMessageSource = new EgovMessageSource();
+		egovMessageSource.setReloadableResourceBundleMessageSource(bundle);
+
+		advice = new EgovValidationControllerAdvice();
+		Field field = EgovValidationControllerAdvice.class.getDeclaredField("egovMessageSource");
+		field.setAccessible(true);
+		field.set(advice, egovMessageSource);
+	}
+
+	@AfterEach
+	void tearDown() {
+		Locale.setDefault(savedLocale);
+	}
+
+	/** 형제 경로: @Size가 아닌 제약은 사용자 지정 message를 그대로 돌려준다. */
+	@Test
+	void nonSizeConstraint_keepsUserSuppliedMessage() {
+		String actual = validateAndGetMessage(new Fixture(), "fixture", "blank");
+		assertEquals(bundle.getMessage(CUSTOM_KEY, null, Locale.KOREA), actual);
+	}
+
+	/** @Size도 같은 message 속성을 같은 방식으로 존중해야 한다. */
+	@Test
+	void sizeConstraint_keepsUserSuppliedMessage() {
+		String actual = validateAndGetMessage(new Fixture(), "fixture", "sized");
+		assertEquals(bundle.getMessage(CUSTOM_KEY, null, Locale.KOREA), actual);
+	}
+
+	/** message 속성이 없는 @Size는 종전대로 공용 validation.size.max 메시지를 쓴다. */
+	@Test
+	void sizeConstraintWithoutMessage_stillUsesCommonSizeMessage() {
+		String actual = validateAndGetMessage(new Fixture(), "fixture", "capped");
+		assertEquals(bundle.getMessage("validation.size.max", new Object[] { 2 }, Locale.KOREA), actual);
+	}
+
+	/** 저장소에 실재하는 사례: NotificationVO.bhNtfcIntrvl. */
+	@Test
+	void notificationVO_bhNtfcIntrvl_keepsUserSuppliedMessage() {
+		String actual = validateAndGetMessage(new NotificationVO(), "notificationVO", "bhNtfcIntrvl");
+		assertEquals(bundle.getMessage(CUSTOM_KEY, null, Locale.KOREA), actual);
+	}
+
+	private String validateAndGetMessage(Object target, String objectName, String fieldName) {
+		WebDataBinder binder = new WebDataBinder(target, objectName);
+		advice.initBinder(binder);
+		binder.validate();
+
+		BindingResult result = binder.getBindingResult();
+		assertNotNull(result.getFieldError(fieldName), fieldName + "에 검증 오류가 등록되지 않았다");
+		return result.getFieldError(fieldName).getDefaultMessage();
+	}
+
+	public static class Fixture {
+
+		@Size(min = 1, message = "{" + CUSTOM_KEY + "}")
+		private String[] sized = new String[0];
+
+		@NotBlank(message = "{" + CUSTOM_KEY + "}")
+		private String blank = "";
+
+		@Size(max = 2)
+		private String capped = "abc";
+
+		public String[] getSized() {
+			return sized.clone();
+		}
+
+		public String getBlank() {
+			return blank;
+		}
+
+		public String getCapped() {
+			return capped;
+		}
+	}
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

사전알림간격을 고르지 않고 정보알림을 등록하면 1분·3분·5분·10분·30분 체크박스 묶음 밑에 `1자 이상 입력해야 합니다.` 가 붙습니다. `NotificationVO` 는 이 항목에 쓸 문구로 `사전알림간격 지정이 필요합니다.`(`message_ko.properties:44`)를 직접 지정해 두었습니다.

```java
// NotificationVO.java:61
@Size(min = 1, message = "{ussIonNoi.notificationVO.bhNtfcIntrvlRequired}")
private String[] bhNtfcIntrvl = new String[0];
```

메시지를 정하는 `EgovValidationControllerAdvice.resolveMessage` 는 `@Size` 만 나머지 제약보다 먼저 빼내 처리합니다.

```java
// EgovValidationControllerAdvice.java:201
// @Size 어노테이션은 별도 처리
if (annotationType != null && "Size".equals(annotationType.getSimpleName())) {
	String sizeMessage = resolveSizeConstraintMessage(defaultMessage, fieldName, annotationMessage, violation);
	if (sizeMessage != null) {
		return sizeMessage;
	}
}

// 사용자지정 메시지가 없으면
if ( annotationMessage == null ) {
```

`resolveSizeConstraintMessage` 는 `annotationMessage` 를 인자로 받지만 본문에서 한 번도 읽지 않습니다. 그리고 그 안의 `return` 세 개가 모두 값을 돌려줍니다. `validation.size.min`·`validation.size.max` 는 `getValidationMessage` 가 예외를 만나도 기본값을 돌려주고, 마지막 `return defaultMessage` 의 값은 `resolveMessage` 진입부의 `null` 검사를 통과한 것입니다. 그래서 `sizeMessage != null` 가드가 항상 참이 되어 `@Size` 는 그 아래 `annotationMessage == null` 분기까지 내려가지 못합니다.

`@Size` 가 아닌 제약은 그 분기를 거쳐 사용자 지정 메시지를 그대로 해석해 돌려줍니다.

```java
// EgovValidationControllerAdvice.java:269
return replaceMessageKeys(annotationMessage);
```

같은 클래스의 주석이 이 값의 의미를 밝혀 두었습니다.

```java
// EgovValidationControllerAdvice.java:101
 * 사용자가 명시적으로 message 속성을 지정한 경우에만 값을 반환하고,
 * 그렇지 않으면 null을 반환합니다.
```

`annotationMessage` 가 있다는 것은 개발자가 그 자리에 쓸 문구를 직접 적어 넣었다는 뜻입니다. `@Size` 도 그 경우에는 나머지 제약과 같은 경로로 보냈습니다.

TO-BE

```java
private String resolveSizeConstraintMessage(String defaultMessage, String fieldName, String annotationMessage, ConstraintViolation<Object> violation) {

	// 사용자가 message 속성을 명시한 경우에는 공용 size 메시지로 덮어쓰지 않는다.
	// null을 반환하면 resolveMessage()가 형제 제약과 동일하게 사용자 메시지를 처리한다.
	if (annotationMessage != null) {
		return null;
	}

	Integer max = getAnnotationValue(violation, "max");
```

### 영향 범위

`message` 를 지정하지 않은 `@Size` 는 종전대로 `validation.size.min`·`validation.size.max` 를 씁니다. 현재 저장소에서 `message` 를 지정한 `@Size` 는 `NotificationVO.bhNtfcIntrvl` 하나뿐이라 화면에서 문구가 달라지는 곳도 여기뿐입니다. 이 오류는 등록화면(`EgovNotificationRegist.jsp:164`)과 수정화면(`EgovNotificationUpdt.jsp:157`)이 각각 그립니다.

호출부와 메서드 시그니처는 변경하지 않았습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

`src/test/java/egovframework/com/cmm/web/EgovValidationControllerAdviceSizeMessageTest.java` 를 추가했습니다. 같은 `message` 속성을 `@Size` 와 `@NotBlank` 에 각각 붙인 픽스처와 `NotificationVO` 실물을 `WebDataBinder` 로 검증하고 필드 오류 메시지를 대조합니다.

수정 전

```
[ERROR] Tests run: 4, Failures: 2, Errors: 0, Skipped: 0
[ERROR]   EgovValidationControllerAdviceSizeMessageTest.notificationVO_bhNtfcIntrvl_keepsUserSuppliedMessage
          expected: <사전알림간격 지정이 필요합니다.> but was: <1자 이상 입력해야 합니다.>
[ERROR]   EgovValidationControllerAdviceSizeMessageTest.sizeConstraint_keepsUserSuppliedMessage
          expected: <사전알림간격 지정이 필요합니다.> but was: <1자 이상 입력해야 합니다.>
```

같은 `message` 를 붙인 `@NotBlank` 케이스와 `message` 가 없는 `@Size` 케이스는 수정 전에도 통과합니다.

수정 후

```
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

`pom.xml` 의 surefire 설정이 `skipTests=true` 라 기본 빌드에서는 실행되지 않습니다. 확인할 때는 그 값을 잠시 `false` 로 두고 돌렸습니다. 이 테스트는 검증기가 EL 구현을 요구해 `test` 프로파일도 함께 필요합니다.

```
mvn -Ptest -DskipTests=false -Dtest=EgovValidationControllerAdviceSizeMessageTest test
```

프로파일 없이 돌리면 `HV000183 Unable to initialize 'jakarta.el.ExpressionFactory'` 로 끊깁니다.
