### PR TITLE
fix(EgovStringUtil): replaceChar 반복 시 버퍼 누적으로 결과가 손상되는 문제 수정

### DIFF
--- a/src/main/java/egovframework/com/utl/fcc/service/EgovStringUtil.java
+++ b/src/main/java/egovframework/com/utl/fcc/service/EgovStringUtil.java
@@ -256,6 +256,7 @@ public class EgovStringUtil {
 			if (srcStr.indexOf(chA) >= 0) {
 				preStr = srcStr.substring(0, srcStr.indexOf(chA));
 				nextStr = srcStr.substring(srcStr.indexOf(chA) + 1, srcStr.length());
+				rtnStr.setLength(0); // 반복 시 버퍼 누적 방지 (반복문 내 초기화)
 				srcStr = rtnStr.append(preStr).append(object).append(nextStr).toString();
 			}
 		}


### PR DESCRIPTION
## 수정 사유 (Reason for modification)
- [x] 버그수정 (Bug fixes)

## 문제
`EgovStringUtil.replaceChar(source, subject, object)` 는 `subject` 의 **각 문자를** `object` 로 바꾸는 유틸입니다. 그런데 `StringBuilder` 를 반복문 밖에서 한 번만 만들고 **초기화 없이 계속 `append`** 하기 때문에, 이전 반복의 결과가 그대로 남은 상태에서 다음 반복 결과가 덧붙습니다.

```java
StringBuilder rtnStr = new StringBuilder();   // 반복문 밖
...
for (int i = 0; i < subject.length(); i++) {
    ...
    srcStr = rtnStr.append(preStr).append(object).append(nextStr).toString();  // 누적
}
```

`subject` 가 **2자 이상**일 때 결과가 손상됩니다.

| 호출 | 현재 | 기대 |
|---|---|---|
| `replaceChar("a-b/c", "-/", "")` | `ab/cabc` | `abc` |
| `replaceChar("a.b,c", ".,", "_")` | `a_b,ca_b_c` | `a_b_c` |

## 수정 내용
반복마다 버퍼를 초기화합니다. **1줄 추가**입니다.

```diff
     if (srcStr.indexOf(chA) >= 0) {
         preStr = srcStr.substring(0, srcStr.indexOf(chA));
         nextStr = srcStr.substring(srcStr.indexOf(chA) + 1, srcStr.length());
+        rtnStr.setLength(0); // 반복 시 버퍼 누적 방지 (반복문 내 초기화)
         srcStr = rtnStr.append(preStr).append(object).append(nextStr).toString();
     }
```

## 동일 결함의 반영 선례
같은 결함이 다른 표준프레임워크 템플릿 저장소들에도 있었고, **동일한 방식(`setLength(0)` 추가)으로 이미 수정·병합**되었습니다.

- egovframe-enterprise-business-template **#148** (Merged, `b0f6d5e`)
- egovframe-portal-site-template **#86** (Merged)
- egovframe-simple-homepage-template **#61** (Merged)

본 PR 은 같은 수정을 공통컴포넌트에 맞춘 것으로, 세 저장소와 코드가 일치하게 됩니다.

## 검증 (실측)
메서드 본문을 그대로 옮긴 standalone 하네스로 수정 전/후를 비교했습니다.

| 시나리오 | 수정 전 | 수정 후 |
|---|---|---|
| `("a-b/c", "-/", "")` | `ab/cabc` | `abc` |
| `("a.b,c", ".,", "_")` | `a_b,ca_b_c` | `a_b_c` |
| 회귀: `("2026-09-02", "-", "/")` (subject 1자) | `2026/09-02` | **동일** |
| 회귀: `("abc", "x", "_")` (미포함) | `abc` | **동일** |
| 회귀: `("", "-", "_")` (빈 문자열) | `` | **동일** |
| 회귀: `("a-b", "-", "+")` | `a+b` | **동일** |

`subject` 가 1자이거나 대상 문자가 없는 경우 등 기존에 정상 동작하던 경로는 결과가 완전히 같고, **2자 이상에서 손상되던 경우만** 바로잡힙니다.