### PR TITLE
test(captcha): 세션 속성 키를 현재 구현과 맞춰 실패하는 테스트 3건 복구

### DIFF
--- a/src/test/java/egovframework/com/ext/captcha/EgovCaptchaControllerTest.java
+++ b/src/test/java/egovframework/com/ext/captcha/EgovCaptchaControllerTest.java
@@ -101,7 +101,7 @@ class EgovCaptchaControllerTest {
 
 	private void assertCaptcha(RequestStub request, String pgNm, int expectedLength) {
 		assertNotNull(request.session);
-		String captcha = (String) request.sessionAttributes.get("captcha" + pgNm);
+		String captcha = (String) request.sessionAttributes.get("captcha." + pgNm);
 		assertNotNull(captcha);
 		assertEquals(expectedLength, captcha.length());
 		assertTrue(captcha.matches("[A-Za-z0-9]+"));


### PR DESCRIPTION
## 문제

`EgovCaptchaControllerTest` 의 3개 테스트가 실패합니다.

```
Tests run: 11, Failures: 3, Errors: 0
  generateCreatesPngAndStoresDefaultLengthCaptcha
  generateUsesLengthBeforeLegacyLenght
  generateSupportsLegacyLenghtParameter
```

세 건 모두 `assertCaptcha()` 안의 `assertNotNull(captcha)` 에서 걸립니다. 테스트가 읽는 세션 속성 키가 컨트롤러가 쓰는 키와 다르기 때문입니다.

| | 키 |
| --- | --- |
| 컨트롤러 (`CAPTCHA_ATTR_PREFIX + pgNm`) | `captcha.test` |
| 테스트 | `captchatest` |

`fb45f509 NCSC 보안점검 적용` 커밋에서 세션 키가 `"captcha" + pgNm` → `"captcha." + pgNm` 로 바뀌었는데, 그때 테스트가 함께 갱신되지 않았습니다. 본문 코드는 `generate()` 의 쓰기와 `result()` 의 읽기가 모두 새 키를 쓰고 있어 **기능에는 문제가 없고, 테스트만 낡은 상태**입니다.

저장소 전체에서 이 세션 키를 읽는 다른 곳(JSP 포함)이 있는지 확인했으나 없었습니다.

## 변경

테스트가 현재 구현과 같은 키를 보도록 한 글자(`.`)를 맞췄습니다. 본문 코드는 건드리지 않았습니다.

## 검증 (실측)

| | 결과 |
| --- | --- |
| 변경 전 | `Tests run: 11, Failures: 3` |
| 변경 후 | `Tests run: 11, Failures: 0, Errors: 0` |

## 참고

pom 의 surefire 설정이 `<skipTests>true</skipTests>` 로 고정돼 있어 기본 빌드에서는 이 실패가 드러나지 않습니다(`-DskipTests=false` 로도 덮이지 않습니다). 확인할 때만 로컬에서 켰고 이 PR 에는 포함하지 않았습니다 — 별도로 다룰 사안이라 보여 여기서는 언급만 남깁니다.