### PR TITLE
test(cmt): 댓글 DAO 테스트 실행 순서를 명시적으로 정리

### DIFF
--- a/src/test/java/egovframework/com/cop/cmt/service/impl/EgovArticleCommentDAO2Test.java
+++ b/src/test/java/egovframework/com/cop/cmt/service/impl/EgovArticleCommentDAO2Test.java
@@ -7,9 +7,9 @@ import java.util.List;
 
 import org.egovframe.rte.fdl.cmmn.exception.FdlException;
 import org.egovframe.rte.fdl.idgnr.EgovIdGnrService;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.dao.DataAccessException;
 
 import egovframework.com.cmm.LoginVO;
@@ -21,7 +21,6 @@ import egovframework.com.cop.bbs.service.impl.EgovBBSMasterDAO;
 import egovframework.com.cop.cmt.service.Comment;
 import egovframework.com.cop.cmt.service.CommentVO;
 import egovframework.com.test.EgovTestAbstractDAO2;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -30,325 +29,323 @@ import lombok.extern.slf4j.Slf4j;
  * @author 이백행
  *
  */
-@RequiredArgsConstructor
 @Slf4j
-public class EgovArticleCommentDAO2Test extends EgovTestAbstractDAO2 {
-
-    /**
-     * EgovArticleCommentDAO
-     */
-    @Autowired
-    private EgovArticleCommentDAO egovArticleCommentDAO;
-
-    /**
-     * 답글 ANSWER_NO 생성
-     */
-//    @Resource(name = "egovAnswerNoGnrService")
-    @Autowired
-    @Qualifier("egovAnswerNoGnrService")
-    private EgovIdGnrService egovAnswerNoGnrService;
-
-    /**
-     * EgovBBSMasterDAO
-     */
-    @Autowired
-    private EgovBBSMasterDAO egovBBSMasterDAO;
-
-    /**
-     * EgovArticleDAO
-     */
-    @Autowired
-    private EgovArticleDAO egovArticleDAO;
-
-    /**
-     * 게시판용 BBS_ID 생성
-     */
-    @Autowired
-    @Qualifier("egovBBSMstrIdGnrService")
-    private EgovIdGnrService egovBBSMstrIdGnrService;
-
-    /**
-     * 게시판용 NTT_ID 생성
-     */
-    @Autowired
-    @Qualifier("egovNttIdGnrService")
-    private EgovIdGnrService egovNttIdGnrService;
-
-    private void testData(final Comment comment) {
-        final BoardMaster boardMaster = new BoardMaster();
-        final Board board = new Board();
-        final LoginVO loginVO = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();
-
-        if (loginVO != null) {
-            boardMaster.setFrstRegisterId(loginVO.getUniqId());
-            boardMaster.setLastUpdusrId(loginVO.getUniqId());
-
-            board.setFrstRegisterId(loginVO.getUniqId());
-            board.setLastUpdusrId(loginVO.getUniqId());
-        }
-
-        try {
-            boardMaster.setBbsId(egovBBSMstrIdGnrService.getNextStringId());
-        } catch (FdlException e) {
-            log.error("FdlException egovBBSMstrIdGnrService");
-        }
-        egovBBSMasterDAO.insertBBSMasterInf(boardMaster);
-
-        try {
-            board.setNttId(egovNttIdGnrService.getNextLongId());
-        } catch (FdlException e) {
-            log.error("FdlException egovNttIdGnrService");
-        }
-        board.setBbsId(boardMaster.getBbsId());
-        egovArticleDAO.insertArticle(board);
-
-        comment.setNttId(board.getNttId());
-        comment.setBbsId(board.getBbsId());
-    }
-
-    private void testData2(final Comment comment) {
-        final LoginVO loginVO = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();
-
-        testData(comment);
-
-        try {
-            comment.setCommentNo(String.valueOf(egovAnswerNoGnrService.getNextLongId()));
-        } catch (FdlException e) {
-            log.error("FdlException egovAnswerNoGnrService");
-        }
-
-        comment.setCommentPassword("rhdxhd12");
-        comment.setCommentCn("test 이백행 댓글 " + LocalDateTime.now());
-
-        if (loginVO != null) {
-            comment.setFrstRegisterId(loginVO.getUniqId());
-            comment.setLastUpdusrId(loginVO.getUniqId());
-
-            comment.setWrterId(loginVO.getUniqId());
-            comment.setWrterNm(loginVO.getName());
-        }
-
-        egovArticleCommentDAO.insertArticleComment(comment);
-    }
-
-    /**
-     * 댓글 DAO 단위 테스트: 등록
-     */
-    @Test
-//    @Commit
-    void test_a10_insert() {
-        // given
-        final Comment comment = new Comment();
-        final LoginVO loginVO = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();
-
-        testData(comment);
-
-        try {
-            comment.setCommentNo(String.valueOf(egovAnswerNoGnrService.getNextLongId()));
-        } catch (FdlException e) {
-            log.error("FdlException egovAnswerNoGnrService");
-        }
-
-        comment.setCommentPassword("rhdxhd12");
-        comment.setCommentCn("test 이백행 댓글 " + LocalDateTime.now());
-
-        if (loginVO != null) {
-            comment.setFrstRegisterId(loginVO.getUniqId());
-            comment.setLastUpdusrId(loginVO.getUniqId());
-
-            comment.setWrterId(loginVO.getUniqId());
-            comment.setWrterNm(loginVO.getName());
-        }
-
-        // when
-        int result = 1;
-        try {
-            egovArticleCommentDAO.insertArticleComment(comment);
-        } catch (DataAccessException e) {
-            result = 0;
-            error(e);
-        }
-
-        // then
-        assertEquals(1, result, egovMessageSource.getMessage("fail.common.insert"));
-    }
-
-    /**
-     * 댓글 DAO 단위 테스트: 조회(멀티건)
-     */
-    @Test
-    void test_a20_selectList() {
-        // given
-        final CommentVO commentVO = new CommentVO();
-        final Comment comment = new Comment();
-
-        testData2(comment);
-
-        commentVO.setBbsId(comment.getBbsId());
-        commentVO.setNttId(comment.getNttId());
-        commentVO.setSubRecordCountPerPage(1);
-        commentVO.setSubFirstIndex(0);
-
-        // when
-        final List<CommentVO> results = egovArticleCommentDAO.selectArticleCommentList(commentVO);
-        for (final CommentVO result : results) {
-            debug(result);
-//            debug2(result);
-
-            // then
-            assertEquals(comment.getCommentNo(), result.getCommentNo(),
-                    egovMessageSource.getMessage(FAIL_COMMON_SELECT));
-        }
-    }
-
-    /* default */ void debug(final CommentVO result) {
-        if (log.isDebugEnabled()) {
-            log.debug("result={}", result);
-
-            log.debug("getCommentNo={}", result.getCommentNo());
-            log.debug("getNttId={}", result.getNttId());
-            log.debug("getBbsId={}", result.getBbsId());
-
-            log.debug("getWrterId={}", result.getWrterId());
-            log.debug("getWrterNm={}", result.getWrterNm());
-            log.debug("getCommentPassword={}", result.getCommentPassword());
-            log.debug("getCommentCn={}", result.getCommentCn());
-
-            log.debug("getUseAt={}", result.getUseAt());
-
-            log.debug("getFrstRegisterPnttm={}", result.getFrstRegisterPnttm());
-            log.debug("getFrstRegisterNm={}", result.getFrstRegisterNm());
-        }
-    }
-
-    /* default */ void debug2(final CommentVO result) {
-        if (log.isDebugEnabled()) {
-            log.debug("result={}", result);
-
-            log.debug("getNttId={}", result.getNttId());
-            log.debug("getBbsId={}", result.getBbsId());
-            log.debug("getCommentNo={}", result.getCommentNo());
-
-            log.debug("getWrterId={}", result.getWrterId());
-            log.debug("getWrterNm={}", result.getWrterNm());
-            log.debug("getCommentCn={}", result.getCommentCn());
-
-            log.debug("getUseAt={}", result.getUseAt());
-
-            log.debug("getFrstRegisterPnttm={}", result.getFrstRegisterPnttm());
-            log.debug("getFrstRegisterId={}", result.getFrstRegisterId());
-            log.debug("getFrstRegisterNm={}", result.getFrstRegisterNm());
-
-            log.debug("getLastUpdusrPnttm={}", result.getLastUpdusrPnttm());
-            log.debug("getLastUpdusrId={}", result.getLastUpdusrId());
-
-            log.debug("getCommentPassword={}", result.getCommentPassword());
-        }
-    }
-
-    /**
-     * 댓글 DAO 단위 테스트: 조회(멀티건) 총 수
-     */
-    @Test
-    void test_a30_selectListTotCnt() {
-        // given
-        final CommentVO commentVO = new CommentVO();
-        final Comment comment = new Comment();
-
-        testData2(comment);
-
-        commentVO.setBbsId(comment.getBbsId());
-        commentVO.setNttId(comment.getNttId());
-
-        // when
-        final int totCnt = egovArticleCommentDAO.selectArticleCommentListCnt(commentVO);
-
-        log.debug("totCnt={}", totCnt);
-
-        // then
-        assertEquals(1, totCnt, egovMessageSource.getMessage(FAIL_COMMON_SELECT));
-    }
-
-    /**
-     * 댓글 DAO 단위 테스트: 조회(단건)
-     */
-    @Test
-    void test_a40_select() {
-        // given
-        final CommentVO commentVO = new CommentVO();
-        final Comment comment = new Comment();
-
-        testData2(comment);
-
-        commentVO.setCommentNo(comment.getCommentNo());
-
-        // when
-        final CommentVO result = egovArticleCommentDAO.selectArticleCommentDetail(commentVO);
-
-        debug2(result);
-
-        // then
-        if (result != null) {
-            assertEquals(commentVO.getCommentNo(), result.getCommentNo(),
-                    egovMessageSource.getMessage(FAIL_COMMON_SELECT));
-        }
-    }
-
-    /**
-     * 댓글 DAO 단위 테스트: 수정
-     */
-    @Test
-//    @Commit
-    void test_a50_update() {
-        // given
-        final Comment comment = new Comment();
-        final LoginVO loginVO = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();
-
-        testData2(comment);
-
-        comment.setCommentCn(comment.getCommentCn() + " > 수정 test 이백행 댓글 " + LocalDateTime.now());
-
-        if (loginVO != null) {
-            comment.setLastUpdusrId(loginVO.getUniqId());
-        }
-
-        // when
-        int result = 1;
-        try {
-            egovArticleCommentDAO.updateArticleComment(comment);
-        } catch (DataAccessException e) {
-            result = 0;
-            error(e);
-        }
-
-        // then
-        assertEquals(1, result, egovMessageSource.getMessage("fail.common.update"));
-    }
-
-    /**
-     * 댓글 DAO 단위 테스트: 삭제
-     */
-    @Test
-//    @Commit
-    void test_a60_delete() {
-        // given
-        final CommentVO commentVO = new CommentVO();
-        final Comment comment = new Comment();
-
-        testData2(comment);
-
-        commentVO.setCommentNo(comment.getCommentNo());
-
-        // when
-        int result = 1;
-        try {
-            egovArticleCommentDAO.deleteArticleComment(commentVO);
-        } catch (DataAccessException e) {
-            result = 0;
-            error(e);
-        }
-
-        // then
-        assertEquals(1, result, egovMessageSource.getMessage("fail.common.delete"));
-    }
+class EgovArticleCommentDAO2Test extends EgovTestAbstractDAO2 {
+
+	/**
+	 * EgovArticleCommentDAO
+	 */
+	@Autowired
+	private EgovArticleCommentDAO egovArticleCommentDAO;
+
+	/**
+	 * 답글 ANSWER_NO 생성
+	 */
+	@Autowired
+	private EgovIdGnrService egovAnswerNoGnrService;
+
+	/**
+	 * EgovBBSMasterDAO
+	 */
+	@Autowired
+	private EgovBBSMasterDAO egovBBSMasterDAO;
+
+	/**
+	 * EgovArticleDAO
+	 */
+	@Autowired
+	private EgovArticleDAO egovArticleDAO;
+
+	/**
+	 * 게시판용 BBS_ID 생성
+	 */
+	@Autowired
+	private EgovIdGnrService egovBBSMstrIdGnrService;
+
+	/**
+	 * 게시판용 NTT_ID 생성
+	 */
+	@Autowired
+	private EgovIdGnrService egovNttIdGnrService;
+
+	/**
+	 * 댓글 DAO 단위 테스트: 조회(멀티건)
+	 */
+	@Test
+	@Order(1)
+	void selectArticleCommentList() {
+		// given
+		final CommentVO commentVO = new CommentVO();
+		final Comment comment = new Comment();
+
+		testData2(comment);
+
+		commentVO.setBbsId(comment.getBbsId());
+		commentVO.setNttId(comment.getNttId());
+		commentVO.setSubRecordCountPerPage(1);
+		commentVO.setSubFirstIndex(0);
+
+		// when
+		final List<CommentVO> results = egovArticleCommentDAO.selectArticleCommentList(commentVO);
+		for (final CommentVO result : results) {
+			debug(result);
+			// debug2(result);
+
+			// then
+			assertEquals(comment.getCommentNo(), result.getCommentNo(),
+					egovMessageSource.getMessage(FAIL_COMMON_SELECT));
+		}
+	}
+
+	/**
+	 * 댓글 DAO 단위 테스트: 조회(멀티건) 총 수
+	 */
+	@Test
+	@Order(2)
+	void selectArticleCommentListCnt() {
+		// given
+		final CommentVO commentVO = new CommentVO();
+		final Comment comment = new Comment();
+
+		testData2(comment);
+
+		commentVO.setBbsId(comment.getBbsId());
+		commentVO.setNttId(comment.getNttId());
+
+		// when
+		final int totCnt = egovArticleCommentDAO.selectArticleCommentListCnt(commentVO);
+
+		log.debug("totCnt={}", totCnt);
+
+		// then
+		assertEquals(1, totCnt, egovMessageSource.getMessage(FAIL_COMMON_SELECT));
+	}
+
+	/**
+	 * 댓글 DAO 단위 테스트: 등록
+	 */
+	@Test
+	@Order(3)
+	void insertArticleComment() {
+		// given
+		final Comment comment = new Comment();
+		final LoginVO loginVO = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();
+
+		testData(comment);
+
+		try {
+			comment.setCommentNo(String.valueOf(egovAnswerNoGnrService.getNextLongId()));
+		} catch (FdlException e) {
+			log.error("FdlException egovAnswerNoGnrService");
+		}
+
+		comment.setCommentPassword("rhdxhd12");
+		comment.setCommentCn("test 이백행 댓글 " + LocalDateTime.now());
+
+		if (loginVO != null) {
+			comment.setFrstRegisterId(loginVO.getUniqId());
+			comment.setLastUpdusrId(loginVO.getUniqId());
+
+			comment.setWrterId(loginVO.getUniqId());
+			comment.setWrterNm(loginVO.getName());
+		}
+
+		// when
+		int result = 1;
+		try {
+			egovArticleCommentDAO.insertArticleComment(comment);
+		} catch (DataAccessException e) {
+			result = 0;
+			error(e);
+		}
+
+		// then
+		assertEquals(1, result, egovMessageSource.getMessage("fail.common.insert"));
+	}
+
+	/**
+	 * 댓글 DAO 단위 테스트: 삭제
+	 */
+	@Test
+	@Order(4)
+	void deleteArticleComment() {
+		// given
+		final CommentVO commentVO = new CommentVO();
+		final Comment comment = new Comment();
+
+		testData2(comment);
+
+		commentVO.setCommentNo(comment.getCommentNo());
+
+		// when
+		int result = 1;
+		try {
+			egovArticleCommentDAO.deleteArticleComment(commentVO);
+		} catch (DataAccessException e) {
+			result = 0;
+			error(e);
+		}
+
+		// then
+		assertEquals(1, result, egovMessageSource.getMessage("fail.common.delete"));
+	}
+
+	/**
+	 * 댓글 DAO 단위 테스트: 조회(단건)
+	 */
+	@Test
+	@Order(5)
+	void selectArticleCommentDetail() {
+		// given
+		final CommentVO commentVO = new CommentVO();
+		final Comment comment = new Comment();
+
+		testData2(comment);
+
+		commentVO.setCommentNo(comment.getCommentNo());
+
+		// when
+		final CommentVO result = egovArticleCommentDAO.selectArticleCommentDetail(commentVO);
+
+		debug2(result);
+
+		// then
+		if (result != null) {
+			assertEquals(commentVO.getCommentNo(), result.getCommentNo(),
+					egovMessageSource.getMessage(FAIL_COMMON_SELECT));
+		}
+	}
+
+	/**
+	 * 댓글 DAO 단위 테스트: 수정
+	 */
+	@Test
+	@Order(6)
+	void updateArticleComment() {
+		// given
+		final Comment comment = new Comment();
+		final LoginVO loginVO = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();
+
+		testData2(comment);
+
+		comment.setCommentCn(comment.getCommentCn() + " > 수정 test 이백행 댓글 " + LocalDateTime.now());
+
+		if (loginVO != null) {
+			comment.setLastUpdusrId(loginVO.getUniqId());
+		}
+
+		// when
+		int result = 1;
+		try {
+			egovArticleCommentDAO.updateArticleComment(comment);
+		} catch (DataAccessException e) {
+			result = 0;
+			error(e);
+		}
+
+		// then
+		assertEquals(1, result, egovMessageSource.getMessage("fail.common.update"));
+	}
+
+	private void testData(final Comment comment) {
+		final BoardMaster boardMaster = new BoardMaster();
+		final Board board = new Board();
+		final LoginVO loginVO = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();
+
+		if (loginVO != null) {
+			boardMaster.setFrstRegisterId(loginVO.getUniqId());
+			boardMaster.setLastUpdusrId(loginVO.getUniqId());
+
+			board.setFrstRegisterId(loginVO.getUniqId());
+			board.setLastUpdusrId(loginVO.getUniqId());
+		}
+
+		try {
+			boardMaster.setBbsId(egovBBSMstrIdGnrService.getNextStringId());
+		} catch (FdlException e) {
+			log.error("FdlException egovBBSMstrIdGnrService");
+		}
+		egovBBSMasterDAO.insertBBSMasterInf(boardMaster);
+
+		try {
+			board.setNttId(egovNttIdGnrService.getNextLongId());
+		} catch (FdlException e) {
+			log.error("FdlException egovNttIdGnrService");
+		}
+		board.setBbsId(boardMaster.getBbsId());
+		egovArticleDAO.insertArticle(board);
+
+		comment.setNttId(board.getNttId());
+		comment.setBbsId(board.getBbsId());
+	}
+
+	private void testData2(final Comment comment) {
+		final LoginVO loginVO = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();
+
+		testData(comment);
+
+		try {
+			comment.setCommentNo(String.valueOf(egovAnswerNoGnrService.getNextLongId()));
+		} catch (FdlException e) {
+			log.error("FdlException egovAnswerNoGnrService");
+		}
+
+		comment.setCommentPassword("rhdxhd12");
+		comment.setCommentCn("test 이백행 댓글 " + LocalDateTime.now());
+
+		if (loginVO != null) {
+			comment.setFrstRegisterId(loginVO.getUniqId());
+			comment.setLastUpdusrId(loginVO.getUniqId());
+
+			comment.setWrterId(loginVO.getUniqId());
+			comment.setWrterNm(loginVO.getName());
+		}
+
+		egovArticleCommentDAO.insertArticleComment(comment);
+	}
+
+	private void debug(final CommentVO result) {
+		if (log.isDebugEnabled()) {
+			log.debug("result={}", result);
+
+			log.debug("getCommentNo={}", result.getCommentNo());
+			log.debug("getNttId={}", result.getNttId());
+			log.debug("getBbsId={}", result.getBbsId());
+
+			log.debug("getWrterId={}", result.getWrterId());
+			log.debug("getWrterNm={}", result.getWrterNm());
+			log.debug("getCommentPassword={}", result.getCommentPassword());
+			log.debug("getCommentCn={}", result.getCommentCn());
+
+			log.debug("getUseAt={}", result.getUseAt());
+
+			log.debug("getFrstRegisterPnttm={}", result.getFrstRegisterPnttm());
+			log.debug("getFrstRegisterNm={}", result.getFrstRegisterNm());
+		}
+	}
+
+	private void debug2(final CommentVO result) {
+		if (log.isDebugEnabled()) {
+			log.debug("result={}", result);
+
+			log.debug("getNttId={}", result.getNttId());
+			log.debug("getBbsId={}", result.getBbsId());
+			log.debug("getCommentNo={}", result.getCommentNo());
+
+			log.debug("getWrterId={}", result.getWrterId());
+			log.debug("getWrterNm={}", result.getWrterNm());
+			log.debug("getCommentCn={}", result.getCommentCn());
+
+			log.debug("getUseAt={}", result.getUseAt());
+
+			log.debug("getFrstRegisterPnttm={}", result.getFrstRegisterPnttm());
+			log.debug("getFrstRegisterId={}", result.getFrstRegisterId());
+			log.debug("getFrstRegisterNm={}", result.getFrstRegisterNm());
+
+			log.debug("getLastUpdusrPnttm={}", result.getLastUpdusrPnttm());
+			log.debug("getLastUpdusrId={}", result.getLastUpdusrId());
+
+			log.debug("getCommentPassword={}", result.getCommentPassword());
+		}
+	}
 }

--- a/src/test/java/egovframework/com/cop/cmt/service/impl/EgovArticleCommentDAOTest.java
+++ b/src/test/java/egovframework/com/cop/cmt/service/impl/EgovArticleCommentDAOTest.java
@@ -7,18 +7,20 @@ import java.util.List;
 
 import org.egovframe.rte.fdl.cmmn.exception.FdlException;
 import org.egovframe.rte.fdl.idgnr.EgovIdGnrService;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.ComponentScan.Filter;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.ImportResource;
 import org.springframework.dao.DataAccessException;
 import org.springframework.test.context.ContextConfiguration;
 
 import egovframework.com.cmm.LoginVO;
+import egovframework.com.cmm.config.EgovConfigCryptoTest;
 import egovframework.com.cmm.util.EgovUserDetailsHelper;
 import egovframework.com.cop.bbs.service.Board;
 import egovframework.com.cop.bbs.service.BoardMaster;
@@ -28,7 +30,6 @@ import egovframework.com.cop.bbs.service.impl.EgovBBSMasterDAO;
 import egovframework.com.cop.cmt.service.Comment;
 import egovframework.com.cop.cmt.service.CommentVO;
 import egovframework.com.test.EgovTestAbstractDAO;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -44,371 +45,370 @@ import lombok.extern.slf4j.Slf4j;
 
 @ImportResource({
 
-        "classpath*:egovframework/spring/com/idgn/context-idgn-AnswerNo.xml",
+		"classpath*:egovframework/spring/com/idgn/context-idgn-AnswerNo.xml",
 
-        "classpath*:egovframework/spring/com/idgn/context-idgn-bbs.xml",
+		"classpath*:egovframework/spring/com/idgn/context-idgn-bbs.xml",
 
 })
 
+@Import(EgovConfigCryptoTest.class)
+
 @ComponentScan(
 
-        useDefaultFilters = false,
+		useDefaultFilters = false,
 
-        basePackages = {
+		basePackages = {
 
-                "egovframework.com.cop.cmt.service.impl",
+				"egovframework.com.cop.cmt.service.impl",
 
-                "egovframework.com.cop.bbs.service.impl",
+				"egovframework.com.cop.bbs.service.impl",
 
-        },
+		},
 
-        includeFilters = {
+		includeFilters = {
 
-                @Filter(
+				@Filter(
 
-                        type = FilterType.ASSIGNABLE_TYPE,
+						type = FilterType.ASSIGNABLE_TYPE,
 
-                        classes = {
+						classes = {
 
-                                EgovArticleCommentDAO.class,
+								EgovArticleCommentDAO.class,
 
-                                EgovArticleCommentServiceImpl.class,
+								EgovArticleCommentServiceImpl.class,
 
-                                BBSAddedOptionsDAO.class,
+								BBSAddedOptionsDAO.class,
 
-                                EgovBBSMasterDAO.class,
+								EgovBBSMasterDAO.class,
 
-                                EgovArticleDAO.class,
+								EgovArticleDAO.class,
 
-                        }
+						}
 
-                )
+				)
 
-        }
+		}
 
 )
 
-@RequiredArgsConstructor
 @Slf4j
-//@Commit
-public class EgovArticleCommentDAOTest extends EgovTestAbstractDAO {
-
-    /**
-     * EgovArticleCommentDAO
-     */
-    @Autowired
-    private EgovArticleCommentDAO egovArticleCommentDAO;
-
-    /**
-     * 답글 ANSWER_NO 생성
-     */
-//    @Resource(name = "egovAnswerNoGnrService")
-    @Autowired
-    @Qualifier("egovAnswerNoGnrService")
-    private EgovIdGnrService egovAnswerNoGnrService;
-
-    /**
-     * EgovBBSMasterDAO
-     */
-    @Autowired
-    private EgovBBSMasterDAO egovBBSMasterDAO;
-
-    /**
-     * EgovArticleDAO
-     */
-    @Autowired
-    private EgovArticleDAO egovArticleDAO;
-
-    /**
-     * 게시판용 BBS_ID 생성
-     */
-    @Autowired
-    @Qualifier("egovBBSMstrIdGnrService")
-    private EgovIdGnrService egovBBSMstrIdGnrService;
-
-    /**
-     * 게시판용 NTT_ID 생성
-     */
-    @Autowired
-    @Qualifier("egovNttIdGnrService")
-    private EgovIdGnrService egovNttIdGnrService;
-
-    private void testData(final Comment comment) {
-        final BoardMaster boardMaster = new BoardMaster();
-        final Board board = new Board();
-        final LoginVO loginVO = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();
-
-        if (loginVO != null) {
-            boardMaster.setFrstRegisterId(loginVO.getUniqId());
-            boardMaster.setLastUpdusrId(loginVO.getUniqId());
-
-            board.setFrstRegisterId(loginVO.getUniqId());
-            board.setLastUpdusrId(loginVO.getUniqId());
-        }
-
-        try {
-            boardMaster.setBbsId(egovBBSMstrIdGnrService.getNextStringId());
-        } catch (FdlException e) {
-            log.error("FdlException egovBBSMstrIdGnrService");
-        }
-        egovBBSMasterDAO.insertBBSMasterInf(boardMaster);
-
-        try {
-            board.setNttId(egovNttIdGnrService.getNextLongId());
-        } catch (FdlException e) {
-            log.error("FdlException egovNttIdGnrService");
-        }
-        board.setBbsId(boardMaster.getBbsId());
-        egovArticleDAO.insertArticle(board);
-
-        comment.setNttId(board.getNttId());
-        comment.setBbsId(board.getBbsId());
-    }
-
-    private void testData2(final Comment comment) {
-        final LoginVO loginVO = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();
-
-        testData(comment);
-
-        try {
-            comment.setCommentNo(String.valueOf(egovAnswerNoGnrService.getNextLongId()));
-        } catch (FdlException e) {
-            log.error("FdlException egovAnswerNoGnrService");
-        }
-
-        comment.setCommentPassword("rhdxhd12");
-        comment.setCommentCn("test 이백행 댓글 " + LocalDateTime.now());
-
-        if (loginVO != null) {
-            comment.setFrstRegisterId(loginVO.getUniqId());
-            comment.setLastUpdusrId(loginVO.getUniqId());
-
-            comment.setWrterId(loginVO.getUniqId());
-            comment.setWrterNm(loginVO.getName());
-        }
-
-        egovArticleCommentDAO.insertArticleComment(comment);
-    }
-
-    /**
-     * 댓글 DAO 단위 테스트: 등록
-     */
-    @Test
-//    @Commit
-    void test_a10_insert() {
-        // given
-        final Comment comment = new Comment();
-        final LoginVO loginVO = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();
-
-        testData(comment);
-
-        try {
-            comment.setCommentNo(String.valueOf(egovAnswerNoGnrService.getNextLongId()));
-        } catch (FdlException e) {
-            log.error("FdlException egovAnswerNoGnrService");
-        }
-
-        comment.setCommentPassword("rhdxhd12");
-        comment.setCommentCn("test 이백행 댓글 " + LocalDateTime.now());
-
-        if (loginVO != null) {
-            comment.setFrstRegisterId(loginVO.getUniqId());
-            comment.setLastUpdusrId(loginVO.getUniqId());
-
-            comment.setWrterId(loginVO.getUniqId());
-            comment.setWrterNm(loginVO.getName());
-        }
-
-        // when
-        int result = 1;
-        try {
-            egovArticleCommentDAO.insertArticleComment(comment);
-        } catch (DataAccessException e) {
-            result = 0;
-            error(e);
-        }
-
-        // then
-        assertEquals(1, result, egovMessageSource.getMessage("fail.common.insert"));
-    }
-
-    /**
-     * 댓글 DAO 단위 테스트: 조회(멀티건)
-     */
-    @Test
-    void test_a20_selectList() {
-        // given
-        final CommentVO commentVO = new CommentVO();
-        final Comment comment = new Comment();
-
-        testData2(comment);
-
-        commentVO.setBbsId(comment.getBbsId());
-        commentVO.setNttId(comment.getNttId());
-        commentVO.setSubRecordCountPerPage(1);
-        commentVO.setSubFirstIndex(0);
-
-        // when
-        final List<CommentVO> results = egovArticleCommentDAO.selectArticleCommentList(commentVO);
-        for (final CommentVO result : results) {
-            debug(result);
-//            debug2(result);
-
-            // then
-            assertEquals(comment.getCommentNo(), result.getCommentNo(),
-                    egovMessageSource.getMessage(FAIL_COMMON_SELECT));
-        }
-    }
-
-    /* default */ void debug(final CommentVO result) {
-        if (log.isDebugEnabled()) {
-            log.debug("result={}", result);
-
-            log.debug("getCommentNo={}", result.getCommentNo());
-            log.debug("getNttId={}", result.getNttId());
-            log.debug("getBbsId={}", result.getBbsId());
-
-            log.debug("getWrterId={}", result.getWrterId());
-            log.debug("getWrterNm={}", result.getWrterNm());
-            log.debug("getCommentPassword={}", result.getCommentPassword());
-            log.debug("getCommentCn={}", result.getCommentCn());
-
-            log.debug("getUseAt={}", result.getUseAt());
-
-            log.debug("getFrstRegisterPnttm={}", result.getFrstRegisterPnttm());
-            log.debug("getFrstRegisterNm={}", result.getFrstRegisterNm());
-        }
-    }
-
-    /* default */ void debug2(final CommentVO result) {
-        if (log.isDebugEnabled()) {
-            log.debug("result={}", result);
-
-            log.debug("getNttId={}", result.getNttId());
-            log.debug("getBbsId={}", result.getBbsId());
-            log.debug("getCommentNo={}", result.getCommentNo());
-
-            log.debug("getWrterId={}", result.getWrterId());
-            log.debug("getWrterNm={}", result.getWrterNm());
-            log.debug("getCommentCn={}", result.getCommentCn());
-
-            log.debug("getUseAt={}", result.getUseAt());
-
-            log.debug("getFrstRegisterPnttm={}", result.getFrstRegisterPnttm());
-            log.debug("getFrstRegisterId={}", result.getFrstRegisterId());
-            log.debug("getFrstRegisterNm={}", result.getFrstRegisterNm());
-
-            log.debug("getLastUpdusrPnttm={}", result.getLastUpdusrPnttm());
-            log.debug("getLastUpdusrId={}", result.getLastUpdusrId());
-
-            log.debug("getCommentPassword={}", result.getCommentPassword());
-        }
-    }
-
-    /**
-     * 댓글 DAO 단위 테스트: 조회(멀티건) 총 수
-     */
-    @Test
-    void test_a30_selectListTotCnt() {
-        // given
-        final CommentVO commentVO = new CommentVO();
-        final Comment comment = new Comment();
-
-        testData2(comment);
-
-        commentVO.setBbsId(comment.getBbsId());
-        commentVO.setNttId(comment.getNttId());
-
-        // when
-        final int totCnt = egovArticleCommentDAO.selectArticleCommentListCnt(commentVO);
-
-        log.debug("totCnt={}", totCnt);
-
-        // then
-        assertEquals(1, totCnt, egovMessageSource.getMessage(FAIL_COMMON_SELECT));
-    }
-
-    /**
-     * 댓글 DAO 단위 테스트: 조회(단건)
-     */
-    @Test
-    void test_a40_select() {
-        // given
-        final CommentVO commentVO = new CommentVO();
-        final Comment comment = new Comment();
-
-        testData2(comment);
-
-        commentVO.setCommentNo(comment.getCommentNo());
-
-        // when
-        final CommentVO result = egovArticleCommentDAO.selectArticleCommentDetail(commentVO);
-
-        debug2(result);
-
-        // then
-        if (result != null) {
-            assertEquals(commentVO.getCommentNo(), result.getCommentNo(),
-                    egovMessageSource.getMessage(FAIL_COMMON_SELECT));
-        }
-    }
-
-    /**
-     * 댓글 DAO 단위 테스트: 수정
-     */
-    @Test
-//    @Commit
-    void test_a50_update() {
-        // given
-        final Comment comment = new Comment();
-        final LoginVO loginVO = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();
-
-        testData2(comment);
-
-        comment.setCommentCn(comment.getCommentCn() + " > 수정 test 이백행 댓글 " + LocalDateTime.now());
-
-        if (loginVO != null) {
-            comment.setLastUpdusrId(loginVO.getUniqId());
-        }
-
-        // when
-        int result = 1;
-        try {
-            egovArticleCommentDAO.updateArticleComment(comment);
-        } catch (DataAccessException e) {
-            result = 0;
-            error(e);
-        }
-
-        // then
-        assertEquals(1, result, egovMessageSource.getMessage("fail.common.update"));
-    }
-
-    /**
-     * 댓글 DAO 단위 테스트: 삭제
-     */
-    @Test
-//    @Commit
-    void test_a60_delete() {
-        // given
-        final CommentVO commentVO = new CommentVO();
-        final Comment comment = new Comment();
-
-        testData2(comment);
-
-        commentVO.setCommentNo(comment.getCommentNo());
-
-        // when
-        int result = 1;
-        try {
-            egovArticleCommentDAO.deleteArticleComment(commentVO);
-        } catch (DataAccessException e) {
-            result = 0;
-            error(e);
-        }
-
-        // then
-        assertEquals(1, result, egovMessageSource.getMessage("fail.common.delete"));
-    }
+class EgovArticleCommentDAOTest extends EgovTestAbstractDAO {
+
+	/**
+	 * EgovArticleCommentDAO
+	 */
+	@Autowired
+	private EgovArticleCommentDAO egovArticleCommentDAO;
+
+	/**
+	 * 답글 ANSWER_NO 생성
+	 */
+	@Autowired
+	private EgovIdGnrService egovAnswerNoGnrService;
+
+	/**
+	 * EgovBBSMasterDAO
+	 */
+	@Autowired
+	private EgovBBSMasterDAO egovBBSMasterDAO;
+
+	/**
+	 * EgovArticleDAO
+	 */
+	@Autowired
+	private EgovArticleDAO egovArticleDAO;
+
+	/**
+	 * 게시판용 BBS_ID 생성
+	 */
+	@Autowired
+	private EgovIdGnrService egovBBSMstrIdGnrService;
+
+	/**
+	 * 게시판용 NTT_ID 생성
+	 */
+	@Autowired
+	private EgovIdGnrService egovNttIdGnrService;
+
+	/**
+	 * 댓글 DAO 단위 테스트: 조회(멀티건)
+	 */
+	@Test
+	@Order(1)
+	void selectArticleCommentList() {
+		// given
+		final CommentVO commentVO = new CommentVO();
+		final Comment comment = new Comment();
+
+		testData2(comment);
+
+		commentVO.setBbsId(comment.getBbsId());
+		commentVO.setNttId(comment.getNttId());
+		commentVO.setSubRecordCountPerPage(1);
+		commentVO.setSubFirstIndex(0);
+
+		// when
+		final List<CommentVO> results = egovArticleCommentDAO.selectArticleCommentList(commentVO);
+		for (final CommentVO result : results) {
+			debug(result);
+			// debug2(result);
+
+			// then
+			assertEquals(comment.getCommentNo(), result.getCommentNo(),
+					egovMessageSource.getMessage(FAIL_COMMON_SELECT));
+		}
+	}
+
+	/**
+	 * 댓글 DAO 단위 테스트: 조회(멀티건) 총 수
+	 */
+	@Test
+	@Order(2)
+	void selectArticleCommentListCnt() {
+		// given
+		final CommentVO commentVO = new CommentVO();
+		final Comment comment = new Comment();
+
+		testData2(comment);
+
+		commentVO.setBbsId(comment.getBbsId());
+		commentVO.setNttId(comment.getNttId());
+
+		// when
+		final int totCnt = egovArticleCommentDAO.selectArticleCommentListCnt(commentVO);
+
+		log.debug("totCnt={}", totCnt);
+
+		// then
+		assertEquals(1, totCnt, egovMessageSource.getMessage(FAIL_COMMON_SELECT));
+	}
+
+	/**
+	 * 댓글 DAO 단위 테스트: 등록
+	 */
+	@Test
+	@Order(3)
+	void insertArticleComment() {
+		// given
+		final Comment comment = new Comment();
+		final LoginVO loginVO = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();
+
+		testData(comment);
+
+		try {
+			comment.setCommentNo(String.valueOf(egovAnswerNoGnrService.getNextLongId()));
+		} catch (FdlException e) {
+			log.error("FdlException egovAnswerNoGnrService");
+		}
+
+		comment.setCommentPassword("rhdxhd12");
+		comment.setCommentCn("test 이백행 댓글 " + LocalDateTime.now());
+
+		if (loginVO != null) {
+			comment.setFrstRegisterId(loginVO.getUniqId());
+			comment.setLastUpdusrId(loginVO.getUniqId());
+
+			comment.setWrterId(loginVO.getUniqId());
+			comment.setWrterNm(loginVO.getName());
+		}
+
+		// when
+		int result = 1;
+		try {
+			egovArticleCommentDAO.insertArticleComment(comment);
+		} catch (DataAccessException e) {
+			result = 0;
+			error(e);
+		}
+
+		// then
+		assertEquals(1, result, egovMessageSource.getMessage("fail.common.insert"));
+	}
+
+	/**
+	 * 댓글 DAO 단위 테스트: 삭제
+	 */
+	@Test
+	@Order(4)
+	void deleteArticleComment() {
+		// given
+		final CommentVO commentVO = new CommentVO();
+		final Comment comment = new Comment();
+
+		testData2(comment);
+
+		commentVO.setCommentNo(comment.getCommentNo());
+
+		// when
+		int result = 1;
+		try {
+			egovArticleCommentDAO.deleteArticleComment(commentVO);
+		} catch (DataAccessException e) {
+			result = 0;
+			error(e);
+		}
+
+		// then
+		assertEquals(1, result, egovMessageSource.getMessage("fail.common.delete"));
+	}
+
+	/**
+	 * 댓글 DAO 단위 테스트: 조회(단건)
+	 */
+	@Test
+	@Order(5)
+	void selectArticleCommentDetail() {
+		// given
+		final CommentVO commentVO = new CommentVO();
+		final Comment comment = new Comment();
+
+		testData2(comment);
+
+		commentVO.setCommentNo(comment.getCommentNo());
+
+		// when
+		final CommentVO result = egovArticleCommentDAO.selectArticleCommentDetail(commentVO);
+
+		debug2(result);
+
+		// then
+		if (result != null) {
+			assertEquals(commentVO.getCommentNo(), result.getCommentNo(),
+					egovMessageSource.getMessage(FAIL_COMMON_SELECT));
+		}
+	}
+
+	/**
+	 * 댓글 DAO 단위 테스트: 수정
+	 */
+	@Test
+	@Order(6)
+	void updateArticleComment() {
+		// given
+		final Comment comment = new Comment();
+		final LoginVO loginVO = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();
+
+		testData2(comment);
+
+		comment.setCommentCn(comment.getCommentCn() + " > 수정 test 이백행 댓글 " + LocalDateTime.now());
+
+		if (loginVO != null) {
+			comment.setLastUpdusrId(loginVO.getUniqId());
+		}
+
+		// when
+		int result = 1;
+		try {
+			egovArticleCommentDAO.updateArticleComment(comment);
+		} catch (DataAccessException e) {
+			result = 0;
+			error(e);
+		}
+
+		// then
+		assertEquals(1, result, egovMessageSource.getMessage("fail.common.update"));
+	}
+
+	private void testData(final Comment comment) {
+		final BoardMaster boardMaster = new BoardMaster();
+		final Board board = new Board();
+		final LoginVO loginVO = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();
+
+		if (loginVO != null) {
+			boardMaster.setFrstRegisterId(loginVO.getUniqId());
+			boardMaster.setLastUpdusrId(loginVO.getUniqId());
+
+			board.setFrstRegisterId(loginVO.getUniqId());
+			board.setLastUpdusrId(loginVO.getUniqId());
+		}
+
+		try {
+			boardMaster.setBbsId(egovBBSMstrIdGnrService.getNextStringId());
+		} catch (FdlException e) {
+			log.error("FdlException egovBBSMstrIdGnrService");
+		}
+		egovBBSMasterDAO.insertBBSMasterInf(boardMaster);
+
+		try {
+			board.setNttId(egovNttIdGnrService.getNextLongId());
+		} catch (FdlException e) {
+			log.error("FdlException egovNttIdGnrService");
+		}
+		board.setBbsId(boardMaster.getBbsId());
+		egovArticleDAO.insertArticle(board);
+
+		comment.setNttId(board.getNttId());
+		comment.setBbsId(board.getBbsId());
+	}
+
+	private void testData2(final Comment comment) {
+		final LoginVO loginVO = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();
+
+		testData(comment);
+
+		try {
+			comment.setCommentNo(String.valueOf(egovAnswerNoGnrService.getNextLongId()));
+		} catch (FdlException e) {
+			log.error("FdlException egovAnswerNoGnrService");
+		}
+
+		comment.setCommentPassword("rhdxhd12");
+		comment.setCommentCn("test 이백행 댓글 " + LocalDateTime.now());
+
+		if (loginVO != null) {
+			comment.setFrstRegisterId(loginVO.getUniqId());
+			comment.setLastUpdusrId(loginVO.getUniqId());
+
+			comment.setWrterId(loginVO.getUniqId());
+			comment.setWrterNm(loginVO.getName());
+		}
+
+		egovArticleCommentDAO.insertArticleComment(comment);
+	}
+
+	private void debug(final CommentVO result) {
+		if (log.isDebugEnabled()) {
+			log.debug("result={}", result);
+
+			log.debug("getCommentNo={}", result.getCommentNo());
+			log.debug("getNttId={}", result.getNttId());
+			log.debug("getBbsId={}", result.getBbsId());
+
+			log.debug("getWrterId={}", result.getWrterId());
+			log.debug("getWrterNm={}", result.getWrterNm());
+			log.debug("getCommentPassword={}", result.getCommentPassword());
+			log.debug("getCommentCn={}", result.getCommentCn());
+
+			log.debug("getUseAt={}", result.getUseAt());
+
+			log.debug("getFrstRegisterPnttm={}", result.getFrstRegisterPnttm());
+			log.debug("getFrstRegisterNm={}", result.getFrstRegisterNm());
+		}
+	}
+
+	private void debug2(final CommentVO result) {
+		if (log.isDebugEnabled()) {
+			log.debug("result={}", result);
+
+			log.debug("getNttId={}", result.getNttId());
+			log.debug("getBbsId={}", result.getBbsId());
+			log.debug("getCommentNo={}", result.getCommentNo());
+
+			log.debug("getWrterId={}", result.getWrterId());
+			log.debug("getWrterNm={}", result.getWrterNm());
+			log.debug("getCommentCn={}", result.getCommentCn());
+
+			log.debug("getUseAt={}", result.getUseAt());
+
+			log.debug("getFrstRegisterPnttm={}", result.getFrstRegisterPnttm());
+			log.debug("getFrstRegisterId={}", result.getFrstRegisterId());
+			log.debug("getFrstRegisterNm={}", result.getFrstRegisterNm());
+
+			log.debug("getLastUpdusrPnttm={}", result.getLastUpdusrPnttm());
+			log.debug("getLastUpdusrId={}", result.getLastUpdusrId());
+
+			log.debug("getCommentPassword={}", result.getCommentPassword());
+		}
+	}
 
 }

--- a/src/test/java/egovframework/com/test/EgovTestAbstractDAO.java
+++ b/src/test/java/egovframework/com/test/EgovTestAbstractDAO.java
@@ -2,15 +2,14 @@ package egovframework.com.test;
 
 import java.sql.SQLException;
 
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.ImportResource;
@@ -21,7 +20,6 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StopWatch;
 
 import egovframework.com.cmm.EgovMessageSource;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -31,7 +29,7 @@ import lombok.extern.slf4j.Slf4j;
  */
 
 @ExtendWith(SpringExtension.class)
-@TestMethodOrder(MethodOrderer.MethodName.class)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 
 @ActiveProfiles({ "mysql", "dummy" })
 //@ActiveProfiles({ "oracle", "dummy" })
@@ -48,128 +46,124 @@ import lombok.extern.slf4j.Slf4j;
 
 @ImportResource({
 
-//		"classpath*:egovframework/spring/com/**/context-*.xml",
+		"classpath*:egovframework/spring/com/test-context-common.xml",
 
-        "classpath*:egovframework/spring/com/test-context-common.xml",
-
-        "classpath*:egovframework/spring/com/context-crypto.xml",
-        "classpath*:egovframework/spring/com/context-datasource.xml",
-        "classpath*:egovframework/spring/com/context-egovuserdetailshelper.xml",
-        "classpath*:egovframework/spring/com/context-mapper.xml",
-        "classpath*:egovframework/spring/com/context-transaction.xml",
+		"classpath*:egovframework/spring/com/context-crypto.xml",
+		"classpath*:egovframework/spring/com/context-datasource.xml",
+		"classpath*:egovframework/spring/com/context-egovuserdetailshelper.xml",
+		"classpath*:egovframework/spring/com/context-mapper.xml",
+		"classpath*:egovframework/spring/com/context-transaction.xml",
 
 })
 
-@RequiredArgsConstructor
 @Slf4j
 
 public class EgovTestAbstractDAO {
 
-    /**
-     * BeforeClass AfterClass
-     */
-    private static final StopWatch STOP_WATCH = new StopWatch();
+	/**
+	 * BeforeClass AfterClass
+	 */
+	private static final StopWatch STOP_WATCH = new StopWatch();
 
-    /**
-     * Before After
-     */
-    private final StopWatch stopWatch = new StopWatch();
+	/**
+	 * Before After
+	 */
+	private final StopWatch stopWatch = new StopWatch();
 
-    /**
-     * beanDefinitionNames
-     */
-    private static String[] beanDefinitionNames;
+	/**
+	 * beanDefinitionNames
+	 */
+	private static String[] beanDefinitionNames;
 
-    /**
-     * ApplicationContext
-     */
-    @Autowired
-    private ApplicationContext context;
+	/**
+	 * ApplicationContext
+	 */
+	@Autowired
+	private ApplicationContext context;
 
-    /**
-     * 메시지 리소스 사용을 위한 MessageSource 인터페이스 및 ReloadableResourceBundleMessageSource 클래스의 구현체
-     */
-//    @Resource(name = "egovMessageSource")
-    @Autowired
-    @Qualifier("egovMessageSource")
-    protected EgovMessageSource egovMessageSource;
+	/**
+	 * 메시지 리소스 사용을 위한 MessageSource 인터페이스 및 ReloadableResourceBundleMessageSource
+	 * 클래스의 구현체
+	 */
+	@Autowired
+	protected EgovMessageSource egovMessageSource;
 
-    /**
-     * 조회에 실패하였습니다.
-     */
-    protected static final String FAIL_COMMON_SELECT = "fail.common.select";
+	/**
+	 * 조회에 실패하였습니다.
+	 */
+	protected static final String FAIL_COMMON_SELECT = "fail.common.select";
 
-    /**
-     * setUpBeforeClass
-     */
-    @BeforeAll
-    static void setUpBeforeClass() {
-        STOP_WATCH.start();
+	/**
+	 * setUpBeforeClass
+	 */
+	@BeforeAll
+	static void setUpBeforeClass() {
+		STOP_WATCH.start();
 
-        log.debug("setUpBeforeClass start");
-    }
+		log.debug("setUpBeforeClass start");
+	}
 
-    /**
-     * tearDownAfterClass
-     */
-    @AfterAll
-    static void tearDownAfterClass() {
-        STOP_WATCH.stop();
+	/**
+	 * tearDownAfterClass
+	 */
+	@AfterAll
+	static void tearDownAfterClass() {
+		STOP_WATCH.stop();
 
-        if (log.isDebugEnabled()) {
-            log.debug("tearDownAfterClass stop");
+		if (log.isDebugEnabled()) {
+			log.debug("tearDownAfterClass stop");
 
-            log.debug("totalTimeMillis={}", STOP_WATCH.getTotalTimeMillis());
-            log.debug("totalTimeSeconds={}", STOP_WATCH.getTotalTimeSeconds());
-        }
-    }
+			log.debug("totalTimeMillis={}", STOP_WATCH.getTotalTimeMillis());
+			log.debug("totalTimeSeconds={}", STOP_WATCH.getTotalTimeSeconds());
+		}
+	}
 
-    /**
-     * setUp
-     */
-    @BeforeEach
-    void setUp() {
-        stopWatch.start();
+	/**
+	 * setUp
+	 */
+	@BeforeEach
+	void setUp() {
+		stopWatch.start();
 
-        log.debug("setUp start");
+		log.debug("setUp start");
 
-        if (beanDefinitionNames == null) {
-            beanDefinitionNames = context.getBeanDefinitionNames();
-            for (final String beanDefinitionName : beanDefinitionNames) {
-                log.debug("beanDefinitionName={}", beanDefinitionName);
-            }
-            log.debug("length={}", beanDefinitionNames.length);
-        }
-    }
+		if (beanDefinitionNames == null) {
+			beanDefinitionNames = context.getBeanDefinitionNames();
+			for (final String beanDefinitionName : beanDefinitionNames) {
+				log.debug("beanDefinitionName={}", beanDefinitionName);
+			}
+			log.debug("length={}", beanDefinitionNames.length);
+		}
+	}
 
-    /**
-     * tearDown
-     */
-    @AfterEach
-    void tearDown() {
-        stopWatch.stop();
+	/**
+	 * tearDown
+	 */
+	@AfterEach
+	void tearDown() {
+		stopWatch.stop();
 
-        if (log.isDebugEnabled()) {
-            log.debug("tearDown stop");
+		if (log.isDebugEnabled()) {
+			log.debug("tearDown stop");
 
-            log.debug("totalTimeMillis={}", STOP_WATCH.getTotalTimeMillis());
-            log.debug("totalTimeSeconds={}", STOP_WATCH.getTotalTimeSeconds());
-        }
-    }
+			log.debug("totalTimeMillis={}", STOP_WATCH.getTotalTimeMillis());
+			log.debug("totalTimeSeconds={}", STOP_WATCH.getTotalTimeSeconds());
+		}
+	}
 
-    /**
-     * error
-     * 
-     * @param e
-     */
-    protected void error(final DataAccessException e) {
-        final SQLException sqlException = (SQLException) e.getCause();
-        if (log.isErrorEnabled()) {
-            log.error(egovMessageSource.getMessageArgs("fail.common.sql",
-                    new Object[] { sqlException.getErrorCode(), sqlException.getMessage() }));
-            log.error(egovMessageSource.getMessageArgs("fail.common.sql",
-                    new Object[] { sqlException.getSQLState(), sqlException.getMessage() }));
-        }
-    }
+	/**
+	 * error
+	 * 
+	 * @param e
+	 */
+	protected void error(final DataAccessException e) {
+		final SQLException sqlException = (SQLException) e.getCause();
+		if (log.isErrorEnabled()) {
+			log.error(egovMessageSource.getMessageArgs("fail.common.sql",
+					new Object[] { sqlException.getErrorCode(), sqlException.getMessage() }));
+			log.error(egovMessageSource.getMessageArgs("fail.common.sql",
+					new Object[] { sqlException.getSQLState(), sqlException.getMessage() }));
+		}
+	}
 
 }

--- a/src/test/java/egovframework/com/test/EgovTestAbstractDAO2.java
+++ b/src/test/java/egovframework/com/test/EgovTestAbstractDAO2.java
@@ -2,15 +2,14 @@ package egovframework.com.test;
 
 import java.sql.SQLException;
 
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.ApplicationContext;
 import org.springframework.dao.DataAccessException;
 import org.springframework.test.context.ActiveProfiles;
@@ -20,7 +19,6 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StopWatch;
 
 import egovframework.com.cmm.EgovMessageSource;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -30,7 +28,7 @@ import lombok.extern.slf4j.Slf4j;
  */
 
 @ExtendWith(SpringExtension.class)
-@TestMethodOrder(MethodOrderer.MethodName.class)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 
 @ActiveProfiles({ "mysql", "dummy" })
 //@ActiveProfiles({ "oracle", "dummy" })
@@ -45,126 +43,122 @@ import lombok.extern.slf4j.Slf4j;
 
 @ContextConfiguration(locations = {
 
-//		"classpath*:egovframework/spring/com/**/context-*.xml",
+		"classpath*:egovframework/spring/com/context-*.xml",
 
-        "classpath*:egovframework/spring/com/context-*.xml",
+		"classpath*:egovframework/spring/com/idgn/context-*.xml",
 
-        "classpath*:egovframework/spring/com/idgn/context-*.xml",
-
-        "classpath*:egovframework/spring/com/scheduling/context-*.xml",
+		"classpath*:egovframework/spring/com/scheduling/context-*.xml",
 
 })
 
-@RequiredArgsConstructor
 @Slf4j
 
 public class EgovTestAbstractDAO2 {
 
-    /**
-     * BeforeClass AfterClass
-     */
-    private static final StopWatch STOP_WATCH = new StopWatch();
+	/**
+	 * BeforeClass AfterClass
+	 */
+	private static final StopWatch STOP_WATCH = new StopWatch();
 
-    /**
-     * Before After
-     */
-    private final StopWatch stopWatch = new StopWatch();
+	/**
+	 * Before After
+	 */
+	private final StopWatch stopWatch = new StopWatch();
 
-    /**
-     * beanDefinitionNames
-     */
-    private static String[] beanDefinitionNames;
+	/**
+	 * beanDefinitionNames
+	 */
+	private static String[] beanDefinitionNames;
 
-    /**
-     * ApplicationContext
-     */
-    @Autowired
-    private ApplicationContext context;
+	/**
+	 * ApplicationContext
+	 */
+	@Autowired
+	private ApplicationContext context;
 
-    /**
-     * 메시지 리소스 사용을 위한 MessageSource 인터페이스 및 ReloadableResourceBundleMessageSource 클래스의 구현체
-     */
-//    @Resource(name = "egovMessageSource")
-    @Autowired
-    @Qualifier("egovMessageSource")
-    protected EgovMessageSource egovMessageSource;
+	/**
+	 * 메시지 리소스 사용을 위한 MessageSource 인터페이스 및 ReloadableResourceBundleMessageSource
+	 * 클래스의 구현체
+	 */
+	@Autowired
+	protected EgovMessageSource egovMessageSource;
 
-    /**
-     * 조회에 실패하였습니다.
-     */
-    protected static final String FAIL_COMMON_SELECT = "fail.common.select";
+	/**
+	 * 조회에 실패하였습니다.
+	 */
+	protected static final String FAIL_COMMON_SELECT = "fail.common.select";
 
-    /**
-     * setUpBeforeClass
-     */
-    @BeforeAll
-    static void setUpBeforeClass() {
-        STOP_WATCH.start();
+	/**
+	 * setUpBeforeClass
+	 */
+	@BeforeAll
+	static void setUpBeforeClass() {
+		STOP_WATCH.start();
 
-        log.debug("setUpBeforeClass start");
-    }
+		log.debug("setUpBeforeClass start");
+	}
 
-    /**
-     * tearDownAfterClass
-     */
-    @AfterAll
-    static void tearDownAfterClass() {
-        STOP_WATCH.stop();
+	/**
+	 * tearDownAfterClass
+	 */
+	@AfterAll
+	static void tearDownAfterClass() {
+		STOP_WATCH.stop();
 
-        if (log.isDebugEnabled()) {
-            log.debug("tearDownAfterClass stop");
+		if (log.isDebugEnabled()) {
+			log.debug("tearDownAfterClass stop");
 
-            log.debug("totalTimeMillis={}", STOP_WATCH.getTotalTimeMillis());
-            log.debug("totalTimeSeconds={}", STOP_WATCH.getTotalTimeSeconds());
-        }
-    }
+			log.debug("totalTimeMillis={}", STOP_WATCH.getTotalTimeMillis());
+			log.debug("totalTimeSeconds={}", STOP_WATCH.getTotalTimeSeconds());
+		}
+	}
 
-    /**
-     * setUp
-     */
-    @BeforeEach
-    void setUp() {
-        stopWatch.start();
+	/**
+	 * setUp
+	 */
+	@BeforeEach
+	void setUp() {
+		stopWatch.start();
 
-        log.debug("setUp start");
+		log.debug("setUp start");
 
-        if (beanDefinitionNames == null) {
-            beanDefinitionNames = context.getBeanDefinitionNames();
-            for (final String beanDefinitionName : beanDefinitionNames) {
-                log.debug("beanDefinitionName={}", beanDefinitionName);
-            }
-            log.debug("length={}", beanDefinitionNames.length);
-        }
-    }
+		if (beanDefinitionNames == null) {
+			beanDefinitionNames = context.getBeanDefinitionNames();
+			for (final String beanDefinitionName : beanDefinitionNames) {
+				log.debug("beanDefinitionName={}", beanDefinitionName);
+			}
+			log.debug("length={}", beanDefinitionNames.length);
+		}
+	}
 
-    /**
-     * tearDown
-     */
-    @AfterEach
-    void tearDown() {
-        stopWatch.stop();
+	/**
+	 * tearDown
+	 */
+	@AfterEach
+	void tearDown() {
+		stopWatch.stop();
 
-        if (log.isDebugEnabled()) {
-            log.debug("tearDown stop");
+		if (log.isDebugEnabled()) {
+			log.debug("tearDown stop");
 
-            log.debug("totalTimeMillis={}", STOP_WATCH.getTotalTimeMillis());
-            log.debug("totalTimeSeconds={}", STOP_WATCH.getTotalTimeSeconds());
-        }
-    }
+			log.debug("totalTimeMillis={}", STOP_WATCH.getTotalTimeMillis());
+			log.debug("totalTimeSeconds={}", STOP_WATCH.getTotalTimeSeconds());
+		}
+	}
 
-    /**
-     * error
-     * 
-     * @param e
-     */
-    protected void error(final DataAccessException e) {
-        final SQLException sqlException = (SQLException) e.getCause();
-        if (log.isErrorEnabled()) {
-            log.error(egovMessageSource.getMessageArgs("fail.common.sql",
-                    new Object[] { sqlException.getErrorCode(), sqlException.getMessage() }));
-            log.error(egovMessageSource.getMessageArgs("fail.common.sql",
-                    new Object[] { sqlException.getSQLState(), sqlException.getMessage() }));
-        }
-    }
+	/**
+	 * error
+	 * 
+	 * @param e
+	 */
+	protected void error(final DataAccessException e) {
+		final SQLException sqlException = (SQLException) e.getCause();
+		if (log.isErrorEnabled()) {
+			log.error(egovMessageSource.getMessageArgs("fail.common.sql",
+					new Object[] { sqlException.getErrorCode(), sqlException.getMessage() }));
+			log.error(egovMessageSource.getMessageArgs("fail.common.sql",
+					new Object[] { sqlException.getSQLState(), sqlException.getMessage() }));
+		}
+	}
 
 }


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [x] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

제가 이전에 작성했던 테스트 코드라 `Eclipse > Source > Format`을 적용하여 소스 포맷을 정리했습니다.

이로 인해 머지하실 때 변경 사항이 많아 다소 헷갈리실 수 있을 것 같습니다. 번거롭게 해드려 죄송합니다.

## 개요

댓글 DAO 테스트가 메서드 이름에 암묵적으로 의존하지 않고 명시된 순서대로 실행되도록 테스트 구조를 정리합니다.

## 주요 변경 사항

- 공통 DAO 테스트의 정렬 방식을 `MethodName`에서 `OrderAnnotation`으로 변경
- 댓글 DAO 테스트 메서드에 `@Order`를 지정하여 실행 순서를 명시
- 테스트 메서드명을 대상 DAO 메서드와 일치하도록 정리
- 테스트 클래스와 디버그 보조 메서드의 가시성을 필요한 범위로 축소
- 불필요한 `@RequiredArgsConstructor` 및 `@Qualifier` 제거
- `EgovArticleCommentDAOTest`에 `EgovConfigCryptoTest` 설정 등록
- 조회, 등록, 삭제, 상세 조회, 수정 테스트와 테스트 데이터 생성 코드를 실행 순서에 맞게 재배치
- 들여쓰기와 import 순서를 프로젝트 코드 스타일에 맞게 정리

## 변경 파일

- `EgovArticleCommentDAOTest.java`
- `EgovArticleCommentDAO2Test.java`
- `EgovTestAbstractDAO.java`
- `EgovTestAbstractDAO2.java`

## 테스트

사용 환경:

- Java: `17.0.17`
- Maven: `3.9.9`

실행 명령:

```shell
mvn -Dtest=EgovArticleCommentDAOTest,EgovArticleCommentDAO2Test -DskipTests=false test
```
결과:
- 메인 소스 1,092개 및 테스트 소스 326개 컴파일 성공
- Maven 빌드 성공
- pom.xml의 Surefire skipTests 설정이 직접 활성화되어 있어 대상 테스트 본체는 실행되지 않음
검토 참고 사항
- 실제 로직 변경 외에 탭 기반 들여쓰기 정리가 포함되어 diff 규모가 큽니다.
- EgovTestAbstractDAO.java와 EgovTestAbstractDAO2.java의 Javadoc에 trailing whitespace가 각각 1건씩 남아 있습니다.
- @Qualifier 제거 후 동일 타입의 ID 생성 서비스가 실행 시점에 올바르게 주입되는지 확인이 필요합니다.

현재 변경은 스테이징되지 않았으며, 새 파일이나 삭제된 파일은 없습니다. 또한 `git diff --check`에서 Javadoc 후행 공백 2건이 확인되어 커밋 전 제거하는 편이 좋습니다.

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [x] JUnit 테스트 JUnit tests
- [x] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

테스트 후

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/12389458-3582-4d12-8bca-db97407a7576" />

https://youtu.be/Zi87dWKNNcY
