### PR TITLE
fix(ssi/syi): 시스템연계 상세·수정·승인 화면이 없는 연계ID에 NPE를 내는 문제 수정

### DIFF
--- a/src/main/java/egovframework/com/ssi/syi/sim/web/EgovSystemCntcController.java
+++ b/src/main/java/egovframework/com/ssi/syi/sim/web/EgovSystemCntcController.java
@@ -183,6 +183,10 @@ public class EgovSystemCntcController {
 		model.addAttribute("selfUri", selfUri);
 
 		SystemCntc vo = systemCntcService.selectSystemCntcDetail(systemCntc);
+		if (vo == null) {
+			model.addAttribute("message", egovMessageSource.getMessage("fail.common.select"));
+			return "forward:/ssi/syi/sim/getSystemCntcList.do";
+		}
 		model.addAttribute("result", vo);
 
 		// 드롭다운 리스트 데이터 설정 (상세 조회용)
@@ -257,6 +261,10 @@ public class EgovSystemCntcController {
 
 
 		SystemCntc vo = systemCntcService.selectSystemCntcDetail(systemCntc);
+		if (vo == null) {
+			model.addAttribute("message", egovMessageSource.getMessage("fail.common.select"));
+			return "forward:/ssi/syi/sim/getSystemCntcList.do";
+		}
 		model.addAttribute("systemCntc", vo);
 
 		// 드롭다운 리스트 데이터 설정 (상세 조회용)
@@ -379,6 +387,10 @@ public class EgovSystemCntcController {
 		model.addAttribute("selfUri", selfUri);
 
 		SystemCntc vo = systemCntcService.selectSystemCntcDetail(systemCntc);
+		if (vo == null) {
+			model.addAttribute("message", egovMessageSource.getMessage("fail.common.select"));
+			return "forward:/ssi/syi/scm/getConfirmSystemCntcList.do";
+		}
 		model.addAttribute("result", vo);
 
 		// 드롭다운 리스트 데이터 설정 (상세 조회용)

--- a/src/test/java/egovframework/com/ssi/syi/sim/web/EgovSystemCntcControllerMissingRecordTest.java
+++ b/src/test/java/egovframework/com/ssi/syi/sim/web/EgovSystemCntcControllerMissingRecordTest.java
@@ -1,0 +1,125 @@
+package egovframework.com.ssi.syi.sim.web;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.ui.ModelMap;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+import org.springframework.web.servlet.mvc.support.RedirectAttributesModelMap;
+
+import egovframework.com.cmm.EgovMessageSource;
+import egovframework.com.cmm.LoginVO;
+import egovframework.com.cmm.service.EgovUserDetailsService;
+import egovframework.com.cmm.util.EgovUserDetailsHelper;
+import egovframework.com.ssi.syi.iis.service.EgovCntcInsttService;
+import egovframework.com.ssi.syi.sim.service.EgovSystemCntcService;
+import egovframework.com.ssi.syi.sim.service.SystemCntc;
+import egovframework.com.ssi.syi.sim.service.SystemCntcVO;
+
+/**
+ * 지워진 시스템연계를 상세·수정화면·승인상세로 열었을 때 목록으로 되돌아가는지 확인한다.
+ *
+ * <p>selectSystemCntcDetail 은 매칭 행이 없으면 null 을 준다
+ * (SystemCntcDAO:56 의 selectOne, EgovSystemCntc_SQL_*.xml 의 WHERE CNTC_ID = #{cntcId}).
+ * 형제 deleteSystemCntc(:97-101)는 그 null 을 검사하고 목록으로 되돌린다.</p>
+ *
+ * <p>스프링 컨텍스트·DB 없이 동적 프록시 페이크와 ReflectionTestUtils 필드 주입으로 돌린다.</p>
+ */
+class EgovSystemCntcControllerMissingRecordTest {
+
+	private static final String LIST = "forward:/ssi/syi/sim/getSystemCntcList.do";
+	private static final String CONFIRM_LIST = "forward:/ssi/syi/scm/getConfirmSystemCntcList.do";
+
+	private EgovSystemCntcController controller;
+	private EgovUserDetailsService originalUserDetailsService;
+
+	@BeforeEach
+	void setUp() {
+		EgovUserDetailsHelper helper = new EgovUserDetailsHelper();
+		originalUserDetailsService = helper.getEgovUserDetailsService();
+		LoginVO loginVO = new LoginVO();
+		loginVO.setUniqId("USRCNFRM_00000000001");
+		helper.setEgovUserDetailsService(stub(EgovUserDetailsService.class, (proxy, method, args) -> {
+			switch (method.getName()) {
+			case "isAuthenticated":
+				return Boolean.TRUE;
+			case "getAuthenticatedUser":
+				return loginVO;
+			case "getAuthorities":
+				return new ArrayList<String>();
+			default:
+				return null;
+			}
+		}));
+
+		controller = new EgovSystemCntcController();
+		// 요청한 cntcId 의 행이 이미 없는 상태
+		ReflectionTestUtils.setField(controller, "systemCntcService",
+				stub(EgovSystemCntcService.class, (proxy, method, args) -> null));
+		ReflectionTestUtils.setField(controller, "cntcInsttService",
+				stub(EgovCntcInsttService.class, (proxy, method, args) -> new ArrayList<>()));
+		ReflectionTestUtils.setField(controller, "egovMessageSource", new EgovMessageSource() {
+			@Override
+			public String getMessage(String code) {
+				return code;
+			}
+		});
+	}
+
+	@AfterEach
+	void restoreUserDetailsService() {
+		new EgovUserDetailsHelper().setEgovUserDetailsService(originalUserDetailsService);
+	}
+
+	@Test
+	void detailFallsBackToListWhenRecordIsGone() throws Exception {
+		ModelMap model = new ModelMap();
+
+		String view = controller.selectSystemCntcDetail(new SystemCntcVO(), gone(), model, redirect());
+
+		assertEquals(LIST, view, "없는 시스템연계 상세는 목록으로 되돌려야 한다");
+		assertEquals("fail.common.select", model.get("message"));
+	}
+
+	@Test
+	void updateViewFallsBackToListWhenRecordIsGone() throws Exception {
+		ModelMap model = new ModelMap();
+
+		String view = controller.updateSystemCntcView(new SystemCntcVO(), gone(), model);
+
+		assertEquals(LIST, view, "없는 시스템연계 수정화면은 목록으로 되돌려야 한다");
+		assertEquals("fail.common.select", model.get("message"));
+	}
+
+	@Test
+	void confirmDetailFallsBackToListWhenRecordIsGone() throws Exception {
+		ModelMap model = new ModelMap();
+
+		String view = controller.selectConfirmSystemCntcDetail(new SystemCntcVO(), gone(), "", model, redirect());
+
+		assertEquals(CONFIRM_LIST, view, "없는 시스템연계 승인상세는 승인목록으로 되돌려야 한다");
+		assertEquals("fail.common.select", model.get("message"));
+	}
+
+	private SystemCntc gone() {
+		SystemCntc systemCntc = new SystemCntc();
+		systemCntc.setCntcId("SYSTEMCNTC_00000000099");
+		return systemCntc;
+	}
+
+	private RedirectAttributes redirect() {
+		return new RedirectAttributesModelMap();
+	}
+
+	@SuppressWarnings("unchecked")
+	private static <T> T stub(Class<T> type, InvocationHandler handler) {
+		return (T) Proxy.newProxyInstance(type.getClassLoader(), new Class<?>[] { type }, handler);
+	}
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`EgovSystemCntcController`에서 `systemCntcService.selectSystemCntcDetail()`을 부르는 곳은 네 군데인데, 결과가 null인지 보는 곳은 삭제 한 곳뿐입니다.

| 호출 위치 | null 검사 | 없는 연계ID가 들어왔을 때 |
|---|---|---|
| `deleteSystemCntc`(`:97`) | 있음 | 목록으로 되돌아갑니다 |
| `selectSystemCntcDetail`(`:185`) | 없음 | `:471`에서 NPE |
| `updateSystemCntcView`(`:259`) | 없음 | `:471`에서 NPE |
| `selectConfirmSystemCntcDetail`(`:381`) | 없음 | `:471`에서 NPE |

세 곳 모두 조회 결과를 그대로 `setDropdownListDataForDetail(vo, model)`에 넘기고 그 안 `:471`이 `systemCntc.getProvdInsttId()`를 부릅니다.

`SystemCntcDAO:56`이 `selectOne`을 그대로 돌려주고 매퍼는 `WHERE CNTC_ID = #{cntcId}` 한 줄이라(여덟 방언이 같습니다) 맞는 행이 없으면 null이 올라옵니다.

그 상황을 상세화면이 스스로 만듭니다. 미승인 상태의 `EgovSystemCntcDetail.jsp`는 [수정]·[삭제]·[승인]을 한 화면에 두고 셋 다 같은 `cntcId`를 hidden으로 실어보냅니다(`:239`·`:245`·`:251`). 한쪽 창에서 지운 뒤 다른 창에서 [수정]이나 [승인]을 누르면 이미 없는 연계ID가 그대로 갑니다. 목록에서 상세로 들어가는 사이에 다른 사용자가 지운 경우도 같습니다.

지금은 `SimpleMappingExceptionResolver`의 `defaultErrorView`가 NPE를 받아 "알 수 없는 오류가 발생했습니다!" 화면이 뜹니다. 같은 조건에서 [삭제]는 목록으로 돌아갑니다.

AS-IS

```java
SystemCntc vo = systemCntcService.selectSystemCntcDetail(systemCntc);
model.addAttribute("result", vo);

// 드롭다운 리스트 데이터 설정 (상세 조회용)
setDropdownListDataForDetail(vo, model);
```

TO-BE

```java
SystemCntc vo = systemCntcService.selectSystemCntcDetail(systemCntc);
if (vo == null) {
    model.addAttribute("message", egovMessageSource.getMessage("fail.common.select"));
    return "forward:/ssi/syi/sim/getSystemCntcList.do";
}
model.addAttribute("result", vo);

// 드롭다운 리스트 데이터 설정 (상세 조회용)
setDropdownListDataForDetail(vo, model);
```

승인상세는 원래 화면인 `/ssi/syi/scm/getConfirmSystemCntcList.do`로 되돌립니다.

### 영향 범위

조회 결과가 null일 때만 동작이 달라집니다. 행이 있으면 종전과 같습니다. 서비스·DAO·매퍼는 변경하지 않았습니다.

`fail.common.select`는 한글·영문 메시지에 이미 있습니다(`message-common_ko.properties:123`). 메시지를 모델에 담는 형태는 `deleteSystemCntc`에 맞췄습니다. 다만 `EgovSystemCntcList.jsp`가 `${message}`를 그리지 않아 지금은 화면에 뜨지 않습니다 — 삭제 경로도 사정이 같아 목록 화면에는 손대지 않았습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

`src/test/java/egovframework/com/ssi/syi/sim/web/EgovSystemCntcControllerMissingRecordTest.java`를 추가했습니다. 조회가 null을 돌려주는 상황을 동적 프록시로 만들고 세 화면이 각각 제 목록으로 되돌아가는지 봅니다. 스프링 컨텍스트와 DB 없이 돌아갑니다.

수정 전

```
[ERROR] Tests run: 3, Failures: 0, Errors: 3, Skipped: 0
[ERROR]   EgovSystemCntcControllerMissingRecordTest.detailFallsBackToListWhenRecordIsGone
          » NullPointer Cannot invoke "...SystemCntc.getProvdInsttId()" because "systemCntc" is null
(updateViewFallsBackToListWhenRecordIsGone, confirmDetailFallsBackToListWhenRecordIsGone 도 같은 예외입니다)
```

수정 후

```
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

`pom.xml`의 surefire 설정이 `skipTests=true`라 기본 빌드에서는 실행되지 않습니다. 확인할 때는 그 값을 잠시 `false`로 두고 돌렸습니다.
