### PR TITLE
fix(bnt): 당직체크관리 목록 건수가 사용여부 조건을 무시함

### DIFF
--- a/src/main/resources/egovframework/mapper/com/uss/ion/bnt/EgovBndtManage_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/bnt/EgovBndtManage_SQL_maria.xml
@@ -142,8 +142,8 @@
         <if test="searchBndtCeckSe != null and searchBndtCeckSe != ''">AND
                binary(BNDT_CECK_SE) like  CONCAT('%', #{searchBndtCeckSe}, '%')  
         </if>
-        <if test="searchBndtCeckCd != null and searchBndtCeckCd != ''">AND
-               binary(BNDT_CECK_CODE) like  CONCAT('%', #{searchBndtCeckCd}, '%')   
+        <if test="searchUseAt != null and searchUseAt != ''">AND
+               binary(USE_AT) like  CONCAT('%', #{searchUseAt}, '%')   
         </if>
         <if test="searchKeyword != null and searchKeyword != ''">AND
                binary(BNDT_CECK_CODE_NM) like  CONCAT('%', #{searchKeyword}, '%')   

--- a/src/main/resources/egovframework/mapper/com/uss/ion/bnt/EgovBndtManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/bnt/EgovBndtManage_SQL_mysql.xml
@@ -142,8 +142,8 @@
         <if test="searchBndtCeckSe != null and searchBndtCeckSe != ''">AND
                binary(BNDT_CECK_SE) like  CONCAT('%', #{searchBndtCeckSe}, '%')  
         </if>
-        <if test="searchBndtCeckCd != null and searchBndtCeckCd != ''">AND
-               binary(BNDT_CECK_CODE) like  CONCAT('%', #{searchBndtCeckCd}, '%')   
+        <if test="searchUseAt != null and searchUseAt != ''">AND
+               binary(USE_AT) like  CONCAT('%', #{searchUseAt}, '%')   
         </if>
         <if test="searchKeyword != null and searchKeyword != ''">AND
                binary(BNDT_CECK_CODE_NM) like  CONCAT('%', #{searchKeyword}, '%')   

--- a/src/main/resources/egovframework/mapper/com/uss/ion/bnt/EgovBndtManage_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/bnt/EgovBndtManage_SQL_postgres.xml
@@ -142,8 +142,8 @@
         <if test="searchBndtCeckSe != null and searchBndtCeckSe != ''">AND
                BNDT_CECK_SE like  CONCAT('%', #{searchBndtCeckSe}, '%')  
         </if>
-        <if test="searchBndtCeckCd != null and searchBndtCeckCd != ''">AND
-               BNDT_CECK_CODE like  CONCAT('%', #{searchBndtCeckCd}, '%')   
+        <if test="searchUseAt != null and searchUseAt != ''">AND
+               USE_AT like  CONCAT('%', #{searchUseAt}, '%')   
         </if>
         <if test="searchKeyword != null and searchKeyword != ''">AND
                BNDT_CECK_CODE_NM like  CONCAT('%', #{searchKeyword}, '%')   

--- a/src/test/java/egovframework/com/uss/ion/bnt/service/impl/EgovBndtCeckManageTotCntConditionTest.java
+++ b/src/test/java/egovframework/com/uss/ion/bnt/service/impl/EgovBndtCeckManageTotCntConditionTest.java
@@ -1,0 +1,87 @@
+package egovframework.com.uss.ion.bnt.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.InputStream;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.ibatis.builder.xml.XMLMapperBuilder;
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.mapping.MappedStatement;
+import org.apache.ibatis.session.Configuration;
+import org.egovframe.rte.psl.dataaccess.util.EgovMap;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import egovframework.com.cmm.ComDefaultVO;
+import egovframework.com.uss.ion.bnt.service.BndtCeckManageVO;
+
+/**
+ * 당직체크관리 목록과 총 건수가 8개 DB 방언 모두에서 같은 검색조건을 거는지 검증한다.
+ *
+ * <p>{@code EgovBndtManageController.selectBndtCeckManageList} 는 목록을
+ * {@code selectBndtCeckManageList} 로, 페이저에 넣을 총 건수를
+ * {@code selectBndtCeckManageListTotCnt} 로 각각 조회한다. 두 구문의 조건이 어긋나면 그 방언으로
+ * 기동했을 때만 페이저가 목록에 없는 페이지를 그린다.</p>
+ *
+ * <p>{@code context-mapper.xml} 의 {@code mapperLocations} 가
+ * {@code classpath:/egovframework/mapper/com/**}{@code /*_${Globals.DbType}.xml} 이라 런타임에는
+ * 방언 매퍼가 하나만 로드된다. 방언별로 매퍼를 직접 파싱해 DB 연결 없이 검증한다.</p>
+ */
+class EgovBndtCeckManageTotCntConditionTest {
+
+	private static final String LIST_STATEMENT_ID = "bndtManageDAO.selectBndtCeckManageList";
+
+	private static final String TOT_CNT_STATEMENT_ID = "bndtManageDAO.selectBndtCeckManageListTotCnt";
+
+	/**
+	 * 두 구문의 검색조건은 {@code WHERE 1=1} 뒤에서 시작해 정렬 앞에서 끝난다.
+	 * 건수 구문에는 열 목록도 정렬·페이징 꼬리도 없어 조건 부분만 비교한다.
+	 */
+	private static final Pattern SEARCH_CONDITION = Pattern.compile("WHERE\\s+1=1(.*?)(?:ORDER\\s+BY|$)",
+			Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
+
+	private Configuration loadMapper(String dialect) throws Exception {
+		String resource = "egovframework/mapper/com/uss/ion/bnt/EgovBndtManage_SQL_" + dialect + ".xml";
+		Configuration configuration = new Configuration();
+		configuration.getTypeAliasRegistry().registerAlias("comDefaultVO", ComDefaultVO.class);
+		configuration.getTypeAliasRegistry().registerAlias("egovMap", EgovMap.class);
+		try (InputStream inputStream = Resources.getResourceAsStream(resource)) {
+			new XMLMapperBuilder(inputStream, configuration, resource, configuration.getSqlFragments()).parse();
+		}
+		return configuration;
+	}
+
+	private String searchConditionOf(Configuration configuration, String statementId, Object parameter) {
+		MappedStatement statement = configuration.getMappedStatement(statementId);
+		String sql = statement.getBoundSql(parameter).getSql();
+
+		Matcher matcher = SEARCH_CONDITION.matcher(sql);
+		assertTrue(matcher.find(), statementId + " 이 WHERE 1=1 로 조건을 열지 않는다: " + sql);
+		return matcher.group(1).replaceAll("\\s+", " ").trim();
+	}
+
+	@ParameterizedTest(name = "{0}")
+	@ValueSource(strings = { "mysql", "maria", "oracle", "postgres", "tibero", "altibase", "cubrid", "goldilocks" })
+	@DisplayName("사용여부로 거른 당직체크 목록과 총 건수는 방언과 무관하게 같은 조건을 건다")
+	void listAndTotalCountFilterOnTheSameCondition(String dialect) throws Exception {
+		Configuration configuration = loadMapper(dialect);
+
+		// 목록 화면의 사용여부 select 로 '사용'만 골라 조회한 상태다.
+		BndtCeckManageVO bndtCeckManageVO = new BndtCeckManageVO();
+		bndtCeckManageVO.setSearchUseAt("Y");
+
+		String listCondition = searchConditionOf(configuration, LIST_STATEMENT_ID, bndtCeckManageVO);
+		String totCntCondition = searchConditionOf(configuration, TOT_CNT_STATEMENT_ID, bndtCeckManageVO);
+
+		System.out.println("[" + dialect + "] 목록 " + listCondition);
+		System.out.println("[" + dialect + "] 건수 " + totCntCondition);
+
+		assertEquals(listCondition, totCntCondition,
+				dialect + " 매퍼의 총 건수가 목록과 다른 조건을 센다");
+	}
+
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`EgovBndtManage_SQL_mysql.xml`·`maria`·`postgres` 의 목록 구문 `selectBndtCeckManageList` 는 화면이 보내는 `searchUseAt` 으로 사용여부를 거르는데, 짝이 되는 건수 구문 `selectBndtCeckManageListTotCnt` 는 같은 자리에서 `searchBndtCeckCd` 를 봅니다.

그 `searchBndtCeckCd` 는 고치려는 이 세 건수 구문을 빼면 `BndtCeckManageVO.java:93` 의 선언 한 줄이 전부입니다.

검색 화면 `EgovBndtCeckManageList.jsp` 의 검색 상자가 받는 조회 항목은 `searchBndtCeckSe`(:99)·`searchKeyword`(:107)·`searchUseAt`(:110) 셋이고, `searchBndtCeckCd` 를 보내는 자리는 화면에 없습니다. 컨트롤러도 채우지 않습니다. 조건이 걸리지 않으므로 사용여부로 거른 화면에서도 건수에는 그 조건이 빠집니다. 구분·검색어까지 비어 있으면 `COMTNBNDTCECKMANAGE` 전체를 셉니다.

이 값이 그대로 `PaginationInfo` 의 총 건수가 되어 `<ui:pagination>` 이 실제 결과보다 많은 페이지를 그리고, 뒷 페이지를 누르면 빈 목록이 나옵니다.

세 방언의 조건을 같은 파일 목록 구문과 같게 맞췄습니다. mysql(:145)·maria(:145) 는 아래와 같고 postgres(:145) 는 `binary()` 감싸기 없이 같은 변경입니다.

```diff
-        <if test="searchBndtCeckCd != null and searchBndtCeckCd != ''">AND
-               binary(BNDT_CECK_CODE) like  CONCAT('%', #{searchBndtCeckCd}, '%')
+        <if test="searchUseAt != null and searchUseAt != ''">AND
+               binary(USE_AT) like  CONCAT('%', #{searchUseAt}, '%')
```

식별자 두 개만 바꿨고 들여쓰기와 `like`·`CONCAT` 형태는 그대로 뒀습니다.

여덟 방언의 두 구문이 거는 조건을 모두 뽑아 손댈 범위를 정했습니다. 수정 전 기준입니다.

```
             목록                    건수
altibase     Se · UseAt · Keyword    Se · UseAt · Keyword
cubrid       Se · UseAt · Keyword    Se · UseAt · Keyword
goldilocks   Se · UseAt · Keyword    Se · UseAt · Keyword
oracle       Se · UseAt · Keyword    Se · UseAt · Keyword
tibero       Se · UseAt · Keyword    Se · UseAt · Keyword
maria        Se · UseAt · Keyword    Se · BndtCeckCd · Keyword
mysql        Se · UseAt · Keyword    Se · BndtCeckCd · Keyword
postgres     Se · UseAt · Keyword    Se · BndtCeckCd · Keyword
```

어긋나는 것은 가운데 조건뿐이라 나머지 다섯 방언과, 같은 구문의 다른 두 조건(`searchBndtCeckSe`·`searchKeyword`)은 손대지 않았습니다. `BndtCeckManageVO` 의 `searchBndtCeckCd` 는 이제 참조가 없는 필드가 되지만 롬복 `@Getter`·`@Setter` 로 접근자가 붙는 프로퍼티라 이 PR 에서는 그대로 뒀습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

`EgovBndtCeckManageTotCntConditionTest` 를 추가했습니다. 여덟 방언 매퍼를 `XMLMapperBuilder` 로 읽어 목록과 건수를 `getBoundSql` 로 렌더하고, `WHERE 1=1` 뒤부터 정렬 앞까지 잘라 두 조건을 맞춰봅니다. 건수 구문에는 열 목록도 정렬·페이징 꼬리도 없어 조건 부분만 잘라 비교했습니다. 데이터베이스 연결은 필요하지 않습니다.

```
mvn -o test -Dtest=EgovBndtCeckManageTotCntConditionTest

[mysql] 목록 AND binary(USE_AT) like CONCAT('%', ?, '%')
[mysql] 건수 AND binary(USE_AT) like CONCAT('%', ?, '%')
Tests run: 8, Failures: 0, Errors: 0, Skipped: 0
```

세 방언의 수정을 도로 빼면 그 세 방언만 실패합니다.

```
mysql 매퍼의 총 건수가 목록과 다른 조건을 센다
  expected: <AND binary(USE_AT) like CONCAT('%', ?, '%')> but was: <>
Tests run: 8, Failures: 3, Errors: 0, Skipped: 0
```

모듈의 기존 테스트도 회귀로 함께 돌렸습니다.

```
mvn -o test -Dtest='egovframework.com.uss.**.*Test,EgovMapperVariantTest'
Tests run: 124, Failures: 0, Errors: 1, Skipped: 0
```

오류 한 건은 `FormValidationTest` 가 `jakarta/servlet/ServletConnection` 을 찾지 못하는 것으로, 이 변경을 되돌린 상태에서도 같습니다.

위 출력은 `pom.xml` 의 surefire `<skipTests>true</skipTests>` 를 잠시 해제하고 얻은 것이며 값은 되돌려 뒀습니다. 그 값이 고정이라 명령만으로는 `Tests are skipped.` 로 끝납니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

브라우저 테스트는 하지 않았습니다. 매퍼가 렌더하는 SQL 로 확인했습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

위 테스트 출력으로 대신합니다.
