### PR TITLE
test(adb): 주소록 테스트 암호화 설정을 Java 구성으로 전환

### DIFF
--- a/src/test/java/egovframework/com/cop/adb/service/impl/AddressBookConfigurationTest.java
+++ b/src/test/java/egovframework/com/cop/adb/service/impl/AddressBookConfigurationTest.java
@@ -4,17 +4,16 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.ComponentScan.Filter;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.ImportResource;
 
+import egovframework.com.cmm.config.EgovConfigCryptoTest;
 import egovframework.com.cop.adb.service.EgovAddressBookService;
 
 @Configuration
 
 @ImportResource({
 
-//	"classpath*:egovframework/spring/com/**/context-*.xml",
-
-		"classpath*:/egovframework/spring/com/context-crypto.xml",
 		"classpath*:/egovframework/spring/com/context-datasource.xml",
 		"classpath*:/egovframework/spring/com/context-mapper.xml",
 		"classpath*:/egovframework/spring/com/context-transaction.xml",
@@ -24,6 +23,8 @@ import egovframework.com.cop.adb.service.EgovAddressBookService;
 		"classpath*:/egovframework/spring/com/test-context-common.xml",
 
 })
+
+@Import(EgovConfigCryptoTest.class)
 
 @ComponentScan(useDefaultFilters = false, basePackages = {
 		"egovframework.com.cop.adb.service.impl" }, includeFilters = {


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [x] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

## 개요

주소록 테스트 컨텍스트의 암호화 설정을 XML 기반 구성에서 테스트 전용 Java 구성으로 전환합니다.

## 변경 사항

- `AddressBookConfigurationTest`에서 `context-crypto.xml` 로딩 제거
- `EgovConfigCryptoTest`를 `@Import`로 등록
- 사용하지 않는 주석 처리된 컨텍스트 경로 제거

## 변경 이유

주소록 테스트가 운영용 암호화 XML 설정에 직접 의존하지 않고, 테스트에 필요한 암호화 빈만 명시적으로 구성하도록 개선합니다.

이를 통해 테스트 컨텍스트의 구성 범위를 명확하게 하고 `EgovPasswordResolver`를 포함한 테스트 전용 암호화 설정을 재사용할 수 있습니다.

## 영향 범위

- 주소록 DAO 및 서비스 테스트 컨텍스트
- 운영 코드 및 운영 암호화 설정에는 영향 없음
- 호환성을 깨뜨리는 변경 없음

## 검증

- `git diff --check` 통과
- JDK 17.0.17 및 Maven 3.9.9 환경에서 main/test 소스 컴파일 성공
- 프로젝트의 Surefire 설정에 `<skipTests>true</skipTests>`가 직접 지정되어 있어 테스트 케이스 실행은 생략됨

https://github.com/eGovFramework/egovframe-common-components/pull/1264

https://github.com/eGovFramework/egovframe-common-components/pull/1259

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [x] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

테스트 후

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/7c4f14c7-46ef-4c9b-b8d8-6f26b3d90b1a" />

https://youtu.be/Cztrczrfszs
