### PR TITLE
fix: 기념일 알림 화면이 남의 기념일을 보여주는 문제 수정

### DIFF
--- a/src/main/java/egovframework/com/uss/ion/ans/web/EgovAnnvrsryManageController.java
+++ b/src/main/java/egovframework/com/uss/ion/ans/web/EgovAnnvrsryManageController.java
@@ -444,6 +444,8 @@ public class EgovAnnvrsryManageController {
 		if (resultVO == null) {
 			throw new IllegalStateException("권한이 없습니다.");
 		}
+		// 상세조회·수정·삭제와 동일하게 소유자 또는 관리자만 볼 수 있다.
+		egovAssertAdminOrOwner(resultVO.getUsid());
 		sAnnvrsryDe = EgovStringUtil.removeMinusChar(resultVO.getAnnvrsryDe());
 		if ("1".equals(resultVO.getCldrSe())) {
 			sTempCldrSe = egovMessageSource.getMessage("comUssIonAns.annvrsryGdcc.cldrSe1");// 양

--- a/src/test/java/egovframework/com/uss/ion/ans/web/EgovAnnvrsryManageControllerOwnershipTest.java
+++ b/src/test/java/egovframework/com/uss/ion/ans/web/EgovAnnvrsryManageControllerOwnershipTest.java
@@ -1,0 +1,178 @@
+package egovframework.com.uss.ion.ans.web;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.InputStream;
+import java.lang.reflect.Field;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.ui.ModelMap;
+
+import egovframework.com.cmm.LoginVO;
+import egovframework.com.cmm.service.EgovUserDetailsService;
+import egovframework.com.cmm.util.EgovUserDetailsHelper;
+import egovframework.com.uss.ion.ans.service.AnnvrsryManage;
+import egovframework.com.uss.ion.ans.service.AnnvrsryManageVO;
+import egovframework.com.uss.ion.ans.service.EgovAnnvrsryManageService;
+
+/**
+ * selectAnnvrsryGdcc의 소유권 검증 회귀 테스트.
+ *
+ * 알림 화면은 요청이 보낸 annId로 기념일을 그대로 읽어 화면에 싣는다. 같은 컨트롤러의
+ * selectAnnvrsryManage(169행)·updateAnnvrsryManage(316행)·deleteAnnvrsryManage(366행)는 읽어온
+ * 레코드의 USID를 로그인 사용자와 대조하고 관리자만 예외로 두는데, 이 경로에만 그 대조가 없다.
+ */
+class EgovAnnvrsryManageControllerOwnershipTest {
+
+	private static final String OWNER_UNIQ_ID = "USRCNFRM_00000000001";
+	private static final String OTHER_UNIQ_ID = "USRCNFRM_00000000009";
+	private static final String ADMIN_UNIQ_ID = "USRCNFRM_00000000002";
+
+	/** 요청한 annId의 소유자를 고정해 돌려주는 스텁. */
+	private static final class StubService implements EgovAnnvrsryManageService {
+		private final String ownerUniqId;
+
+		private StubService(String ownerUniqId) {
+			this.ownerUniqId = ownerUniqId;
+		}
+
+		@Override
+		public AnnvrsryManageVO selectAnnvrsryManage(AnnvrsryManageVO annvrsryManageVO) {
+			AnnvrsryManageVO stored = new AnnvrsryManageVO();
+			stored.setAnnId(annvrsryManageVO.getAnnId());
+			stored.setUsid(ownerUniqId);
+			stored.setAnnvrsryNm("결혼기념일");
+			stored.setAnnvrsryDe("20261225");
+			stored.setCldrSe("1");
+			stored.setAnnvrsrySetup("Y");
+			return stored;
+		}
+
+		@Override
+		public List<AnnvrsryManageVO> selectAnnvrsryManageList(AnnvrsryManageVO annvrsryManageVO) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public int selectAnnvrsryManageListTotCnt(AnnvrsryManageVO annvrsryManageVO) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public void insertAnnvrsryManage(AnnvrsryManage annvrsryManage) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public void updateAnnvrsryManage(AnnvrsryManage annvrsryManage) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public void deleteAnnvrsryManage(AnnvrsryManage annvrsryManage) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public List<AnnvrsryManageVO> selectAnnvrsryGdcc(AnnvrsryManageVO annvrsryManageVO) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public int selectAnnvrsryManageDplctAt(AnnvrsryManage annvrsryManage) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public List<AnnvrsryManageVO> selectAnnvrsryManageBnde(InputStream inputStream) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public void insertAnnvrsryManageBnde(AnnvrsryManageVO annvrsryManageVO, String checkedAnnvrsryManageForInsert) {
+			throw new UnsupportedOperationException();
+		}
+	}
+
+	private static void bindLoginUser(String uniqId, List<String> authorities) {
+		LoginVO login = new LoginVO();
+		login.setUniqId(uniqId);
+		EgovUserDetailsService stub = new EgovUserDetailsService() {
+			@Override
+			public Object getAuthenticatedUser() {
+				return login;
+			}
+
+			@Override
+			public List<String> getAuthorities() {
+				return authorities;
+			}
+
+			@Override
+			public Boolean isAuthenticated() {
+				return Boolean.TRUE;
+			}
+		};
+		new EgovUserDetailsHelper().setEgovUserDetailsService(stub);
+	}
+
+	private static EgovAnnvrsryManageController controllerWith(StubService service) throws Exception {
+		EgovAnnvrsryManageController controller = new EgovAnnvrsryManageController();
+		Field serviceField = EgovAnnvrsryManageController.class.getDeclaredField("egovAnnvrsryManageService");
+		serviceField.setAccessible(true);
+		serviceField.set(controller, service);
+
+		Field messageSourceField = EgovAnnvrsryManageController.class.getDeclaredField("egovMessageSource");
+		messageSourceField.setAccessible(true);
+		messageSourceField.set(controller, new egovframework.com.cmm.EgovMessageSource() {
+			@Override
+			public String getMessage(String code) {
+				return code;
+			}
+		});
+		return controller;
+	}
+
+	private static AnnvrsryManageVO request(String annId) {
+		AnnvrsryManageVO annvrsryManageVO = new AnnvrsryManageVO();
+		annvrsryManageVO.setAnnId(annId);
+		return annvrsryManageVO;
+	}
+
+	@Test
+	void selectAnnvrsryGdccRejectsAnotherUsersAnniversary() throws Exception {
+		EgovAnnvrsryManageController controller = controllerWith(new StubService(OTHER_UNIQ_ID));
+		bindLoginUser(OWNER_UNIQ_ID, List.of());
+		ModelMap model = new ModelMap();
+
+		assertThrows(IllegalStateException.class,
+				() -> controller.selectAnnvrsryGdcc(request("ANN_0000000000009"), model),
+				"남의 기념일 annId로 알림 화면을 요청하면 거부해야 한다.");
+	}
+
+	@Test
+	void selectAnnvrsryGdccAllowsTheOwner() throws Exception {
+		EgovAnnvrsryManageController controller = controllerWith(new StubService(OWNER_UNIQ_ID));
+		bindLoginUser(OWNER_UNIQ_ID, List.of());
+		ModelMap model = new ModelMap();
+
+		String view = controller.selectAnnvrsryGdcc(request("ANN_0000000000001"), model);
+
+		assertEquals("egovframework/com/uss/ion/ans/EgovAnnvrsryGdcc", view,
+				"소유자 본인의 요청은 그대로 알림 화면을 받아야 한다.");
+	}
+
+	@Test
+	void selectAnnvrsryGdccAllowsAnAdministrator() throws Exception {
+		EgovAnnvrsryManageController controller = controllerWith(new StubService(OTHER_UNIQ_ID));
+		bindLoginUser(ADMIN_UNIQ_ID, List.of("ROLE_ADMIN"));
+		ModelMap model = new ModelMap();
+
+		String view = controller.selectAnnvrsryGdcc(request("ANN_0000000000009"), model);
+
+		assertEquals("egovframework/com/uss/ion/ans/EgovAnnvrsryGdcc", view,
+				"관리자는 형제 경로와 마찬가지로 타인의 기념일도 볼 수 있어야 한다.");
+	}
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`EgovAnnvrsryManageController.selectAnnvrsryGdcc` 는 로그인 여부만 확인하고, 요청이 보낸 `annId` 로 기념일을 읽어 알림 화면에 싣습니다. 읽어온 레코드가 누구 것인지는 보지 않습니다.

```java
// EgovAnnvrsryManageController.java:428
LoginVO _loginVO = egovAssertLoginUser();
...
// :443
AnnvrsryManageVO resultVO = egovAnnvrsryManageService.selectAnnvrsryManage(annvrsryManageVO);
if (resultVO == null) {
    throw new IllegalStateException("권한이 없습니다.");
}
sAnnvrsryDe = EgovStringUtil.removeMinusChar(resultVO.getAnnvrsryDe());
```

같은 컨트롤러의 다른 세 경로는 읽어온 레코드의 `USID` 를 로그인 사용자와 대조하고 관리자만 예외로 둡니다.

| 메서드 | 위치 | 소유권 대조 |
|---|---|---|
| `selectAnnvrsryManage` | `:169` | `loginVO.getUniqId().equals(resultVO.getUsid())` |
| `updateAnnvrsryManage` | `:316` | `egovAssertAdminOrOwner(storedVO.getUsid())` |
| `deleteAnnvrsryManage` | `:366` | `loginVO.getUniqId().equals(resultVO.getUsid())` |
| `selectAnnvrsryGdcc` | `:443` | 없음 |

목록 화면 `EgovAnnvrsryMainList.jsp` 는 `annId` 를 히든 필드로 실어 POST 합니다. 목록 자체는 `selectAnnvrsryMainList` 가 로그인 사용자의 `USID` 로 걸러 뿌리지만, 요청 본문의 `annId` 는 클라이언트가 정하는 값이라 다른 사용자의 기념일 식별자로 바꾸면 그 사람의 기념일명·기념일자·음양력 구분·D-day 가 그대로 화면에 실립니다.

`AnnvrsryManageVO` 조회는 `annId` 만으로 이루어지고 `USID` 조건이 없습니다.

같은 클래스에 이미 있는 `egovAssertAdminOrOwner` 를 읽어온 레코드의 소유자로 호출하도록 한 줄 추가했습니다.

```diff
 		if (resultVO == null) {
 			throw new IllegalStateException("권한이 없습니다.");
 		}
+		// 상세조회·수정·삭제와 동일하게 소유자 또는 관리자만 볼 수 있다.
+		egovAssertAdminOrOwner(resultVO.getUsid());
 		sAnnvrsryDe = EgovStringUtil.removeMinusChar(resultVO.getAnnvrsryDe());
 		if ("1".equals(resultVO.getCldrSe())) {
```

`ROLE_ADMIN` 예외도 형제 경로와 같은 헬퍼를 쓰므로 동일하게 동작합니다. 소유자 본인과 관리자의 화면은 바뀌지 않습니다.

## JUnit 테스트 JUnit tests

- [x] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

`EgovAnnvrsryManageControllerOwnershipTest` 를 추가했습니다. 스텁 서비스가 요청한 `annId` 의 소유자를 고정해 돌려주고, 로그인 사용자를 소유자 / 타인 / 관리자로 바꿔 가며 컨트롤러를 직접 호출합니다. 데이터베이스가 필요 없습니다.

`pom.xml` 의 surefire 설정이 `<skipTests>true</skipTests>` 로 고정돼 있어, 아래 출력은 그 값을 `${skipTests}` 로 잠시 파라미터화해 받은 것이고 값은 되돌려 뒀습니다.

수정 전:

```
[ERROR] Tests run: 3, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.214 s <<< FAILURE! -- in egovframework.com.uss.ion.ans.web.EgovAnnvrsryManageControllerOwnershipTest
[ERROR]   EgovAnnvrsryManageControllerOwnershipTest.selectAnnvrsryGdccRejectsAnotherUsersAnniversary:150 남의 기념일 annId로 알림 화면을 요청하면 거부해야 한다. ==> Expected java.lang.IllegalStateException to be thrown, but nothing was thrown.
[ERROR] Tests run: 3, Failures: 1, Errors: 0, Skipped: 0
```

수정 후:

```
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.204 s -- in egovframework.com.uss.ion.ans.web.EgovAnnvrsryManageControllerOwnershipTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

같은 패키지 회귀:

```
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.211 s -- in egovframework.com.uss.ion.ans.web.EgovAnnvrsryManageControllerOwnershipTest
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 s -- in egovframework.com.uss.ion.ans.service.impl.EgovAnnvrsryManageServiceImplTest
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

브라우저 테스트는 하지 않았습니다. 컨트롤러를 직접 호출하는 JUnit 테스트로 확인했습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

검증은 위 JUnit 출력으로 대신합니다.
