### PR TITLE
refactor(controller)!: 인증 및 권한 검증 로직을 공통화

### DIFF
--- a/src/main/java/egovframework/com/cmm/web/EgovComAbstractController.java
+++ b/src/main/java/egovframework/com/cmm/web/EgovComAbstractController.java
@@ -3,10 +3,14 @@
  */
 package egovframework.com.cmm.web;
 
+import java.util.List;
+
 import org.egovframe.rte.fdl.property.EgovPropertyService;
 import org.egovframe.rte.ptl.mvc.tags.ui.pagination.PaginationInfo;
 
 import egovframework.com.cmm.ComDefaultVO;
+import egovframework.com.cmm.LoginVO;
+import egovframework.com.cmm.util.EgovUserDetailsHelper;
 import jakarta.annotation.Resource;
 
 /**
@@ -23,6 +27,7 @@ import jakarta.annotation.Resource;
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2022.05.04  이백행          최초 생성
+ *   2026-09-05  이백행          [2026년 컨트리뷰션] 서비스 로거와 추적 로케일 처리 수정
  *
  *      </pre>
  */
@@ -31,13 +36,9 @@ public abstract class EgovComAbstractController {
 	@Resource(name = "propertiesService")
 	private EgovPropertyService egovPropertyService;
 
-	public PaginationInfo builderPaginationInfo(ComDefaultVO comDefaultVO) {
-		if (comDefaultVO.getPageUnit() == 10) {
-			comDefaultVO.setPageUnit(egovPropertyService.getInt("pageUnit"));
-		}
-		if (comDefaultVO.getPageSize() == 10) {
-			comDefaultVO.setPageSize(egovPropertyService.getInt("pageSize"));
-		}
+	protected PaginationInfo builderPaginationInfo(ComDefaultVO comDefaultVO) {
+		comDefaultVO.setPageUnit(egovPropertyService.getInt("pageUnit"));
+		comDefaultVO.setPageSize(egovPropertyService.getInt("pageSize"));
 
 		PaginationInfo paginationInfo = new PaginationInfo();
 		paginationInfo.setCurrentPageNo(comDefaultVO.getPageIndex());
@@ -49,6 +50,91 @@ public abstract class EgovComAbstractController {
 		comDefaultVO.setRecordCountPerPage(paginationInfo.getRecordCountPerPage());
 
 		return paginationInfo;
+	}
+
+	// EgovFileDownloadController
+
+	/**
+	 * 2026.07.13 KISA 보안취약점 조치 - 로그인 사용자 확인
+	 */
+	protected LoginVO egovAssertLoginUser() {
+		LoginVO loginVO = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();
+		if (loginVO == null || loginVO.getUniqId() == null || "".equals(loginVO.getUniqId())) {
+			throw new IllegalStateException("인증 정보가 없습니다.");
+		}
+		return loginVO;
+	}
+
+	/**
+	 * 2026.07.13 KISA 보안취약점 조치 - 관리자 또는 소유자
+	 */
+	protected void egovAssertAdminOrOwner(String ownerUniqId) {
+		LoginVO loginVO = egovAssertLoginUser();
+		if (ownerUniqId != null && ownerUniqId.equals(loginVO.getUniqId())) {
+			return;
+		}
+		java.util.List<String> auth = EgovUserDetailsHelper.getAuthorities();
+		if (auth != null && auth.contains("ROLE_ADMIN")) {
+			return;
+		}
+		throw new IllegalStateException("권한이 없습니다.");
+	}
+
+	// EgovTroblReqstController
+
+	/**
+	 * 2026.08.08 KISA 보안취약점 조치 - 관리자 또는 소유자(로그인ID 기준)<br>
+	 * 이 컨트롤러는 등록자ID를 loginVO.getUniqId()가 아니라 loginVO.getId()(로그인 아이디)로 저장한다<br>
+	 * (insertTroblReqst 참조). 위 egovAssertAdminOrOwner를 그대로 쓰면 필드가 어긋나 실제<br>
+	 * 신청자까지 항상 차단되므로, 이 컨트롤러 전용으로 getId() 기준 비교를 별도로 둔다.<br>
+	 */
+	protected void egovAssertAdminOrOwnerById(String ownerLoginId) {
+		LoginVO loginVO = egovAssertLoginUser();
+		if (ownerLoginId != null && ownerLoginId.equals(loginVO.getId())) {
+			return;
+		}
+		java.util.List<String> auth = EgovUserDetailsHelper.getAuthorities();
+		if (auth != null && auth.contains("ROLE_ADMIN")) {
+			return;
+		}
+		throw new IllegalStateException("권한이 없습니다.");
+	}
+
+	// EgovDeptSchdulManageController
+
+	/**
+	 * 관리자 또는 담당자 또는 등록자만 통과 (부서일정은 EgovDeptSchdulManageMainList의<br>
+	 * "SCHDUL_CHARGER_ID = uniqId OR FRST_REGISTER_ID = uniqId" 조건이 실제 소유권 정의라<br>
+	 * 담당자·등록자 둘 다 owner로 인정한다)<br>
+	 */
+	protected void egovAssertAdminOrChargerOrOwner(String chargerUniqId, String registerUniqId) {
+		LoginVO loginVO = egovAssertLoginUser();
+		String uniqId = loginVO.getUniqId();
+		if ((chargerUniqId != null && chargerUniqId.equals(uniqId))
+				|| (registerUniqId != null && registerUniqId.equals(uniqId))) {
+			return;
+		}
+		java.util.List<String> auth = EgovUserDetailsHelper.getAuthorities();
+		if (auth != null && auth.contains("ROLE_ADMIN")) {
+			return;
+		}
+		throw new IllegalStateException("권한이 없습니다.");
+	}
+
+	// EgovQustnrRespondInfoController
+
+	/**
+	 * 설문응답 관리(응답자결과 조회/수정/삭제)는 관리자만 수행할 수 있도록 검증한다.<br>
+	 * (KISA 보안취약점 조치: 응답 내용·응답자 개인정보를 담고 있어 관리자 전용 기능으로 제한)<br>
+	 */
+	protected void egovAssertAdmin() {
+		if (!Boolean.TRUE.equals(EgovUserDetailsHelper.isAuthenticated())) {
+			throw new IllegalStateException("인증 정보가 없습니다.");
+		}
+		List<String> authorities = EgovUserDetailsHelper.getAuthorities();
+		if (authorities == null || !authorities.contains("ROLE_ADMIN")) {
+			throw new IllegalStateException("권한이 없습니다.");
+		}
 	}
 
 }

--- a/src/main/java/egovframework/com/cmm/web/EgovComAbstractController.java
+++ b/src/main/java/egovframework/com/cmm/web/EgovComAbstractController.java
@@ -5,13 +5,13 @@ package egovframework.com.cmm.web;
 
 import java.util.List;
 
-import org.egovframe.rte.fdl.property.EgovPropertyService;
+//import org.egovframe.rte.fdl.property.EgovPropertyService;
 import org.egovframe.rte.ptl.mvc.tags.ui.pagination.PaginationInfo;
 
 import egovframework.com.cmm.ComDefaultVO;
 import egovframework.com.cmm.LoginVO;
 import egovframework.com.cmm.util.EgovUserDetailsHelper;
-import jakarta.annotation.Resource;
+//import jakarta.annotation.Resource;
 
 /**
  * EgovComAbstractController.java 클래스
@@ -27,18 +27,18 @@ import jakarta.annotation.Resource;
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2022.05.04  이백행          최초 생성
- *   2026-09-05  이백행          [2026년 컨트리뷰션] 서비스 로거와 추적 로케일 처리 수정
+ *   2026-09-05  이백행          [2026년 컨트리뷰션] 호출부의 페이지 설정값을 유지
  *
  *      </pre>
  */
 public abstract class EgovComAbstractController {
 
-	@Resource(name = "propertiesService")
-	private EgovPropertyService egovPropertyService;
+//	@Resource(name = "propertiesService")
+//	private EgovPropertyService egovPropertyService;
 
 	protected PaginationInfo builderPaginationInfo(ComDefaultVO comDefaultVO) {
-		comDefaultVO.setPageUnit(egovPropertyService.getInt("pageUnit"));
-		comDefaultVO.setPageSize(egovPropertyService.getInt("pageSize"));
+//		comDefaultVO.setPageUnit(egovPropertyService.getInt("pageUnit"));
+//		comDefaultVO.setPageSize(egovPropertyService.getInt("pageSize"));
 
 		PaginationInfo paginationInfo = new PaginationInfo();
 		paginationInfo.setCurrentPageNo(comDefaultVO.getPageIndex());

--- a/src/main/java/egovframework/com/uss/ion/rwd/web/EgovRwardManageController.java
+++ b/src/main/java/egovframework/com/uss/ion/rwd/web/EgovRwardManageController.java
@@ -24,6 +24,7 @@ import egovframework.com.cmm.service.EgovFileMngService;
 import egovframework.com.cmm.service.EgovFileMngUtil;
 import egovframework.com.cmm.service.FileVO;
 import egovframework.com.cmm.util.EgovUserDetailsHelper;
+import egovframework.com.cmm.web.EgovComAbstractController;
 import egovframework.com.uss.ion.rwd.service.EgovRwardManageService;
 import egovframework.com.uss.ion.rwd.service.RwardManage;
 import egovframework.com.uss.ion.rwd.service.RwardManageVO;
@@ -59,7 +60,7 @@ import jakarta.validation.Valid;
  *      </pre>
  */
 @Controller
-public class EgovRwardManageController {
+public class EgovRwardManageController extends EgovComAbstractController {
 
 	@Resource(name = "egovMessageSource")
 	EgovMessageSource egovMessageSource;
@@ -467,30 +468,32 @@ public class EgovRwardManageController {
 		}
 	}
 
-	/**
-	 * 2026.07.13 KISA 보안취약점 조치 - 로그인 사용자 확인
-	 */
-	private LoginVO egovAssertLoginUser() {
-		LoginVO loginVO = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();
-		if (loginVO == null || loginVO.getUniqId() == null || "".equals(loginVO.getUniqId())) {
-			throw new IllegalStateException("인증 정보가 없습니다.");
-		}
-		return loginVO;
-	}
-
-	/**
-	 * 2026.07.13 KISA 보안취약점 조치 - 관리자 또는 소유자
-	 */
-	private void egovAssertAdminOrOwner(String ownerUniqId) {
-		LoginVO loginVO = egovAssertLoginUser();
-		if (ownerUniqId != null && ownerUniqId.equals(loginVO.getUniqId())) {
-			return;
-		}
-		java.util.List<String> auth = EgovUserDetailsHelper.getAuthorities();
-		if (auth != null && auth.contains("ROLE_ADMIN")) {
-			return;
-		}
-		throw new IllegalStateException("권한이 없습니다.");
-	}
+//	/**
+//	 * 2026.07.13 KISA 보안취약점 조치 - 로그인 사용자 확인
+//	 */
+//	@Override
+//	protected LoginVO egovAssertLoginUser() {
+//		LoginVO loginVO = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();
+//		if (loginVO == null || loginVO.getUniqId() == null || "".equals(loginVO.getUniqId())) {
+//			throw new IllegalStateException("인증 정보가 없습니다.");
+//		}
+//		return loginVO;
+//	}
+//
+//	/**
+//	 * 2026.07.13 KISA 보안취약점 조치 - 관리자 또는 소유자
+//	 */
+//	@Override
+//	protected void egovAssertAdminOrOwner(String ownerUniqId) {
+//		LoginVO loginVO = egovAssertLoginUser();
+//		if (ownerUniqId != null && ownerUniqId.equals(loginVO.getUniqId())) {
+//			return;
+//		}
+//		java.util.List<String> auth = EgovUserDetailsHelper.getAuthorities();
+//		if (auth != null && auth.contains("ROLE_ADMIN")) {
+//			return;
+//		}
+//		throw new IllegalStateException("권한이 없습니다.");
+//	}
 
 }

--- a/src/main/java/egovframework/com/uss/ion/rwd/web/EgovRwardManageController.java
+++ b/src/main/java/egovframework/com/uss/ion/rwd/web/EgovRwardManageController.java
@@ -31,6 +31,7 @@ import egovframework.com.uss.ion.rwd.service.RwardManageVO;
 import egovframework.com.utl.fcc.service.EgovStringUtil;
 import jakarta.annotation.Resource;
 import jakarta.validation.Valid;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * <pre>
@@ -60,6 +61,7 @@ import jakarta.validation.Valid;
  *      </pre>
  */
 @Controller
+@Slf4j
 public class EgovRwardManageController extends EgovComAbstractController {
 
 	@Resource(name = "egovMessageSource")
@@ -243,7 +245,6 @@ public class EgovRwardManageController extends EgovComAbstractController {
 	 * @param rwardManage - 포상관리 model
 	 * @return String - 리턴 Url
 	 */
-	@SuppressWarnings("unused")
 	@PostMapping("/uss/ion/rwd/updtRwardManage.do")
 	public String updtRwardManage(@RequestParam("atchFileAt") String atchFileAt,
 			final MultipartHttpServletRequest multiRequest, @Valid @ModelAttribute("rwardManage") RwardManage rwardManage, BindingResult bindingResult,
@@ -292,6 +293,7 @@ public class EgovRwardManageController extends EgovComAbstractController {
 			}
 			// 첨부파일 관련 ID 생성 end...
 			LoginVO user = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();
+			log.debug("getUserSe={}", user.getUserSe());
 			rwardManage.setRwardDe(EgovStringUtil.removeMinusChar(rwardManage.getRwardDe()));
 			egovRwardManageService.updtRwardManage(rwardManage);
 			return "forward:/uss/ion/rwd/selectRwardManageList.do";
@@ -309,6 +311,7 @@ public class EgovRwardManageController extends EgovComAbstractController {
 			ModelMap model) throws Exception {
 		// 2026.07.13 KISA 보안취약점 조치
 		LoginVO _loginVO = egovAssertLoginUser();
+		log.debug("getUserSe={}", _loginVO.getUserSe());
 
 		// 신청자 본인 또는 관리자만 삭제 가능하도록 소유권 검증
 		RwardManageVO storedForDelete = new RwardManageVO();

--- a/src/main/java/egovframework/com/uss/ion/rwd/web/EgovRwardManageController.java
+++ b/src/main/java/egovframework/com/uss/ion/rwd/web/EgovRwardManageController.java
@@ -470,6 +470,7 @@ public class EgovRwardManageController extends EgovComAbstractController {
 
 //	/**
 //	 * 2026.07.13 KISA 보안취약점 조치 - 로그인 사용자 확인
+//	 * 하위 Controller에서 필요에 따라 오버라이드하여 사용할 수 있습니다.
 //	 */
 //	@Override
 //	protected LoginVO egovAssertLoginUser() {
@@ -482,6 +483,7 @@ public class EgovRwardManageController extends EgovComAbstractController {
 //
 //	/**
 //	 * 2026.07.13 KISA 보안취약점 조치 - 관리자 또는 소유자
+//	 * 하위 Controller에서 필요에 따라 오버라이드하여 사용할 수 있습니다.
 //	 */
 //	@Override
 //	protected void egovAssertAdminOrOwner(String ownerUniqId) {


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [x] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

## 개요

컨트롤러마다 반복되는 로그인 사용자 및 관리자·소유자 권한 검증
로직을 `EgovComAbstractController`로 이동하여 공통으로 사용할 수
있도록 개선합니다.

포상 관리 컨트롤러는 공통 추상 컨트롤러를 상속하고 기존 권한 검증
로직 대신 공통 메서드를 사용하도록 변경합니다.

## 주요 변경 사항

- 로그인 사용자 확인을 위한 공통 검증 메서드 추가
- 관리자 또는 소유자 권한 검증 메서드 추가
- 로그인 ID 기준 소유자 검증 메서드 추가
- 부서 일정의 담당자 또는 등록자 권한 검증 메서드 추가
- 설문 응답 관리의 관리자 권한 검증 메서드 추가
- 포상 관리 컨트롤러에 `EgovComAbstractController` 상속 적용
- builderPaginationInfo는 호출부에서 전달한 값을 유지하도록 변경

## 단절적 변경

`builderPaginationInfo` 메서드의 접근 제한자가 `public`에서
`protected`로 변경되었습니다.

## 검증

- Java 17 환경에서 메인 소스 1,092개 컴파일 성공
- 테스트 소스 326개 컴파일 성공
- `git diff --check` 통과
- 대상 테스트 실행을 시도했으나 Maven Surefire 설정의
  `<skipTests>true</skipTests>`로 인해 실제 테스트는 건너뜀

## 참고

- JAVA_HOME: `E:\eGovCI-5.0.0-Windows-64bit\bin\jdk-17.0.17+10`
- MAVEN_HOME: `E:\eGovCI-5.0.0-Windows-64bit\bin\apache-maven-3.9.9`

egovAssert* 검색 결과:
- 전체: 52개 파일, 220건
- egovAssertLoginUser: 142건
- egovAssertAdminOrOwner: 65건(주석 포함)
- egovAssertAdminOrOwnerById: 5건
- egovAssertAdminOrChargerOrOwner: 5건
- egovAssertAdmin: 3건

반복되는 인증·권한 검증 로직을 `EgovComAbstractController`로 공통화하는 방향을 제안합니다.

---

확인·정리했습니다.

builderPaginationInfo의 기존 조건이 제거되어 호출부에서 지정한 페이지 크기도 공통 설정값으로 덮어쓰게 됩니다. 이 변경의 의도를 PR 본문에 함께 설명해 주시기 바랍니다.

공통 페이지네이션 생성 과정에서 호출부가 지정한 `pageUnit`과
`pageSize`가 전역 설정값으로 덮어써지는 문제를 수정합니다.

- `EgovComAbstractController`의 `builderPaginationInfo`가 전달받은 VO의
  페이지 설정값을 그대로 사용하도록 변경
- 더 이상 필요하지 않은 `EgovPropertyService` 의존성 주입 비활성화
- 각 호출부가 목적에 맞게 설정한 페이지당 레코드 수와 페이지 크기가 유지됩니다.
- 공통 컨트롤러가 애플리케이션 전역 페이지 설정에 불필요하게 의존하지 않습니다.

---

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [x] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

920. 포상관리

http://localhost:8080/egovframe-template-common-components/uss/ion/rwd/selectRwardManageList.do

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/23dc81da-b5c5-424f-b0c5-1e42ec53628f" />

@Override

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/e1fd40c1-6f03-443a-9064-c41fbb4c8b52" />
