### PR TITLE
fix(rss): RSS태그관리 검색조건 세 개가 건수 구문에서 걸러지지 않아 페이지 수가 어긋남

### DIFF
--- a/src/main/resources/egovframework/mapper/com/uss/ion/rss/EgovRssTagManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/rss/EgovRssTagManage_SQL_altibase.xml
@@ -120,7 +120,7 @@
 		<if test="searchCondition == 'A.HDER_LINK'">
 		AND A.HDER_LINK LIKE '%' || #{searchKeyword} || '%'
 		</if>
-		<if test="searchCondition == 'A.HDER_DC'">
+		<if test="searchCondition == 'A.HDER_DESCRIPTION'">
 		AND A.HDER_DC LIKE '%' || #{searchKeyword} || '%'
 		</if>
 		<if test="searchCondition == 'A.HDER_TAG'">
@@ -132,13 +132,13 @@
 		<if test="searchCondition == 'A.BDT_LINK'">
 		AND A.BDT_LINK LIKE '%' || #{searchKeyword} || '%'
 		</if>
-		<if test="searchCondition == 'A.BDT_DC'">
+		<if test="searchCondition == 'A.BDT_DESCRIPTION'">
 		AND A.BDT_DC LIKE '%' || #{searchKeyword} || '%'
 		</if>
 		<if test="searchCondition == 'A.BDT_TAG'">
 		AND A.BDT_TAG LIKE '%' || #{searchKeyword} || '%'
 		</if>
-		<if test="searchCondition == 'A.BDT_ETC_TAG'">
+		<if test="searchCondition == 'A.BDT_ETC'">
 		AND A.BDT_ETC_TAG LIKE '%' || #{searchKeyword} || '%'
 		</if>
 	 	

--- a/src/main/resources/egovframework/mapper/com/uss/ion/rss/EgovRssTagManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/rss/EgovRssTagManage_SQL_cubrid.xml
@@ -120,7 +120,7 @@
 		<if test="searchCondition == 'A.HDER_LINK'">
 		AND A.HDER_LINK LIKE '%' || #{searchKeyword} || '%'
 		</if>
-		<if test="searchCondition == 'A.HDER_DC'">
+		<if test="searchCondition == 'A.HDER_DESCRIPTION'">
 		AND A.HDER_DC LIKE '%' || #{searchKeyword} || '%'
 		</if>
 		<if test="searchCondition == 'A.HDER_TAG'">
@@ -132,13 +132,13 @@
 		<if test="searchCondition == 'A.BDT_LINK'">
 		AND A.BDT_LINK LIKE '%' || #{searchKeyword} || '%'
 		</if>
-		<if test="searchCondition == 'A.BDT_DC'">
+		<if test="searchCondition == 'A.BDT_DESCRIPTION'">
 		AND A.BDT_DC LIKE '%' || #{searchKeyword} || '%'
 		</if>
 		<if test="searchCondition == 'A.BDT_TAG'">
 		AND A.BDT_TAG LIKE '%' || #{searchKeyword} || '%'
 		</if>
-		<if test="searchCondition == 'A.BDT_ETC_TAG'">
+		<if test="searchCondition == 'A.BDT_ETC'">
 		AND A.BDT_ETC_TAG LIKE '%' || #{searchKeyword} || '%'
 		</if>
 	 	

--- a/src/main/resources/egovframework/mapper/com/uss/ion/rss/EgovRssTagManage_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/rss/EgovRssTagManage_SQL_goldilocks.xml
@@ -120,7 +120,7 @@
 		<if test="searchCondition == 'A.HDER_LINK'">
 		AND A.HDER_LINK LIKE '%' || #{searchKeyword} || '%'
 		</if>
-		<if test="searchCondition == 'A.HDER_DC'">
+		<if test="searchCondition == 'A.HDER_DESCRIPTION'">
 		AND A.HDER_DC LIKE '%' || #{searchKeyword} || '%'
 		</if>
 		<if test="searchCondition == 'A.HDER_TAG'">
@@ -132,13 +132,13 @@
 		<if test="searchCondition == 'A.BDT_LINK'">
 		AND A.BDT_LINK LIKE '%' || #{searchKeyword} || '%'
 		</if>
-		<if test="searchCondition == 'A.BDT_DC'">
+		<if test="searchCondition == 'A.BDT_DESCRIPTION'">
 		AND A.BDT_DC LIKE '%' || #{searchKeyword} || '%'
 		</if>
 		<if test="searchCondition == 'A.BDT_TAG'">
 		AND A.BDT_TAG LIKE '%' || #{searchKeyword} || '%'
 		</if>
-		<if test="searchCondition == 'A.BDT_ETC_TAG'">
+		<if test="searchCondition == 'A.BDT_ETC'">
 		AND A.BDT_ETC_TAG LIKE '%' || #{searchKeyword} || '%'
 		</if>
 	 	

--- a/src/main/resources/egovframework/mapper/com/uss/ion/rss/EgovRssTagManage_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/rss/EgovRssTagManage_SQL_maria.xml
@@ -110,7 +110,7 @@
 		<if test="searchCondition == 'A.HDER_LINK'">
 		AND A.HDER_LINK LIKE CONCAT('%', #{searchKeyword}, '%')
 		</if>
-		<if test="searchCondition == 'A.HDER_DC'">
+		<if test="searchCondition == 'A.HDER_DESCRIPTION'">
 		AND A.HDER_DC LIKE CONCAT('%', #{searchKeyword}, '%')
 		</if>
 		<if test="searchCondition == 'A.HDER_TAG'">
@@ -122,13 +122,13 @@
 		<if test="searchCondition == 'A.BDT_LINK'">
 		AND A.BDT_LINK LIKE CONCAT('%', #{searchKeyword}, '%')
 		</if>
-		<if test="searchCondition == 'A.BDT_DC'">
+		<if test="searchCondition == 'A.BDT_DESCRIPTION'">
 		AND A.BDT_DC LIKE CONCAT('%', #{searchKeyword}, '%')
 		</if>
 		<if test="searchCondition == 'A.BDT_TAG'">
 		AND A.BDT_TAG LIKE CONCAT('%', #{searchKeyword}, '%')
 		</if>
-		<if test="searchCondition == 'A.BDT_ETC_TAG'">
+		<if test="searchCondition == 'A.BDT_ETC'">
 		AND A.BDT_ETC_TAG LIKE CONCAT('%', #{searchKeyword}, '%')
 		</if>
 	 	

--- a/src/main/resources/egovframework/mapper/com/uss/ion/rss/EgovRssTagManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/rss/EgovRssTagManage_SQL_mysql.xml
@@ -110,7 +110,7 @@
 		<if test="searchCondition == 'A.HDER_LINK'">
 		AND A.HDER_LINK LIKE CONCAT('%', #{searchKeyword}, '%')
 		</if>
-		<if test="searchCondition == 'A.HDER_DC'">
+		<if test="searchCondition == 'A.HDER_DESCRIPTION'">
 		AND A.HDER_DC LIKE CONCAT('%', #{searchKeyword}, '%')
 		</if>
 		<if test="searchCondition == 'A.HDER_TAG'">
@@ -122,13 +122,13 @@
 		<if test="searchCondition == 'A.BDT_LINK'">
 		AND A.BDT_LINK LIKE CONCAT('%', #{searchKeyword}, '%')
 		</if>
-		<if test="searchCondition == 'A.BDT_DC'">
+		<if test="searchCondition == 'A.BDT_DESCRIPTION'">
 		AND A.BDT_DC LIKE CONCAT('%', #{searchKeyword}, '%')
 		</if>
 		<if test="searchCondition == 'A.BDT_TAG'">
 		AND A.BDT_TAG LIKE CONCAT('%', #{searchKeyword}, '%')
 		</if>
-		<if test="searchCondition == 'A.BDT_ETC_TAG'">
+		<if test="searchCondition == 'A.BDT_ETC'">
 		AND A.BDT_ETC_TAG LIKE CONCAT('%', #{searchKeyword}, '%')
 		</if>
 	 	

--- a/src/main/resources/egovframework/mapper/com/uss/ion/rss/EgovRssTagManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/rss/EgovRssTagManage_SQL_oracle.xml
@@ -120,7 +120,7 @@
 		<if test="searchCondition == 'A.HDER_LINK'">
 		AND A.HDER_LINK LIKE '%' || #{searchKeyword} || '%'
 		</if>
-		<if test="searchCondition == 'A.HDER_DC'">
+		<if test="searchCondition == 'A.HDER_DESCRIPTION'">
 		AND A.HDER_DC LIKE '%' || #{searchKeyword} || '%'
 		</if>
 		<if test="searchCondition == 'A.HDER_TAG'">
@@ -132,13 +132,13 @@
 		<if test="searchCondition == 'A.BDT_LINK'">
 		AND A.BDT_LINK LIKE '%' || #{searchKeyword} || '%'
 		</if>
-		<if test="searchCondition == 'A.BDT_DC'">
+		<if test="searchCondition == 'A.BDT_DESCRIPTION'">
 		AND A.BDT_DC LIKE '%' || #{searchKeyword} || '%'
 		</if>
 		<if test="searchCondition == 'A.BDT_TAG'">
 		AND A.BDT_TAG LIKE '%' || #{searchKeyword} || '%'
 		</if>
-		<if test="searchCondition == 'A.BDT_ETC_TAG'">
+		<if test="searchCondition == 'A.BDT_ETC'">
 		AND A.BDT_ETC_TAG LIKE '%' || #{searchKeyword} || '%'
 		</if>
 	 	

--- a/src/main/resources/egovframework/mapper/com/uss/ion/rss/EgovRssTagManage_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/rss/EgovRssTagManage_SQL_postgres.xml
@@ -110,7 +110,7 @@
 		<if test="searchCondition == 'A.HDER_LINK'">
 		AND A.HDER_LINK LIKE CONCAT('%', #{searchKeyword}, '%')
 		</if>
-		<if test="searchCondition == 'A.HDER_DC'">
+		<if test="searchCondition == 'A.HDER_DESCRIPTION'">
 		AND A.HDER_DC LIKE CONCAT('%', #{searchKeyword}, '%')
 		</if>
 		<if test="searchCondition == 'A.HDER_TAG'">
@@ -122,13 +122,13 @@
 		<if test="searchCondition == 'A.BDT_LINK'">
 		AND A.BDT_LINK LIKE CONCAT('%', #{searchKeyword}, '%')
 		</if>
-		<if test="searchCondition == 'A.BDT_DC'">
+		<if test="searchCondition == 'A.BDT_DESCRIPTION'">
 		AND A.BDT_DC LIKE CONCAT('%', #{searchKeyword}, '%')
 		</if>
 		<if test="searchCondition == 'A.BDT_TAG'">
 		AND A.BDT_TAG LIKE CONCAT('%', #{searchKeyword}, '%')
 		</if>
-		<if test="searchCondition == 'A.BDT_ETC_TAG'">
+		<if test="searchCondition == 'A.BDT_ETC'">
 		AND A.BDT_ETC_TAG LIKE CONCAT('%', #{searchKeyword}, '%')
 		</if>
 	 	

--- a/src/main/resources/egovframework/mapper/com/uss/ion/rss/EgovRssTagManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/rss/EgovRssTagManage_SQL_tibero.xml
@@ -120,7 +120,7 @@
 		<if test="searchCondition == 'A.HDER_LINK'">
 		AND A.HDER_LINK LIKE '%' || #{searchKeyword} || '%'
 		</if>
-		<if test="searchCondition == 'A.HDER_DC'">
+		<if test="searchCondition == 'A.HDER_DESCRIPTION'">
 		AND A.HDER_DC LIKE '%' || #{searchKeyword} || '%'
 		</if>
 		<if test="searchCondition == 'A.HDER_TAG'">
@@ -132,13 +132,13 @@
 		<if test="searchCondition == 'A.BDT_LINK'">
 		AND A.BDT_LINK LIKE '%' || #{searchKeyword} || '%'
 		</if>
-		<if test="searchCondition == 'A.BDT_DC'">
+		<if test="searchCondition == 'A.BDT_DESCRIPTION'">
 		AND A.BDT_DC LIKE '%' || #{searchKeyword} || '%'
 		</if>
 		<if test="searchCondition == 'A.BDT_TAG'">
 		AND A.BDT_TAG LIKE '%' || #{searchKeyword} || '%'
 		</if>
-		<if test="searchCondition == 'A.BDT_ETC_TAG'">
+		<if test="searchCondition == 'A.BDT_ETC'">
 		AND A.BDT_ETC_TAG LIKE '%' || #{searchKeyword} || '%'
 		</if>
 	 	

--- a/src/test/java/egovframework/com/uss/ion/rss/service/impl/EgovRssTagManageCountFilterTest.java
+++ b/src/test/java/egovframework/com/uss/ion/rss/service/impl/EgovRssTagManageCountFilterTest.java
@@ -1,0 +1,92 @@
+package egovframework.com.uss.ion.rss.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.ibatis.builder.xml.XMLMapperBuilder;
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.mapping.MappedStatement;
+import org.apache.ibatis.session.Configuration;
+import org.egovframe.rte.psl.dataaccess.util.EgovMap;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import egovframework.com.cmm.ComDefaultVO;
+import egovframework.com.uss.ion.rss.service.RssManage;
+
+/**
+ * RSS태그관리 목록 구문과 건수 구문이 같은 검색조건을 같은 컬럼으로 거르는지 8개 DB 방언에서 검증한다.
+ *
+ * <p>{@link RssTagManageDao#selectRssTagManageList} 와 {@link RssTagManageDao#selectRssTagManageListCnt} 는
+ * 컨트롤러가 화면에서 온 searchCondition 을 가공 없이 담아 넘긴 같은 VO 를 받는다. 그래서 두 구문의
+ * 조건 분기가 보는 리터럴이 어긋나면 목록만 걸러지고 건수는 테이블 전체를 세어 페이저가 실제보다
+ * 많은 페이지를 그린다.</p>
+ *
+ * <p>{@code context-mapper.xml} 의 {@code mapperLocations} 가
+ * {@code classpath:/egovframework/mapper/com/**}{@code /*_${Globals.DbType}.xml} 이라 런타임에는
+ * 방언 매퍼가 하나만 로드된다. 방언별로 매퍼를 직접 파싱해 DB 연결 없이 검증한다.</p>
+ */
+class EgovRssTagManageCountFilterTest {
+
+	private static final String LIST_STATEMENT_ID = "RssTagManage.selectRssTagManage";
+
+	private static final String COUNT_STATEMENT_ID = "RssTagManage.selectRssTagManageCnt";
+
+	/** EgovRssTagManageList.jsp 의 검색조건 드롭다운이 보내는 값. */
+	private static final String[] SEARCH_CONDITIONS = {
+		"A.TRGET_SVC_NM", "A.TRGET_SVC_TABLE", "A.HDER_TITLE", "A.HDER_LINK", "A.HDER_DESCRIPTION",
+		"A.HDER_TAG", "A.HDER_ETC", "A.BDT_LINK", "A.BDT_DESCRIPTION", "A.BDT_TAG", "A.BDT_ETC"
+	};
+
+	/** 방언마다 뒤에 붙는 문자열 결합 표기가 달라 컬럼명까지만 본다. */
+	private static final Pattern FILTER_COLUMN = Pattern.compile("AND\\s+(\\S+)\\s+LIKE", Pattern.CASE_INSENSITIVE);
+
+	private static final String NO_FILTER = "조건없음";
+
+	private Configuration loadMapper(String dialect) throws Exception {
+		String resource = "egovframework/mapper/com/uss/ion/rss/EgovRssTagManage_SQL_" + dialect + ".xml";
+		Configuration configuration = new Configuration();
+		configuration.getTypeAliasRegistry().registerAlias("comDefaultVO", ComDefaultVO.class);
+		configuration.getTypeAliasRegistry().registerAlias("egovMap", EgovMap.class);
+		try (InputStream inputStream = Resources.getResourceAsStream(resource)) {
+			new XMLMapperBuilder(inputStream, configuration, resource, configuration.getSqlFragments()).parse();
+		}
+		return configuration;
+	}
+
+	private String filterColumnOf(Configuration configuration, String statementId, RssManage rssManage) {
+		MappedStatement statement = configuration.getMappedStatement(statementId);
+		Matcher filter = FILTER_COLUMN.matcher(statement.getBoundSql(rssManage).getSql());
+		return filter.find() ? filter.group(1) : NO_FILTER;
+	}
+
+	@ParameterizedTest(name = "{0}")
+	@ValueSource(strings = { "mysql", "maria", "oracle", "postgres", "tibero", "altibase", "cubrid", "goldilocks" })
+	@DisplayName("검색조건 열한 개 모두 목록 구문과 건수 구문이 같은 컬럼을 거른다")
+	void countStatementFiltersTheSameColumnAsListStatement(String dialect) throws Exception {
+		Configuration configuration = loadMapper(dialect);
+
+		List<String> mismatched = new ArrayList<>();
+		for (String searchCondition : SEARCH_CONDITIONS) {
+			RssManage rssManage = new RssManage();
+			rssManage.setSearchCondition(searchCondition);
+			rssManage.setSearchKeyword("rss");
+
+			String listColumn = filterColumnOf(configuration, LIST_STATEMENT_ID, rssManage);
+			String countColumn = filterColumnOf(configuration, COUNT_STATEMENT_ID, rssManage);
+
+			if (NO_FILTER.equals(listColumn) || !listColumn.equals(countColumn)) {
+				mismatched.add(searchCondition + " 목록=" + listColumn + " 건수=" + countColumn);
+			}
+		}
+
+		assertTrue(mismatched.isEmpty(), dialect + " 매퍼에서 건수 구문이 목록과 다른 컬럼을 거른다: " + mismatched);
+	}
+
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`/uss/ion/rss/listRssTagManage.do` 는 화면에서 온 `searchCondition` 을 가공 없이 같은 VO 에 담아 목록 구문 `selectRssTagManage` 와 건수 구문 `selectRssTagManageCnt` 에 넘기고 그 건수를 `paginationInfo.setTotalRecordCount` 로 씁니다(`EgovRssTagManageController.java:158,164-165`). 그런데 두 구문이 보는 조건 리터럴이 세 곳에서 어긋납니다.

목록 구문과 화면 드롭다운(`EgovRssTagManageList.jsp:149,153,155`)은 `A.HDER_DESCRIPTION`·`A.BDT_DESCRIPTION`·`A.BDT_ETC` 를 쓰는데, 건수 구문만 컬럼명 그대로인 `A.HDER_DC`·`A.BDT_DC`·`A.BDT_ETC_TAG` 를 봅니다. 헤더DESCRIPTION·본문DESCRIPTION·본문ETC 로 검색하면 목록은 걸러지지만 건수 구문의 WHERE 에는 `1=1` 만 남아 테이블 전체를 셉니다. 페이저가 실제보다 많은 페이지를 그립니다. 뒷 페이지는 모두 빈 목록입니다.

건수 구문의 `<if>` 조건만 목록에 맞췄습니다. 조건절이 비교하는 컬럼은 그대로 뒀습니다(`EgovRssTagManage_SQL_mysql.xml:113,125,131`).

```xml
-		<if test="searchCondition == 'A.HDER_DC'">
+		<if test="searchCondition == 'A.HDER_DESCRIPTION'">
 		AND A.HDER_DC LIKE CONCAT('%', #{searchKeyword}, '%')
```

나머지 여덟 조건은 목록과 건수의 리터럴이 같아 정상 동작합니다. 어긋나는 자리는 여덟 방언 모두 같은 세 곳입니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

`EgovRssTagManageCountFilterTest` 를 추가했습니다. 화면 드롭다운 11개 값을 여덟 방언 매퍼에 각각 넣고 목록 구문과 건수 구문의 `getBoundSql` 이 같은 컬럼을 거르는지 봅니다. 데이터베이스 연결은 필요하지 않습니다. surefire 의 `skipTests` 가 `true` 로 고정돼 있어 실행할 때만 잠시 풀었습니다.

```
[INFO] Running egovframework.com.uss.ion.rss.service.impl.EgovRssTagManageCountFilterTest
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0
```

건수 쪽 리터럴을 되돌리면 여덟 방언 모두 실패합니다.

```
[ERROR] Failures:
[ERROR]   EgovRssTagManageCountFilterTest.countStatementFiltersTheSameColumnAsListStatement:89 mysql 매퍼에서 건수 구문이 목록과 다른 컬럼을 거른다: [A.HDER_DESCRIPTION 목록=A.HDER_DC 건수=조건없음, A.BDT_DESCRIPTION 목록=A.BDT_DC 건수=조건없음, A.BDT_ETC 목록=A.BDT_ETC_TAG 건수=조건없음] ==> expected: <true> but was: <false>
[ERROR]   ... (나머지 일곱 방언도 같은 형태)
[ERROR] Tests run: 8, Failures: 8, Errors: 0, Skipped: 0
```

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

브라우저 테스트는 하지 않았습니다. 매퍼가 렌더하는 SQL 로 확인했습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

위 테스트 출력으로 대신합니다.
