### PR TITLE
fix(utl): 숫자 검사에서 null과 빈 문자열 거부

### DIFF
--- a/src/main/java/egovframework/com/utl/fcc/service/EgovNumberUtil.java
+++ b/src/main/java/egovframework/com/utl/fcc/service/EgovNumberUtil.java
@@ -133,11 +133,15 @@ public class EgovNumberUtil {
 	/**
 	 * 체크할 숫자 중에서 숫자인지 아닌지 체크하는 기능
 	 * 숫자이면 True, 아니면 False를 반환한다
+	 * null 또는 빈 문자열은 False를 반환한다.
 	 * @param checkStr - 체크문자열
 	 * @return 숫자여부
 	 * @see
 	 */
 	public static Boolean getNumberValidCheck(String checkStr) {
+		if (checkStr == null || checkStr.isEmpty()) {
+			return false;
+		}
 
 		int i;
 		//String sourceStr = String.valueOf(sourceInt);

--- a/src/test/java/egovframework/com/utl/fcc/service/EgovNumberUtilTest.java
+++ b/src/test/java/egovframework/com/utl/fcc/service/EgovNumberUtilTest.java
@@ -5,8 +5,30 @@ import static org.junit.jupiter.api.Assertions.*;
 import java.time.Duration;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class EgovNumberUtilTest {
+
+	@ParameterizedTest
+	@NullAndEmptySource
+	void numberValidationRejectsNullAndEmptyInput(String input) {
+		assertFalse(EgovNumberUtil.getNumberValidCheck(input));
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = {"0", "2026", "0001", "0123456789", "2147483648"})
+	void numberValidationAcceptsAsciiDigits(String input) {
+		// 숫자 형식 검사이므로 선행 0이나 int 범위를 넘는 숫자도 허용한다.
+		assertTrue(EgovNumberUtil.getNumberValidCheck(input));
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = {" ", "\t", "\n", "-1", "+1", "1.0", "20a6", "１２３", "١٢٣", "1 2"})
+	void numberValidationRejectsNonAsciiDigitInput(String input) {
+		assertFalse(EgovNumberUtil.getNumberValidCheck(input));
+	}
 
 	@Test
 	void testRandomInRange() {


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

숫자 형식 검사에서 빈 문자열은 숫자로 판단하고 null 입력에는 예외가 발생해, 유효하지 않은 빈 입력을 일관되게 걸러내지 못합니다.

## 수정된 소스 내용 Modified source

- `getNumberValidCheck`에서 null·빈 문자열은 false를 반환합니다.
- 기존 ASCII 숫자 판정을 유지하면서 빈 입력·공백·부호·소수점·문자·전각 숫자 테스트를 추가합니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

JUnit **23개 통과**(신규 17개, 기존 6개). 변경 전에는 null·빈 문자열 2개 사례가 실패하는 것을 확인했습니다.

HTTP 통합 검증 3개 조건을 전후 비교했습니다. 기본·정상 연도 조회는 정상이고, `year=`만 지정한 요청은 수정 전 JSP 숫자 변환 오류(500)에서 수정 후 달력 표시(200)로 바뀌었습니다.

기능별 격리 통합 환경에서 실제 MVC·JSP를 실행했으며, 인증 세션과 달력 조회 데이터는 테스트용으로 제공했습니다.

## 테스트 브라우저 Test Browser

- [X] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

Chrome 자동 검증 캡처입니다. 결과표는 실제 HTTP 응답과 DB·파일 저장 관찰값을 정리한 테스트 보고서입니다.

<details>
<summary>수정 전후 및 정상 동작 캡처</summary>

수정 전: year= 요청으로 실제 달력 JSP에서 500 오류가 발생합니다.

![수정 전: year= 요청으로 실제 달력 JSP에서 500 오류가 발생합니다.](https://raw.githubusercontent.com/wizlife/egovframe-common-components/5d345d1872f8c61c526c049cd336c38e9d9801f8/screenshots/number/before-empty-year-error.png)

수정 후: 같은 빈 연도 요청에 실제 달력이 정상 표시됩니다.

![수정 후: 같은 빈 연도 요청에 실제 달력이 정상 표시됩니다.](https://raw.githubusercontent.com/wizlife/egovframe-common-components/5d345d1872f8c61c526c049cd336c38e9d9801f8/screenshots/number/after-empty-year-calendar.png)

수정 후: 정상 연도·월 요청도 달력이 정상 표시됩니다.

![수정 후: 정상 연도·월 요청도 달력이 정상 표시됩니다.](https://raw.githubusercontent.com/wizlife/egovframe-common-components/5d345d1872f8c61c526c049cd336c38e9d9801f8/screenshots/number/after-valid-year-calendar.png)

</details>
