### PR TITLE
fix(prm): 프로그램변경요청 삭제가 등록·수정과 다른 LoginVO 필드로 요청자를 확인하는 문제 수정

### DIFF
--- a/src/main/java/egovframework/com/sym/prm/web/EgovProgrmManageController.java
+++ b/src/main/java/egovframework/com/sym/prm/web/EgovProgrmManageController.java
@@ -474,8 +474,7 @@ public class EgovProgrmManageController {
 		LoginVO loginVO = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();
 		// KISA 보안약점 조치 (2018-10-29, 윤창원)
 		if (EgovStringUtil.isNullToString(progrmManageDtlVO.getRqesterPersonId())
-				.equals(loginVO == null ? "" : EgovStringUtil.isNullToString(loginVO.getId()))) {
-			// progrmManageDtlVO.setRqesterPersonId(user.getId());
+				.equals(loginVO == null ? "" : EgovStringUtil.isNullToString(loginVO.getUniqId()))) {
 			model.addAttribute("resultMsg", egovMessageSource.getMessage("success.common.delete"));
 			progrmManageService.deleteProgrmChangeRequst(progrmManageDtlVO);
 			sLocationUrl = "forward:/sym/prm/EgovProgramChangeRequstSelect.do";

--- a/src/test/java/egovframework/com/sym/prm/web/EgovProgrmManageControllerChangRequstDeleteTest.java
+++ b/src/test/java/egovframework/com/sym/prm/web/EgovProgrmManageControllerChangRequstDeleteTest.java
@@ -1,0 +1,211 @@
+package egovframework.com.sym.prm.web;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Field;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.ui.ModelMap;
+
+import egovframework.com.cmm.ComDefaultVO;
+import egovframework.com.cmm.EgovMessageSource;
+import egovframework.com.cmm.LoginVO;
+import egovframework.com.cmm.service.EgovUserDetailsService;
+import egovframework.com.cmm.util.EgovUserDetailsHelper;
+import egovframework.com.sym.prm.service.EgovProgrmManageService;
+import egovframework.com.sym.prm.service.ProgrmManageDtlVO;
+import egovframework.com.sym.prm.service.ProgrmManageVO;
+
+/**
+ * 프로그램변경요청 삭제의 요청자 확인 회귀 테스트.
+ *
+ * 요청자ID(RQESTER_ID)는 등록 시 LoginVO.getUniqId()(ESNTL_ID)로 저장되고,
+ * 수정(updateProgrmChangeRequst)도 같은 값으로 비교한다.
+ * 삭제만 LoginVO.getId()(로그인 아이디)로 비교하면 요청자 본인도 항상 차단된다.
+ */
+class EgovProgrmManageControllerChangRequstDeleteTest {
+
+	private static final String OWNER_LOGIN_ID = "TEST1";
+	private static final String OWNER_UNIQ_ID = "USRCNFRM_00000000000";
+	private static final String OTHER_LOGIN_ID = "webmaster";
+	private static final String OTHER_UNIQ_ID = "USRCNFRM_99999999999";
+
+	private static final String PROGRM_FILE_NM = "EgovSample.java";
+	private static final int RQESTER_NO = 1;
+
+	/** 삭제 호출 여부만 기록하는 스텁. */
+	private static final class StubService implements EgovProgrmManageService {
+
+		private boolean deleteCalled = false;
+
+		@Override
+		public void deleteProgrmChangeRequst(ProgrmManageDtlVO vo) {
+			deleteCalled = true;
+		}
+
+		@Override
+		public ProgrmManageDtlVO selectProgrmChangeRequst(ProgrmManageDtlVO vo) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public ProgrmManageVO selectProgrm(ProgrmManageVO vo) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public List<ProgrmManageVO> selectProgrmList(ComDefaultVO vo) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public int selectProgrmListTotCnt(ComDefaultVO vo) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public void insertProgrm(ProgrmManageVO vo) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public void updateProgrm(ProgrmManageVO vo) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public void deleteProgrm(ProgrmManageVO vo) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public int selectProgrmNMTotCnt(ComDefaultVO vo) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public List<ProgrmManageDtlVO> selectProgrmChangeRequstList(ComDefaultVO vo) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public int selectProgrmChangeRequstListTotCnt(ComDefaultVO vo) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public void insertProgrmChangeRequst(ProgrmManageDtlVO vo) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public void updateProgrmChangeRequst(ProgrmManageDtlVO vo) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public ProgrmManageDtlVO selectProgrmChangeRequstNo(ProgrmManageDtlVO vo) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public List<?> selectChangeRequstProcessList(ComDefaultVO vo) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public int selectChangeRequstProcessListTotCnt(ComDefaultVO vo) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public void updateProgrmChangeRequstProcess(ProgrmManageDtlVO vo) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public void deleteProgrmManageList(String checkedProgrmFileNmForDel) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public ProgrmManageDtlVO selectRqesterEmail(ProgrmManageDtlVO vo) {
+			throw new UnsupportedOperationException();
+		}
+	}
+
+	private static void bindLoginUser(String loginId, String uniqId) {
+		LoginVO login = new LoginVO();
+		login.setId(loginId);
+		login.setUniqId(uniqId);
+		EgovUserDetailsService stub = new EgovUserDetailsService() {
+			@Override
+			public Object getAuthenticatedUser() {
+				return login;
+			}
+
+			@Override
+			public List<String> getAuthorities() {
+				return List.of();
+			}
+
+			@Override
+			public Boolean isAuthenticated() {
+				return Boolean.TRUE;
+			}
+		};
+		new EgovUserDetailsHelper().setEgovUserDetailsService(stub);
+	}
+
+	private static EgovProgrmManageController controllerWith(StubService service) throws Exception {
+		EgovProgrmManageController controller = new EgovProgrmManageController();
+
+		Field serviceField = EgovProgrmManageController.class.getDeclaredField("progrmManageService");
+		serviceField.setAccessible(true);
+		serviceField.set(controller, service);
+
+		Field messageSourceField = EgovProgrmManageController.class.getDeclaredField("egovMessageSource");
+		messageSourceField.setAccessible(true);
+		messageSourceField.set(controller, new EgovMessageSource() {
+			@Override
+			public String getMessage(String code) {
+				return code;
+			}
+		});
+		return controller;
+	}
+
+	/** 상세화면이 숨은 필드로 돌려주는 값, 즉 DB에 저장된 요청자ID(ESNTL_ID)를 담은 폼. */
+	private static ProgrmManageDtlVO submittedForm(String storedRqesterPersonId) {
+		ProgrmManageDtlVO form = new ProgrmManageDtlVO();
+		form.setProgrmFileNm(PROGRM_FILE_NM);
+		form.setRqesterNo(RQESTER_NO);
+		form.setRqesterPersonId(storedRqesterPersonId);
+		return form;
+	}
+
+	@Test
+	void requesterCanDeleteOwnChangeRequest() throws Exception {
+		StubService service = new StubService();
+		EgovProgrmManageController controller = controllerWith(service);
+		bindLoginUser(OWNER_LOGIN_ID, OWNER_UNIQ_ID);
+
+		controller.deleteProgrmChangeRequst(submittedForm(OWNER_UNIQ_ID), new ModelMap());
+
+		assertTrue(service.deleteCalled,
+				"등록 시 uniqId로 저장된 요청자 본인은 자신의 변경요청을 삭제할 수 있어야 한다.");
+	}
+
+	@Test
+	void otherUserCannotDeleteChangeRequest() throws Exception {
+		StubService service = new StubService();
+		EgovProgrmManageController controller = controllerWith(service);
+		bindLoginUser(OTHER_LOGIN_ID, OTHER_UNIQ_ID);
+
+		controller.deleteProgrmChangeRequst(submittedForm(OWNER_UNIQ_ID), new ModelMap());
+
+		assertFalse(service.deleteCalled, "요청자가 아닌 사용자의 삭제는 서비스까지 도달하면 안 된다.");
+	}
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

프로그램변경요청의 요청자ID(`RQESTER_ID`)에는 등록화면이 `LoginVO.getUniqId()`로 채워 보낸 값이 들어갑니다. `EgovProgrmManageController` 400행이 그 값으로 폼을 채우고, `EgovProgramChangRequstStre.jsp` 138행의 `readonly` 필드가 그대로 제출해 393행 등록에서 저장됩니다. 수정도 같은 `getUniqId()`로 요청자 본인인지 판정합니다(436행). 그런데 바로 아래 삭제만 `LoginVO.getId()`와 비교합니다(477행).

`RQESTER_ID`에 들어 있는 값이 `ESNTL_ID`라는 것은 매퍼 자신이 말해 줍니다. `EgovProgrmManageDtl_SQL_mysql.xml` 193행의 `selectRqesterEmail`이 `where ESNTL_ID = #{rqesterPersonId}`로 사용자를 찾습니다. 그리고 두 값은 서로 다른 컬럼입니다 — 로그인 쿼리(`EgovLoginUsr_SQL_mysql.xml`)가 `emplyr_id AS id`, `esntl_id AS uniqId`로 매핑하고, 초기 데이터(`script/dml/mysql/com_DML_mysql.sql:627`)의 업무사용자는 `EMPLYR_ID`가 `TEST1`, `ESNTL_ID`가 `USRCNFRM_00000000000`입니다.

그래서 요청자 본인이 상세화면에서 삭제를 눌러도 "삭제에 실패하였습니다. 변경요청자만 삭제가능합니다."만 나옵니다. 상세화면(`EgovProgramChangRequstDetailSelectUpdt.jsp`)은 수정과 삭제가 `rqesterPersonId` 숨은 필드가 담긴 같은 폼을 그대로 제출하는데, 같은 값을 두고 수정은 통과하고 삭제는 막힙니다.

삭제의 비교 대상을 등록·수정과 같은 `getUniqId()`로 맞췄습니다. 함께 지운 주석 한 줄은 이 메서드에 없는 변수(`user`)를 참조하는 옛 코드입니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

`EgovProgrmManageControllerChangRequstDeleteTest`를 추가했습니다. 요청자 본인의 삭제가 서비스까지 도달하는지, 다른 사용자의 삭제가 막히는지 두 가지를 확인합니다. 수정 전에는 앞의 하나가 실패합니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

없습니다.
