### PR TITLE
docs(cmm,utl): 표준 헤더 @Class Name 세 곳이 저장소에 없는 파일명을 가리킴

### DIFF
--- a/src/main/java/egovframework/com/cmm/service/impl/FileManageDAO.java
+++ b/src/main/java/egovframework/com/cmm/service/impl/FileManageDAO.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Repository;
 import egovframework.com.cmm.service.FileVO;
 
 /**
- * @Class Name : EgovFileMngDAO.java
+ * @Class Name : FileManageDAO.java
  * @Description : 파일정보 관리를 위한 데이터 처리 클래스
  * @Modification Information
  *

--- a/src/main/java/egovframework/com/sym/log/slg/service/SysHistory.java
+++ b/src/main/java/egovframework/com/sym/log/slg/service/SysHistory.java
@@ -69,13 +69,13 @@ public class SysHistory implements Serializable {
 	 */
 	private String atchFileId = "";
 	/**
-	 * @return the creatDt
+	 * @return the histId
 	 */
 	public String getHistId() {
 		return histId;
 	}
 	/**
-	 * @param creatDt the creatDt to set
+	 * @param histId the histId to set
 	 */
 	public void setHistId(String histId) {
 		this.histId = histId;

--- a/src/main/java/egovframework/com/sym/sym/bak/service/BackupOpert.java
+++ b/src/main/java/egovframework/com/sym/sym/bak/service/BackupOpert.java
@@ -160,7 +160,7 @@ public class BackupOpert extends ComDefaultVO implements Serializable {
 		return executSchdulDe;
 	}
 	/**
-	 * @return the executSchdulOur
+	 * @return the executSchdulHour
 	 */
 	public String getExecutSchdulHour() {
 		return executSchdulHour;
@@ -283,7 +283,7 @@ public class BackupOpert extends ComDefaultVO implements Serializable {
 		this.executSchdulDe = executSchdulDe;
 	}
 	/**
-	 * @param executSchdulOur the executSchdulOur to set
+	 * @param executSchdulHour the executSchdulHour to set
 	 */
 	public void setExecutSchdulHour(String executSchdulHour) {
 		this.executSchdulHour = executSchdulHour;

--- a/src/main/java/egovframework/com/sym/sym/bak/service/BackupScheduler.java
+++ b/src/main/java/egovframework/com/sym/sym/bak/service/BackupScheduler.java
@@ -214,7 +214,7 @@ public class BackupScheduler {
 
 	/**
 	 * 백업작업서비스 리턴
-	 * @return the egovBackupSchdulService
+	 * @return the egovBackupOpertService
 	 */
 	public EgovBackupOpertService getEgovBackupOpertService() {
 		return egovBackupOpertService;

--- a/src/main/java/egovframework/com/uss/ion/evt/service/EventManage.java
+++ b/src/main/java/egovframework/com/uss/ion/evt/service/EventManage.java
@@ -327,14 +327,14 @@ public class EventManage extends ComDefaultVO {
 	}
 
 	/**
-	 * @return the garden
+	 * @return the psncpa
 	 */
 	public int getPsncpa() {
 		return psncpa;
 	}
 
 	/**
-	 * @param garden the garden to set
+	 * @param psncpa the psncpa to set
 	 */
 	public void setPsncpa(int psncpa) {
 		this.psncpa = psncpa;

--- a/src/main/java/egovframework/com/uss/ion/yrc/service/IndvdlYrycManage.java
+++ b/src/main/java/egovframework/com/uss/ion/yrc/service/IndvdlYrycManage.java
@@ -126,7 +126,7 @@ public class IndvdlYrycManage extends ComDefaultVO {
 	}
 
 	/**
-	 * @param mberId the mberNm to set
+	 * @param mberNm the mberNm to set
 	 */
 	public void setMberNm(String mberNm) {
 		this.mberNm = mberNm;

--- a/src/main/java/egovframework/com/utl/cas/service/EgovSessionCookieUtil.java
+++ b/src/main/java/egovframework/com/utl/cas/service/EgovSessionCookieUtil.java
@@ -1,5 +1,5 @@
 /**
- * @Class Name  : EgovSessionUtil.java
+ * @Class Name  : EgovSessionCookieUtil.java
  * @Description : 세션 처리 관련 유틸리티
  * @Modification Information
  *

--- a/src/main/java/egovframework/com/utl/sys/trm/service/TrsmrcvMntrngChecker.java
+++ b/src/main/java/egovframework/com/utl/sys/trm/service/TrsmrcvMntrngChecker.java
@@ -1,7 +1,7 @@
 package egovframework.com.utl.sys.trm.service;
 
 /**
- * @Class Name : EgovTrsmrcvMntrngChecker.java
+ * @Class Name : TrsmrcvMntrngChecker.java
  * @Description : 송수신모니터링을 위한 Check interface
  * @Modification Information
  *


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [X] 기타 Others

## 수정된 소스 내용 Modified source

표준 헤더의 `@Class Name` 세 곳이 실제 파일명과 다릅니다. 적힌 이름은 셋 다 저장소에 없는 파일입니다.

| 파일 | 줄 | 적힌 이름 |
|---|---|---|
| `cmm/service/impl/FileManageDAO.java` | 11 | `EgovFileMngDAO.java` |
| `utl/cas/service/EgovSessionCookieUtil.java` | 2 | `EgovSessionUtil.java` |
| `utl/sys/trm/service/TrsmrcvMntrngChecker.java` | 4 | `EgovTrsmrcvMntrngChecker.java` |

`src/main/java` 에서 이 헤더를 가진 파일은 69개이고 그중 65개가 자기 파일명을 적습니다. 세 이름은 파일명으로도 소스 심볼로도 없습니다. 각각 이 헤더 한 줄 말고는 저장소 어디에도 나오지 않습니다.

```
$ grep -rn 'EgovFileMngDAO\|EgovSessionUtil\|EgovTrsmrcvMntrngChecker' src/main/java
src/main/java/egovframework/com/cmm/service/impl/FileManageDAO.java:11: * @Class Name : EgovFileMngDAO.java
src/main/java/egovframework/com/utl/cas/service/EgovSessionCookieUtil.java:2: * @Class Name  : EgovSessionUtil.java
src/main/java/egovframework/com/utl/sys/trm/service/TrsmrcvMntrngChecker.java:4: * @Class Name : EgovTrsmrcvMntrngChecker.java
```

반대 방향, 그러니까 클래스명을 헤더에 맞추는 쪽은 택하지 않았습니다. `FileManageDAO` 만 해도 `@Repository("FileManageDAO")` 로 등록된 빈 이름과 매퍼 네임스페이스 `<mapper namespace="FileManageDAO">`, `FileManageDAOConfigurationTest` 가 현재 이름을 쓰고 있어 개명은 배선까지 번집니다. 헤더 한 줄을 실제 파일명에 맞추는 데까지만 했습니다.

개정이력 행은 붙이지 않았습니다. 표기를 실제 파일명으로 되돌린 것이라 이력에 남길 변경으로 보지 않았는데, 붙이는 편이 낫다면 알려주십시오.

같은 불일치가 `cop/adb/service/impl/AddressBookDAO.java:15`(`AdressBookDAO.java`)에 하나 더 있습니다. 열린 PR #1263 이 같은 파일을 수정 중이라 이번에는 넣지 않았습니다.

JSP 쪽도 세어 봤습니다. 헤더 578개 중 74개가 다른 파일명을, 122개가 같은 이름에 `.java` 확장자를 적고 있습니다. 뒤쪽은 성격이 달라 이 PR 은 `src/main/java` 만 다뤘습니다.

주석 세 줄만 바꾸었고 코드는 그대로입니다(3파일, +3/-3).

### 검증

- 헤더 69개를 전부 파일명과 대조했습니다. 수정 전 불일치는 4건이고 수정 후 남는 것은 위 `AddressBookDAO.java` 한 건입니다.
- 변경 줄 세 개가 모두 주석 안임을 확인했습니다.
- 현재 열려 있는 PR 들의 변경 파일과 겹치지 않습니다.

## JUnit 테스트 JUnit tests

- [ ] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

주석만 바뀌어 바이트코드가 그대로이므로 단위 테스트는 해당 없습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음 (화면 영향 없음)

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

주석 변경이라 화면에 나타나는 변화가 없습니다.
