### PR TITLE
fix(EgovMybatisUtil): isEquals가 128 이상 Integer를 다르다고 판정하는 문제 수정

### DIFF
--- a/src/main/java/egovframework/com/cmm/util/EgovMybatisUtil.java
+++ b/src/main/java/egovframework/com/cmm/util/EgovMybatisUtil.java
@@ -103,7 +103,7 @@ public class EgovMybatisUtil {
 				return true;
 			}
 		} else if (obj instanceof Integer && obj2 instanceof Integer) {
-			if ((Integer) obj == (Integer) obj2) {
+			if (obj.equals(obj2)) {
 				return true;
 			}
 		}


### PR DESCRIPTION
## 문제

`EgovMybatisUtil.isEquals(Object, Object)` 의 Integer 분기가 값이 아니라 **참조**를 비교합니다.

```java
} else if (obj instanceof Integer && obj2 instanceof Integer) {
    if ((Integer) obj == (Integer) obj2) {
```

양쪽 모두 `Integer` 로 캐스팅돼 있어 언박싱이 일어나지 않습니다. 그래서 `Integer` 캐시 범위(-128~127) 안에서는 우연히 맞고, 그 밖에서는 **같은 값인데도 false** 가 됩니다.

## 재현 (실측)

실제 컴파일된 코드로 호출한 결과입니다.

| 호출 | 변경 전 | 변경 후 |
| --- | --- | --- |
| `isEquals(1, 1)` | true | true |
| `isEquals(127, 127)` | true | true |
| `isEquals(128, 128)` | **false** | true |
| `isEquals(1000, 1000)` | **false** | true |
| `isEquals(20260906, 20260906)` | **false** | true |
| `isEquals(1000, 999)` | false | false |
| `isEquals("1000", 1000)` | true | true |

마지막 줄이 이 문제를 잘 보여줍니다. 같은 값을 비교해도 **String↔Integer 분기로 가면 true, Integer↔Integer 분기로 가면 false** 였습니다. 127을 경계로 결과가 갈리는 것도 값이 아닌 참조를 비교하고 있다는 증거입니다.

## 변경

같은 메서드의 다른 분기들이 모두 `equals` 를 쓰고 있어 동일한 방식으로 맞췄습니다.

```diff
-			if ((Integer) obj == (Integer) obj2) {
+			if (obj.equals(obj2)) {
```

## 검증

`egovframework.com.cmm.**.*Test` + `egovframework.com.utl.**.*Test` 를 변경 전/후 동일하게 실행했습니다.

| | 결과 |
| --- | --- |
| 변경 전 | `Tests run: 297, Failures: 0, Errors: 18` |
| 변경 후 | `Tests run: 297, Failures: 0, Errors: 18` |

에러 18건은 DB·스프링 컨텍스트가 필요한 DAO 테스트로, 변경 전에도 같은 수가 납니다(제 환경에 DB가 없어서 발생). 실패는 양쪽 모두 0건입니다.

## 발견 경위

SpotBugs(effort=Max) 로 저장소를 훑다가 `RC_REF_COMPARISON` 우선순위 1 로 잡힌 항목입니다. 저장소에 이 메서드를 호출하는 곳은 없어 지금 당장의 기능 영향은 없고, 적용 프로젝트가 이 유틸리티를 직접 쓸 때 드러나는 문제입니다.