### PR TITLE
fix(prm): 프로그램변경요청처리 상세조회가 해당 요청이 없을 때 NPE를 내는 문제 수정

### DIFF
--- a/src/main/java/egovframework/com/sym/prm/web/EgovProgrmManageController.java
+++ b/src/main/java/egovframework/com/sym/prm/web/EgovProgrmManageController.java
@@ -553,6 +553,10 @@ public class EgovProgrmManageController {
 			progrmManageDtlVO.setRqesterNo(progrmManageDtlVO.getTmpRqesterNo());
 		}
 		ProgrmManageDtlVO resultVO = progrmManageService.selectProgrmChangeRequst(progrmManageDtlVO);
+		if (resultVO == null) {
+			model.addAttribute("resultMsg", egovMessageSource.getMessage("fail.common.select"));
+			return "forward:/sym/prm/EgovProgramChangeRequstProcessListSelect.do";
+		}
 		if (resultVO.getProcessDe() != null) {
 			resultVO.setProcessDe(resultVO.getProcessDe().trim());// 2011.08.22
 		}

--- a/src/test/java/egovframework/com/sym/prm/web/EgovProgrmManageControllerChangRequstProcessDetailTest.java
+++ b/src/test/java/egovframework/com/sym/prm/web/EgovProgrmManageControllerChangRequstProcessDetailTest.java
@@ -1,0 +1,185 @@
+package egovframework.com.sym.prm.web;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.lang.reflect.Field;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.ui.ModelMap;
+
+import egovframework.com.cmm.ComDefaultVO;
+import egovframework.com.cmm.EgovMessageSource;
+import egovframework.com.cmm.LoginVO;
+import egovframework.com.cmm.service.EgovUserDetailsService;
+import egovframework.com.cmm.util.EgovUserDetailsHelper;
+import egovframework.com.sym.prm.service.EgovProgrmManageService;
+import egovframework.com.sym.prm.service.ProgrmManageDtlVO;
+import egovframework.com.sym.prm.service.ProgrmManageVO;
+
+/**
+ * 프로그램변경요청처리 상세조회가 없는 요청을 만났을 때의 회귀 테스트.
+ *
+ * selectProgrmChangeRequst는 MyBatis selectOne을 그대로 돌려주므로 해당 행이 없으면 null이다.
+ * 상세조회가 그 결과를 바로 역참조하면 NullPointerException으로 500이 난다.
+ */
+class EgovProgrmManageControllerChangRequstProcessDetailTest {
+
+	/** 해당 행이 없어 selectOne이 null을 돌려주는 상황을 재현하는 스텁. */
+	private static final class StubService implements EgovProgrmManageService {
+
+		@Override
+		public ProgrmManageDtlVO selectProgrmChangeRequst(ProgrmManageDtlVO vo) {
+			return null;
+		}
+
+		@Override
+		public void deleteProgrmChangeRequst(ProgrmManageDtlVO vo) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public ProgrmManageVO selectProgrm(ProgrmManageVO vo) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public List<ProgrmManageVO> selectProgrmList(ComDefaultVO vo) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public int selectProgrmListTotCnt(ComDefaultVO vo) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public void insertProgrm(ProgrmManageVO vo) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public void updateProgrm(ProgrmManageVO vo) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public void deleteProgrm(ProgrmManageVO vo) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public int selectProgrmNMTotCnt(ComDefaultVO vo) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public List<ProgrmManageDtlVO> selectProgrmChangeRequstList(ComDefaultVO vo) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public int selectProgrmChangeRequstListTotCnt(ComDefaultVO vo) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public void insertProgrmChangeRequst(ProgrmManageDtlVO vo) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public void updateProgrmChangeRequst(ProgrmManageDtlVO vo) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public ProgrmManageDtlVO selectProgrmChangeRequstNo(ProgrmManageDtlVO vo) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public List<?> selectChangeRequstProcessList(ComDefaultVO vo) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public int selectChangeRequstProcessListTotCnt(ComDefaultVO vo) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public void updateProgrmChangeRequstProcess(ProgrmManageDtlVO vo) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public void deleteProgrmManageList(String checkedProgrmFileNmForDel) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public ProgrmManageDtlVO selectRqesterEmail(ProgrmManageDtlVO vo) {
+			throw new UnsupportedOperationException();
+		}
+	}
+
+	private static void bindLoginUser() {
+		LoginVO login = new LoginVO();
+		login.setId("TEST1");
+		login.setUniqId("USRCNFRM_00000000000");
+		EgovUserDetailsService stub = new EgovUserDetailsService() {
+			@Override
+			public Object getAuthenticatedUser() {
+				return login;
+			}
+
+			@Override
+			public List<String> getAuthorities() {
+				return List.of();
+			}
+
+			@Override
+			public Boolean isAuthenticated() {
+				return Boolean.TRUE;
+			}
+		};
+		new EgovUserDetailsHelper().setEgovUserDetailsService(stub);
+	}
+
+	private static EgovProgrmManageController controllerWith(StubService service) throws Exception {
+		EgovProgrmManageController controller = new EgovProgrmManageController();
+
+		Field serviceField = EgovProgrmManageController.class.getDeclaredField("progrmManageService");
+		serviceField.setAccessible(true);
+		serviceField.set(controller, service);
+
+		Field messageSourceField = EgovProgrmManageController.class.getDeclaredField("egovMessageSource");
+		messageSourceField.setAccessible(true);
+		messageSourceField.set(controller, new EgovMessageSource() {
+			@Override
+			public String getMessage(String code) {
+				return code;
+			}
+		});
+		return controller;
+	}
+
+	@Test
+	void missingChangeRequestGoesBackToTheListInsteadOfThrowing() throws Exception {
+		EgovProgrmManageController controller = controllerWith(new StubService());
+		bindLoginUser();
+
+		ProgrmManageDtlVO progrmManageDtlVO = new ProgrmManageDtlVO();
+		progrmManageDtlVO.setProgrmFileNm("NotExists.java");
+		progrmManageDtlVO.setRqesterNo(9999);
+		ModelMap model = new ModelMap();
+
+		String view = controller.selectProgrmChangRequstProcess(progrmManageDtlVO, model);
+
+		assertEquals("forward:/sym/prm/EgovProgramChangeRequstProcessListSelect.do", view,
+				"없는 변경요청이면 목록으로 되돌려보내야 한다.");
+		assertNotNull(model.get("resultMsg"), "실패 사유를 화면에 남겨야 한다.");
+	}
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`selectProgrmChangRequstProcess`는 변경요청 단건조회 결과를 확인 없이 역참조합니다.

```java
ProgrmManageDtlVO resultVO = progrmManageService.selectProgrmChangeRequst(progrmManageDtlVO);
if (resultVO.getProcessDe() != null) {
	resultVO.setProcessDe(resultVO.getProcessDe().trim());// 2011.08.22
}
```

이 서비스는 `ProgrmManageDAO`의 `selectOne` 결과를 그대로 돌려주고, 매퍼는 프로그램파일명과 요청번호로 한 건을 찾습니다.

```xml
FROM COMTHPROGRMCHANGEDTLS
WHERE PROGRM_FILE_NM=#{progrmFileNm}
AND   REQUST_NO    =#{rqesterNo}
```

해당 행이 없으면 `null`이 돌아옵니다. 변경요청처리 목록을 띄워둔 사이에 그 변경요청이 지워지면(`EgovProgramChangRequstDelete.do`, `EgovProgramChangRequstProcessDelete.do`) 목록에서 그 행을 눌렀을 때 `NullPointerException`이 나면서 화면이 뜨지 않습니다.

같은 컨트롤러에서 이 서비스를 부르는 나머지 두 곳, 변경요청 상세조회(`EgovProgramChangRequstDetailSelect.do`)와 변경이력 상세조회(`EgovProgramChgHstListDetailSelect.do`)는 결과를 모델에 담기만 하고 역참조하지 않습니다. 역참조는 이 핸들러 한 곳입니다.

TO-BE

```java
ProgrmManageDtlVO resultVO = progrmManageService.selectProgrmChangeRequst(progrmManageDtlVO);

// 해당 변경요청이 없으면 조회 결과가 없다. 목록으로 돌려보내고 사유를 남긴다.
if (resultVO == null) {
	model.addAttribute("resultMsg", egovMessageSource.getMessage("fail.common.select"));
	return "forward:/sym/prm/EgovProgramChangeRequstProcessListSelect.do";
}

if (resultVO.getProcessDe() != null) {
```

돌아가는 목록은 같은 컨트롤러의 변경요청처리 삭제 경로가 쓰는 화면과 같습니다. 속성명은 그 목록 화면(`EgovProgramChangeRequstProcess.jsp`)이 안내문을 띄울 때 읽는 `resultMsg`에 맞췄습니다.

### 영향 범위

조회에 성공하는 흐름은 종전과 같습니다. 해당 행이 없을 때만 예외 대신 목록으로 돌아갑니다. 서비스·DAO·매퍼는 변경하지 않았습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

`src/test/java/egovframework/com/sym/prm/web/EgovProgrmManageControllerChangRequstProcessDetailTest.java`를 추가했습니다. 단건조회가 `null`을 돌려주는 상황을 서비스 스텁으로 만들고 핸들러를 부릅니다.

수정 전

```
[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0
[ERROR]   EgovProgrmManageControllerChangRequstProcessDetailTest.missingChangeRequestGoesBackToTheListInsteadOfThrowing
          » NullPointer Cannot invoke "...ProgrmManageDtlVO.getProcessDe()" because "resultVO" is null
```

수정 후

```
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

`pom.xml`의 surefire 설정이 `skipTests=true`라 기본 빌드에서는 실행되지 않습니다. 확인할 때는 그 값을 잠시 `false`로 두고 돌렸습니다.
