### PR TITLE
refactor(cmm): 업로드 검증의 최대 크기 설정을 확장자 목록과 같이 요청당 한 번만 읽도록 수정

### DIFF
--- a/src/main/java/egovframework/com/cmm/web/EgovMultipartResolver.java
+++ b/src/main/java/egovframework/com/cmm/web/EgovMultipartResolver.java
@@ -91,6 +91,7 @@ public class EgovMultipartResolver extends StandardServletMultipartResolver {
 	private void validateUploadedFiles(MultipartHttpServletRequest multipartRequest) throws SecurityException {
 		Map<String, List<MultipartFile>> fileMap = multipartRequest.getMultiFileMap();
 		String whiteListFileUploadExtensions = EgovProperties.getProperty("Globals.fileUpload.Extensions");
+		long maxFileSize = getMaxFileSize();
 
 		// 파일 개수 제한 검증 추가
 		validateFileCount(multipartRequest);
@@ -103,7 +104,7 @@ public class EgovMultipartResolver extends StandardServletMultipartResolver {
 
 			for (MultipartFile file : files) {
 				if (file != null && !file.isEmpty()) {
-					validateFile(file, whiteListFileUploadExtensions);
+					validateFile(file, whiteListFileUploadExtensions, maxFileSize);
 					LOGGER.debug("File validation passed for field [{}]: {} ({} bytes)",
 						fieldName, file.getOriginalFilename(), file.getSize());
 				}
@@ -116,9 +117,10 @@ public class EgovMultipartResolver extends StandardServletMultipartResolver {
 	 *
 	 * @param file 검증할 파일
 	 * @param whiteListFileUploadExtensions 허용된 파일 확장자 목록
+	 * @param maxFileSize 허용된 최대 파일 크기 (바이트)
 	 * @throws SecurityException 보안 검증 실패 시
 	 */
-	private void validateFile(MultipartFile file, String whiteListFileUploadExtensions) throws SecurityException {
+	private void validateFile(MultipartFile file, String whiteListFileUploadExtensions, long maxFileSize) throws SecurityException {
 		String fileName = file.getOriginalFilename();
 
 		if (fileName == null || fileName.trim().isEmpty()) {
@@ -161,7 +163,6 @@ public class EgovMultipartResolver extends StandardServletMultipartResolver {
 		}
 
 		// 파일 크기 검증 (기본값: 10MB)
-		long maxFileSize = getMaxFileSize();
 		if (file.getSize() > maxFileSize) {
 			LOGGER.warn("File size [{}] exceeds maximum allowed size [{}] for file: {}",
 				file.getSize(), maxFileSize, fileName);

--- a/src/test/java/egovframework/com/cmm/web/EgovMultipartResolverConfigReadTest.java
+++ b/src/test/java/egovframework/com/cmm/web/EgovMultipartResolverConfigReadTest.java
@@ -1,0 +1,142 @@
+package egovframework.com.cmm.web;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.multipart.MultipartHttpServletRequest;
+
+import egovframework.com.cmm.service.EgovProperties;
+
+/**
+ * EgovMultipartResolver가 업로드 설정을 요청당 한 번만 읽는지 검증한다.
+ */
+class EgovMultipartResolverConfigReadTest {
+
+	private static final String BASE_CONFIG =
+		"Globals.fileUpload.Extensions = .png\n"
+		+ "Globals.fileUpload.maxFileCount = 10\n"
+		+ "Globals.fileUpload.maxSize = 104857600\n";
+
+	@Test
+	void maxFileSizeIsReadOncePerRequestNotOncePerFile() throws Exception {
+		Path config = Paths.get(EgovProperties.GLOBALS_PROPERTIES_FILE);
+		byte[] original = Files.readAllBytes(config);
+		try {
+			Files.write(config, BASE_CONFIG.getBytes(StandardCharsets.UTF_8));
+
+			// 첫 번째 파일을 검증하는 도중 설정 파일의 최대 크기를 1바이트로 바꾼다.
+			// 최대 크기를 파일마다 다시 읽으면 뒤이은 크기 검증이 바뀐 값을 보게 된다.
+			Runnable shrinkMaxSize = () -> {
+				try {
+					Files.write(config, BASE_CONFIG.replace("104857600", "1").getBytes(StandardCharsets.UTF_8));
+				} catch (Exception e) {
+					throw new IllegalStateException(e);
+				}
+			};
+
+			MultipartHttpServletRequest request = multipartRequest(
+				file("first.png", 100L, shrinkMaxSize),
+				file("second.png", 100L, null));
+
+			assertDoesNotThrow(() -> validateUploadedFiles(request));
+		} finally {
+			Files.write(config, original);
+		}
+	}
+
+	@Test
+	void fileLargerThanMaxSizeIsStillRejected() throws Exception {
+		Path config = Paths.get(EgovProperties.GLOBALS_PROPERTIES_FILE);
+		byte[] original = Files.readAllBytes(config);
+		try {
+			Files.write(config, BASE_CONFIG.replace("104857600", "99").getBytes(StandardCharsets.UTF_8));
+
+			MultipartHttpServletRequest request = multipartRequest(file("big.png", 100L, null));
+
+			assertThrows(SecurityException.class, () -> validateUploadedFiles(request));
+		} finally {
+			Files.write(config, original);
+		}
+	}
+
+	private static void validateUploadedFiles(MultipartHttpServletRequest request) throws Exception {
+		Method validate = EgovMultipartResolver.class
+			.getDeclaredMethod("validateUploadedFiles", MultipartHttpServletRequest.class);
+		validate.setAccessible(true);
+		try {
+			validate.invoke(new EgovMultipartResolver(), request);
+		} catch (InvocationTargetException e) {
+			throw e.getCause() instanceof Exception ? (Exception)e.getCause() : e;
+		}
+	}
+
+	private static MultipartFile file(String name, long size, Runnable onNameRead) {
+		return (MultipartFile)Proxy.newProxyInstance(
+			EgovMultipartResolverConfigReadTest.class.getClassLoader(),
+			new Class<?>[] {MultipartFile.class},
+			(proxy, method, args) -> {
+				switch (method.getName()) {
+					case "getOriginalFilename":
+						if (onNameRead != null) {
+							onNameRead.run();
+						}
+						return name;
+					case "getName":
+						return "atchFile";
+					case "isEmpty":
+						return Boolean.FALSE;
+					case "getSize":
+						return size;
+					case "hashCode":
+						return System.identityHashCode(proxy);
+					case "equals":
+						return proxy == args[0];
+					case "toString":
+						return name;
+					default:
+						return null;
+				}
+			});
+	}
+
+	private static MultipartHttpServletRequest multipartRequest(MultipartFile... files) {
+		List<MultipartFile> list = new ArrayList<>();
+		for (MultipartFile file : files) {
+			list.add(file);
+		}
+		Map<String, List<MultipartFile>> map = new LinkedHashMap<>();
+		map.put("atchFile", list);
+		return (MultipartHttpServletRequest)Proxy.newProxyInstance(
+			EgovMultipartResolverConfigReadTest.class.getClassLoader(),
+			new Class<?>[] {MultipartHttpServletRequest.class},
+			(proxy, method, args) -> {
+				switch (method.getName()) {
+					case "getMultiFileMap":
+						return new LinkedMultiValueMap<>(map);
+					case "hashCode":
+						return System.identityHashCode(proxy);
+					case "equals":
+						return proxy == args[0];
+					case "toString":
+						return "multipartRequest";
+					default:
+						return null;
+				}
+			});
+	}
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [ ] 버그수정 Bug fixes
- [X] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`EgovMultipartResolver.validateUploadedFiles`는 허용 확장자 목록을 반복문 밖에서 한 번 읽어 `validateFile` 인자로 넘깁니다. 반면 최대 파일 크기는 같은 `validateFile` 안에서 `getMaxFileSize()`로 파일마다 다시 읽습니다. 한 메서드가 같은 성격의 설정 두 개를 다르게 다루고 있어서 최대 크기도 확장자 목록과 같은 자리에서 한 번 읽어 인자로 넘기도록 맞췄습니다.

`EgovProperties.getProperty`에는 캐시가 없어 호출마다 `loadPropertiesFromFile`이 `globals.properties`를 `FileInputStream`으로 열고 다시 파싱합니다. 그래서 파일 N개가 담긴 요청은 이 설정 파일을 N+2번 읽습니다.

```java
// AS-IS : validateFile 안이라 파일마다 실행된다
long maxFileSize = getMaxFileSize();
if (file.getSize() > maxFileSize) {
```

이득은 첨부 개수에 달려 있어 측정값을 그대로 싣습니다. 첨부 2개부터 이득이고 1개면 동일합니다. 첨부가 없는 multipart 요청은 설정 읽기가 한 번 늘어납니다.

측정 (`validateUploadedFiles` 1회 소요시간, `globals.properties` 12,058바이트, 500회 5라운드 중 최솟값). `EgovProperties` 가 읽기마다 디버그 로그를 남기므로 로그 출력을 끄고 측정했습니다 — 켠 채로는 로깅이 측정을 지배합니다.

```
첨부   0개   0.043ms -> 0.065ms
      1개   0.065ms -> 0.065ms
      2개   0.087ms -> 0.065ms
     10개   0.262ms -> 0.066ms
    100개   2.231ms -> 0.078ms
```

10개는 `getMaxFileCount()`의 코드 기본값이자 그 주석이 적고 있는 Tomcat 9.0.106+ 기본 파트 개수입니다. `globals.properties`의 `Globals.fileUpload.maxFileCount = 1000`은 설정상 최대치이며 한 요청에 실제로 몇 개가 담기는지는 컨테이너의 파트 개수 제한도 함께 정합니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

`EgovMultipartResolverConfigReadTest` 2건을 추가했습니다. 하나는 첫 파일을 검증하는 도중 설정의 최대 크기를 줄여 뒤따르는 파일이 바뀐 값을 보지 않는지 확인합니다(현재 main 에서는 실패합니다). 다른 하나는 최대 크기를 넘는 파일이 여전히 `SecurityException`으로 거절되는지 확인합니다.

`pom.xml` 647행이 surefire 의 `skipTests`를 `true`로 두고 있어 CI 의 `mvn -B verify`는 이 테스트를 컴파일만 하고 실행하지는 않습니다. 확인하실 때는 그 줄을 잠시 `false`로 바꾸고 `mvn test -Dtest=EgovMultipartResolverConfigReadTest`로 실행해 주십시오.

## 테스트 브라우저 Test Browser

UI 변경 없음.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

UI 변경 없음.