### PR TITLE
fix: 휴가관리 상세조회 postgres 매퍼가 종료일 조건을 뺀 문제 수정

### DIFF
--- a/src/main/resources/egovframework/mapper/com/uss/ion/vct/EgovVcatnManage_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/com/uss/ion/vct/EgovVcatnManage_SQL_postgres.xml
@@ -75,7 +75,8 @@
 			WHERE		APPLCNT_ID     = #{applcntId}
 			AND			VCATN_SE       = #{vcatnSe}
 			AND			BGNDE		   = #{bgnde}
-        
+			AND			ENDDE		   = #{endde}
+
     </select>
 
     <insert id="insertVcatnManage" parameterType="egovframework.com.uss.ion.vct.service.VcatnManageVO">

--- a/src/test/java/egovframework/com/uss/ion/vct/service/impl/EgovVcatnManageDetailKeyTest.java
+++ b/src/test/java/egovframework/com/uss/ion/vct/service/impl/EgovVcatnManageDetailKeyTest.java
@@ -1,0 +1,61 @@
+package egovframework.com.uss.ion.vct.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.InputStream;
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.apache.ibatis.builder.xml.XMLMapperBuilder;
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.mapping.MappedStatement;
+import org.apache.ibatis.mapping.ParameterMapping;
+import org.apache.ibatis.session.Configuration;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * 휴가관리 상세조회는 방언과 무관하게 신청자·휴가구분·시작일·종료일 네 키로 한 건을 찾아야 한다.
+ *
+ * <p>{@code EgovVcatnManageController.selectVcatnManage}(상세보기 화면 진입점)는
+ * {@code vcatnManageDAO.selectVcatnManage} 를 MyBatis {@code selectOne} 으로 호출한다.
+ * 이 구문의 WHERE 절이 키 하나를 빼면, 같은 신청자·구분·시작일로 두 건 이상이 존재할 때
+ * (반려 후 재신청 등으로 시작일은 같고 종료일만 다른 경우) 그 방언에서만
+ * {@code TooManyResultsException} 이 나 상세보기가 깨진다.</p>
+ *
+ * <p>{@code context-mapper.xml} 의 {@code mapperLocations} 가
+ * {@code classpath:/egovframework/mapper/com/**}{@code /*_${Globals.DbType}.xml} 이라 런타임에는
+ * 방언 매퍼가 하나만 로드된다. 방언별로 매퍼를 직접 파싱해 DB 연결 없이 검증한다.</p>
+ */
+class EgovVcatnManageDetailKeyTest {
+
+	private static final String STATEMENT_ID = "vcatnManageDAO.selectVcatnManage";
+
+	private static final Set<String> EXPECTED_KEYS = new TreeSet<>(Set.of("applcntId", "vcatnSe", "bgnde", "endde"));
+
+	private Configuration loadMapper(String dialect) throws Exception {
+		String resource = "egovframework/mapper/com/uss/ion/vct/EgovVcatnManage_SQL_" + dialect + ".xml";
+		Configuration configuration = new Configuration();
+		try (InputStream inputStream = Resources.getResourceAsStream(resource)) {
+			new XMLMapperBuilder(inputStream, configuration, resource, configuration.getSqlFragments()).parse();
+		}
+		return configuration;
+	}
+
+	@ParameterizedTest(name = "{0}")
+	@ValueSource(strings = { "mysql", "maria", "oracle", "postgres", "tibero", "altibase", "cubrid", "goldilocks" })
+	@DisplayName("휴가 상세조회는 방언과 무관하게 신청자·구분·시작일·종료일 네 키를 모두 바인딩한다")
+	void selectVcatnManageBindsAllFourKeys(String dialect) throws Exception {
+		Configuration configuration = loadMapper(dialect);
+		MappedStatement statement = configuration.getMappedStatement(STATEMENT_ID);
+
+		Set<String> boundKeys = new TreeSet<>();
+		for (ParameterMapping parameterMapping : statement.getBoundSql(null).getParameterMappings()) {
+			boundKeys.add(parameterMapping.getProperty());
+		}
+
+		assertEquals(EXPECTED_KEYS, boundKeys, dialect + " 이 selectVcatnManage 조회조건에서 키를 뺀다: " + boundKeys);
+	}
+
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

휴가관리 상세조회 `vcatnManageDAO.selectVcatnManage`는 신청자ID·휴가구분·시작일·종료일 네 키로 한 건을 찾습니다. 같은 파일의 `updateVcatnManage`·`deleteVcatnManage`도 이 네 키를 그대로 씁니다.

`EgovVcatnManage_SQL_postgres.xml`만 종료일(`ENDDE`) 조건이 빠져 있었습니다. 나머지 7개 방언(mysql·maria·oracle·tibero·altibase·cubrid·goldilocks)은 모두 네 키를 씁니다.

파일 상단 변경이력에 `2024.10.29 권태성 휴가승인상세(selectVcatnManage) 테이블관계 수정`이 있습니다. git 이력을 대조하면 이 변경은 `FROM A, B, C WHERE ...` 식의 암묵적 조인을 `LEFT JOIN ... ON ...`으로 바꾸는 작업이었고, WHERE 절을 다시 쓰는 과정에서 `ENDDE` 조건 한 줄이 함께 빠졌습니다. 같은 커밋에서 8개 방언 매퍼가 전부 같은 LEFT JOIN 방식을 쓰는데, postgres만 이 줄이 빠졌습니다.

`vcatnManageDAO.selectVcatnManage`는 `VcatnManageDAO.selectVcatnManage`에서 MyBatis `selectOne`으로 호출되고, `EgovVcatnManageController`의 `/uss/ion/vct/EgovVcatnManageDetail.do`(상세보기)·`/uss/ion/vct/EgovVcatnConfm.do`(승인상세)·수정 폼 재표시 세 곳에서 씁니다. `selectOne`은 결과가 2건 이상이면 예외를 던집니다.

같은 신청자가 같은 휴가구분·시작일로 재신청해(반려 후 재신청 등) 종료일만 다른 행이 두 건 이상 쌓이면, postgres로 기동한 서버에서만 상세보기·승인상세 조회가 실패합니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

`EgovVcatnManageDetailKeyTest`를 추가했습니다. 8개 방언 매퍼를 `XMLMapperBuilder`로 읽어 `selectVcatnManage`가 바인딩하는 파라미터 이름 집합을 신청자ID·휴가구분·시작일·종료일 네 키와 대조합니다. 데이터베이스 연결은 필요하지 않습니다.

`mvn -o -DskipTests=false -Dtest=EgovVcatnManageDetailKeyTest test`의 출력입니다.

```
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.710 s -- in egovframework.com.uss.ion.vct.service.impl.EgovVcatnManageDetailKeyTest
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0
```

수정을 도로 빼면 postgres 한 건만 실패합니다.

```
[ERROR]   EgovVcatnManageDetailKeyTest.selectVcatnManageBindsAllFourKeys:58 postgres 이 selectVcatnManage 조회조건에서 키를 뺀다: [applcntId, bgnde, vcatnSe] ==> expected: <[applcntId, bgnde, endde, vcatnSe]> but was: <[applcntId, bgnde, vcatnSe]>
[ERROR] Tests run: 8, Failures: 1, Errors: 0, Skipped: 0
```

같은 패키지의 기존 테스트도 회귀로 돌렸습니다.

```
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.419 s -- in egovframework.com.uss.ion.vct.web.EgovVcatnManageControllerOwnershipTest
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.310 s -- in egovframework.com.uss.ion.vct.service.impl.EgovVcatnManageDetailKeyTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.015 s -- in egovframework.com.uss.ion.vct.service.impl.EgovVcatnManageServiceImplTest
[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0
```

위 출력은 `pom.xml`의 surefire `<skipTests>true</skipTests>`를 잠시 해제하고 얻었으며 값은 되돌려 뒀습니다. 그 값이 고정이라 명령만으로는 `Tests are skipped.`로 끝납니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

브라우저 테스트는 하지 않았습니다. 매퍼가 렌더하는 SQL로 확인했습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

위 테스트 출력으로 대신합니다.
