### PR TITLE
docs(sym,uss): 접근자 Javadoc 여덟 줄이 자기 프로퍼티가 아닌 이름을 문서화하고 있음

### DIFF
--- a/src/main/java/egovframework/com/sym/log/slg/service/SysHistory.java
+++ b/src/main/java/egovframework/com/sym/log/slg/service/SysHistory.java
@@ -69,13 +69,13 @@ public class SysHistory implements Serializable {
 	 */
 	private String atchFileId = "";
 	/**
-	 * @return the creatDt
+	 * @return the histId
 	 */
 	public String getHistId() {
 		return histId;
 	}
 	/**
-	 * @param creatDt the creatDt to set
+	 * @param histId the histId to set
 	 */
 	public void setHistId(String histId) {
 		this.histId = histId;

--- a/src/main/java/egovframework/com/sym/sym/bak/service/BackupOpert.java
+++ b/src/main/java/egovframework/com/sym/sym/bak/service/BackupOpert.java
@@ -160,7 +160,7 @@ public class BackupOpert extends ComDefaultVO implements Serializable {
 		return executSchdulDe;
 	}
 	/**
-	 * @return the executSchdulOur
+	 * @return the executSchdulHour
 	 */
 	public String getExecutSchdulHour() {
 		return executSchdulHour;
@@ -283,7 +283,7 @@ public class BackupOpert extends ComDefaultVO implements Serializable {
 		this.executSchdulDe = executSchdulDe;
 	}
 	/**
-	 * @param executSchdulOur the executSchdulOur to set
+	 * @param executSchdulHour the executSchdulHour to set
 	 */
 	public void setExecutSchdulHour(String executSchdulHour) {
 		this.executSchdulHour = executSchdulHour;

--- a/src/main/java/egovframework/com/sym/sym/bak/service/BackupScheduler.java
+++ b/src/main/java/egovframework/com/sym/sym/bak/service/BackupScheduler.java
@@ -214,7 +214,7 @@ public class BackupScheduler {
 
 	/**
 	 * 백업작업서비스 리턴
-	 * @return the egovBackupSchdulService
+	 * @return the egovBackupOpertService
 	 */
 	public EgovBackupOpertService getEgovBackupOpertService() {
 		return egovBackupOpertService;

--- a/src/main/java/egovframework/com/uss/ion/evt/service/EventManage.java
+++ b/src/main/java/egovframework/com/uss/ion/evt/service/EventManage.java
@@ -327,14 +327,14 @@ public class EventManage extends ComDefaultVO {
 	}
 
 	/**
-	 * @return the garden
+	 * @return the psncpa
 	 */
 	public int getPsncpa() {
 		return psncpa;
 	}
 
 	/**
-	 * @param garden the garden to set
+	 * @param psncpa the psncpa to set
 	 */
 	public void setPsncpa(int psncpa) {
 		this.psncpa = psncpa;

--- a/src/main/java/egovframework/com/uss/ion/yrc/service/IndvdlYrycManage.java
+++ b/src/main/java/egovframework/com/uss/ion/yrc/service/IndvdlYrycManage.java
@@ -126,7 +126,7 @@ public class IndvdlYrycManage extends ComDefaultVO {
 	}
 
 	/**
-	 * @param mberId the mberNm to set
+	 * @param mberNm the mberNm to set
 	 */
 	public void setMberNm(String mberNm) {
 		this.mberNm = mberNm;


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [X] 기타 Others

## 수정된 소스 내용 Modified source

접근자 Javadoc 여덟 줄이 그 접근자가 다루는 프로퍼티가 아닌 이름을 문서화하고 있습니다.

| 파일 | 줄 | 적힌 이름 | 접근자의 프로퍼티 |
|---|---|---|---|
| `sym/log/slg/service/SysHistory.java` | 72, 78 | `creatDt` | `histId` |
| `sym/sym/bak/service/BackupOpert.java` | 163, 286 | `executSchdulOur` | `executSchdulHour` |
| `sym/sym/bak/service/BackupScheduler.java` | 217 | `egovBackupSchdulService` | `egovBackupOpertService` |
| `uss/ion/evt/service/EventManage.java` | 330, 337 | `garden` | `psncpa` |
| `uss/ion/yrc/service/IndvdlYrycManage.java` | 129 | `mberId` | `mberNm` |

고칠 이름은 파일이 스스로 정해 줍니다. 다섯 파일 모두 나머지 접근자는 `@return the <프로퍼티>` / `@param <프로퍼티> the <프로퍼티> to set` 형식을 지키고 있습니다.

- `BackupScheduler` 는 같은 필드의 세터가 여덟 줄 아래에서 이미 `@param egovBackupOpertService` 라고 적고 있습니다(:225). `EgovBackupSchdulService` 라는 타입은 이 저장소에 없습니다.
- `BackupOpert` 는 앞뒤 줄이 `executSchdulDe`(:157)와 `executSchdulMnt`(:169)로 실제 프로퍼티를 적고 있고 가운데 :163 만 `executSchdulOur` 입니다.
- `IndvdlYrycManage.java:129` 는 한 줄 안에서 갈립니다. 설명은 `the mberNm to set` 인데 이름 자리만 `mberId` 입니다.

적힌 이름 셋은 저장소 안에서 이 주석 줄에만 나옵니다.

```
$ grep -rn 'garden\|executSchdulOur\|egovBackupSchdulService' src/main/java
src/main/java/egovframework/com/sym/sym/bak/service/BackupOpert.java:163:	 * @return the executSchdulOur
src/main/java/egovframework/com/sym/sym/bak/service/BackupOpert.java:286:	 * @param executSchdulOur the executSchdulOur to set
src/main/java/egovframework/com/sym/sym/bak/service/BackupScheduler.java:217:	 * @return the egovBackupSchdulService
src/main/java/egovframework/com/uss/ion/evt/service/EventManage.java:330:	 * @return the garden
src/main/java/egovframework/com/uss/ion/evt/service/EventManage.java:337:	 * @param garden the garden to set
```

`creatDt` 도 `SysHistory` 의 필드가 아니라 같은 로그 모듈 `sym/log/clg` 의 `LoginLog` 가 가진 이름입니다.

주석 여덟 줄만 바꾸었고 코드와 시그니처는 그대로입니다(5파일, +8/-8).

### 검증

`pom.xml` 의 maven-javadoc-plugin 이 `<doclint>none</doclint>` 이라 빌드에서는 드러나지 않습니다. 위 다섯 파일만 지정해 `javadoc -Xdoclint:reference` 로 수정 전후를 비교했습니다(JDK 21, `-sourcepath src/main/java` 와 프로젝트 의존성 classpath 지정).

수정 전

```
.../sym/sym/bak/service/BackupOpert.java:286: error: @param name not found
.../uss/ion/evt/service/EventManage.java:337: error: @param name not found
.../uss/ion/yrc/service/IndvdlYrycManage.java:129: error: @param name not found
.../sym/log/slg/service/SysHistory.java:78: error: @param name not found
4 errors
```

수정 후

```
(출력 없음, exit 0)
```

doclint 가 대조하는 것은 `@param` 이름뿐이라 `@return` 네 줄(:72, :163, :217, :330)은 여기 잡히지 않습니다. 그쪽 근거는 위 `grep` 결과입니다.

이 PR 은 이름이 어긋난 여덟 줄만 다룹니다. 저장소 Javadoc 전반을 손보는 변경이 아니고, 손댄 다섯 파일 안에서만 위 오류가 사라집니다.

오늘 올린 #1269 와 성격이 같은 수정이며 파일은 겹치지 않습니다. 현재 열려 있는 PR 들의 변경 파일과도 겹치지 않습니다.

## JUnit 테스트 JUnit tests

- [ ] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

주석만 바뀌어 바이트코드가 그대로이므로 단위 테스트는 해당 없습니다. 위 `javadoc` 실행으로 대신했습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음 (화면 영향 없음)

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

위 `javadoc` 출력으로 대신합니다.
