### PR TITLE
fix(EgovFileTool): parsFileByChar가 모든 레코드에 같은 List를 재사용하는 문제 수정

### DIFF
--- a/src/main/java/egovframework/com/utl/sim/service/EgovFileTool.java
+++ b/src/main/java/egovframework/com/utl/sim/service/EgovFileTool.java
@@ -387,6 +387,9 @@ public class EgovFileTool {
 
 					if (parField != 1) {
 						if ((filedCnt % parField) == 1) {
+							// 2026.09.03 레코드가 시작될 때 새 List를 할당한다.
+							// (할당하지 않으면 모든 레코드가 같은 List 인스턴스를 참조하게 된다.)
+							arr = new ArrayList<>();
 							if (strArr[i] != null) {
 								arr.add(strArr[i]);
 							}


### PR DESCRIPTION
## 문제

`EgovFileTool.parsFileByChar()` 는 구분자로 나눈 토큰을 `parField` 개씩 묶어 레코드 단위로 돌려주는 메서드입니다. 그런데 `parField != 1` 분기에서는 레코드가 끝난 뒤에도 `arr` 를 새로 만들지 않고 계속 같은 리스트에 담습니다.

그 결과 **반환된 모든 행이 같은 List 인스턴스**가 되고, 그 안에는 파일 전체 토큰이 들어 있습니다. 바로 아래 `else` 분기(`parField == 1`)는 매 반복 `arr = new ArrayList<>()` 를 하고 있어, 원래 의도를 그대로 보여줍니다.

## 재현 (실측)

같은 저장소의 `EgovMenuGov.setDataByDATFile()` 은 한 줄에 `id|level|name|url|` 4필드를 쓰고, `EgovMenuGov.parsFileByMenuChar()` 가 그것을 다시 `parsFileByChar(..., 4)` 로 읽습니다. 이 왕복을 실제 컴파일된 코드로 실행했습니다.

변경 전
```
행 수 = 4
  [0] size=13 [1000, 1, 업무관리, /mng/main.do, 2000, 2, 일정관리, /sch/list.do, 3000, 2, 게시판, /bbs/list.do, ]
  [1] size=13 (위와 동일)
  [2] size=13 (위와 동일)
  [3] size=13 (위와 동일)
서로 다른 List 인스턴스 수 = 1
```

변경 후
```
행 수 = 4
  [0] size=4 [1000, 1, 업무관리, /mng/main.do]
  [1] size=4 [2000, 2, 일정관리, /sch/list.do]
  [2] size=4 [3000, 2, 게시판, /bbs/list.do]
  [3] size=1 []
서로 다른 List 인스턴스 수 = 4
```

마지막 `[]` 는 줄 끝 구분자에서 생기는 빈 토큰으로, 변경 전후 동일합니다.

## 변경

레코드 시작 분기(`(filedCnt % parField) == 1`)에서 새 List 를 할당합니다. `parField == 1` 경로가 쓰는 방식과 같습니다.

## 회귀 확인 (실측)

| parField | 입력 | 변경 전 | 변경 후 |
| --- | --- | --- | --- |
| 1 | `a\|b\|c\|d\|` | `[[a], [b], [c], [d], []]` | 동일 |
| 2 | `a\|b\|c\|d\|` | `[[a, b, c, d, ], (같은 것 x2)]` | `[[a, b], [c, d], []]` |
| 3 | `a\|b\|c\|d\|e\|` | `[[a, b, c, d, e, ], (같은 것)]` | `[[a, b, c], [d, e, ]]` |
| 2 | 빈 파일 | `[[]]` | 동일 |
| 2 | `a\|` | `[[a, ]]` | 동일 |

`parField == 1`·빈 파일·필드 수 미만 입력은 변경 전과 동일하고, 묶음이 필요한 경우만 달라집니다.

## 참고

`EgovFileToolBean` 이 이 메서드를 스프링 빈으로도 노출하고 있어, 적용 프로젝트에서 직접 호출할 수 있는 공개 API 입니다. 기존 테스트(`TestFileToolBasePath`)는 basePath 보안 검증만 확인하고 반환 내용은 검증하지 않아 이 문제가 드러나지 않았습니다.