### PR TITLE
fix(EgovDateUtil): getCurrentDate(dateType)가 항상 예외를 내는 문제 수정

### DIFF
--- a/src/main/java/egovframework/com/utl/fcc/service/EgovDateUtil.java
+++ b/src/main/java/egovframework/com/utl/fcc/service/EgovDateUtil.java
@@ -453,7 +453,9 @@ public class EgovDateUtil {
 				+ ((date < 10) ? "0" + Integer.toString(date) : Integer.toString(date));
 
 		if (!"".equals(dateType)) {
-			strDate = convertDate(strDate, SIMPLE_DATE_PATTERN, dateType);
+			// 2026.09.03 포맷 변환용 4-인자 convertDate를 호출한다.
+			// (3-인자 오버로드는 두 번째 인자를 "시간"으로 해석하여 항상 IllegalArgumentException이 발생한다.)
+			strDate = convertDate(strDate, SIMPLE_DATE_PATTERN, dateType, "");
 		}
 
 		return strDate;


### PR DESCRIPTION
## 문제

`EgovDateUtil.getCurrentDate(String dateType)` 는 오늘 날짜를 `dateType` 포맷으로 돌려주는 메서드인데, `dateType` 이 비어 있지 않으면 **항상** `IllegalArgumentException` 이 납니다.

원인은 오버로드 선택입니다.

```java
strDate = convertDate(strDate, SIMPLE_DATE_PATTERN, dateType);
```

인자가 3개라서 포맷 변환용
`convertDate(String strSource, String fromDateFormat, String toDateFormat, String strTimeZone)` 가 아니라
`convertDate(String sDate, String sTime, String sFormatStr)` 가 선택됩니다. 즉 `SIMPLE_DATE_PATTERN`(`"yyyyMMdd"`) 이 **시간 문자열** 자리로 들어가 `validChkTime("yyyyMMdd")` 에서 걸립니다.

## 재현 (실측)

실제 컴파일된 코드로 실행한 결과입니다.

| 호출 | 변경 전 | 변경 후 |
| --- | --- | --- |
| `getCurrentDate("")` | `"20260903"` | 동일 |
| `getCurrentDate("yyyy-MM-dd")` | `IllegalArgumentException: Invalid time format: yyyyMMdd` | `"2026-09-03"` |
| `getCurrentDate("yyyy.MM.dd")` | 같은 예외 | `"2026.09.03"` |
| `getCurrentDate("yyyy년 MM월 dd일")` | 같은 예외 | `"2026년 09월 03일"` |
| `getToday()` | `"20260903"` | 동일 |

## 변경

TimeZone 인자를 붙여 포맷 변환용 4-인자 오버로드를 호출합니다. 4-인자 쪽 문서에 `strTimeZone` 은 `""` 이면 변경하지 않는다고 되어 있어 `""` 을 넘겼고, 따라서 TimeZone 동작 변화는 없습니다.

`getToday()` 가 쓰는 `dateType == ""` 경로는 이 분기 자체를 타지 않으므로 기존과 완전히 동일합니다.