### PR TITLE
fix: DB모니터링·송수신모니터링 총 건수가 상태 검색조건을 빼고 셈

### DIFF
--- a/src/main/resources/egovframework/mapper/com/utl/sys/dbm/EgovDbMntrng_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/dbm/EgovDbMntrng_SQL_altibase.xml
@@ -90,6 +90,9 @@
             <if test="searchCondition == 2">AND
                    A.MNGR_NM LIKE '%' || #{searchKeyword} || '%'        
             </if>
+            <if test="searchCondition == 3">AND
+                   C.CODE_NM LIKE #{searchKeyword} || '%'        
+            </if>
     </select>
     
     <select id="selectDbMntrng" parameterType="egovframework.com.utl.sys.dbm.service.DbMntrng" resultMap="dbMntrngResult">

--- a/src/main/resources/egovframework/mapper/com/utl/sys/dbm/EgovDbMntrng_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/dbm/EgovDbMntrng_SQL_cubrid.xml
@@ -90,6 +90,9 @@
             <if test="searchCondition == 2">AND
                    A.MNGR_NM LIKE '%' || #{searchKeyword} || '%'        
             </if>
+            <if test="searchCondition == 3">AND
+                   C.CODE_NM LIKE #{searchKeyword} || '%'        
+            </if>
     </select>
     
     <select id="selectDbMntrng" parameterType="egovframework.com.utl.sys.dbm.service.DbMntrng" resultMap="dbMntrngResult">

--- a/src/main/resources/egovframework/mapper/com/utl/sys/dbm/EgovDbMntrng_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/dbm/EgovDbMntrng_SQL_goldilocks.xml
@@ -90,6 +90,9 @@
             <if test="searchCondition == 2">AND
                    A.MNGR_NM LIKE '%' || #{searchKeyword} || '%'        
             </if>
+            <if test="searchCondition == 3">AND
+                   C.CODE_NM LIKE #{searchKeyword} || '%'        
+            </if>
     </select>
     
     <select id="selectDbMntrng" parameterType="egovframework.com.utl.sys.dbm.service.DbMntrng" resultMap="dbMntrngResult">

--- a/src/main/resources/egovframework/mapper/com/utl/sys/dbm/EgovDbMntrng_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/dbm/EgovDbMntrng_SQL_maria.xml
@@ -89,6 +89,9 @@
 			<if test="searchCondition == 2">AND
 					A.MNGR_NM LIKE CONCAT ('%', #{searchKeyword},'%') 		
 			</if>
+			<if test="searchCondition == 3">AND
+					C.CODE_NM LIKE CONCAT(#{searchKeyword},'%') 		
+			</if>
 	</select>
 	
 	<select id="selectDbMntrng" parameterType="egovframework.com.utl.sys.dbm.service.DbMntrng" resultMap="dbMntrngResult">

--- a/src/main/resources/egovframework/mapper/com/utl/sys/dbm/EgovDbMntrng_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/dbm/EgovDbMntrng_SQL_mysql.xml
@@ -89,6 +89,9 @@
 			<if test="searchCondition == 2">AND
 					A.MNGR_NM LIKE CONCAT ('%', #{searchKeyword},'%') 		
 			</if>
+			<if test="searchCondition == 3">AND
+					C.CODE_NM LIKE CONCAT(#{searchKeyword},'%') 		
+			</if>
 	</select>
 	
 	<select id="selectDbMntrng" parameterType="egovframework.com.utl.sys.dbm.service.DbMntrng" resultMap="dbMntrngResult">

--- a/src/main/resources/egovframework/mapper/com/utl/sys/dbm/EgovDbMntrng_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/dbm/EgovDbMntrng_SQL_oracle.xml
@@ -90,6 +90,9 @@
             <if test="searchCondition == 2">AND
                    A.MNGR_NM LIKE '%' || #{searchKeyword} || '%'        
             </if>
+            <if test="searchCondition == 3">AND
+                   C.CODE_NM LIKE #{searchKeyword} || '%'        
+            </if>
     </select>
     
     <select id="selectDbMntrng" parameterType="egovframework.com.utl.sys.dbm.service.DbMntrng" resultMap="dbMntrngResult">

--- a/src/main/resources/egovframework/mapper/com/utl/sys/dbm/EgovDbMntrng_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/dbm/EgovDbMntrng_SQL_postgres.xml
@@ -89,6 +89,9 @@
 			<if test="searchCondition == 2">AND
 					A.MNGR_NM LIKE CONCAT ('%', #{searchKeyword},'%') 		
 			</if>
+			<if test="searchCondition == 3">AND
+					C.CODE_NM LIKE CONCAT(#{searchKeyword},'%') 		
+			</if>
 	</select>
 	
 	<select id="selectDbMntrng" parameterType="egovframework.com.utl.sys.dbm.service.DbMntrng" resultMap="dbMntrngResult">

--- a/src/main/resources/egovframework/mapper/com/utl/sys/dbm/EgovDbMntrng_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/dbm/EgovDbMntrng_SQL_tibero.xml
@@ -90,6 +90,9 @@
             <if test="searchCondition == 2">AND
                    A.MNGR_NM LIKE '%' || #{searchKeyword} || '%'        
             </if>
+            <if test="searchCondition == 3">AND
+                   C.CODE_NM LIKE #{searchKeyword} || '%'        
+            </if>
     </select>
     
     <select id="selectDbMntrng" parameterType="egovframework.com.utl.sys.dbm.service.DbMntrng" resultMap="dbMntrngResult">

--- a/src/main/resources/egovframework/mapper/com/utl/sys/trm/EgovTrsmrcvMntrng_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/trm/EgovTrsmrcvMntrng_SQL_altibase.xml
@@ -132,6 +132,9 @@
             <if test="searchCondition == 2">AND
                    A.MNGR_NM LIKE '%' || #{searchKeyword} || '%'        
             </if>
+            <if test="searchCondition == 3">AND
+                   B.CODE_NM LIKE  '%' || #{searchKeyword} || '%'        
+            </if>
 	</select>
 	
 	<select id="selectTrsmrcvMntrng" parameterType="egovframework.com.utl.sys.trm.service.TrsmrcvMntrng" resultMap="trsmrcvMntrngResult">

--- a/src/main/resources/egovframework/mapper/com/utl/sys/trm/EgovTrsmrcvMntrng_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/trm/EgovTrsmrcvMntrng_SQL_cubrid.xml
@@ -132,6 +132,9 @@
             <if test="searchCondition == 2">AND
                    A.MNGR_NM LIKE '%' || #{searchKeyword} || '%'        
             </if>
+            <if test="searchCondition == 3">AND
+                   B.CODE_NM LIKE '%' || #{searchKeyword} || '%'        
+            </if>
 	</select>
 	
 	<select id="selectTrsmrcvMntrng" parameterType="egovframework.com.utl.sys.trm.service.TrsmrcvMntrng" resultMap="trsmrcvMntrngResult">

--- a/src/main/resources/egovframework/mapper/com/utl/sys/trm/EgovTrsmrcvMntrng_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/trm/EgovTrsmrcvMntrng_SQL_goldilocks.xml
@@ -132,6 +132,9 @@
             <if test="searchCondition == 2">AND
                    A.MNGR_NM LIKE '%' || #{searchKeyword} || '%'        
             </if>
+            <if test="searchCondition == 3">AND
+                   B.CODE_NM LIKE  '%' || #{searchKeyword} || '%'        
+            </if>
 	</select>
 	
 	<select id="selectTrsmrcvMntrng" parameterType="egovframework.com.utl.sys.trm.service.TrsmrcvMntrng" resultMap="trsmrcvMntrngResult">

--- a/src/main/resources/egovframework/mapper/com/utl/sys/trm/EgovTrsmrcvMntrng_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/trm/EgovTrsmrcvMntrng_SQL_maria.xml
@@ -131,6 +131,9 @@
             <if test="searchCondition == 2">AND
                    A.MNGR_NM LIKE CONCAT ('%', #{searchKeyword},'%')        
             </if>
+            <if test="searchCondition == 3">AND
+                   B.CODE_NM LIKE CONCAT ('%', #{searchKeyword},'%')        
+            </if>
 	</select>
 	
 	<select id="selectTrsmrcvMntrng" parameterType="egovframework.com.utl.sys.trm.service.TrsmrcvMntrng" resultMap="trsmrcvMntrngResult">

--- a/src/main/resources/egovframework/mapper/com/utl/sys/trm/EgovTrsmrcvMntrng_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/trm/EgovTrsmrcvMntrng_SQL_mysql.xml
@@ -131,6 +131,9 @@
             <if test="searchCondition == 2">AND
                    A.MNGR_NM LIKE CONCAT ('%', #{searchKeyword},'%')        
             </if>
+            <if test="searchCondition == 3">AND
+                   B.CODE_NM LIKE CONCAT ('%', #{searchKeyword},'%')        
+            </if>
 	</select>
 	
 	<select id="selectTrsmrcvMntrng" parameterType="egovframework.com.utl.sys.trm.service.TrsmrcvMntrng" resultMap="trsmrcvMntrngResult">

--- a/src/main/resources/egovframework/mapper/com/utl/sys/trm/EgovTrsmrcvMntrng_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/trm/EgovTrsmrcvMntrng_SQL_oracle.xml
@@ -132,6 +132,9 @@
             <if test="searchCondition == 2">AND
                    A.MNGR_NM LIKE '%' || #{searchKeyword} || '%'        
             </if>
+            <if test="searchCondition == 3">AND
+                   B.CODE_NM LIKE '%' || #{searchKeyword} || '%'        
+            </if>
 	</select>
 	
 	<select id="selectTrsmrcvMntrng" parameterType="egovframework.com.utl.sys.trm.service.TrsmrcvMntrng" resultMap="trsmrcvMntrngResult">

--- a/src/main/resources/egovframework/mapper/com/utl/sys/trm/EgovTrsmrcvMntrng_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/trm/EgovTrsmrcvMntrng_SQL_postgres.xml
@@ -131,6 +131,9 @@
             <if test="searchCondition == 2">AND
                    A.MNGR_NM LIKE CONCAT ('%', #{searchKeyword},'%')        
             </if>
+            <if test="searchCondition == 3">AND
+                   B.CODE_NM LIKE CONCAT ('%', #{searchKeyword},'%')        
+            </if>
 	</select>
 	
 	<select id="selectTrsmrcvMntrng" parameterType="egovframework.com.utl.sys.trm.service.TrsmrcvMntrng" resultMap="trsmrcvMntrngResult">

--- a/src/main/resources/egovframework/mapper/com/utl/sys/trm/EgovTrsmrcvMntrng_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/utl/sys/trm/EgovTrsmrcvMntrng_SQL_tibero.xml
@@ -132,6 +132,9 @@
             <if test="searchCondition == 2">AND
                    A.MNGR_NM LIKE '%' || #{searchKeyword} || '%'        
             </if>
+            <if test="searchCondition == 3">AND
+                   B.CODE_NM LIKE  '%' || #{searchKeyword} || '%'        
+            </if>
 	</select>
 	
 	<select id="selectTrsmrcvMntrng" parameterType="egovframework.com.utl.sys.trm.service.TrsmrcvMntrng" resultMap="trsmrcvMntrngResult">

--- a/src/test/java/egovframework/com/utl/sys/EgovMntrngListCntConditionTest.java
+++ b/src/test/java/egovframework/com/utl/sys/EgovMntrngListCntConditionTest.java
@@ -1,0 +1,124 @@
+package egovframework.com.utl.sys;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.io.InputStream;
+
+import org.apache.ibatis.builder.xml.XMLMapperBuilder;
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.session.Configuration;
+import org.egovframe.rte.psl.dataaccess.util.EgovMap;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import egovframework.com.cmm.ComDefaultVO;
+import egovframework.com.utl.sys.dbm.service.DbMntrng;
+import egovframework.com.utl.sys.trm.service.TrsmrcvMntrng;
+
+/**
+ * DB모니터링·송수신모니터링의 목록과 총 건수가 8개 DB 방언 모두에서 같은 검색조건을 거는지 검증한다.
+ *
+ * <p>두 화면 모두 목록을 {@code select...List} 로, 페이저에 넣을 총 건수를 {@code select...ListCnt} 로
+ * 각각 조회한다. 두 구문의 조건이 어긋나면 그 검색조건을 고른 화면에서만 페이저가 목록과 다른 페이지 수를
+ * 그린다.</p>
+ *
+ * <p>{@code context-mapper.xml} 의 {@code mapperLocations} 가
+ * {@code classpath:/egovframework/mapper/com/**}{@code /*_${Globals.DbType}.xml} 이라 런타임에는
+ * 방언 매퍼가 하나만 로드된다. 방언별로 매퍼를 직접 파싱해 DB 연결 없이 검증한다.</p>
+ */
+class EgovMntrngListCntConditionTest {
+
+
+	private Configuration loadMapper(String resource) throws Exception {
+		Configuration configuration = new Configuration();
+		configuration.getTypeAliasRegistry().registerAlias("comDefaultVO", ComDefaultVO.class);
+		configuration.getTypeAliasRegistry().registerAlias("egovMap", EgovMap.class);
+		try (InputStream inputStream = Resources.getResourceAsStream(resource)) {
+			new XMLMapperBuilder(inputStream, configuration, resource, configuration.getSqlFragments()).parse();
+		}
+		return configuration;
+	}
+
+	private String sqlOf(Configuration configuration, String statementId, Object parameter) {
+		return configuration.getMappedStatement(statementId).getBoundSql(parameter).getSql();
+	}
+
+	/**
+	 * 어느 {@code <if>} 에도 걸리지 않는 검색조건이다. 빈 문자열은 쓸 수 없다 — OGNL 이
+	 * {@code "" == 0} 을 참으로 보아 첫 분기가 켜진다.
+	 */
+	private static final String NO_CONDITION = "9";
+
+	/**
+	 * 검색조건이 얹은 절만 뽑는다. 검색조건을 넣은 SQL 과 아무 조건도 걸리지 않는 SQL 의 공통 앞·뒤를
+	 * 걷어내면 남는 것이 {@code <if>} 가 끼워넣은 절이다. 구문마다 다른 고정 조건·정렬·페이징 껍데기에
+	 * 기대지 않는 방법이다.
+	 */
+	private String searchClauseOf(Configuration configuration, String statementId, Object withSearch, Object noSearch) {
+		String full = sqlOf(configuration, statementId, withSearch);
+		String bare = sqlOf(configuration, statementId, noSearch);
+
+		int head = 0;
+		while (head < full.length() && head < bare.length() && full.charAt(head) == bare.charAt(head)) {
+			head++;
+		}
+		int tail = 0;
+		while (tail < full.length() - head && tail < bare.length() - head
+				&& full.charAt(full.length() - 1 - tail) == bare.charAt(bare.length() - 1 - tail)) {
+			tail++;
+		}
+		return full.substring(head, full.length() - tail).replaceAll("\\s+", " ").trim();
+	}
+
+	private void assertSameSearchClause(String dialect, String resource, String listId, String cntId, Object withSearch,
+			Object noSearch) throws Exception {
+		Configuration configuration = loadMapper(resource);
+
+		String listClause = searchClauseOf(configuration, listId, withSearch, noSearch);
+		String cntClause = searchClauseOf(configuration, cntId, withSearch, noSearch);
+
+		System.out.println("[" + dialect + "] 목록 " + listClause);
+		System.out.println("[" + dialect + "] 건수 " + cntClause);
+
+		// 두 구문에서 조건이 함께 사라지면 양쪽 다 빈 문자열이 되어 조용히 통과한다.
+		assertFalse(listClause.isEmpty(), dialect + " 매퍼의 목록이 검색조건을 걸지 않는다");
+		assertEquals(listClause, cntClause, dialect + " 매퍼의 총 건수가 목록과 다른 조건을 센다");
+	}
+
+	@ParameterizedTest(name = "{0}")
+	@ValueSource(strings = { "mysql", "maria", "oracle", "postgres", "tibero", "altibase", "cubrid", "goldilocks" })
+	@DisplayName("상태로 거른 DB모니터링 목록과 총 건수는 방언과 무관하게 같은 조건을 건다")
+	void dbMntrngListAndCountFilterOnTheSameCondition(String dialect) throws Exception {
+		// 목록 화면의 검색조건 셀렉트에서 '상태'(EgovDbMntrngList.jsp 의 value="3")를 골라 조회한 상태다.
+		DbMntrng withSearch = new DbMntrng();
+		withSearch.setSearchCondition("3");
+		withSearch.setSearchKeyword("정상");
+
+		DbMntrng noSearch = new DbMntrng();
+		noSearch.setSearchCondition(NO_CONDITION);
+
+		assertSameSearchClause(dialect, "egovframework/mapper/com/utl/sys/dbm/EgovDbMntrng_SQL_" + dialect + ".xml",
+				"DbMntrngDao.selectDbMntrngList", "DbMntrngDao.selectDbMntrngListCnt", withSearch, noSearch);
+	}
+
+	@ParameterizedTest(name = "{0}")
+	@ValueSource(strings = { "mysql", "maria", "oracle", "postgres", "tibero", "altibase", "cubrid", "goldilocks" })
+	@DisplayName("상태로 거른 송수신모니터링 목록과 총 건수는 방언과 무관하게 같은 조건을 건다")
+	void trsmrcvMntrngListAndCountFilterOnTheSameCondition(String dialect) throws Exception {
+		// 목록 화면의 검색조건 셀렉트에서 '상태'(EgovTrsmrcvMntrngList.jsp 의 value="3")를 골라 조회한 상태다.
+		TrsmrcvMntrng withSearch = new TrsmrcvMntrng();
+		withSearch.setSearchCondition("3");
+		withSearch.setSearchKeyword("정상");
+
+		TrsmrcvMntrng noSearch = new TrsmrcvMntrng();
+		noSearch.setSearchCondition(NO_CONDITION);
+
+		assertSameSearchClause(dialect,
+				"egovframework/mapper/com/utl/sys/trm/EgovTrsmrcvMntrng_SQL_" + dialect + ".xml",
+				"TrsmrcvMntrngDao.selectTrsmrcvMntrngList", "TrsmrcvMntrngDao.selectTrsmrcvMntrngListCnt", withSearch,
+				noSearch);
+	}
+
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

DB모니터링과 송수신모니터링은 목록을 `select...List` 로, 페이저에 넣을 총 건수를 `select...ListCnt` 로 각각 조회합니다.

두 화면의 검색조건 셀렉트에는 상태가 들어 있습니다 — `EgovDbMntrngList.jsp:89` 와 `EgovTrsmrcvMntrngList.jsp:87` 의 `<option value="3">` 입니다. 목록 구문에는 그 값을 받는 `<if test="searchCondition == 3">` 블록이 있는데 건수 구문에는 8개 방언 모두 그 블록이 없습니다. 두 구문의 다른 세 조건(`0`·`1`·`2`)은 이미 같습니다.

그래서 상태로 걸러도 총 건수는 거르지 않은 전체를 셉니다. 그 값이 `PaginationInfo` 의 총 건수가 되어 `<ui:pagination>` 이 목록에 없는 페이지를 그리고, 뒷 페이지를 누르면 빈 목록이 나옵니다.

같은 `utl/sys` 의 형제 모듈인 네트워크서비스모니터링과 파일시스템모니터링은 목록과 건수 양쪽에서 상태를 거릅니다. 여덟 방언 모두 그렇습니다 — `EgovNtwrkSvcMntrng_SQL_mysql.xml:80`·`:111` 과 `EgovFileSysMntrng_SQL_mysql.xml:105`·`:136` 입니다. DB모니터링과 송수신모니터링만 건수에서 빠뜨렸습니다.

목록 구문의 조건 블록을 건수 구문에 옮겼습니다. 술어는 목록에서 그대로 뜬 것이고 들여쓰기와 후행 공백은 붙는 자리의 이웃 블록을 따랐습니다. 아래는 `EgovTrsmrcvMntrng_SQL_mysql.xml:131` 이고 나머지 방언은 각자의 문자열 결합 문법(`||` 또는 `CONCAT`)을 쓰는 같은 변경입니다.

```diff
             <if test="searchCondition == 2">AND
                    A.MNGR_NM LIKE CONCAT ('%', #{searchKeyword},'%')        
             </if>
+            <if test="searchCondition == 3">AND
+                   B.CODE_NM LIKE CONCAT ('%', #{searchKeyword},'%')        
+            </if>
```

두 술어가 다릅니다. DB모니터링은 목록이 `C.CODE_NM LIKE CONCAT(#{searchKeyword},'%')` 로 접두 일치를 쓰고 송수신모니터링은 `B.CODE_NM LIKE CONCAT ('%', #{searchKeyword},'%')` 로 부분 일치를 씁니다. 어느 쪽이 옳은지는 판단하지 않고 각 목록 구문이 쓰던 것을 그대로 옮겼습니다.

손댈 범위는 매퍼 전체를 훑어 정했습니다. `src/main/resources/egovframework/mapper` 아래 모든 매퍼에서 구문 5,752 개를 읽어 `...Cnt`·`...TotCnt` 와 그 짝이 되는 목록 구문의 `<if>` 조건식 집합을 대조했습니다. 어긋난 것은 117 건이고 서로 다른 구문쌍으로는 17 개였습니다. 그 가운데 목록에만 `searchCondition == 3` 이 있고 건수에는 없는 것이 세 쌍입니다.

셋 중 둘이 이 PR 이 고치는 것이고 나머지 하나인 `EgovCmmnClCodeManage_SQL_*.xml` 의 `selectCmmnClCodeList` 는 제외했습니다. 그쪽 조건 3 은 `AND USE_AT = 'Y'` 를 렌더하는데 `EgovCcmCmmnClCodeList.jsp` 의 검색조건 셀렉트에는 `1`·`2` 만 있어 화면에서 그 값이 오지 않습니다. 나머지 14 쌍은 어긋난 조건이 달라 이 PR 에서 다루지 않았습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

`EgovMntrngListCntConditionTest` 를 추가했습니다. 여덟 방언 매퍼를 `XMLMapperBuilder` 로 읽어 두 구문을 `getBoundSql` 로 렌더하고 검색조건이 얹은 절만 비교합니다.

그 절은 조건을 넣은 SQL 과 아무 조건도 걸리지 않는 SQL 의 공통 앞·뒤를 걷어내 얻습니다. 구문마다 다른 고정 조건·정렬·페이징 껍데기에 기대지 않아 두 모듈에 같은 코드를 쓸 수 있습니다. 데이터베이스 연결은 필요하지 않습니다.

두 구문에서 조건이 함께 사라지면 양쪽 델타가 빈 문자열이 되어 조용히 통과하므로, 목록 쪽 절이 비지 않는지 먼저 봅니다.

조건이 걸리지 않는 쪽에 빈 문자열은 쓸 수 없습니다. OGNL 이 `"" == 0` 을 참으로 보아 첫 분기가 켜지므로, 어느 분기에도 해당하지 않는 값을 넣습니다.

`mvn -o -DskipTests=false -Dtest=EgovMntrngListCntConditionTest test` 의 출력입니다.

```
[mysql] 목록 AND B.CODE_NM LIKE CONCAT ('%', ?,'%')
[mysql] 건수 AND B.CODE_NM LIKE CONCAT ('%', ?,'%')
[mysql] 목록 AND C.CODE_NM LIKE CONCAT(?,'%')
[mysql] 건수 AND C.CODE_NM LIKE CONCAT(?,'%')
[INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0
```

출력은 송수신모니터링 여덟 방언, DB모니터링 여덟 방언 순서로 찍힙니다. 위는 그중 mysql 두 쌍을 뽑은 것이라 실제 출력에서는 두 쌍 사이에 나머지 방언 열네 줄이 있습니다.

수정을 도로 빼면 열여섯 건이 모두 실패합니다.

```
[ERROR]   EgovMntrngListCntConditionTest.dbMntrngListAndCountFilterOnTheSameCondition:102->assertSameSearchClause:87 mysql 매퍼의 총 건수가 목록과 다른 조건을 센다 ==> expected: <AND C.CODE_NM LIKE CONCAT(?,'%')> but was: <>
[ERROR] Tests run: 16, Failures: 16, Errors: 0, Skipped: 0
```

한 방언만 되돌리면 그 방언 하나만 실패합니다.

같은 패키지의 기존 테스트도 회귀로 돌렸습니다.

`mvn -o -DskipTests=false -Dtest='egovframework.com.utl.**.*Test' test` 의 요약 줄입니다. 앞이 수정 전입니다.

```
[INFO] Tests run: 192, Failures: 0, Errors: 0, Skipped: 0
[INFO] Tests run: 208, Failures: 0, Errors: 0, Skipped: 0
```

늘어난 열여섯 건이 추가한 테스트입니다.

위 출력은 `pom.xml` 의 surefire `<skipTests>true</skipTests>` 를 잠시 해제하고 얻은 것이며 값은 되돌려 뒀습니다. 그 값이 고정이라 명령만으로는 `Tests are skipped.` 로 끝납니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

브라우저 테스트는 하지 않았습니다. 매퍼가 렌더하는 SQL 로 확인했습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

위 테스트 출력으로 대신합니다.
