### PR TITLE
fix: 메뉴 다건 삭제가 첫 항목만 하위 메뉴 검사를 하던 문제 수정

### DIFF
--- a/src/main/java/egovframework/com/sym/mnu/mpm/web/EgovMenuManageController.java
+++ b/src/main/java/egovframework/com/sym/mnu/mpm/web/EgovMenuManageController.java
@@ -171,12 +171,18 @@ public class EgovMenuManageController {
 		String resultMsg = "";
 
 		String[] delMenuNo = checkedMenuNoForDel.split(",");
-		if (delMenuNo.length != 0) {
-			menuManageVO.setMenuNo(Integer.parseInt(delMenuNo[0]));
+		boolean upperMenuExist = false;
+		// 단건 삭제와 동일하게, 지울 메뉴마다 하위 메뉴 존재 여부를 확인한다.
+		for (String menuNo : delMenuNo) {
+			menuManageVO.setMenuNo(Integer.parseInt(menuNo));
+			if (menuManageService.selectUpperMenuNoByPk(menuManageVO) != 0) {
+				upperMenuExist = true;
+				break;
+			}
 		}
 
 		// 2022.11.11 시큐어코딩 처리
-		if (menuManageService.selectUpperMenuNoByPk(menuManageVO) != 0) {
+		if (upperMenuExist) {
 			resultMsg = egovMessageSource.getMessage("fail.common.delete.upperMenuExist");
 			sLocationUrl = "forward:/sym/mnu/mpm/EgovMenuManageSelect.do";
 		} else if (delMenuNo.length == 0) {

--- a/src/test/java/egovframework/com/sym/mnu/mpm/web/EgovMenuManageControllerBatchDeleteTest.java
+++ b/src/test/java/egovframework/com/sym/mnu/mpm/web/EgovMenuManageControllerBatchDeleteTest.java
@@ -1,0 +1,193 @@
+package egovframework.com.sym.mnu.mpm.web;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.io.InputStream;
+import java.lang.reflect.Field;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.ui.ModelMap;
+
+import egovframework.com.cmm.ComDefaultVO;
+import egovframework.com.cmm.LoginVO;
+import egovframework.com.cmm.service.EgovUserDetailsService;
+import egovframework.com.cmm.util.EgovUserDetailsHelper;
+import egovframework.com.sym.mnu.mpm.service.EgovMenuManageService;
+import egovframework.com.sym.mnu.mpm.service.MenuManageVO;
+import org.egovframe.rte.psl.dataaccess.util.EgovMap;
+
+/**
+ * 메뉴 다건 삭제의 하위 메뉴 검사 회귀 테스트.
+ *
+ * 단건 삭제 deleteMenuManage 는 자기가 지울 메뉴로 selectUpperMenuNoByPk 를 물어 하위 메뉴가
+ * 있으면 거절한다. 다건 삭제 deleteMenuManageList 는 체크된 목록의 첫 항목으로만 같은 검사를
+ * 하고, 통과하면 체크된 전체를 삭제한다.
+ */
+class EgovMenuManageControllerBatchDeleteTest {
+
+	/** 하위 메뉴를 가진 메뉴번호 하나만 1 을 돌려주고, 삭제 호출 인자를 기록하는 스텁. */
+	private static final class StubService implements EgovMenuManageService {
+		private final int menuNoWithChild;
+		private String lastDeletedList;
+
+		private StubService(int menuNoWithChild) {
+			this.menuNoWithChild = menuNoWithChild;
+		}
+
+		@Override
+		public int selectUpperMenuNoByPk(MenuManageVO vo) {
+			return vo.getMenuNo() == menuNoWithChild ? 1 : 0;
+		}
+
+		@Override
+		public void deleteMenuManageList(String checkedMenuNoForDel) {
+			lastDeletedList = checkedMenuNoForDel;
+		}
+
+		@Override
+		public MenuManageVO selectMenuManage(ComDefaultVO vo) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public List<EgovMap> selectMenuManageList(ComDefaultVO vo) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public int selectMenuManageListTotCnt(ComDefaultVO vo) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public int selectMenuNoByPk(MenuManageVO vo) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public void insertMenuManage(MenuManageVO vo) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public void updateMenuManage(MenuManageVO vo) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public void deleteMenuManage(MenuManageVO vo) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public List<EgovMap> selectMenuList() {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public List<?> selectMainMenuHead(MenuManageVO vo) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public List<?> selectMainMenuLeft(MenuManageVO vo) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public String selectLastMenuURL(int iMenuNo, String sUniqId) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public boolean menuBndeAllDelete() {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public String menuBndeRegist(MenuManageVO vo, InputStream inputStream) {
+			throw new UnsupportedOperationException();
+		}
+	}
+
+	private static void bindLoginUser() {
+		LoginVO login = new LoginVO();
+		login.setUniqId("USRCNFRM_00000000001");
+		EgovUserDetailsService stub = new EgovUserDetailsService() {
+			@Override
+			public Object getAuthenticatedUser() {
+				return login;
+			}
+
+			@Override
+			public List<String> getAuthorities() {
+				return List.of("ROLE_ADMIN");
+			}
+
+			@Override
+			public Boolean isAuthenticated() {
+				return Boolean.TRUE;
+			}
+		};
+		new EgovUserDetailsHelper().setEgovUserDetailsService(stub);
+	}
+
+	private static EgovMenuManageController controllerWith(StubService service) throws Exception {
+		EgovMenuManageController controller = new EgovMenuManageController();
+		Field serviceField = EgovMenuManageController.class.getDeclaredField("menuManageService");
+		serviceField.setAccessible(true);
+		serviceField.set(controller, service);
+
+		Field messageSourceField = EgovMenuManageController.class.getDeclaredField("egovMessageSource");
+		messageSourceField.setAccessible(true);
+		messageSourceField.set(controller, new egovframework.com.cmm.EgovMessageSource() {
+			@Override
+			public String getMessage(String code) {
+				return code;
+			}
+		});
+		return controller;
+	}
+
+	@Test
+	void batchDeleteRejectsWhenAnyCheckedMenuHasChildren() throws Exception {
+		StubService service = new StubService(20); // 두 번째 항목이 하위 메뉴를 갖는다
+		EgovMenuManageController controller = controllerWith(service);
+		bindLoginUser();
+		ModelMap model = new ModelMap();
+
+		controller.deleteMenuManageList("10,20,30", new MenuManageVO(), model);
+
+		assertNull(service.lastDeletedList,
+				"체크된 항목 중 하나라도 하위 메뉴를 가지면 다건 삭제를 실행하지 않아야 한다.");
+		assertEquals("fail.common.delete.upperMenuExist", model.get("resultMsg"),
+				"단건 삭제와 같은 사유 메시지로 거절해야 한다.");
+	}
+
+	@Test
+	void batchDeleteStillRejectsWhenTheFirstCheckedMenuHasChildren() throws Exception {
+		StubService service = new StubService(10); // 첫 항목이 하위 메뉴를 갖는다 (기존에도 잡히던 경우)
+		EgovMenuManageController controller = controllerWith(service);
+		bindLoginUser();
+		ModelMap model = new ModelMap();
+
+		controller.deleteMenuManageList("10,20,30", new MenuManageVO(), model);
+
+		assertNull(service.lastDeletedList, "첫 항목이 하위 메뉴를 가지면 기존과 같이 거절해야 한다.");
+	}
+
+	@Test
+	void batchDeleteProceedsWhenNoCheckedMenuHasChildren() throws Exception {
+		StubService service = new StubService(-1); // 아무도 하위 메뉴가 없다
+		EgovMenuManageController controller = controllerWith(service);
+		bindLoginUser();
+		ModelMap model = new ModelMap();
+
+		controller.deleteMenuManageList("10,20,30", new MenuManageVO(), model);
+
+		assertEquals("10,20,30", service.lastDeletedList,
+				"하위 메뉴가 없으면 체크된 전체를 그대로 삭제해야 한다.");
+	}
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`EgovMenuManageController.deleteMenuManageList` 는 체크된 메뉴번호를 쉼표로 쪼갠 뒤 **첫 항목 하나만** `menuManageVO` 에 실어 하위 메뉴 존재 여부를 검사합니다.

```java
// EgovMenuManageController.java:173
		String[] delMenuNo = checkedMenuNoForDel.split(",");
		if (delMenuNo.length != 0) {
			menuManageVO.setMenuNo(Integer.parseInt(delMenuNo[0]));
		}

		// 2022.11.11 시큐어코딩 처리
		if (menuManageService.selectUpperMenuNoByPk(menuManageVO) != 0) {
			resultMsg = egovMessageSource.getMessage("fail.common.delete.upperMenuExist");
			sLocationUrl = "forward:/sym/mnu/mpm/EgovMenuManageSelect.do";
		} else if (delMenuNo.length == 0) {
			resultMsg = egovMessageSource.getMessage("fail.common.delete");
			sLocationUrl = "forward:/sym/mnu/mpm/EgovMenuManageSelect.do";
		} else {
			menuManageService.deleteMenuManageList(checkedMenuNoForDel);
			resultMsg = egovMessageSource.getMessage("success.common.delete");
			sLocationUrl = "forward:/sym/mnu/mpm/EgovMenuManageSelect.do";
		}
```

검사를 통과하면 `deleteMenuManageList` 가 **체크된 전체**를 받습니다. 서비스는 그 문자열을 다시 쪼개 하나씩 지웁니다.

```java
// EgovMenuManageServiceImpl.java:160
	public void deleteMenuManageList(String checkedMenuNoForDel) throws Exception {
		MenuManageVO vo = null;

		String[] delMenuNo = checkedMenuNoForDel.split(",");

		if (delMenuNo == null || (delMenuNo.length == 0)) {
			throw new java.lang.Exception("String Split Error!");
		}
		for (String element : delMenuNo) {
			vo = new MenuManageVO();
			vo.setMenuNo(Integer.parseInt(element));
			menuManageDAO.deleteMenuManage(vo);
		}
```

검사 쿼리는 넘겨받은 메뉴번호 하나를 상위 메뉴로 삼는 행이 있는지만 셉니다.

```xml
<!-- EgovMenuManage_SQL_mysql.xml:102 -->
	<select id="selectUpperMenuNoByPk" parameterType="egovframework.com.sym.mnu.mpm.service.MenuManageVO" resultType="int">
		
		SELECT COUNT(MENU_NO) AS totcnt
		  FROM COMTNMENUINFO
		 WHERE UPPER_MENU_NO = #{menuNo}
		
	</select>
```

그래서 하위 메뉴를 가진 메뉴가 체크 목록의 두 번째 이후에 있으면 검사를 지나쳐 삭제됩니다.

지워진 뒤의 결과는 DDL 에 따라 갈립니다. `UPPER_MENU_NO` 에 자기참조 외래키와 `ON DELETE CASCADE` 가 걸린 여섯(`mysql`·`maria`·`postgres`·`oracle`·`tibero`·`altibase`)에서는 체크하지 않은 하위 메뉴까지 함께 지워집니다.

```sql
-- src/script/ddl/mysql/sym.mnu_create_mysql.sql
	FOREIGN KEY COMTNMENUINFO_FK1 (UPPER_MENU_NO) REFERENCES COMTNMENUINFO(MENU_NO)
		ON DELETE CASCADE
```

그 외래키가 없는 `cubrid`·`goldilocks` 에서는 삭제된 부모를 가리키는 행이 남습니다. 어느 쪽이든 이 검사가 막으려던 상태입니다.

같은 컨트롤러의 단건 삭제는 자기가 지울 메뉴로 같은 검사를 합니다.

| 메서드 | 위치 | 검사 대상 |
|---|---|---|
| `deleteMenuManage` | `:299` | 지울 메뉴 그 자체 |
| `deleteMenuManageList` | `:179` | 체크 목록의 첫 항목만 |

목록 화면 `EgovMenuManage.jsp` 에는 전체선택 체크박스가 있어 다건 삭제가 기본 사용 방식입니다.

체크된 메뉴마다 검사하도록 고쳤습니다. 메시지 키와 이동 경로는 그대로입니다.

```diff
 		String[] delMenuNo = checkedMenuNoForDel.split(",");
-		if (delMenuNo.length != 0) {
-			menuManageVO.setMenuNo(Integer.parseInt(delMenuNo[0]));
+		boolean upperMenuExist = false;
+		// 단건 삭제와 동일하게, 지울 메뉴마다 하위 메뉴 존재 여부를 확인한다.
+		for (String menuNo : delMenuNo) {
+			menuManageVO.setMenuNo(Integer.parseInt(menuNo));
+			if (menuManageService.selectUpperMenuNoByPk(menuManageVO) != 0) {
+				upperMenuExist = true;
+				break;
+			}
 		}
 
 		// 2022.11.11 시큐어코딩 처리
-		if (menuManageService.selectUpperMenuNoByPk(menuManageVO) != 0) {
+		if (upperMenuExist) {
```

하위 메뉴가 하나도 없으면 기존과 같이 전체를 삭제하고, 첫 항목이 하위 메뉴를 가진 경우도 기존과 같이 거절합니다.

## JUnit 테스트 JUnit tests

- [x] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

`EgovMenuManageControllerBatchDeleteTest` 를 추가했습니다. 스텁 서비스가 지정한 메뉴번호에만 하위 메뉴가 있다고 답하고 삭제 호출 인자를 기록합니다. 하위 메뉴를 가진 메뉴를 목록의 첫 번째 · 두 번째에 두는 경우와 아무도 갖지 않는 경우를 각각 확인합니다. 데이터베이스가 필요 없습니다.

`pom.xml` 의 surefire 설정이 `<skipTests>true</skipTests>` 로 고정돼 있어, 아래 출력은 그 값을 `${skipTests}` 로 잠시 파라미터화해 받은 것이고 값은 되돌려 뒀습니다.

수정 전:

```
[ERROR] Tests run: 3, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.192 s <<< FAILURE! -- in egovframework.com.sym.mnu.mpm.web.EgovMenuManageControllerBatchDeleteTest
[ERROR]   EgovMenuManageControllerBatchDeleteTest.batchDeleteRejectsWhenAnyCheckedMenuHasChildren:163 체크된 항목 중 하나라도 하위 메뉴를 가지면 다건 삭제를 실행하지 않아야 한다. ==> expected: <null> but was: <10,20,30>
[ERROR] Tests run: 3, Failures: 1, Errors: 0, Skipped: 0
```

수정 후:

```
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.196 s -- in egovframework.com.sym.mnu.mpm.web.EgovMenuManageControllerBatchDeleteTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

같은 패키지의 `EgovMenuManageControllerValidationTest` 도 함께 돌려 그대로 통과합니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

브라우저 테스트는 하지 않았습니다. 컨트롤러를 직접 호출하는 JUnit 테스트로 확인했습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

검증은 위 JUnit 출력으로 대신합니다.
