### PR TITLE
fix(file): 확장자 없는 파일명 판정 수정

### DIFF
--- a/src/main/java/egovframework/com/utl/fcc/service/EgovFileUploadUtil.java
+++ b/src/main/java/egovframework/com/utl/fcc/service/EgovFileUploadUtil.java
@@ -177,9 +177,12 @@ public class EgovFileUploadUtil extends EgovFormBasedFileUtil {
 		if (fileNamePath == null) {
 			return "";
 		}
-		String ext = fileNamePath.substring(fileNamePath.lastIndexOf(".") + 1, fileNamePath.length());
+		int extensionIndex = fileNamePath.lastIndexOf(".");
+		if (extensionIndex < 0) {
+			return "";
+		}
 
-		return (ext == null) ? "" : ext;
+		return fileNamePath.substring(extensionIndex + 1);
 	}
 
 	/**

--- a/src/test/java/egovframework/com/cmm/web/EgovMultipartResolverFileExtensionTest.java
+++ b/src/test/java/egovframework/com/cmm/web/EgovMultipartResolverFileExtensionTest.java
@@ -1,0 +1,42 @@
+package egovframework.com.cmm.web;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+class EgovMultipartResolverFileExtensionTest {
+
+	@ParameterizedTest
+	@ValueSource(strings = {"png", "pdf", "README"})
+	void rejectsFilenamesWithoutExtension(String filename) {
+		SecurityException exception = assertThrows(SecurityException.class, () -> validateFile(filename));
+
+		assertEquals("[No file extension] File extension not allowed.", exception.getMessage());
+	}
+
+	@Test
+	void allowsFilenameWithUppercaseExtension() {
+		assertDoesNotThrow(() -> validateFile("image.PNG"));
+	}
+
+	private void validateFile(String filename) throws Exception {
+		MultipartFile file = new MockMultipartFile("file", filename, "application/octet-stream", new byte[] {1});
+		Method validate = EgovMultipartResolver.class
+			.getDeclaredMethod("validateFile", MultipartFile.class, String.class, long.class);
+		validate.setAccessible(true);
+		try {
+			validate.invoke(new EgovMultipartResolver(), file, ".png,.pdf", 10L);
+		} catch (InvocationTargetException e) {
+			throw e.getCause() instanceof Exception ? (Exception)e.getCause() : e;
+		}
+	}
+}

--- a/src/test/java/egovframework/com/utl/fcc/service/EgovFileUploadUtilTest.java
+++ b/src/test/java/egovframework/com/utl/fcc/service/EgovFileUploadUtilTest.java
@@ -2,6 +2,7 @@ package egovframework.com.utl.fcc.service;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -18,6 +19,10 @@ import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.multipart.MultipartHttpServletRequest;
 
@@ -25,6 +30,21 @@ class EgovFileUploadUtilTest {
 
 	@TempDir
 	Path uploadDir;
+
+	@ParameterizedTest
+	@NullAndEmptySource
+	@ValueSource(strings = {"png", "pdf", "README", "image."})
+	void filenamesWithoutExtensionAreNotAllowed(String filename) {
+		assertEquals("", EgovFileUploadUtil.getFileExtension(filename));
+		assertFalse(EgovFileUploadUtil.checkFileExtension(filename, ".png,.pdf,.gz"));
+	}
+
+	@ParameterizedTest
+	@CsvSource({"image.PNG, PNG", "archive.tar.gz, gz", ".png, png"})
+	void existingExtensionHandlingIsPreserved(String filename, String expectedExtension) {
+		assertEquals(expectedExtension, EgovFileUploadUtil.getFileExtension(filename));
+		assertTrue(EgovFileUploadUtil.checkFileExtension(filename, ".png,.pdf,.gz"));
+	}
 
 	@Test
 	void uploadFilesExtRejectsFilesExceedingMaxFileSizeBeforeSaving() throws Exception {


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

점이 없는 파일명 전체를 확장자로 추출하여, 이름이 `png`나 `pdf`인 파일도 허용 확장자 검사를 통과할 수 있습니다.

## 수정된 소스 내용 Modified source

- 점이 없는 파일명은 빈 확장자로 처리해 기존 허용 목록과 multipart 검증에서 거부합니다.
- 확장자 누락과 정상 대문자·다중 점 확장자 처리, 실제 resolver의 검증 테스트를 추가합니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

JUnit **15개 통과**(기존 업로드 크기 검사 포함). 변경 전에는 파일명 추출·resolver 검증 6개 사례가 실패하는 것을 확인했습니다.

실제 multipart 요청 통합 검증 10개 조건을 전후 비교했습니다. 확장자 누락·금지 확장자·크기 초과·혼합 첨부 거부 시 저장 핸들러 호출과 새 파일이 없으며, 정상 확장자는 저장되는 것을 확인했습니다.

기능별 격리 통합 환경에서 실제 multipart resolver를 사용하고, 인증 세션과 파일 저장 핸들러는 테스트용으로 제공했습니다.

## 테스트 브라우저 Test Browser

- [X] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

Chrome 자동 검증 캡처입니다. 결과표는 실제 HTTP 응답과 DB·파일 저장 관찰값을 정리한 테스트 보고서입니다.

<details>
<summary>수정 전후 및 정상 동작 캡처</summary>

수정 전: 점 없는 png 파일명이 실제 resolver를 통과한 테스트 저장 핸들러 화면입니다.

![수정 전: 점 없는 png 파일명이 실제 resolver를 통과한 테스트 저장 핸들러 화면입니다.](https://raw.githubusercontent.com/wizlife/egovframe-common-components/5d345d1872f8c61c526c049cd336c38e9d9801f8/screenshots/extension/01-before-dotless-accepted.png)

수정 후: 같은 파일을 거부하며 기존 오류 JSP를 표시합니다.

![수정 후: 같은 파일을 거부하며 기존 오류 JSP를 표시합니다.](https://raw.githubusercontent.com/wizlife/egovframe-common-components/5d345d1872f8c61c526c049cd336c38e9d9801f8/screenshots/extension/02-after-dotless-rejected.png)

수정 후: normal.PNG는 실제 resolver 검증 후 테스트 저장에 성공합니다.

![수정 후: normal.PNG는 실제 resolver 검증 후 테스트 저장에 성공합니다.](https://raw.githubusercontent.com/wizlife/egovframe-common-components/5d345d1872f8c61c526c049cd336c38e9d9801f8/screenshots/extension/03-after-normal-accepted.png)

수정 후: 실제 HTTP 응답과 저장 여부로 작성한 10개 조건의 결과표입니다. 거부 시 핸들러 호출과 저장 파일 증가가 0입니다.

![수정 후: 실제 HTTP 응답과 저장 여부로 작성한 10개 조건의 결과표입니다. 거부 시 핸들러 호출과 저장 파일 증가가 0입니다.](https://raw.githubusercontent.com/wizlife/egovframe-common-components/5d345d1872f8c61c526c049cd336c38e9d9801f8/screenshots/extension/04-after-http-results.png)

수정 전: 같은 10개 조건의 관찰 결과입니다. 확인 표시는 기존 문제의 재현도 포함합니다.

![수정 전: 같은 10개 조건의 관찰 결과입니다. 확인 표시는 기존 문제의 재현도 포함합니다.](https://raw.githubusercontent.com/wizlife/egovframe-common-components/5d345d1872f8c61c526c049cd336c38e9d9801f8/screenshots/extension/05-before-http-results.png)

</details>
