### PR TITLE
fix(EgovFileScrty): 비밀번호 해시가 JVM 기본 문자집합에 따라 달라지는 문제 수정

### DIFF
--- a/src/main/java/egovframework/com/utl/sim/service/EgovFileScrty.java
+++ b/src/main/java/egovframework/com/utl/sim/service/EgovFileScrty.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 
 import org.apache.commons.codec.binary.Base64;
@@ -84,8 +85,8 @@ public class EgovFileScrty {
 				while ((length = input.read(buffer)) >= 0) {
 					byte[] data = new byte[length];
 					System.arraycopy(buffer, 0, data, 0, length);
-					output.write(encodeBinary(data).getBytes());
-					output.write(System.getProperty("line.separator").getBytes());
+					output.write(encodeBinary(data).getBytes(StandardCharsets.UTF_8));
+					output.write(System.getProperty("line.separator").getBytes(StandardCharsets.UTF_8));
 				}
 				result = true;
 			}
@@ -120,12 +121,12 @@ public class EgovFileScrty {
 		try {
 		    if (srcFile.exists() && srcFile.isFile()) {
 
-			input = new BufferedReader(new InputStreamReader(new FileInputStream(srcFile)));
+			input = new BufferedReader(new InputStreamReader(new FileInputStream(srcFile), StandardCharsets.UTF_8));
 			output = new BufferedOutputStream(new FileOutputStream(EgovWebUtil.filePathBlackList(STORE_FILE_PATH + FilenameUtils.getName(target))));
 
 			while ((line = input.readLine()) != null) {
-			    byte[] data = line.getBytes();
-			    output.write(decodeBinary(new String(data)));
+			    byte[] data = line.getBytes(StandardCharsets.UTF_8);
+			    output.write(decodeBinary(new String(data, StandardCharsets.UTF_8)));
 			}
 
 			result = true;
@@ -149,7 +150,7 @@ public class EgovFileScrty {
 		    return "";
 		}
 
-		return new String(Base64.encodeBase64(data));
+		return new String(Base64.encodeBase64(data), StandardCharsets.UTF_8);
     }
 
     /**
@@ -161,7 +162,7 @@ public class EgovFileScrty {
      */
     @Deprecated
     public static String encode(String data) throws Exception {
-    	return encodeBinary(data.getBytes());
+    	return encodeBinary(data.getBytes(StandardCharsets.UTF_8));
     }
 
     /**
@@ -172,7 +173,7 @@ public class EgovFileScrty {
      * @exception Exception
      */
     public static byte[] decodeBinary(String data) throws Exception {
-    	return Base64.decodeBase64(data.getBytes());
+    	return Base64.decodeBase64(data.getBytes(StandardCharsets.UTF_8));
     }
 
     /**
@@ -184,7 +185,7 @@ public class EgovFileScrty {
      */
     @Deprecated
     public static String decode(String data) throws Exception {
-    	return new String(decodeBinary(data));
+    	return new String(decodeBinary(data), StandardCharsets.UTF_8);
     }
 
     /**
@@ -207,11 +208,11 @@ public class EgovFileScrty {
 		MessageDigest md = MessageDigest.getInstance("SHA-256");
 
 		md.reset();
-		md.update(id.getBytes());
+		md.update(id.getBytes(StandardCharsets.UTF_8));
 
-		hashValue = md.digest(password.getBytes());
+		hashValue = md.digest(password.getBytes(StandardCharsets.UTF_8));
 
-		return new String(Base64.encodeBase64(hashValue));
+		return new String(Base64.encodeBase64(hashValue), StandardCharsets.UTF_8);
     }
 
     /**
@@ -234,9 +235,9 @@ public class EgovFileScrty {
 		md.reset();
 		md.update(salt);
 
-		hashValue = md.digest(data.getBytes());
+		hashValue = md.digest(data.getBytes(StandardCharsets.UTF_8));
 
-		return new String(Base64.encodeBase64(hashValue));
+		return new String(Base64.encodeBase64(hashValue), StandardCharsets.UTF_8);
     }
 
     /**
@@ -254,9 +255,9 @@ public class EgovFileScrty {
 
     	md.reset();
     	md.update(salt);
-    	hashValue = md.digest(data.getBytes());
+    	hashValue = md.digest(data.getBytes(StandardCharsets.UTF_8));
 
-    	return MessageDigest.isEqual(hashValue, Base64.decodeBase64(encoded.getBytes()));
+    	return MessageDigest.isEqual(hashValue, Base64.decodeBase64(encoded.getBytes(StandardCharsets.UTF_8)));
     }
 
 }


### PR DESCRIPTION
## 문제

`EgovFileScrty` 는 `getBytes()`·`new String(byte[])`·`InputStreamReader` 를 문자집합 없이 호출합니다. 그래서 **JVM 기본 문자집합에 따라 결과가 달라집니다.**

가장 문제가 되는 곳은 비밀번호 해시입니다.

```java
md.update(id.getBytes());
hashValue = md.digest(password.getBytes());
```

## 재현 (실측)

같은 코드를 기본 문자집합만 바꿔 실행했습니다(`encryptPassword(pw, "egovframe")`).

| 비밀번호 | UTF-8 JVM | EUC-KR JVM |
| --- | --- | --- |
| `admin1234` | `4gAe44XAZC9glX8lx3nR2Ko+ISUUKilO+T0Dn8X4snw=` | 동일 |
| `한글비밀번호1234` | `Vp3+wd7C+ehPWpqi99xfaq2/OswD5xp8GCCh1OBAxtY=` | **`9DTd4aSEoqmf8HWx3BrmxxxwHvx6Hg7AKqjfGuxG2Ss=`** |

ASCII 비밀번호는 우연히 같지만, 한글이 들어가면 해시가 달라집니다. 같은 비밀번호인데도 서버의 로케일·기동 옵션이 바뀌면 로그인이 실패할 수 있습니다.

## 변경

파일 안의 모든 문자집합 의존 호출에 UTF-8 을 명시했습니다(총 15곳, 무인자 `getBytes()` 0건). 해시 알고리즘·Base64 처리 방식은 그대로입니다.

## 변경 후 (실측)

| 비밀번호 | UTF-8 JVM | EUC-KR JVM |
| --- | --- | --- |
| `admin1234` | `4gAe44XAZC9glX8lx3nR2Ko+ISUUKilO+T0Dn8X4snw=` | 동일 |
| `한글비밀번호1234` | `Vp3+wd7C+ehPWpqi99xfaq2/OswD5xp8GCCh1OBAxtY=` | 동일 |

## 기존 데이터 영향 (중요)

**UTF-8 이 기본인 JVM 에서는 결과값이 바뀌지 않습니다.** 위 표에서 보시다시피 변경 전 UTF-8 값과 변경 후 값이 같습니다. JDK 18 부터는 JEP 400 으로 기본 문자집합이 UTF-8 이므로 대부분의 환경은 해당됩니다.

값이 달라지는 경우는 하나입니다 — **기본 문자집합이 UTF-8 이 아닌 JVM에서 비ASCII 비밀번호로 저장된 기존 해시**. 그런 환경이 있다면 재설정 절차가 필요하므로, 판단을 위해 미리 밝혀 둡니다.

## 발견 경위

SpotBugs(effort=Max) 의 `DM_DEFAULT_ENCODING` 우선순위 1 항목이 이 파일에 13건 집중돼 있어 확인했습니다.

## 회귀 확인

`egovframework.com.utl.**.*Test` + `egovframework.com.cmm.**.*Test` — 변경 전후 모두 `Tests run: 297, Failures: 0, Errors: 18`(에러 18건은 DB·스프링 컨텍스트가 필요한 DAO 테스트로 변경 전에도 동일).