### PR TITLE
test(file-manage-dao): 암호화 설정을 Java 구성으로 전환

### DIFF
--- a/src/test/java/egovframework/com/cmm/service/impl/FileManageDAOConfigurationTest.java
+++ b/src/test/java/egovframework/com/cmm/service/impl/FileManageDAOConfigurationTest.java
@@ -4,15 +4,15 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.ComponentScan.Filter;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.ImportResource;
+
+import egovframework.com.cmm.config.EgovConfigCryptoTest;
 
 @Configuration
 
 @ImportResource({
 
-//	"classpath*:egovframework/spring/com/**/context-*.xml",
-
-		"classpath*:/egovframework/spring/com/context-crypto.xml",
 		"classpath*:/egovframework/spring/com/context-datasource.xml",
 		"classpath*:/egovframework/spring/com/context-mapper.xml",
 		"classpath*:/egovframework/spring/com/context-transaction.xml",
@@ -22,6 +22,8 @@ import org.springframework.context.annotation.ImportResource;
 		"classpath*:/egovframework/spring/com/test-context-common.xml",
 
 })
+
+@Import(EgovConfigCryptoTest.class)
 
 @ComponentScan(useDefaultFilters = false, basePackages = { "egovframework.com.cmm.service.impl" }, includeFilters = {
 		@Filter(type = FilterType.ASSIGNABLE_TYPE, classes = { FileManageDAO.class }) })


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [x] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

## 개요

FileManageDAO 테스트 컨텍스트의 암호화 설정 방식을 XML 기반 구성에서
테스트용 Java 구성 클래스 기반으로 전환합니다.

## 변경 내용

- `FileManageDAOConfigurationTest`에서 `context-crypto.xml` 직접 로딩 제거
- `EgovConfigCryptoTest`를 `@Import`로 등록
- 암호화 관련 컴포넌트와 `EgovPasswordResolver` 빈을 테스트 구성으로 제공
- 데이터소스, MyBatis 매퍼, 트랜잭션 등 기존 XML 설정은 유지

## 변경 이유

FileManageDAO 테스트가 공용 XML 암호화 설정에 직접 의존하지 않고,
테스트 전용 Java 설정을 통해 필요한 암호화 구성을 명시적으로
불러오도록 테스트 컨텍스트를 정리합니다.

## 영향 범위

- `FileManageDAOConfigurationTest`를 사용하는 FileManageDAO DAO 테스트
- 운영 코드 및 운영 환경 설정에는 영향 없음
- 단절적 변경 없음

## 검증

- [x] JDK 17.0.17 및 Maven 3.9.9 환경에서 main/test 소스 컴파일 성공
- [x] `git diff --check` 통과
- [ ] FileManageDAO 테스트 실행 확인

> `maven-surefire-plugin`의 `skipTests` 설정이 `true`로 고정되어 있어
> Maven 빌드에서는 테스트가 실행되지 않고 건너뛰어졌습니다.

https://github.com/eGovFramework/egovframe-common-components/pull/1218

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [x] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

테스트 후

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/b95e8cc8-ae43-4cf3-9af9-9af504e0c63b" />
