### PR TITLE
fix(adb): 주소록 목록이 회사 공개 주소록을 빼고 보여줌

### DIFF
--- a/src/main/resources/egovframework/mapper/com/cop/adb/EgovAdbk_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/adb/EgovAdbk_SQL_altibase.xml
@@ -110,7 +110,7 @@
 			FROM
 				COMTNADBKMANAGE		
 			WHERE USE_AT = 'Y'		
-				AND( OTHBC_SCOPE = '회사	'
+				AND( OTHBC_SCOPE = '회사'
 					OR WRTER_ID = #{wrterId}
 						OR (OTHBC_SCOPE = '부서'
 							AND TRGET_ORGNZT_ID = #{trgetOrgnztId})	)		

--- a/src/main/resources/egovframework/mapper/com/cop/adb/EgovAdbk_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/adb/EgovAdbk_SQL_cubrid.xml
@@ -110,7 +110,7 @@
 			FROM
 				COMTNADBKMANAGE		
 			WHERE USE_AT = 'Y'		
-				AND( OTHBC_SCOPE = '회사	'
+				AND( OTHBC_SCOPE = '회사'
 					OR WRTER_ID = #{wrterId}
 						OR (OTHBC_SCOPE = '부서'
 							AND TRGET_ORGNZT_ID = #{trgetOrgnztId})	)		

--- a/src/main/resources/egovframework/mapper/com/cop/adb/EgovAdbk_SQL_goldilocks.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/adb/EgovAdbk_SQL_goldilocks.xml
@@ -110,7 +110,7 @@
 			FROM
 				COMTNADBKMANAGE		
 			WHERE USE_AT = 'Y'		
-				AND( OTHBC_SCOPE = '회사	'
+				AND( OTHBC_SCOPE = '회사'
 					OR WRTER_ID = #{wrterId}
 						OR (OTHBC_SCOPE = '부서'
 							AND TRGET_ORGNZT_ID = #{trgetOrgnztId})	)		

--- a/src/main/resources/egovframework/mapper/com/cop/adb/EgovAdbk_SQL_maria.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/adb/EgovAdbk_SQL_maria.xml
@@ -98,7 +98,7 @@
 			FROM
 				COMTNADBKMANAGE
 			WHERE USE_AT = 'Y'
-				AND( OTHBC_SCOPE = '회사	'
+				AND( OTHBC_SCOPE = '회사'
 					OR WRTER_ID = #{wrterId}
 						OR (OTHBC_SCOPE = '부서'
 							AND TRGET_ORGNZT_ID = #{trgetOrgnztId})	)

--- a/src/main/resources/egovframework/mapper/com/cop/adb/EgovAdbk_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/adb/EgovAdbk_SQL_mysql.xml
@@ -98,7 +98,7 @@
 			FROM
 				COMTNADBKMANAGE
 			WHERE USE_AT = 'Y'
-				AND( OTHBC_SCOPE = '회사	'
+				AND( OTHBC_SCOPE = '회사'
 					OR WRTER_ID = #{wrterId}
 						OR (OTHBC_SCOPE = '부서'
 							AND TRGET_ORGNZT_ID = #{trgetOrgnztId})	)

--- a/src/main/resources/egovframework/mapper/com/cop/adb/EgovAdbk_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/adb/EgovAdbk_SQL_oracle.xml
@@ -110,7 +110,7 @@
 			FROM
 				COMTNADBKMANAGE		
 			WHERE USE_AT = 'Y'		
-				AND( OTHBC_SCOPE = '회사	'
+				AND( OTHBC_SCOPE = '회사'
 					OR WRTER_ID = #{wrterId}
 						OR (OTHBC_SCOPE = '부서'
 							AND TRGET_ORGNZT_ID = #{trgetOrgnztId})	)		

--- a/src/main/resources/egovframework/mapper/com/cop/adb/EgovAdbk_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/adb/EgovAdbk_SQL_postgres.xml
@@ -98,7 +98,7 @@
 			FROM
 				COMTNADBKMANAGE
 			WHERE USE_AT = 'Y'
-				AND( OTHBC_SCOPE = '회사	'
+				AND( OTHBC_SCOPE = '회사'
 					OR WRTER_ID = #{wrterId}
 						OR (OTHBC_SCOPE = '부서'
 							AND TRGET_ORGNZT_ID = #{trgetOrgnztId})	)

--- a/src/main/resources/egovframework/mapper/com/cop/adb/EgovAdbk_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/com/cop/adb/EgovAdbk_SQL_tibero.xml
@@ -107,7 +107,7 @@
 			FROM
 				COMTNADBKMANAGE		
 			WHERE USE_AT = 'Y'		
-				AND( OTHBC_SCOPE = '회사	'
+				AND( OTHBC_SCOPE = '회사'
 					OR WRTER_ID = #{wrterId}
 						OR (OTHBC_SCOPE = '부서'
 							AND TRGET_ORGNZT_ID = #{trgetOrgnztId})	)		

--- a/src/test/java/egovframework/com/cop/adb/service/impl/EgovAdressBookOthbcScopeTest.java
+++ b/src/test/java/egovframework/com/cop/adb/service/impl/EgovAdressBookOthbcScopeTest.java
@@ -1,0 +1,91 @@
+package egovframework.com.cop.adb.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.InputStream;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.ibatis.builder.xml.XMLMapperBuilder;
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.session.Configuration;
+import org.egovframe.rte.psl.dataaccess.util.EgovMap;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import egovframework.com.cmm.ComDefaultVO;
+import egovframework.com.cop.adb.service.AddressBookVO;
+
+/**
+ * 주소록 목록과 총 건수가 8개 DB 방언 모두에서 같은 공개범위 값으로 회사 공개를 가리는지 검증한다.
+ *
+ * <p>{@code EgovAddressBookController.selectAdressBookList} 는 목록을 {@code selectAdressBookList} 로,
+ * 페이저에 넣을 총 건수를 {@code selectAdressBookListCnt} 로 각각 조회한다. 두 구문이 회사 공개를
+ * 다른 값으로 판단하면 한쪽에만 잡히는 주소록이 생겨 페이저가 목록과 어긋난다.</p>
+ *
+ * <p>{@code context-mapper.xml} 의 {@code mapperLocations} 가
+ * {@code classpath:/egovframework/mapper/com/**}{@code /*_${Globals.DbType}.xml} 이라 런타임에는
+ * 방언 매퍼가 하나만 로드된다. 방언별로 매퍼를 직접 파싱해 DB 연결 없이 검증한다.</p>
+ */
+class EgovAdressBookOthbcScopeTest {
+
+	private static final String LIST_STATEMENT_ID = "AdressBookDAO.selectAdressBookList";
+
+	private static final String CNT_STATEMENT_ID = "AdressBookDAO.selectAdressBookListCnt";
+
+	/** 공개범위로 볼 수 있는 주소록을 가리는 절에서 회사 공개를 판단하는 리터럴이다. */
+	private static final Pattern COMPANY_SCOPE = Pattern.compile("OTHBC_SCOPE\\s*=\\s*'([^']*)'");
+
+	/**
+	 * 어느 {@code <if>} 에도 걸리지 않는 검색조건이다. 빈 문자열은 쓸 수 없다 — OGNL 이
+	 * {@code "" == 0} 을 참으로 보아 첫 분기가 켜진다.
+	 */
+	private static final String NO_CONDITION = "9";
+
+	private Configuration loadMapper(String dialect) throws Exception {
+		String resource = "egovframework/mapper/com/cop/adb/EgovAdbk_SQL_" + dialect + ".xml";
+		Configuration configuration = new Configuration();
+		configuration.getTypeAliasRegistry().registerAlias("comDefaultVO", ComDefaultVO.class);
+		configuration.getTypeAliasRegistry().registerAlias("egovMap", EgovMap.class);
+		try (InputStream inputStream = Resources.getResourceAsStream(resource)) {
+			new XMLMapperBuilder(inputStream, configuration, resource, configuration.getSqlFragments()).parse();
+		}
+		return configuration;
+	}
+
+	private String companyScopeOf(Configuration configuration, String statementId, Object parameter) {
+		String sql = configuration.getMappedStatement(statementId).getBoundSql(parameter).getSql();
+
+		Matcher matcher = COMPANY_SCOPE.matcher(sql);
+		assertTrue(matcher.find(), statementId + " 이 공개범위로 가리지 않는다: " + sql);
+		return matcher.group(1);
+	}
+
+	@ParameterizedTest(name = "{0}")
+	@ValueSource(strings = { "mysql", "maria", "oracle", "postgres", "tibero", "altibase", "cubrid", "goldilocks" })
+	@DisplayName("주소록 목록과 총 건수는 방언과 무관하게 같은 값으로 회사 공개를 가린다")
+	void listAndTotalCountUseTheSameCompanyScope(String dialect) throws Exception {
+		Configuration configuration = loadMapper(dialect);
+
+		// 로그인한 사용자가 주소록 목록을 검색 없이 연 상태다.
+		AddressBookVO addressBookVO = new AddressBookVO();
+		addressBookVO.setSearchCnd(NO_CONDITION);
+		addressBookVO.setWrterId("USRCNFRM_00000000000");
+		addressBookVO.setTrgetOrgnztId("ORGNZT_0000000000000");
+
+		String listScope = companyScopeOf(configuration, LIST_STATEMENT_ID, addressBookVO);
+		String cntScope = companyScopeOf(configuration, CNT_STATEMENT_ID, addressBookVO);
+
+		System.out.println("[" + dialect + "] 목록 " + escape(listScope) + " / 건수 " + escape(cntScope));
+
+		assertEquals(cntScope, listScope, dialect + " 매퍼의 목록이 총 건수와 다른 값으로 회사 공개를 가린다");
+	}
+
+	/** 탭은 눈에 보이지 않으므로 출력에서 드러나게 바꾼다. */
+	private String escape(String scope) {
+		return '\'' + scope.replace("\t", "\\t") + '\'';
+	}
+
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

주소록 목록화면은 목록을 `selectAdressBookList` 로, 페이저에 넣을 총 건수를 `selectAdressBookListCnt` 로 조회합니다. 두 구문 모두 공개범위가 회사이거나, 작성자 본인이거나, 같은 부서인 주소록을 보여줍니다.

그런데 목록 구문만 회사 공개를 `'회사<탭>'` 으로 판단합니다. 건수 구문은 `'회사'` 입니다. 여덟 방언 모두 그렇습니다.

등록·수정 매퍼는 화면이 보낸 `#{othbcScope}` 를 그대로 넣습니다. 그 값은 등록 화면의 라디오가 `comCopAdb.regist.company` 메시지에서 가져오고 `message_ko.properties` 의 그 값은 `회사` 로 탭이 없습니다.

그래서 회사 공개 주소록은 건수에는 잡히고 목록에서는 빠집니다. 페이저가 목록에 없는 페이지를 그리고, 작성자 본인이나 같은 부서가 아니면 그 주소록을 목록에서 볼 수 없습니다.

목록 구문의 리터럴에서 탭만 뺐습니다. mysql 은 아래와 같고 나머지 방언도 같은 한 글자입니다.

```diff
 			WHERE USE_AT = 'Y'
-				AND( OTHBC_SCOPE = '회사	'
+				AND( OTHBC_SCOPE = '회사'
 					OR WRTER_ID = #{wrterId}
```

같은 절의 `'부서'` 리터럴은 두 구문이 이미 같아서 손대지 않았습니다.

손댈 범위는 `src/main/resources/egovframework/mapper` 아래 모든 매퍼의 작은따옴표 리터럴에서 탭을 찾아 정했습니다. 여기 여덟 건이 나왔고 수정 후에는 나오지 않습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

`EgovAdressBookOthbcScopeTest` 를 추가했습니다. 여덟 방언 매퍼를 `XMLMapperBuilder` 로 읽어 두 구문을 `getBoundSql` 로 렌더하고 공개범위로 가리는 절의 회사 리터럴을 뽑아 맞춰봅니다. 탭은 눈에 보이지 않으므로 출력에서 드러나게 바꿔 찍습니다. 데이터베이스 연결은 필요하지 않습니다.

`mvn -o -DskipTests=false -Dtest=EgovAdressBookOthbcScopeTest test` 의 출력입니다.

```
[mysql] 목록 '회사' / 건수 '회사'
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0
```

수정을 도로 빼면 여덟 건이 모두 실패합니다.

```
[mysql] 목록 '회사\t' / 건수 '회사'
[ERROR] Tests run: 8, Failures: 8, Errors: 0, Skipped: 0
```

한 방언만 되돌리면 그 방언 하나만 실패합니다.

같은 패키지의 기존 테스트도 회귀로 돌렸습니다. `mvn -o -DskipTests=false -Dtest='egovframework.com.cop.**.*Test' test` 의 요약 줄이고 앞이 수정 전입니다.

```
[ERROR] Tests run: 130, Failures: 0, Errors: 90, Skipped: 0
[ERROR] Tests run: 138, Failures: 0, Errors: 90, Skipped: 0
```

늘어난 여덟 건이 추가한 테스트입니다. 오류 90 건은 데이터베이스가 필요한 DAO 테스트가 `ApplicationContext` 를 못 올리는 것으로, 실패한 테스트 이름 집합이 수정 전후 같습니다.

`pom.xml` 의 surefire `<skipTests>` 가 리터럴 `true` 라 `-DskipTests=false` 로는 열리지 않습니다. 위 출력은 그 값을 잠시 파라미터로 바꿔 얻었고 값은 되돌려 뒀습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

브라우저 테스트는 하지 않았습니다. 매퍼가 렌더하는 SQL 로 확인했습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

위 테스트 출력으로 대신합니다.
