### PR TITLE
fix(ssi/syi): 연계관리 삭제가 감사항목 LAST_UPDUSR_ID 를 요청값으로 기록

### DIFF
--- a/src/main/java/egovframework/com/ssi/syi/iis/web/EgovCntcInsttController.java
+++ b/src/main/java/egovframework/com/ssi/syi/iis/web/EgovCntcInsttController.java
@@ -105,6 +105,12 @@ public class EgovCntcInsttController {
 	 */
 	@PostMapping("/ssi/syi/iis/removeCntcInstt.do")
 	public String deleteCntcInstt(CntcInstt cntcInstt, ModelMap model) throws Exception {
+
+		// 로그인VO에서 사용자 정보 가져오기
+		LoginVO loginVO = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();
+		String uniqId = loginVO == null ? "" : EgovStringUtil.isNullToString(loginVO.getUniqId());
+
+		cntcInstt.setLastUpdusrId(uniqId);
 		cntcInsttService.deleteCntcInstt(cntcInstt);
 		return "forward:/ssi/syi/iis/getCntcInsttList.do";
 	}
@@ -120,6 +126,12 @@ public class EgovCntcInsttController {
 	 */
 	@PostMapping("/ssi/syi/iis/removeCntcSystem.do")
 	public String deleteCntcSystem(CntcSystem cntcSystem, ModelMap model) throws Exception {
+
+		// 로그인VO에서 사용자 정보 가져오기
+		LoginVO loginVO = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();
+		String uniqId = loginVO == null ? "" : EgovStringUtil.isNullToString(loginVO.getUniqId());
+
+		cntcSystem.setLastUpdusrId(uniqId);
 		cntcInsttService.deleteCntcSystem(cntcSystem);
 		return "forward:/ssi/syi/iis/getCntcInsttList.do";
 	}
@@ -135,6 +147,12 @@ public class EgovCntcInsttController {
 	 */
 	@PostMapping("/ssi/syi/iis/removeCntcService.do")
 	public String deleteCntcService(CntcService cntcService, ModelMap model) throws Exception {
+
+		// 로그인VO에서 사용자 정보 가져오기
+		LoginVO loginVO = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();
+		String uniqId = loginVO == null ? "" : EgovStringUtil.isNullToString(loginVO.getUniqId());
+
+		cntcService.setLastUpdusrId(uniqId);
 		cntcInsttService.deleteCntcService(cntcService);
 		return "forward:/ssi/syi/iis/getCntcInsttList.do";
 	}

--- a/src/main/java/egovframework/com/ssi/syi/ims/web/EgovCntcMessageController.java
+++ b/src/main/java/egovframework/com/ssi/syi/ims/web/EgovCntcMessageController.java
@@ -92,6 +92,12 @@ public class EgovCntcMessageController {
 	 */
 	@PostMapping("/ssi/syi/ims/removeCntcMessage.do")
 	public String deleteCntcMessage(CntcMessage cntcMessage, ModelMap model) throws Exception {
+
+		// 로그인VO에서 사용자 정보 가져오기
+		LoginVO loginVO = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();
+		String uniqId = loginVO == null ? "" : EgovStringUtil.isNullToString(loginVO.getUniqId());
+		cntcMessage.setLastUpdusrId(uniqId);
+
 		cntcMessageService.deleteCntcMessage(cntcMessage);
 		return "forward:/ssi/syi/ims/getCntcMessageList.do";
 	}
@@ -107,6 +113,12 @@ public class EgovCntcMessageController {
 	 */
 	@PostMapping("/ssi/syi/ims/removeCntcMessageItem.do")
 	public String deleteCntcMessageItem(CntcMessageItem cntcMessageItem, ModelMap model) throws Exception {
+
+		// 로그인VO에서 사용자 정보 가져오기
+		LoginVO loginVO = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();
+		String uniqId = loginVO == null ? "" : EgovStringUtil.isNullToString(loginVO.getUniqId());
+		cntcMessageItem.setLastUpdusrId(uniqId);
+
 		cntcMessageService.deleteCntcMessageItem(cntcMessageItem);
 		return "forward:/ssi/syi/ims/getCntcMessageList.do";
 	}

--- a/src/test/java/egovframework/com/ssi/syi/iis/web/EgovCntcInsttControllerDeleteAuditTest.java
+++ b/src/test/java/egovframework/com/ssi/syi/iis/web/EgovCntcInsttControllerDeleteAuditTest.java
@@ -1,0 +1,182 @@
+package egovframework.com.ssi.syi.iis.web;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Proxy;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.ui.ModelMap;
+import org.springframework.web.bind.ServletRequestDataBinder;
+
+import egovframework.com.cmm.LoginVO;
+import egovframework.com.cmm.service.EgovUserDetailsService;
+import egovframework.com.cmm.util.EgovUserDetailsHelper;
+import egovframework.com.ssi.syi.iis.service.CntcInstt;
+import egovframework.com.ssi.syi.iis.service.CntcService;
+import egovframework.com.ssi.syi.iis.service.CntcSystem;
+import egovframework.com.ssi.syi.iis.service.EgovCntcInsttService;
+import jakarta.servlet.ServletRequest;
+
+/**
+ * 연계기관/연계시스템/연계서비스 삭제 핸들러가 감사 컬럼 LAST_UPDUSR_ID 에
+ * 무엇을 넘기는지 확인한다.
+ *
+ * 같은 컨트롤러의 insert/update 6개 핸들러는 예외 없이
+ * EgovUserDetailsHelper.getAuthenticatedUser() 의 uniqId 로 덮어쓴다.
+ */
+class EgovCntcInsttControllerDeleteAuditTest {
+
+	/** 로그인 세션이 가진 식별자 */
+	private static final String SESSION_UNIQ_ID = "USRCNFRM_00000000001";
+
+	private EgovCntcInsttController controller;
+	private final AtomicReference<Object> deleted = new AtomicReference<>();
+
+	@BeforeEach
+	void setUp() throws Exception {
+		LoginVO loginVO = new LoginVO();
+		loginVO.setUniqId(SESSION_UNIQ_ID);
+		new EgovUserDetailsHelper().setEgovUserDetailsService(new EgovUserDetailsService() {
+			public Object getAuthenticatedUser() {
+				return loginVO;
+			}
+
+			public java.util.List<String> getAuthorities() {
+				return Collections.singletonList("ROLE_ADMIN");
+			}
+
+			public Boolean isAuthenticated() {
+				return Boolean.TRUE;
+			}
+		});
+
+		EgovCntcInsttService service = (EgovCntcInsttService) Proxy.newProxyInstance(
+				EgovCntcInsttService.class.getClassLoader(),
+				new Class<?>[] { EgovCntcInsttService.class },
+				(proxy, method, args) -> {
+					if (method.getName().startsWith("delete")) {
+						deleted.set(args[0]);
+					}
+					return null;
+				});
+
+		controller = new EgovCntcInsttController();
+		Field f = EgovCntcInsttController.class.getDeclaredField("cntcInsttService");
+		f.setAccessible(true);
+		f.set(controller, service);
+	}
+
+	/** 커맨드 객체에 실제 요청 파라미터를 Spring 바인더로 바인딩한다. */
+	private <T> T bind(T target, Map<String, String> params) {
+		ServletRequestDataBinder binder = new ServletRequestDataBinder(target);
+		binder.bind(stubRequest(params));
+		return target;
+	}
+
+	private ServletRequest stubRequest(Map<String, String> params) {
+		return (ServletRequest) Proxy.newProxyInstance(
+				ServletRequest.class.getClassLoader(),
+				new Class<?>[] { ServletRequest.class },
+				(proxy, method, args) -> {
+					switch (method.getName()) {
+					case "getParameterNames":
+						return Collections.enumeration(params.keySet());
+					case "getParameterValues":
+						String v = params.get(args[0]);
+						return v == null ? null : new String[] { v };
+					case "getParameter":
+						return params.get(args[0]);
+					case "getParameterMap":
+						Map<String, String[]> m = new LinkedHashMap<>();
+						params.forEach((k, val) -> m.put(k, new String[] { val }));
+						return m;
+					case "getAttribute":
+						return null;
+					default:
+						return null;
+					}
+				});
+	}
+
+	private static Map<String, String> params(String... kv) {
+		Map<String, String> m = new LinkedHashMap<>();
+		for (int i = 0; i < kv.length; i += 2) {
+			m.put(kv[i], kv[i + 1]);
+		}
+		return m;
+	}
+
+	// ---------------------------------------------------------------
+	// EgovCntcInsttDetail.jsp 의 삭제 버튼이 제출하는 Form(143행)이
+	// 실제로 담고 있는 항목만 보낸 경우 — lastUpdusrId 항목은 없다
+	// ---------------------------------------------------------------
+
+	@Test
+	@DisplayName("연계기관 삭제 - 삭제 폼 그대로 보냈을 때 LAST_UPDUSR_ID")
+	void deleteCntcInstt_formPost() throws Exception {
+		CntcInstt vo = bind(new CntcInstt(), params("insttId", "INSTT_0001", "sysId", "", "svcId", ""));
+		controller.deleteCntcInstt(vo, new ModelMap());
+		assertEquals(SESSION_UNIQ_ID, ((CntcInstt) deleted.get()).getLastUpdusrId(),
+				"LAST_UPDUSR_ID 로 저장되는 값");
+	}
+
+	@Test
+	@DisplayName("연계시스템 삭제 - 삭제 폼 그대로 보냈을 때 LAST_UPDUSR_ID")
+	void deleteCntcSystem_formPost() throws Exception {
+		CntcSystem vo = bind(new CntcSystem(), params("insttId", "INSTT_0001", "sysId", "SYS_0001"));
+		controller.deleteCntcSystem(vo, new ModelMap());
+		assertEquals(SESSION_UNIQ_ID, ((CntcSystem) deleted.get()).getLastUpdusrId(),
+				"LAST_UPDUSR_ID 로 저장되는 값");
+	}
+
+	@Test
+	@DisplayName("연계서비스 삭제 - 삭제 폼 그대로 보냈을 때 LAST_UPDUSR_ID")
+	void deleteCntcService_formPost() throws Exception {
+		CntcService vo = bind(new CntcService(),
+				params("insttId", "INSTT_0001", "sysId", "SYS_0001", "svcId", "SVC_0001"));
+		controller.deleteCntcService(vo, new ModelMap());
+		assertEquals(SESSION_UNIQ_ID, ((CntcService) deleted.get()).getLastUpdusrId(),
+				"LAST_UPDUSR_ID 로 저장되는 값");
+	}
+
+	// ---------------------------------------------------------------
+	// 요청에 lastUpdusrId 파라미터를 함께 보낸 경우
+	// ---------------------------------------------------------------
+
+	@Test
+	@DisplayName("연계기관 삭제 - 요청에 lastUpdusrId 를 실었을 때 LAST_UPDUSR_ID")
+	void deleteCntcInstt_paramWins() throws Exception {
+		CntcInstt vo = bind(new CntcInstt(),
+				params("insttId", "INSTT_0001", "lastUpdusrId", "USRCNFRM_00000000999"));
+		controller.deleteCntcInstt(vo, new ModelMap());
+		assertEquals(SESSION_UNIQ_ID, ((CntcInstt) deleted.get()).getLastUpdusrId(),
+				"LAST_UPDUSR_ID 로 저장되는 값");
+	}
+
+	@Test
+	@DisplayName("연계시스템 삭제 - 요청에 lastUpdusrId 를 실었을 때 LAST_UPDUSR_ID")
+	void deleteCntcSystem_paramWins() throws Exception {
+		CntcSystem vo = bind(new CntcSystem(),
+				params("insttId", "INSTT_0001", "sysId", "SYS_0001", "lastUpdusrId", "USRCNFRM_00000000999"));
+		controller.deleteCntcSystem(vo, new ModelMap());
+		assertEquals(SESSION_UNIQ_ID, ((CntcSystem) deleted.get()).getLastUpdusrId(),
+				"LAST_UPDUSR_ID 로 저장되는 값");
+	}
+
+	@Test
+	@DisplayName("연계서비스 삭제 - 요청에 lastUpdusrId 를 실었을 때 LAST_UPDUSR_ID")
+	void deleteCntcService_paramWins() throws Exception {
+		CntcService vo = bind(new CntcService(), params("insttId", "INSTT_0001", "sysId", "SYS_0001",
+				"svcId", "SVC_0001", "lastUpdusrId", "USRCNFRM_00000000999"));
+		controller.deleteCntcService(vo, new ModelMap());
+		assertEquals(SESSION_UNIQ_ID, ((CntcService) deleted.get()).getLastUpdusrId(),
+				"LAST_UPDUSR_ID 로 저장되는 값");
+	}
+}

--- a/src/test/java/egovframework/com/ssi/syi/ims/web/EgovCntcMessageControllerDeleteAuditTest.java
+++ b/src/test/java/egovframework/com/ssi/syi/ims/web/EgovCntcMessageControllerDeleteAuditTest.java
@@ -1,0 +1,162 @@
+package egovframework.com.ssi.syi.ims.web;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Proxy;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.ui.ModelMap;
+import org.springframework.web.bind.ServletRequestDataBinder;
+
+import egovframework.com.cmm.LoginVO;
+import egovframework.com.cmm.service.EgovUserDetailsService;
+import egovframework.com.cmm.util.EgovUserDetailsHelper;
+import egovframework.com.ssi.syi.ims.service.CntcMessage;
+import egovframework.com.ssi.syi.ims.service.CntcMessageItem;
+import egovframework.com.ssi.syi.ims.service.EgovCntcMessageService;
+import jakarta.servlet.ServletRequest;
+
+/**
+ * 연계메시지/연계메시지항목 삭제 핸들러가 감사 컬럼 LAST_UPDUSR_ID 에
+ * 무엇을 넘기는지 확인한다.
+ *
+ * 같은 컨트롤러의 insert/update 4개 핸들러는 예외 없이
+ * EgovUserDetailsHelper.getAuthenticatedUser() 의 uniqId 로 덮어쓴다.
+ */
+class EgovCntcMessageControllerDeleteAuditTest {
+
+	/** 로그인 세션이 가진 식별자 */
+	private static final String SESSION_UNIQ_ID = "USRCNFRM_00000000001";
+
+	private EgovCntcMessageController controller;
+	private final AtomicReference<Object> deleted = new AtomicReference<>();
+
+	@BeforeEach
+	void setUp() throws Exception {
+		LoginVO loginVO = new LoginVO();
+		loginVO.setUniqId(SESSION_UNIQ_ID);
+		new EgovUserDetailsHelper().setEgovUserDetailsService(new EgovUserDetailsService() {
+			public Object getAuthenticatedUser() {
+				return loginVO;
+			}
+
+			public java.util.List<String> getAuthorities() {
+				return Collections.singletonList("ROLE_ADMIN");
+			}
+
+			public Boolean isAuthenticated() {
+				return Boolean.TRUE;
+			}
+		});
+
+		EgovCntcMessageService service = (EgovCntcMessageService) Proxy.newProxyInstance(
+				EgovCntcMessageService.class.getClassLoader(),
+				new Class<?>[] { EgovCntcMessageService.class },
+				(proxy, method, args) -> {
+					if (method.getName().startsWith("delete")) {
+						deleted.set(args[0]);
+					}
+					return null;
+				});
+
+		controller = new EgovCntcMessageController();
+		Field f = EgovCntcMessageController.class.getDeclaredField("cntcMessageService");
+		f.setAccessible(true);
+		f.set(controller, service);
+	}
+
+	/** 커맨드 객체에 실제 요청 파라미터를 Spring 바인더로 바인딩한다. */
+	private <T> T bind(T target, Map<String, String> params) {
+		ServletRequestDataBinder binder = new ServletRequestDataBinder(target);
+		binder.bind(stubRequest(params));
+		return target;
+	}
+
+	private ServletRequest stubRequest(Map<String, String> params) {
+		return (ServletRequest) Proxy.newProxyInstance(
+				ServletRequest.class.getClassLoader(),
+				new Class<?>[] { ServletRequest.class },
+				(proxy, method, args) -> {
+					switch (method.getName()) {
+					case "getParameterNames":
+						return Collections.enumeration(params.keySet());
+					case "getParameterValues":
+						String v = params.get(args[0]);
+						return v == null ? null : new String[] { v };
+					case "getParameter":
+						return params.get(args[0]);
+					case "getParameterMap":
+						Map<String, String[]> m = new LinkedHashMap<>();
+						params.forEach((k, val) -> m.put(k, new String[] { val }));
+						return m;
+					case "getAttribute":
+						return null;
+					default:
+						return null;
+					}
+				});
+	}
+
+	private static Map<String, String> params(String... kv) {
+		Map<String, String> m = new LinkedHashMap<>();
+		for (int i = 0; i < kv.length; i += 2) {
+			m.put(kv[i], kv[i + 1]);
+		}
+		return m;
+	}
+
+	// ---------------------------------------------------------------
+	// EgovCntcMessageDetail.jsp 의 삭제 버튼이 제출하는 Form(112행)이
+	// 실제로 담고 있는 항목만 보낸 경우 — lastUpdusrId 항목은 없다
+	// ---------------------------------------------------------------
+
+	@Test
+	@DisplayName("연계메시지 삭제 - 삭제 폼 그대로 보냈을 때 LAST_UPDUSR_ID")
+	void deleteCntcMessage_formPost() throws Exception {
+		CntcMessage vo = bind(new CntcMessage(), params("cntcMessageId", "MSG_0001", "itemId", ""));
+		controller.deleteCntcMessage(vo, new ModelMap());
+		assertEquals(SESSION_UNIQ_ID, ((CntcMessage) deleted.get()).getLastUpdusrId(),
+				"LAST_UPDUSR_ID 로 저장되는 값");
+	}
+
+	@Test
+	@DisplayName("연계메시지항목 삭제 - 삭제 폼 그대로 보냈을 때 LAST_UPDUSR_ID")
+	void deleteCntcMessageItem_formPost() throws Exception {
+		CntcMessageItem vo = bind(new CntcMessageItem(),
+				params("cntcMessageId", "MSG_0001", "itemId", "ITEM_0001"));
+		controller.deleteCntcMessageItem(vo, new ModelMap());
+		assertEquals(SESSION_UNIQ_ID, ((CntcMessageItem) deleted.get()).getLastUpdusrId(),
+				"LAST_UPDUSR_ID 로 저장되는 값");
+	}
+
+	// ---------------------------------------------------------------
+	// 요청에 lastUpdusrId 파라미터를 함께 보낸 경우
+	// ---------------------------------------------------------------
+
+	@Test
+	@DisplayName("연계메시지 삭제 - 요청에 lastUpdusrId 를 실었을 때 LAST_UPDUSR_ID")
+	void deleteCntcMessage_paramWins() throws Exception {
+		CntcMessage vo = bind(new CntcMessage(),
+				params("cntcMessageId", "MSG_0001", "lastUpdusrId", "USRCNFRM_00000000999"));
+		controller.deleteCntcMessage(vo, new ModelMap());
+		assertEquals(SESSION_UNIQ_ID, ((CntcMessage) deleted.get()).getLastUpdusrId(),
+				"LAST_UPDUSR_ID 로 저장되는 값");
+	}
+
+	@Test
+	@DisplayName("연계메시지항목 삭제 - 요청에 lastUpdusrId 를 실었을 때 LAST_UPDUSR_ID")
+	void deleteCntcMessageItem_paramWins() throws Exception {
+		CntcMessageItem vo = bind(new CntcMessageItem(), params("cntcMessageId", "MSG_0001",
+				"itemId", "ITEM_0001", "lastUpdusrId", "USRCNFRM_00000000999"));
+		controller.deleteCntcMessageItem(vo, new ModelMap());
+		assertEquals(SESSION_UNIQ_ID, ((CntcMessageItem) deleted.get()).getLastUpdusrId(),
+				"LAST_UPDUSR_ID 로 저장되는 값");
+	}
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

연계관리의 삭제 핸들러 다섯 곳이 커맨드 객체를 그대로 서비스에 넘깁니다.

```java
// EgovCntcInsttController.java:107
public String deleteCntcInstt(CntcInstt cntcInstt, ModelMap model) throws Exception {
    cntcInsttService.deleteCntcInstt(cntcInstt);
```

이 객체의 `lastUpdusrId`가 소프트 삭제 구문의 감사항목으로 들어갑니다.

```sql
-- EgovCntcInstt_SQL_mysql.xml:267
UPDATE COMTNCNTCINSTT
   SET USE_AT = 'N', LAST_UPDUSR_ID = #{lastUpdusrId}, LAST_UPDT_PNTTM = sysdate()
 WHERE INSTT_ID = #{insttId}
```

두 매퍼에서 `LAST_UPDUSR_ID`에 값을 넣는 구문은 열다섯 개입니다(연계기관 아홉, 연계메시지 여섯). 등록·수정 열 곳은 핸들러가 호출 직전에 세션 값으로 덮어씁니다.

```java
// EgovCntcInsttController.java:496-499 (updateCntcInstt)
LoginVO loginVO = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();
String uniqId = loginVO == null ? "" : EgovStringUtil.isNullToString(loginVO.getUniqId());

cntcInstt.setLastUpdusrId(uniqId);
```

이 재정의가 `EgovCntcInsttController` 178-180·245-247·360-362·496-499·562-565·677-680, `EgovCntcMessageController` 166-168·230-232·362-365·425-428 열 곳에 있습니다. 삭제 다섯 곳에만 없어서 나머지 다섯 구문은 요청에서 온 값을 그대로 기록합니다.

결과는 두 가지입니다.

삭제 버튼은 화면의 숨은 폼을 제출합니다(`EgovCntcInsttDetail.jsp` 143행, `EgovCntcMessageDetail.jsp` 112행). 그 폼에는 식별자와 검색조건만 있고 `lastUpdusrId` 항목이 없어 VO 초기값인 빈 문자열이 기록됩니다. 등록·수정이 채워둔 값이 이때 덮여 그 전에 손댄 사람도 남지 않습니다.

그리고 커맨드 객체는 요청 항목으로 바인딩되고 다섯 VO 모두 `setLastUpdusrId`가 public이라, 요청에 `lastUpdusrId`를 실어 보내면 그 값이 감사항목에 들어갑니다.

여덟 방언 매퍼가 같은 구문이라 데이터베이스와 무관하게 동일합니다.

수정은 나머지 열 개 핸들러와 같은 세 줄을 삭제 핸들러 다섯 곳에 넣는 것입니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

삭제 핸들러가 서비스로 넘기는 `lastUpdusrId`를 확인하는 테스트를 두 개 넣었습니다. 삭제 폼이 보내는 항목만 담은 요청과 거기에 `lastUpdusrId`를 실은 요청을 스프링 `ServletRequestDataBinder`로 바인딩한 뒤 핸들러를 부릅니다. 세션 값은 `USRCNFRM_00000000001`입니다.

수정 전

```
[ERROR] Tests run: 10, Failures: 10, Errors: 0, Skipped: 0
[ERROR]   EgovCntcInsttControllerDeleteAuditTest.deleteCntcInstt_formPost:126 LAST_UPDUSR_ID 로 저장되는 값 ==> expected: <USRCNFRM_00000000001> but was: <>
[ERROR]   EgovCntcInsttControllerDeleteAuditTest.deleteCntcInstt_paramWins:159 LAST_UPDUSR_ID 로 저장되는 값 ==> expected: <USRCNFRM_00000000001> but was: <USRCNFRM_00000000999>
[ERROR]   EgovCntcMessageControllerDeleteAuditTest.deleteCntcMessage_formPost:125 LAST_UPDUSR_ID 로 저장되는 값 ==> expected: <USRCNFRM_00000000001> but was: <>
[ERROR]   EgovCntcMessageControllerDeleteAuditTest.deleteCntcMessage_paramWins:149 LAST_UPDUSR_ID 로 저장되는 값 ==> expected: <USRCNFRM_00000000001> but was: <USRCNFRM_00000000999>
(연계시스템·연계서비스·연계메시지항목 여섯 건도 같은 형태입니다)
```

수정 후

```
[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

`pom.xml`의 surefire 설정이 `<skipTests>true</skipTests>`로 고정돼 있어 이 값을 잠시 해제하고 실행한 결과입니다. 커밋에는 포함하지 않았습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

화면 동작이 달라지는 수정이 아니라 브라우저 확인은 하지 않았습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

위 테스트 결과로 대신합니다.
