### PR TITLE
fix(EgovFileTool): createDirectories가 성공해도 빈 문자열을 반환하는 문제 수정

### DIFF
--- a/src/main/java/egovframework/com/utl/sim/service/EgovFileTool.java
+++ b/src/main/java/egovframework/com/utl/sim/service/EgovFileTool.java
@@ -146,7 +146,7 @@ public class EgovFileTool {
 		if (!file.exists()) {
 			if (file.mkdirs()) {
 				LOGGER.debug("[file.mkdirs] file : Path Creation Success");
-				file.getAbsolutePath();
+				result = file.getAbsolutePath();
 			} else {
 				LOGGER.error("[file.mkdirs] file : Path Creation Fail");
 			}


### PR DESCRIPTION
## 문제

`EgovFileTool.createDirectories(basePath, dirPath)` 의 javadoc 은 `@return 성공하면 생성된 절대경로, 아니면 블랭크` 인데, 생성에 성공해도 **항상 빈 문자열을 반환**합니다. 성공 분기에서 `getAbsolutePath()` 를 호출하고 그 결과를 버리기 때문입니다.

```java
if (file.mkdirs()) {
    LOGGER.debug("[file.mkdirs] file : Path Creation Success");
    file.getAbsolutePath();   // 반환값을 쓰지 않음
}
```

같은 파일의 형제 메서드 `createNewDirectory()` 는 동일한 javadoc 문구를 쓰면서 `result = file.getAbsolutePath();` 로 대입하고 있습니다.

## 검증 (실측)

실제 컴파일된 코드로 호출한 결과입니다.

| 호출 | 변경 전 | 변경 후 |
| --- | --- | --- |
| `createDirectories(base, "/dp_.../x/y")` (신규 3단계) | `""` | `"/upload/allinone/dp_.../x/y"` |
| 같은 경로 재호출 (이미 존재) | `""` | `""` (동일) |
| 참고: `createNewDirectory(base, ...)` (신규) | `"/upload/allinone/dn_..."` | 동일 |

디렉터리 자체는 변경 전에도 정상 생성되고 있었습니다(`isDirectory() == true`). 반환값만 사라지던 문제입니다.

## 범위에 대해

`if (file.mkdirs())` 성공 분기에만 대입했습니다. 이미 존재하는 경우는 javadoc 의 "성공하면"에 해당하지 않는다고 보아 그대로 두었는데, `createNewDirectory()` 는 이미 존재하는 디렉터리에도 경로를 돌려줍니다. 이쪽까지 맞추는 편이 낫다고 보시면 알려주시면 반영하겠습니다.

## 회귀 확인

`TestFileToolBasePath`·`TestFileToolBasePathAOP` 포함 `egovframework.com.utl.**.*Test` **196 tests, 0 failures, 0 errors**.

저장소 내 유일한 호출처인 `EgovFileCmprs` 98행은 반환값을 쓰지 않아 동작 변화가 없습니다. 영향은 이 유틸리티를 직접 쓰는 적용 프로젝트 쪽입니다(`EgovFileToolBean` 으로도 노출되어 있습니다).

같은 파일을 건드리는 #1293 과는 수정 위치가 달라(149행 vs 390행대) 서로 충돌하지 않습니다.