### PR TITLE
fix(exception): 예외 처리와 오류 로깅을 일관되게 정비

### DIFF
--- a/src/main/java/egovframework/com/uat/uia/web/EgovLoginController.java
+++ b/src/main/java/egovframework/com/uat/uia/web/EgovLoginController.java
@@ -20,8 +20,8 @@ import egovframework.com.cmm.ComDefaultCodeVO;
 import egovframework.com.cmm.ComDefaultVO;
 import egovframework.com.cmm.EgovComponentChecker;
 import egovframework.com.cmm.EgovMessageSource;
-import egovframework.com.cmm.LoginVO;
 import egovframework.com.cmm.LoginRequestVO;
+import egovframework.com.cmm.LoginVO;
 import egovframework.com.cmm.SearchIdRequestVO;
 import egovframework.com.cmm.SearchPasswordRequestVO;
 import egovframework.com.cmm.annotation.IncludedInfo;
@@ -521,7 +521,7 @@ public class EgovLoginController {
 		 * x509Cert.getCert(); Base64 base64 = new Base64(); base64cert =
 		 * base64.encode(cert); log.info("+++ Base64로 변환된 인증서는 : " + base64cert);
 		 * 
-		 * } catch (GpkiApiException e) { e.printStackTrace(); }
+		 * } catch (GpkiApiException e) { throw new BaseRuntimeException(e); }
 		 */
 	}
 

--- a/src/test/java/egovframework/code/security/exception/TestException.java
+++ b/src/test/java/egovframework/code/security/exception/TestException.java
@@ -1,13 +1,13 @@
 package egovframework.code.security.exception;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import egovframework.com.cmm.service.EgovProperties;
+import lombok.extern.slf4j.Slf4j;
 
 /**
- * TestException Test Class 구현
- * Catch a list of specific exception subtypes instead.
+ * 시스템 프로퍼티와 전자정부 표준프레임워크 프로퍼티의 연계 동작을 확인한다.
+ *
+ * <p>{@code my.active} 시스템 프로퍼티를 직접 설정한 경우와
+ * {@link EgovProperties}에서 조회한 값으로 설정한 경우를 로그로 비교한다.</p>
  * 
  * @author 표준프레임워크 신용호
  * @since 2022.11.11
@@ -22,21 +22,31 @@ import egovframework.com.cmm.service.EgovProperties;
    
  * </pre>
  */
-
+@Slf4j
 public class TestException {
-	
-	private static final Logger LOGGER = LoggerFactory.getLogger(TestException.class);
-	
+
+	/**
+	 * 시스템 프로퍼티의 초기값과 변경된 값을 순서대로 출력한다.
+	 *
+	 * @param args 명령행 인수(사용하지 않음)
+	 */
 	public static void main(String[] args) {
-		
+		// 시스템 프로퍼티를 설정하기 전의 값을 확인한다.
+		log.debug("my.active={}", System.getProperty("my.active"));
+
+		// 시스템 프로퍼티를 직접 설정한 후 변경 결과를 확인한다.
 		System.setProperty("my.active", "OK");
-		try {
-			System.setProperty("my.active", EgovProperties.getProperty("egov.none.id"));
-		} catch (RuntimeException e) {
-			// TODO Auto-generated catch block
-			//e.printStackTrace();
-			LOGGER.error("[" + e.getClass() +"] search fail : " + e.getMessage());
-		}
+
+		log.debug("my.active={}", System.getProperty("my.active"));
+
+		// 프레임워크 프로퍼티 값을 조회해 시스템 프로퍼티에 반영한다.
+		String egovNoneId = EgovProperties.getProperty("egov.none.id");
+
+		log.debug("egov.none.id={}", egovNoneId);
+
+		System.setProperty("my.active", egovNoneId);
+
+		log.debug("my.active={}", System.getProperty("my.active"));
 	}
 
 }

--- a/src/test/java/egovframework/code/security/file/TestFileName.java
+++ b/src/test/java/egovframework/code/security/file/TestFileName.java
@@ -1,15 +1,14 @@
 package egovframework.code.security.file;
 
 import org.apache.commons.io.FilenameUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import egovframework.code.security.exception.TestException;
+import lombok.extern.slf4j.Slf4j;
 
 /**
- * TestFileName Test Class 구현
- * Null Byte (\u0000) 공격 차단
- * 파일명 추출 테스트
+ * 경로 문자열에서 안전하게 파일명을 추출하는 동작을 확인한다.
+ *
+ * <p>상위 경로를 포함한 입력에서는 마지막 파일명만 추출하고,
+ * 널 바이트가 포함된 비정상 입력에서는 예외가 발생하는지 확인한다.</p>
  * 
  * @author 표준프레임워크 신용호
  * @since 2022.11.16
@@ -25,28 +24,35 @@ import egovframework.code.security.exception.TestException;
  * </pre>
  */
 
-
+@Slf4j
 public class TestFileName {
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(TestException.class);
-	
+	/**
+	 * 경로 조작 및 널 바이트가 포함된 파일명 처리 결과를 출력한다.
+	 *
+	 * @param args 명령행 인수(사용하지 않음)
+	 */
 	public static void main(String[] args) {
-		
+		// 상위 경로가 포함된 일반 파일 및 확장자가 없는 파일을 준비한다.
 		String file1 = "../../../config/test.png";
 		String file2 = "../../../config/overide_file";
+		// 확장자를 위장하기 위해 널 바이트를 삽입한 비정상 파일명이다.
 		String file3 = "shell.jsp\u0000expected.gif";
+
+		// 전체 경로를 제거하고 마지막 파일명 부분만 추출한다.
 		String fn1 = FilenameUtils.getName(file1);
 		String fn2 = FilenameUtils.getName(file2);
+
+		// 비정상 입력 처리에 실패한 경우에도 출력할 기본값을 지정한다.
 		String fn3 = "-";
 		try {
 			fn3 = FilenameUtils.getName(file3);
-		} catch (Exception e) {
-			e.printStackTrace();
+		} catch (IllegalArgumentException e) {
+			log.error("FilenameUtils가 널 바이트 입력을 거부하면 예외 정보를 기록한다.", e);
 		}
-		LOGGER.debug("safe filename1 = "+fn1);
-		LOGGER.debug("safe filename2 = "+fn2);
-		LOGGER.debug("safe filename3 = "+fn3);
-		
+		log.debug("safe filename1 = {}", fn1);
+		log.debug("safe filename2 = {}", fn2);
+		log.debug("safe filename3 = {}", fn3);
 	}
 
 }

--- a/src/test/java/egovframework/com/cop/cmy/service/impl/EgovCommuBBSMasterDAOTest.java
+++ b/src/test/java/egovframework/com/cop/cmy/service/impl/EgovCommuBBSMasterDAOTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import org.egovframe.rte.fdl.cmmn.exception.BaseRuntimeException;
 import org.egovframe.rte.fdl.cmmn.exception.FdlException;
 import org.egovframe.rte.fdl.idgnr.EgovIdGnrService;
 import org.junit.jupiter.api.Test;
@@ -121,8 +122,7 @@ public class EgovCommuBBSMasterDAOTest extends EgovTestAbstractDAO {
             boardMaster.setCmmntyId(egovCmmntyIdGnrService.getNextStringId());
 
         } catch (FdlException e) {
-            log.error("FdlException egovBBSMstrIdGnrService");
-            // e.printStackTrace();
+            throw new BaseRuntimeException(e);
         }
 
         boardMaster.setBbsTyCode("BBST02");

--- a/src/test/java/egovframework/com/cop/cmy/service/impl/EgovCommuMasterDAOTest.java
+++ b/src/test/java/egovframework/com/cop/cmy/service/impl/EgovCommuMasterDAOTest.java
@@ -2,10 +2,10 @@ package egovframework.com.cop.cmy.service.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.List;
 
+import org.egovframe.rte.fdl.cmmn.exception.BaseRuntimeException;
 import org.egovframe.rte.fdl.idgnr.EgovIdGnrService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -296,11 +296,8 @@ public class EgovCommuMasterDAOTest extends EgovTestAbstractDAO {
         List<CommunityVO> resultList = null;
         try {
             resultList = egovCommuMasterDAO.selectCommuMasterListPortlet(cmmntyVO);
-        } catch (DataAccessException eDAE) {
-            // eDAE.printStackTrace();
-            log.error("DataAccessException selectCommuMasterListPortlet");
-            error(eDAE);
-            fail("DataAccessException selectCommuMasterListPortlet");
+        } catch (DataAccessException e) {
+        	throw new BaseRuntimeException(e);
         }
 
         // log.info("resultList=[{}]", resultList);

--- a/src/test/java/egovframework/com/cop/ems/service/impl/SndngMailDetailDAOTest.java
+++ b/src/test/java/egovframework/com/cop/ems/service/impl/SndngMailDetailDAOTest.java
@@ -260,15 +260,7 @@ public class SndngMailDetailDAOTest extends EgovTestAbstractDAO {
         testData(sndngMailVO , loginVO);
 
         // when
-        int result = 0;
-        try {
-            result = sndngMailDetailDAO.deleteSndngMail(sndngMailVO);
-        } catch (Exception e) {
-          // e.printStackTrace();
-          log.error("Exception deleteSndngMail");
-          // error(e);
-          result = 0;
-        }
+        int result = sndngMailDetailDAO.deleteSndngMail(sndngMailVO);
 
         // then
         assertEquals(1, result, egovMessageSource.getMessage("fail.common.delete"));

--- a/src/test/java/egovframework/com/cop/sms/service/impl/SmsDAOTest.java
+++ b/src/test/java/egovframework/com/cop/sms/service/impl/SmsDAOTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import org.egovframe.rte.fdl.cmmn.exception.BaseRuntimeException;
 import org.egovframe.rte.fdl.cmmn.exception.FdlException;
 import org.egovframe.rte.fdl.idgnr.EgovIdGnrService;
 import org.junit.jupiter.api.Test;
@@ -101,9 +102,7 @@ public class SmsDAOTest extends EgovTestAbstractDAO {
         try {
             testDataSms.setSmsId(egovSmsIdGnrService.getNextStringId()); // 문자메시지ID
         } catch (FdlException e) {
-//            e.printStackTrace();
-            log.error("FdlException egovSmsIdGnrService");
-//            fail("FdlException egovSmsIdGnrService");
+            throw new BaseRuntimeException(e);
         }
 
         testDataSms.setTrnsmitTelno("전송전화번호"); // 전송전화번호
@@ -217,9 +216,7 @@ public class SmsDAOTest extends EgovTestAbstractDAO {
         try {
             sms.setSmsId(egovSmsIdGnrService.getNextStringId());
         } catch (FdlException e) {
-//            e.printStackTrace();
-            log.error("FdlException egovSmsIdGnrService");
-//            fail("FdlException egovSmsIdGnrService");
+            throw new BaseRuntimeException(e);
         }
 
         if (loginVO != null) {

--- a/src/test/java/egovframework/com/cop/smt/djm/service/impl/DeptJobDAOTest.java
+++ b/src/test/java/egovframework/com/cop/smt/djm/service/impl/DeptJobDAOTest.java
@@ -1,12 +1,12 @@
 package egovframework.com.cop.smt.djm.service.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
+import org.egovframe.rte.fdl.cmmn.exception.BaseRuntimeException;
 import org.egovframe.rte.fdl.cmmn.exception.FdlException;
 import org.egovframe.rte.fdl.idgnr.EgovIdGnrService;
 import org.junit.jupiter.api.Test;
@@ -106,9 +106,7 @@ public class DeptJobDAOTest extends EgovTestAbstractDAO {
         try {
             testDataDeptJobBx.setDeptJobBxId(egovDeptJobBxIdGnrService.getNextStringId());
         } catch (FdlException e) {
-//            e.printStackTrace();
-            log.error("FdlException egovDeptJobBxIdGnrService");
-            fail("FdlException egovDeptJobBxIdGnrService");
+            throw new BaseRuntimeException(e);
         }
 
         testDataDeptJobBx.setDeptJobBxNm("test 이백행 부서업무함명 " + LocalDateTime.now());
@@ -131,9 +129,7 @@ public class DeptJobDAOTest extends EgovTestAbstractDAO {
             testDataDeptJob.setDeptJobId(egovDeptJobIdGnrService.getNextStringId());
             testDataDeptJob.setDeptJobBxId(testDataDeptJobBx.getDeptJobBxId());
         } catch (FdlException e) {
-//            e.printStackTrace();
-            log.error("FdlException egovDeptJobBxIdGnrService");
-            fail("FdlException egovDeptJobBxIdGnrService");
+            throw new BaseRuntimeException(e);
         }
 
         testDataDeptJob.setDeptJobNm("test 이백행 부서업무명 " + LocalDateTime.now());
@@ -162,8 +158,7 @@ public class DeptJobDAOTest extends EgovTestAbstractDAO {
         try {
             deptJobBx.setDeptJobBxId(egovDeptJobBxIdGnrService.getNextStringId());
         } catch (FdlException e) {
-//            e.printStackTrace();
-            log.error("FdlException egovDeptJobBxIdGnrService");
+        	throw new BaseRuntimeException(e);
         }
 
         deptJobBx.setDeptJobBxNm("test 이백행 부서업무함명 " + LocalDateTime.now());
@@ -199,8 +194,7 @@ public class DeptJobDAOTest extends EgovTestAbstractDAO {
             deptJob.setDeptJobId(egovDeptJobIdGnrService.getNextStringId());
             deptJob.setDeptJobBxId(egovDeptJobBxIdGnrService.getNextStringId());
         } catch (FdlException e) {
-//            e.printStackTrace();
-            log.error("FdlException egovDeptJobBxIdGnrService");
+        	throw new BaseRuntimeException(e);
         }
 
         deptJob.setDeptJobNm("test 이백행 부서업무명 " + LocalDateTime.now());

--- a/src/test/java/egovframework/com/file/TestDecompress.java
+++ b/src/test/java/egovframework/com/file/TestDecompress.java
@@ -4,12 +4,14 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.io.File;
 
+import org.egovframe.rte.fdl.cmmn.exception.BaseRuntimeException;
+
 import egovframework.com.utl.sim.service.EgovFileCmprs;
 
 @Slf4j
 public class TestDecompress {
 
-	public static void main(String[] args) {
+	public static void main(String[] args) throws BaseRuntimeException, Exception {
 		
 		// 프로젝트 ROOT
 		//String strDirPath = "C:\\eGovFrameDev-4.0.0-64bit\\workspace\\test.simple_homepage";
@@ -19,19 +21,14 @@ public class TestDecompress {
 
 	    //Path relativePath = Paths.get("");
 	    //strDirPath = relativePath.toAbsolutePath().toString();
-	    //System.out.println("Working Directory = " + strDirPath);
 
 	    String source = strDirPath + File.separator + "src" + File.separator + "test" + File.separator + "resources" + File.separator + "egovframework" + File.separator + "file" + File.separator + "sample.zip";
 	    String target = strDirPath + File.separator + "target" + File.separator + "result";
 	    String moved = target + File.separator + "sample.zip.bak";
 	    log.debug("source = {}", source);
 	    log.debug("target = {}", target);
-	    boolean result = false;
-	    try {
-	    	result = EgovFileCmprs.decmprsFile(source, target);
-		} catch (Exception e) {
-			e.printStackTrace();
-		}
+	    log.debug("moved = {}", moved);
+	    boolean result = EgovFileCmprs.decmprsFile(source, target);
 	    
 	    log.debug("result = {}", result);
 
@@ -43,7 +40,7 @@ public class TestDecompress {
 	        Path filePathToMove = Paths.get(moved);
 	        Files.move(filePath, filePathToMove);
 	    } catch (IOException e) {
-	        e.printStackTrace();
+	        throw new BaseRuntimeException(e);
 	    }
 	    */
 		

--- a/src/test/java/egovframework/com/idgen/TestIDGen.java
+++ b/src/test/java/egovframework/com/idgen/TestIDGen.java
@@ -2,6 +2,7 @@ package egovframework.com.idgen;
 
 import lombok.extern.slf4j.Slf4j;
 
+import org.egovframe.rte.fdl.cmmn.exception.BaseRuntimeException;
 import org.egovframe.rte.fdl.cmmn.exception.FdlException;
 import org.egovframe.rte.fdl.idgnr.EgovIdGnrService;
 import org.springframework.context.ApplicationContext;
@@ -43,12 +44,8 @@ public class TestIDGen {
 			log.debug("=====>>>>> Result Next ID = {}", result);
 			log.debug("=====>>>>> Result Next ID = {}", idgenService.getNextStringId());
 			log.debug("=====>>>>> Result Next ID = {}", idgenService.getNextStringId());
-			//System.out.println("=====>>>>> Result Next ID = "+idgenService.getNextIntegerId());
-			//System.out.println("=====>>>>> Result Next ID = "+idgenService.getNextIntegerId());
-			//System.out.println("=====>>>>> Result Next ID = "+idgenService.getNextIntegerId());
-			//System.out.println("=====>>>>> Result Next ID = "+idgenService.getNextBigDecimalId());
 		} catch (FdlException e) {
-			e.printStackTrace();
+			throw new BaseRuntimeException(e);
 		}
 		
 		//BeanFactory

--- a/src/test/java/egovframework/com/idgen/TestIDGenDev.java
+++ b/src/test/java/egovframework/com/idgen/TestIDGenDev.java
@@ -1,11 +1,12 @@
 package egovframework.com.idgen;
 
-import lombok.extern.slf4j.Slf4j;
-
+import org.egovframe.rte.fdl.cmmn.exception.BaseRuntimeException;
 import org.egovframe.rte.fdl.cmmn.exception.FdlException;
 import org.egovframe.rte.fdl.idgnr.EgovIdGnrService;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
+
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * ID Generation Test Class 구현
@@ -43,21 +44,21 @@ public class TestIDGenDev {
 			log.debug("=====>>>>> Result Next ID = {}", idgenService1.getNextStringId());
 			log.debug("=====>>>>> Result Next ID = {}", idgenService1.getNextStringId());
 		} catch (FdlException e) {
-			e.printStackTrace();
+			throw new BaseRuntimeException(e);
 		}
 		
 		EgovIdGnrService idgenService2 = (EgovIdGnrService)context.getBean("sequenceIdGnrService");
 		try {
 			log.debug("=====>>>>> Result Next String ID (Sequence) = {}", idgenService2.getNextStringId());
 		} catch (FdlException e) {
-			e.printStackTrace();
+			throw new BaseRuntimeException(e);
 		}
 		
 		EgovIdGnrService idgenService3 = (EgovIdGnrService)context.getBean("uuidIdGnrService");
 		try {
 			log.debug("=====>>>>> Result Next String ID (UUID) = {}", idgenService3.getNextStringId());
 		} catch (FdlException e) {
-			e.printStackTrace();
+			throw new BaseRuntimeException(e);
 		}
 		
 	}

--- a/src/test/java/egovframework/com/json/TestJson2ListMap.java
+++ b/src/test/java/egovframework/com/json/TestJson2ListMap.java
@@ -1,16 +1,18 @@
 package egovframework.com.json;
 
-import lombok.extern.slf4j.Slf4j;
-
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.collections.MapUtils;
+import org.egovframe.rte.fdl.cmmn.exception.BaseRuntimeException;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class TestJson2ListMap {
@@ -33,11 +35,11 @@ public class TestJson2ListMap {
 				}
 			}
 		} catch (JsonParseException e) {
-			e.printStackTrace();
+			throw new BaseRuntimeException(e);
 		} catch (JsonMappingException e) {
-			e.printStackTrace();
+			throw new BaseRuntimeException(e);
 		} catch (IOException e) {
-			e.printStackTrace();
+			throw new BaseRuntimeException(e);
 		}
 	}
 }

--- a/src/test/java/egovframework/com/json/TestJson2ListVO.java
+++ b/src/test/java/egovframework/com/json/TestJson2ListVO.java
@@ -1,15 +1,18 @@
 package egovframework.com.json;
 
-import lombok.extern.slf4j.Slf4j;
-
 import java.io.BufferedReader;
 import java.io.FileReader;
 import java.io.IOException;
 import java.util.List;
 
+import org.egovframe.rte.fdl.cmmn.exception.BaseRuntimeException;
+
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class TestJson2ListVO {
@@ -65,15 +68,13 @@ public class TestJson2ListVO {
 				log.debug(str);
 				jsonStr += str;
 			}
-		} catch (IOException e1) {
-			// TODO Auto-generated catch block
-			e1.printStackTrace();
+		} catch (IOException e) {
+			throw new BaseRuntimeException(e);
 		} finally {
 			try {
 				reader.close();
 			} catch (IOException e) {
-				// TODO Auto-generated catch block
-				e.printStackTrace();
+				throw new BaseRuntimeException(e);
 			}
 		}
 
@@ -91,14 +92,11 @@ public class TestJson2ListVO {
 				log.debug(vo.getDataSetFile());
 			}
 		} catch (JsonParseException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
+			throw new BaseRuntimeException(e);
 		} catch (JsonMappingException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
+			throw new BaseRuntimeException(e);
 		} catch (IOException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
+			throw new BaseRuntimeException(e);
 		}
 	}
 }

--- a/src/test/java/egovframework/com/secure/path/FileDownloadController.java
+++ b/src/test/java/egovframework/com/secure/path/FileDownloadController.java
@@ -26,7 +26,7 @@ public class FileDownloadController {
         try {
             fileMngUtil.downFile(response, streFileNm, orignFileNm);
         } catch (Exception e) {
-            e.printStackTrace();
+            log.error("서버 파일 다운로드 처리 중 오류가 발생했습니다.", e);
             response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
         }
     }

--- a/src/test/java/egovframework/com/utl/sim/TestPdfConverter.java
+++ b/src/test/java/egovframework/com/utl/sim/TestPdfConverter.java
@@ -3,6 +3,8 @@ package egovframework.com.utl.sim;
 import java.io.File;
 import java.net.ConnectException;
 
+import org.egovframe.rte.fdl.cmmn.exception.BaseRuntimeException;
+
 import com.artofsolving.jodconverter.DocumentConverter;
 import com.artofsolving.jodconverter.openoffice.connection.SocketOpenOfficeConnection;
 import com.artofsolving.jodconverter.openoffice.converter.OpenOfficeDocumentConverter;
@@ -54,7 +56,7 @@ public class TestPdfConverter {
 			try {
 				connection.connect();
 			} catch (ConnectException e) {
-				e.printStackTrace();
+				throw new BaseRuntimeException(e);
 			}
 			//원본 디렉토리에 targetPdf 명칭지정
 			File outputFile = new File(sourcePath + targetPath + targetFileName);

--- a/src/test/java/egovframework/com/utl/sim/TestPdfConverter2.java
+++ b/src/test/java/egovframework/com/utl/sim/TestPdfConverter2.java
@@ -57,8 +57,7 @@ public class TestPdfConverter2 {
 		             .to(outputFile)
 		             .execute();
 		} catch (OfficeException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
+			throw new BaseRuntimeException(e);
 		} finally {
 		    // Stop the office process
 		    OfficeUtils.stopQuietly(officeManager);

--- a/src/test/java/egovframework/config/EgovConfigIdGenUuid.java
+++ b/src/test/java/egovframework/config/EgovConfigIdGenUuid.java
@@ -10,7 +10,7 @@ public class EgovConfigIdGenUuid {
         try {
 			egovUUIdGnrService.setAddress("00:00:F0:79:19:5B");
 		} catch (FdlException | NoSuchAlgorithmException e) {
-			e.printStackTrace();
+			throw new BaseRuntimeException(e);
 		}
         return egovUUIdGnrService;
     }


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [x] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

## 개요

예외 발생 시 `printStackTrace()`를 호출하거나 오류를 기록한 뒤 실행을
계속하던 처리를 정비했습니다.

예외를 `BaseRuntimeException`으로 전환하여 실패가 호출자에게 명확하게
전파되도록 하고, 복구 가능한 웹 요청 오류는 구조화된 오류 로그와
HTTP 상태 코드로 처리합니다.

## 주요 변경 사항

- ID 생성 과정의 `FdlException`을 `BaseRuntimeException`으로 전환
- 커뮤니티, 문자 메시지 및 부서 업무 DAO 테스트의 예외 전파 방식 통일
- JSON 파싱과 파일 처리 테스트의 `printStackTrace()` 제거
- 압축 해제 및 PDF 변환 과정에서 발생한 예외를 런타임 예외로 전환
- 메일 삭제 테스트에서 예외를 숨기던 불필요한 `try-catch` 제거
- 파일 다운로드 실패 시 예외 스택을 구조화 로그로 기록
- 파일명 보안 확인 코드의 로거 선언과 널 바이트 예외 처리 개선
- 시스템 및 프레임워크 프로퍼티 확인 코드의 로그와 문서화 보강
- 관련 import와 주석 예제 정리

## 기대 효과

- 테스트 및 보조 코드에서 오류가 조용히 무시되는 문제 방지
- 예외 처리 정책의 일관성 향상
- 장애 원인 추적에 필요한 예외 정보 보존
- 불필요한 콘솔 출력과 광범위한 예외 처리 감소

## 검증

- Java: JDK 17.0.17
- Maven: 3.9.9
- `mvn -DskipTests test-compile` 성공
- 운영 코드 1개 및 테스트 코드 16개 변경 검토 완료

## 참고 사항

- 전체 테스트 실행은 생략하고 메인 및 테스트 소스 컴파일까지 검증했습니다.
- 기존 코드에서 발생하는 deprecated API 경고는 이번 변경 범위에 포함하지 않았습니다.

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [x] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.
