### PR TITLE
fix(srm): 서버자원모니터링 대상목록의 2페이지가 1페이지와 같은 목록을 보여줌

### DIFF
--- a/src/main/resources/egovframework/mapper/com/utl/sys/srm/EgovServerResrceMntrng_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/srm/EgovServerResrceMntrng_SQL_altibase.xml
@@ -156,6 +156,12 @@
     </insert>
 
     <select id="selectMntrngServerList" resultMap="mntrngServer">
+            <if test="recordCountPerPage != null">
+            SELECT  *
+              FROM  (
+            SELECT ROWNUM RNUM, ALL_LIST.*
+              FROM  (
+            </if>
              SELECT A.SERVER_ID,
                     A.SERVER_EQPMN_ID, 
                     B.SERVER_EQPMN_NM, 
@@ -166,7 +172,16 @@
               WHERE A.SERVER_EQPMN_ID = B.SERVER_EQPMN_ID     
             <if test="strServerNm != null">AND
                     B.SERVER_EQPMN_NM LIKE '%'||#{strServerNm}||'%'
-            </if>                   
+            </if>
+              ORDER BY A.SERVER_EQPMN_ID, A.SERVER_ID
+            <if test="recordCountPerPage != null">
+            <![CDATA[
+                    ) ALL_LIST
+                    )
+             WHERE  RNUM  > #{firstIndex}
+               AND  RNUM <= #{firstIndex} + #{recordCountPerPage}
+            ]]>
+            </if>
     </select>
 
     <select id="selectMntrngServerListTotCnt" parameterType="egovframework.com.utl.sys.srm.service.ServerResrceMntrngVO" resultType="int">

--- a/src/main/resources/egovframework/mapper/com/utl/sys/srm/EgovServerResrceMntrng_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/srm/EgovServerResrceMntrng_SQL_cubrid.xml
@@ -156,6 +156,12 @@
     </insert>
 
     <select id="selectMntrngServerList" resultMap="mntrngServer">
+            <if test="recordCountPerPage != null">
+            SELECT  *
+              FROM  (
+            SELECT ROWNUM RNUM, ALL_LIST.*
+              FROM  (
+            </if>
              SELECT A.SERVER_ID,
                     A.SERVER_EQPMN_ID, 
                     B.SERVER_EQPMN_NM, 
@@ -166,7 +172,16 @@
               WHERE A.SERVER_EQPMN_ID = B.SERVER_EQPMN_ID     
             <if test="strServerNm != null">AND
                     B.SERVER_EQPMN_NM LIKE '%'||#{strServerNm}||'%'
-            </if>                   
+            </if>
+              ORDER BY A.SERVER_EQPMN_ID, A.SERVER_ID
+            <if test="recordCountPerPage != null">
+            <![CDATA[
+                    ) ALL_LIST
+                    ) Z
+             WHERE  RNUM  > #{firstIndex}
+               AND  RNUM <= #{firstIndex} + #{recordCountPerPage}
+            ]]>
+            </if>
     </select>
 
     <select id="selectMntrngServerListTotCnt" parameterType="egovframework.com.utl.sys.srm.service.ServerResrceMntrngVO" resultType="int">

--- a/src/main/resources/egovframework/mapper/com/utl/sys/srm/EgovServerResrceMntrng_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/srm/EgovServerResrceMntrng_SQL_goldilocks.xml
@@ -156,6 +156,12 @@
     </insert>
 
     <select id="selectMntrngServerList" resultMap="mntrngServer">
+            <if test="recordCountPerPage != null">
+            SELECT  *
+              FROM  (
+            SELECT ROWNUM RNUM, ALL_LIST.*
+              FROM  (
+            </if>
              SELECT A.SERVER_ID,
                     A.SERVER_EQPMN_ID, 
                     B.SERVER_EQPMN_NM, 
@@ -166,7 +172,16 @@
               WHERE A.SERVER_EQPMN_ID = B.SERVER_EQPMN_ID     
             <if test="strServerNm != null">AND
                     B.SERVER_EQPMN_NM LIKE '%'||#{strServerNm}||'%'
-            </if>                   
+            </if>
+              ORDER BY A.SERVER_EQPMN_ID, A.SERVER_ID
+            <if test="recordCountPerPage != null">
+            <![CDATA[
+                    ) ALL_LIST
+                    )
+             WHERE  RNUM  > #{firstIndex}
+               AND  RNUM <= #{firstIndex} + #{recordCountPerPage}
+            ]]>
+            </if>
     </select>
 
     <select id="selectMntrngServerListTotCnt" parameterType="egovframework.com.utl.sys.srm.service.ServerResrceMntrngVO" resultType="int">

--- a/src/main/resources/egovframework/mapper/com/utl/sys/srm/EgovServerResrceMntrng_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/srm/EgovServerResrceMntrng_SQL_maria.xml
@@ -157,6 +157,10 @@
               <if test="strServerNm != null">AND
                     SERVER_EQPMN_NM LIKE CONCAT('%' , #{strServerNm}, '%')
               </if>
+              ORDER BY A.SERVER_EQPMN_ID, A.SERVER_ID
+              <if test="recordCountPerPage != null">
+              LIMIT #{recordCountPerPage} OFFSET #{firstIndex}
+              </if>
     </select>
 
     <select id="selectMntrngServerListTotCnt" parameterType="egovframework.com.utl.sys.srm.service.ServerResrceMntrngVO" resultType="int">

--- a/src/main/resources/egovframework/mapper/com/utl/sys/srm/EgovServerResrceMntrng_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/srm/EgovServerResrceMntrng_SQL_mysql.xml
@@ -157,6 +157,10 @@
               <if test="strServerNm != null">AND
                     SERVER_EQPMN_NM LIKE CONCAT('%' , #{strServerNm}, '%')
               </if>
+              ORDER BY A.SERVER_EQPMN_ID, A.SERVER_ID
+              <if test="recordCountPerPage != null">
+              LIMIT #{recordCountPerPage} OFFSET #{firstIndex}
+              </if>
     </select>
 
     <select id="selectMntrngServerListTotCnt" parameterType="egovframework.com.utl.sys.srm.service.ServerResrceMntrngVO" resultType="int">

--- a/src/main/resources/egovframework/mapper/com/utl/sys/srm/EgovServerResrceMntrng_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/srm/EgovServerResrceMntrng_SQL_oracle.xml
@@ -156,6 +156,12 @@
     </insert>
 
     <select id="selectMntrngServerList" resultMap="mntrngServer">
+            <if test="recordCountPerPage != null">
+            SELECT  *
+              FROM  (
+            SELECT ROWNUM RNUM, ALL_LIST.*
+              FROM  (
+            </if>
              SELECT A.SERVER_ID,
                     A.SERVER_EQPMN_ID, 
                     B.SERVER_EQPMN_NM, 
@@ -166,7 +172,16 @@
               WHERE A.SERVER_EQPMN_ID = B.SERVER_EQPMN_ID     
             <if test="strServerNm != null">AND
                     B.SERVER_EQPMN_NM LIKE '%'||#{strServerNm}||'%'
-            </if>                   
+            </if>
+              ORDER BY A.SERVER_EQPMN_ID, A.SERVER_ID
+            <if test="recordCountPerPage != null">
+            <![CDATA[
+                    ) ALL_LIST
+                    )
+             WHERE  RNUM  > #{firstIndex}
+               AND  RNUM <= #{firstIndex} + #{recordCountPerPage}
+            ]]>
+            </if>
     </select>
 
     <select id="selectMntrngServerListTotCnt" parameterType="egovframework.com.utl.sys.srm.service.ServerResrceMntrngVO" resultType="int">

--- a/src/main/resources/egovframework/mapper/com/utl/sys/srm/EgovServerResrceMntrng_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/srm/EgovServerResrceMntrng_SQL_postgres.xml
@@ -157,6 +157,10 @@
               <if test="strServerNm != null">AND
                     SERVER_EQPMN_NM LIKE CONCAT('%' , #{strServerNm}, '%')
               </if>
+              ORDER BY A.SERVER_EQPMN_ID, A.SERVER_ID
+              <if test="recordCountPerPage != null">
+              LIMIT #{recordCountPerPage} OFFSET #{firstIndex}
+              </if>
     </select>
 
     <select id="selectMntrngServerListTotCnt" parameterType="egovframework.com.utl.sys.srm.service.ServerResrceMntrngVO" resultType="int">

--- a/src/main/resources/egovframework/mapper/com/utl/sys/srm/EgovServerResrceMntrng_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/srm/EgovServerResrceMntrng_SQL_tibero.xml
@@ -156,6 +156,12 @@
     </insert>
 
     <select id="selectMntrngServerList" resultMap="mntrngServer">
+            <if test="recordCountPerPage != null">
+            SELECT  *
+              FROM  (
+            SELECT ROWNUM RNUM, ALL_LIST.*
+              FROM  (
+            </if>
              SELECT A.SERVER_ID,
                     A.SERVER_EQPMN_ID, 
                     B.SERVER_EQPMN_NM, 
@@ -166,7 +172,16 @@
               WHERE A.SERVER_EQPMN_ID = B.SERVER_EQPMN_ID     
             <if test="strServerNm != null">AND
                     B.SERVER_EQPMN_NM LIKE '%'||#{strServerNm}||'%'
-            </if>                   
+            </if>
+              ORDER BY A.SERVER_EQPMN_ID, A.SERVER_ID
+            <if test="recordCountPerPage != null">
+            <![CDATA[
+                    ) ALL_LIST
+                    )
+             WHERE  RNUM  > #{firstIndex}
+               AND  RNUM <= #{firstIndex} + #{recordCountPerPage}
+            ]]>
+            </if>
     </select>
 
     <select id="selectMntrngServerListTotCnt" parameterType="egovframework.com.utl.sys.srm.service.ServerResrceMntrngVO" resultType="int">

--- a/src/test/java/egovframework/com/utl/sys/srm/service/impl/EgovMntrngServerListPagingTest.java
+++ b/src/test/java/egovframework/com/utl/sys/srm/service/impl/EgovMntrngServerListPagingTest.java
@@ -1,0 +1,144 @@
+package egovframework.com.utl.sys.srm.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.InputStream;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.ibatis.builder.xml.XMLMapperBuilder;
+import org.apache.ibatis.datasource.unpooled.UnpooledDataSource;
+import org.apache.ibatis.mapping.Environment;
+import org.apache.ibatis.mapping.MappedStatement;
+import org.apache.ibatis.mapping.ParameterMapping;
+import org.apache.ibatis.session.Configuration;
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.apache.ibatis.session.SqlSessionFactoryBuilder;
+import org.apache.ibatis.transaction.jdbc.JdbcTransactionFactory;
+import org.egovframe.rte.psl.dataaccess.util.EgovMap;
+import org.egovframe.rte.ptl.mvc.tags.ui.pagination.PaginationInfo;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import egovframework.com.utl.sys.srm.service.ServerResrceMntrngVO;
+
+class EgovMntrngServerListPagingTest {
+
+	private static final String STATEMENT_ID = "serverResrceMntrngDAO.selectMntrngServerList";
+
+	private static final String JDBC_URL = "jdbc:hsqldb:mem:mntrngServerListPaging";
+
+	private static SqlSessionFactory sqlSessionFactory;
+
+	@BeforeAll
+	static void seedDatabase() throws Exception {
+		Class.forName("org.hsqldb.jdbcDriver");
+		try (Connection connection = DriverManager.getConnection(JDBC_URL, "sa", "");
+				Statement statement = connection.createStatement()) {
+			statement.execute("CREATE TABLE COMTNSERVEREQPMNINFO ("
+					+ "SERVER_EQPMN_ID VARCHAR(20) NOT NULL PRIMARY KEY,"
+					+ "SERVER_EQPMN_NM VARCHAR(60), SERVER_EQPMN_IP VARCHAR(23), MNGR_EMAIL_ADRES VARCHAR(50))");
+			statement.execute("CREATE TABLE COMTNSERVEREQPMNRELATE ("
+					+ "SERVER_EQPMN_ID VARCHAR(20) NOT NULL, SERVER_ID VARCHAR(20) NOT NULL,"
+					+ "PRIMARY KEY (SERVER_EQPMN_ID, SERVER_ID))");
+			for (int i = 1; i <= 12; i++) {
+				String eqpmnId = String.format("EQP%02d", i);
+				statement.execute("INSERT INTO COMTNSERVEREQPMNINFO VALUES ('" + eqpmnId + "', 'server" + eqpmnId
+						+ "', '10.0.0." + i + "', 'adm" + i + "@example.org')");
+				statement.execute("INSERT INTO COMTNSERVEREQPMNRELATE VALUES ('" + eqpmnId + "', 'SRV01')");
+			}
+		}
+
+		Configuration configuration = newConfiguration("mysql");
+		configuration.setEnvironment(new Environment("test", new JdbcTransactionFactory(),
+				new UnpooledDataSource("org.hsqldb.jdbcDriver", JDBC_URL, "sa", "")));
+		sqlSessionFactory = new SqlSessionFactoryBuilder().build(configuration);
+	}
+
+	private static Configuration newConfiguration(String dialect) throws Exception {
+		String resource = "egovframework/mapper/com/utl/sys/srm/EgovServerResrceMntrng_SQL_" + dialect + ".xml";
+		Configuration configuration = new Configuration();
+		configuration.getTypeAliasRegistry().registerAlias("egovMap", EgovMap.class);
+		try (InputStream inputStream = org.apache.ibatis.io.Resources.getResourceAsStream(resource)) {
+			new XMLMapperBuilder(inputStream, configuration, resource, configuration.getSqlFragments()).parse();
+		}
+		return configuration;
+	}
+
+	/** EgovServerResrceMntrngController.selectMntrngServerList 의 페이징 계산을 그대로 옮긴 것. */
+	private static ServerResrceMntrngVO searchConditionOfPage(int pageIndex) {
+		ServerResrceMntrngVO serverResrceMntrngVO = new ServerResrceMntrngVO();
+		serverResrceMntrngVO.setPageIndex(pageIndex);
+
+		PaginationInfo paginationInfo = new PaginationInfo();
+		paginationInfo.setCurrentPageNo(serverResrceMntrngVO.getPageIndex());
+		paginationInfo.setRecordCountPerPage(serverResrceMntrngVO.getPageUnit());
+		paginationInfo.setPageSize(serverResrceMntrngVO.getPageSize());
+
+		serverResrceMntrngVO.setFirstIndex(paginationInfo.getFirstRecordIndex());
+		serverResrceMntrngVO.setLastIndex(paginationInfo.getLastRecordIndex());
+		serverResrceMntrngVO.setRecordCountPerPage(paginationInfo.getRecordCountPerPage());
+		return serverResrceMntrngVO;
+	}
+
+	private static List<String> equipmentIdsOf(Object parameter) {
+		try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+			List<ServerResrceMntrngVO> rows = sqlSession.selectList(STATEMENT_ID, parameter);
+			List<String> ids = new ArrayList<>();
+			for (ServerResrceMntrngVO row : rows) {
+				ids.add(row.getServerEqpmnId());
+			}
+			return ids;
+		}
+	}
+
+	@Test
+	@DisplayName("등록서버 12건 중 2페이지는 11~12번째 서버만 보여준다")
+	void secondPageShowsTheRowsAfterTheFirstPage() {
+		List<String> firstPage = equipmentIdsOf(searchConditionOfPage(1));
+		List<String> secondPage = equipmentIdsOf(searchConditionOfPage(2));
+
+		System.out.println("[1페이지] " + firstPage);
+		System.out.println("[2페이지] " + secondPage);
+
+		assertEquals(List.of("EQP01", "EQP02", "EQP03", "EQP04", "EQP05", "EQP06", "EQP07", "EQP08", "EQP09", "EQP10"),
+				firstPage, "1페이지에 10건이 아니라 전체가 실렸다");
+		assertEquals(List.of("EQP11", "EQP12"), secondPage, "2페이지가 1페이지와 같은 목록을 보여준다");
+	}
+
+	@ParameterizedTest(name = "{0}")
+	@ValueSource(strings = { "mysql", "maria", "oracle", "postgres", "tibero", "altibase", "cubrid", "goldilocks" })
+	@DisplayName("등록서버 목록 조회는 방언과 무관하게 firstIndex 로 행을 건너뛴다")
+	void everyDialectSkipsRowsOfPrecedingPages(String dialect) throws Exception {
+		MappedStatement mappedStatement = newConfiguration(dialect).getMappedStatement(STATEMENT_ID);
+
+		List<String> boundProperties = new ArrayList<>();
+		for (ParameterMapping parameterMapping : mappedStatement.getBoundSql(searchConditionOfPage(2))
+				.getParameterMappings()) {
+			boundProperties.add(parameterMapping.getProperty());
+		}
+
+		assertTrue(boundProperties.contains("firstIndex"),
+				dialect + " 매퍼가 페이지를 건너뛰지 않는다: " + mappedStatement.getBoundSql(searchConditionOfPage(2)).getSql());
+	}
+
+	@Test
+	@DisplayName("스케줄러가 null 을 넘기면 등록서버 전체를 돌려준다")
+	void schedulerWithoutSearchConditionStillGetsEveryServer() {
+		// EgovServerResrceMntrngScheduling.monitorServerResrce 는 null 을 넘긴다.
+		List<String> monitored = equipmentIdsOf(null);
+
+		System.out.println("[스케줄러] " + monitored.size() + "건 " + monitored);
+
+		assertEquals(12, monitored.size(), "모니터링 대상 서버가 누락됐다");
+	}
+
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`/utl/sys/srm/selectMntrngServerList.do` 는 `PaginationInfo` 로 `firstIndex`·`recordCountPerPage` 를 채우고 `selectMntrngServerListTotCnt` 로 총건수를 구해 `EgovMntrngServerList.jsp` 에 `<ui:pagination>` 을 그립니다. 그런데 목록 구문 `selectMntrngServerList` 에는 여덟 방언 어디에도 앞 페이지를 건너뛰는 절이 없어, 2페이지를 눌러도 1페이지와 같은 전체 목록이 나옵니다. 같은 매퍼의 형제 구문 `selectServerResrceMntrngList` 는 여덟 방언 모두 이 두 값으로 앞 페이지를 건너뜁니다.

형제 구문과 같은 형태로 행 제한을 넣었습니다. mysql·maria·postgres 는 `LIMIT ... OFFSET`, oracle·tibero·altibase·cubrid·goldilocks 는 `ROWNUM` 중첩입니다. 정렬키는 관계 테이블 `COMTNSERVEREQPMNRELATE` 의 복합 기본키를 따라 `A.SERVER_EQPMN_ID, A.SERVER_ID` 로 뒀습니다. 이 `ORDER BY` 는 테스트로 걸러지지 않는 방어적 추가이고, 여덟 줄을 지워도 아래 테스트는 통과합니다.

행 제한은 `<if test="recordCountPerPage != null">` 로 감쌌습니다. 이 저장소 매퍼에 없던 형태를 새로 넣는 것입니다. `EgovServerResrceMntrngScheduling.monitorServerResrce` 가 대입된 적 없는 필드를 그대로 넘겨 파라미터가 널인 채로 같은 구문을 부르기 때문입니다. `ComDefaultVO` 의 게터는 널을 돌려주지 않아 화면에서 온 VO 로는 이 분기가 거짓이 되지 않습니다. 빈 VO 를 대신 넘기면 `firstIndex` 기본값이 1이라 등록 서버 12건 중 EQP01·EQP12 가 빠진 10건만 옵니다. 다만 이 스케줄러는 잡·트리거 빈만 있고 `SchedulerFactoryBean` 이 주석 처리돼 있어 기본 설정에서는 돌지 않습니다.

mysql 매퍼 153개에서 `TotCnt` 형제를 가진 목록 구문 중 `firstIndex` 를 쓰지 않는 것은 이 구문까지 12건입니다. 나머지 11건은 DAO 가 `selectOne` 인 단건 조회이거나 화면에 `<ui:pagination>` 이 없어, 이 PR 은 여기만 고칩니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

컨트롤러와 같은 방식으로 `PaginationInfo` 를 계산해 매퍼를 부르는 `EgovMntrngServerListPagingTest` 를 넣었습니다. 등록 서버 12건에서 1·2페이지를 비교하고, 여덟 방언이 각각 `firstIndex` 를 바인딩하는지 봅니다.

수정 전

```
[1페이지] [EQP01, EQP02, EQP03, EQP04, EQP05, EQP06, EQP07, EQP08, EQP09, EQP10, EQP11, EQP12]
[2페이지] [EQP01, EQP02, EQP03, EQP04, EQP05, EQP06, EQP07, EQP08, EQP09, EQP10, EQP11, EQP12]
[ERROR] Tests run: 10, Failures: 9, Errors: 0, Skipped: 0
```

수정 후

```
[1페이지] [EQP01, EQP02, EQP03, EQP04, EQP05, EQP06, EQP07, EQP08, EQP09, EQP10]
[2페이지] [EQP11, EQP12]
[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0
```

`pom.xml` 의 surefire 설정이 `<skipTests>true</skipTests>` 로 고정돼 있어 이 값을 잠시 해제하고 실행한 결과입니다. 되돌려 뒀으므로 CI 에서는 이 테스트가 돌지 않습니다.