### PR TITLE
fix(evt): 행사접수관리 총 건수가 목록과 다른 값으로 참가행을 붙임

### DIFF
--- a/src/main/resources/egovframework/mapper/com/uss/ion/evt/EgovEventManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/evt/EgovEventManage_SQL_altibase.xml
@@ -305,7 +305,7 @@
 				  FROM   COMTNEVENTMANAGE mge
 				         left join COMTNEVENTATDRN atdrn
 				         ON   atdrn.EVENT_ID = mge.EVENT_ID
-				         and  atdrn.APPLCNT_ID = #{searchKeyword}
+				         and  atdrn.APPLCNT_ID = #{applcntId}
 				 WHERE    1=1
 			     AND    (TO_CHAR(sysdate, 'yyyymmdd')  BETWEEN RCEPT_BGNDE  AND RCEPT_ENDDE 
 			             or atdrn.confm_At is not null)

--- a/src/main/resources/egovframework/mapper/com/uss/ion/evt/EgovEventManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/evt/EgovEventManage_SQL_cubrid.xml
@@ -304,7 +304,7 @@
 				  FROM   COMTNEVENTMANAGE mge
 				         left join COMTNEVENTATDRN atdrn
 				         ON   atdrn.EVENT_ID = mge.EVENT_ID
-				         and  atdrn.APPLCNT_ID = #{searchKeyword}
+				         and  atdrn.APPLCNT_ID = #{applcntId}
 				 WHERE    1=1
 			     AND    (TO_CHAR(sysdate, 'yyyymmdd')  BETWEEN RCEPT_BGNDE  AND RCEPT_ENDDE 
 			             or atdrn.confm_At is not null)

--- a/src/main/resources/egovframework/mapper/com/uss/ion/evt/EgovEventManage_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/evt/EgovEventManage_SQL_goldilocks.xml
@@ -305,7 +305,7 @@
 				  FROM   COMTNEVENTMANAGE mge
 				         left join COMTNEVENTATDRN atdrn
 				         ON   atdrn.EVENT_ID = mge.EVENT_ID
-				         and  atdrn.APPLCNT_ID = #{searchKeyword}
+				         and  atdrn.APPLCNT_ID = #{applcntId}
 				 WHERE    1=1
 			     AND    (TO_CHAR(sysdate, 'yyyymmdd')  BETWEEN RCEPT_BGNDE  AND RCEPT_ENDDE 
 			             or atdrn.confm_At is not null)

--- a/src/main/resources/egovframework/mapper/com/uss/ion/evt/EgovEventManage_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/evt/EgovEventManage_SQL_maria.xml
@@ -291,7 +291,7 @@
 				  FROM   (select @RNUM:=0) R, COMTNEVENTMANAGE mge
 				         left join COMTNEVENTATDRN atdrn
 				         ON   atdrn.EVENT_ID = mge.EVENT_ID
-				         and  atdrn.APPLCNT_ID = #{searchKeyword}
+				         and  atdrn.APPLCNT_ID = #{applcntId}
 				 WHERE    1=1
 			     AND     (CAST(DATE_FORMAT(now(),'%Y%m%d') AS CHAR(8))  BETWEEN RCEPT_BGNDE  AND RCEPT_ENDDE 
 			              or atdrn.confm_At is not null)

--- a/src/main/resources/egovframework/mapper/com/uss/ion/evt/EgovEventManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/evt/EgovEventManage_SQL_mysql.xml
@@ -291,7 +291,7 @@
 				  FROM   (select @RNUM:=0) R, COMTNEVENTMANAGE mge
 				         left join COMTNEVENTATDRN atdrn
 				         ON   atdrn.EVENT_ID = mge.EVENT_ID
-				         and  atdrn.APPLCNT_ID = #{searchKeyword}
+				         and  atdrn.APPLCNT_ID = #{applcntId}
 				 WHERE    1=1
 			     AND     (CAST(DATE_FORMAT(now(),'%Y%m%d') AS CHAR(8) CHARACTER SET utf8mb4) COLLATE utf8mb4_unicode_ci BETWEEN RCEPT_BGNDE AND RCEPT_ENDDE
 			              or atdrn.confm_At is not null)

--- a/src/main/resources/egovframework/mapper/com/uss/ion/evt/EgovEventManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/evt/EgovEventManage_SQL_oracle.xml
@@ -304,7 +304,7 @@
 				  FROM   COMTNEVENTMANAGE mge
 				         left join COMTNEVENTATDRN atdrn
 				         ON   atdrn.EVENT_ID = mge.EVENT_ID
-				         and  atdrn.APPLCNT_ID = #{searchKeyword}
+				         and  atdrn.APPLCNT_ID = #{applcntId}
 				 WHERE    1=1
 			     AND    (TO_CHAR(sysdate, 'yyyymmdd')  BETWEEN RCEPT_BGNDE  AND RCEPT_ENDDE 
 			             or atdrn.confm_At is not null)

--- a/src/main/resources/egovframework/mapper/com/uss/ion/evt/EgovEventManage_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/evt/EgovEventManage_SQL_postgres.xml
@@ -291,7 +291,7 @@
 				  FROM   COMTNEVENTMANAGE mge
 				         left join COMTNEVENTATDRN atdrn
 				         ON   atdrn.EVENT_ID = mge.EVENT_ID
-				         and  atdrn.APPLCNT_ID = #{searchKeyword}
+				         and  atdrn.APPLCNT_ID = #{applcntId}
 				 WHERE    1=1
 			     AND     (CAST(TO_CHAR(NOW(),'YYYYmmdd') AS CHAR(8))  BETWEEN RCEPT_BGNDE  AND RCEPT_ENDDE 
 			              or atdrn.confm_At is not null)

--- a/src/main/resources/egovframework/mapper/com/uss/ion/evt/EgovEventManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/evt/EgovEventManage_SQL_tibero.xml
@@ -303,7 +303,7 @@
 				  FROM   COMTNEVENTMANAGE mge
 				         left join COMTNEVENTATDRN atdrn
 				         ON   atdrn.EVENT_ID = mge.EVENT_ID
-				         and  atdrn.APPLCNT_ID = #{searchKeyword}
+				         and  atdrn.APPLCNT_ID = #{applcntId}
 				 WHERE    1=1
 			     AND    (TO_CHAR(sysdate, 'yyyymmdd')  BETWEEN RCEPT_BGNDE  AND RCEPT_ENDDE 
 			             or atdrn.confm_At is not null)

--- a/src/test/java/egovframework/com/uss/ion/evt/service/impl/EgovEventAtdrnListTotCntJoinTest.java
+++ b/src/test/java/egovframework/com/uss/ion/evt/service/impl/EgovEventAtdrnListTotCntJoinTest.java
@@ -1,0 +1,103 @@
+package egovframework.com.uss.ion.evt.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.InputStream;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.ibatis.builder.xml.XMLMapperBuilder;
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.mapping.BoundSql;
+import org.apache.ibatis.mapping.MappedStatement;
+import org.apache.ibatis.mapping.ParameterMapping;
+import org.apache.ibatis.session.Configuration;
+import org.egovframe.rte.psl.dataaccess.util.EgovMap;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import egovframework.com.cmm.ComDefaultVO;
+import egovframework.com.uss.ion.evt.service.EventManageVO;
+
+/**
+ * 행사접수 목록과 총 건수가 8개 DB 방언 모두에서 같은 신청자로 참가행을 붙이는지 검증한다.
+ *
+ * <p>{@code EgovEventManageController.selectEventAtdrnList} 는 한 VO 로 목록을
+ * {@code selectEventAtdrnList} 로, 페이저에 넣을 총 건수를 {@code selectEventAtdrnListTotCnt} 로
+ * 각각 조회한다. 두 구문이 참가행을 다른 값으로 붙이면 목록에 있는 행이 건수에서 빠져
+ * 페이저가 목록과 어긋난 페이지 수를 그린다.</p>
+ *
+ * <p>{@code context-mapper.xml} 의 {@code mapperLocations} 가
+ * {@code classpath:/egovframework/mapper/com/**}{@code /*_${Globals.DbType}.xml} 이라 런타임에는
+ * 방언 매퍼가 하나만 로드된다. 방언별로 매퍼를 직접 파싱해 DB 연결 없이 검증한다.</p>
+ */
+class EgovEventAtdrnListTotCntJoinTest {
+
+	private static final String LIST_STATEMENT_ID = "eventManageDAO.selectEventAtdrnList";
+
+	private static final String TOT_CNT_STATEMENT_ID = "eventManageDAO.selectEventAtdrnListTotCnt";
+
+	/** 두 구문이 참가행을 붙이는 구간이다. 조인으로 시작해 검색조건이 열리는 자리에서 끝난다. */
+	private static final Pattern ATDRN_JOIN = Pattern
+			.compile("(left\\s+join\\s+COMTNEVENTATDRN.*?)WHERE", Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
+
+	private Configuration loadMapper(String dialect) throws Exception {
+		String resource = "egovframework/mapper/com/uss/ion/evt/EgovEventManage_SQL_" + dialect + ".xml";
+		Configuration configuration = new Configuration();
+		configuration.getTypeAliasRegistry().registerAlias("comDefaultVO", ComDefaultVO.class);
+		configuration.getTypeAliasRegistry().registerAlias("egovMap", EgovMap.class);
+		try (InputStream inputStream = Resources.getResourceAsStream(resource)) {
+			new XMLMapperBuilder(inputStream, configuration, resource, configuration.getSqlFragments()).parse();
+		}
+		return configuration;
+	}
+
+	/**
+	 * 바인딩 SQL 은 {@code #{}} 를 {@code ?} 로 바꿔 어느 값을 묶었는지를 지운다. 이 검증의 대상이
+	 * 바로 그 "어느 값" 이라 파라미터 이름을 자리표시자에 되돌려 놓는다.
+	 */
+	private String atdrnJoinOf(Configuration configuration, String statementId, Object parameter) {
+		MappedStatement statement = configuration.getMappedStatement(statementId);
+		BoundSql boundSql = statement.getBoundSql(parameter);
+		String sql = boundSql.getSql();
+
+		StringBuilder named = new StringBuilder();
+		int cursor = 0;
+		for (ParameterMapping parameterMapping : boundSql.getParameterMappings()) {
+			int placeholder = sql.indexOf('?', cursor);
+			named.append(sql, cursor, placeholder).append("#{").append(parameterMapping.getProperty()).append('}');
+			cursor = placeholder + 1;
+		}
+		named.append(sql.substring(cursor));
+
+		Matcher matcher = ATDRN_JOIN.matcher(named);
+		assertTrue(matcher.find(), statementId + " 이 참가행을 조인하지 않는다: " + named);
+		return matcher.group(1).replaceAll("\\s+", " ").trim();
+	}
+
+	@ParameterizedTest(name = "{0}")
+	@ValueSource(strings = { "mysql", "maria", "oracle", "postgres", "tibero", "altibase", "cubrid", "goldilocks" })
+	@DisplayName("행사접수 목록과 총 건수는 방언과 무관하게 같은 신청자로 참가행을 붙인다")
+	void listAndTotalCountJoinOnTheSameApplicant(String dialect) throws Exception {
+		Configuration configuration = loadMapper(dialect);
+
+		// 로그인한 사용자가 2026년 9월 행사접수관리 목록을 연 상태다. 컨트롤러가 조회 직전에
+		// searchKeyword 에는 검색 연월을, applcntId 에는 그 사용자의 고유 ID 를 넣는다.
+		EventManageVO eventManageVO = new EventManageVO();
+		eventManageVO.setSearchYear("2026");
+		eventManageVO.setSearchMonth("09");
+		eventManageVO.setSearchKeyword("202609");
+		eventManageVO.setApplcntId("USRCNFRM_00000000000");
+
+		String listJoin = atdrnJoinOf(configuration, LIST_STATEMENT_ID, eventManageVO);
+		String totCntJoin = atdrnJoinOf(configuration, TOT_CNT_STATEMENT_ID, eventManageVO);
+
+		System.out.println("[" + dialect + "] 목록 " + listJoin);
+		System.out.println("[" + dialect + "] 건수 " + totCntJoin);
+
+		assertEquals(listJoin, totCntJoin, dialect + " 매퍼의 총 건수가 목록과 다른 신청자로 참가행을 붙인다");
+	}
+
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

행사접수관리 목록 `EgovEventRcrptManageList.do` 는 한 VO 로 목록을 `selectEventAtdrnList` 로, 페이저에 넣을 총 건수를 `selectEventAtdrnListTotCnt` 로 조회합니다(`EgovEventManageController.java:316`·`:319`).

그 VO 에 값을 넣는 자리는 조회 바로 앞 두 줄입니다. `:309` 가 `searchKeyword` 에 `getSearchYear() + getSearchMonth()` 로 만든 검색 연월을 넣고 `:315` 가 `applcntId` 에 `user.getUniqId()` 를 넣습니다.

목록 구문은 참가행을 `atdrn.APPLCNT_ID = #{applcntId}` 로 붙이는데 건수 구문만 `#{searchKeyword}` 로 붙습니다. 즉 건수 쪽은 신청자 ID 자리에 연월을 놓고 조인하므로 8개 방언 모두에서 참가행이 붙지 않고 `atdrn` 의 모든 열이 널이 됩니다.

두 구문이 공유하는 `WHERE` 절이 그 널을 세 자리에서 읽습니다. 첫째는 늘 걸려 있고 나머지 둘은 승인구분 셀렉트(`EgovEventRceptManageList.jsp:164`)가 보내는 값에 따라 켜집니다.

- `or atdrn.confm_At is not null` — 접수기간이 지났어도 신청 이력이 남아 목록에 보이는 행이 건수에서는 이 항에 걸리지 못합니다. `CONFM_AT` 은 신청 시점에 약식결재 결과로 채워지므로(`EgovEventManageServiceImpl.java:229`) 신청중·승인·반려 모두 값이 있습니다.
- `atdrn.CONFM_AT = #{searchConfmAt}` — 신청중·승인·반려로 거르면 건수 쪽 비교가 널이라 참이 되는 행이 없어 총 건수가 0 이 됩니다.
- `atdrn.CONFM_AT is null` — 신청전으로 거르면 반대입니다. 건수 쪽에서 이 항이 늘 참이라 필터가 없는 것과 같아져 이미 신청한 행사까지 함께 세어집니다.

앞의 둘은 총 건수가 목록보다 작아지고 마지막은 커집니다. 어느 쪽이든 `PaginationInfo` 의 총 건수가 목록과 맞지 않아 `<ui:pagination>` 이 목록에 없는 페이지를 그리거나 있는 행을 가리키지 못합니다.

건수 구문의 조인을 목록과 같은 `applcntId` 로 맞췄습니다. 여덟 파일 모두 이 한 줄이고 mysql(`:294`) 은 아래와 같습니다.

```diff
 				  FROM   (select @RNUM:=0) R, COMTNEVENTMANAGE mge
 				         left join COMTNEVENTATDRN atdrn
 				         ON   atdrn.EVENT_ID = mge.EVENT_ID
-				         and  atdrn.APPLCNT_ID = #{searchKeyword}
+				         and  atdrn.APPLCNT_ID = #{applcntId}
 				 WHERE    1=1
```

`searchKeyword` 를 쓰는 다른 자리(행사 연월 비교·시작일 `like`)는 8개 방언 모두 두 구문이 글자까지 같습니다. 그 밖에 oracle·cubrid 의 행사구분 조건 한정자(목록 `mge.EVENT_SE` / 건수 `EVENT_SE`)와 goldilocks 의 접수기간 `CAST` 가 두 구문 사이에 다르게 남아 있는데, 참가행 조인과 무관하고 결과가 달라지는지 확인하지 못해 이번 변경에서 제외했습니다.

손댈 범위는 매퍼 전체를 훑어 정했습니다. `src/main/resources/egovframework/mapper` 아래 모든 `<select>` 5,752 개에서 `...TotCnt`·`...Cnt` 구문과 그 짝이 되는 목록 구문을 찾아 조인 절이 묶는 바인딩 변수를 대조했습니다. 어긋나는 것은 이 여덟 건뿐이었습니다. 같은 스캔을 수정본에 돌리면 0 건입니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

`EgovEventAtdrnListTotCntJoinTest` 를 추가했습니다. 여덟 방언 매퍼를 `XMLMapperBuilder` 로 읽어 두 구문을 `getBoundSql` 로 렌더하고 참가행 조인 절만 잘라 맞춰봅니다. 바인딩 SQL 은 `#{}` 를 `?` 로 바꿔 어느 값을 묶었는지를 지우므로 `getParameterMappings()` 의 이름을 자리표시자에 되돌린 뒤 비교합니다. 데이터베이스 연결은 필요하지 않습니다.

```
mvn -o test -Dtest=EgovEventAtdrnListTotCntJoinTest

[mysql] 목록 left join COMTNEVENTATDRN atdrn ON atdrn.EVENT_ID = mge.EVENT_ID and atdrn.APPLCNT_ID = #{applcntId}
[mysql] 건수 left join COMTNEVENTATDRN atdrn ON atdrn.EVENT_ID = mge.EVENT_ID and atdrn.APPLCNT_ID = #{applcntId}
Tests run: 8, Failures: 0, Errors: 0, Skipped: 0
```

수정을 도로 빼면 여덟 방언이 모두 실패합니다.

```
EgovEventAtdrnListTotCntJoinTest.listAndTotalCountJoinOnTheSameApplicant:100 mysql 매퍼의 총 건수가 목록과 다른 신청자로 참가행을 붙인다 ==> expected: <left join COMTNEVENTATDRN atdrn ON atdrn.EVENT_ID = mge.EVENT_ID and atdrn.APPLCNT_ID = #{applcntId}> but was: <left join COMTNEVENTATDRN atdrn ON atdrn.EVENT_ID = mge.EVENT_ID and atdrn.APPLCNT_ID = #{searchKeyword}>
Tests run: 8, Failures: 8, Errors: 0, Skipped: 0
```

한 방언만 되돌리면 그 방언 하나만 실패합니다(`Tests run: 8, Failures: 1`).

같은 패키지의 기존 테스트도 회귀로 돌렸습니다.

```
mvn -o test -Dtest='egovframework.com.uss.**.*Test'

수정 전  Tests run: 115, Failures: 0, Errors: 1, Skipped: 0
수정 후  Tests run: 123, Failures: 0, Errors: 1, Skipped: 0
```

늘어난 여덟 건은 추가한 테스트입니다. 오류 한 건은 `FormValidationTest.testValidationWithServletRequest` 가 `jakarta/servlet/ServletConnection` 을 찾지 못하는 것으로, 이 변경을 되돌린 상태에서도 같은 테스트가 같은 사유로 납니다.

위 출력은 `pom.xml` 의 surefire `<skipTests>true</skipTests>` 를 잠시 해제하고 얻은 것이며 값은 되돌려 뒀습니다. 그 값이 고정이라 명령만으로는 `Tests are skipped.` 로 끝납니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

브라우저 테스트는 하지 않았습니다. 매퍼가 렌더하는 SQL 로 확인했습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

위 테스트 출력으로 대신합니다.
