### PR TITLE
fix(memo): 없는 메모할일 조회 결과 처리

### DIFF
--- a/src/main/java/egovframework/com/cop/smt/mtm/service/impl/MemoTodoDAO.java
+++ b/src/main/java/egovframework/com/cop/smt/mtm/service/impl/MemoTodoDAO.java
@@ -60,6 +60,9 @@ public class MemoTodoDAO extends EgovComAbstractDAO {
 	 */
 	public MemoTodoVO selectMemoTodo(MemoTodoVO memoTodoVO) {
 		MemoTodoVO resultVO = (MemoTodoVO)selectOne("MemoTodoDAO.selectMemoTodo", memoTodoVO);
+		if (resultVO == null) {
+			return null;
+		}
 		resultVO.setTodoDe(resultVO.getTodoBeginTime().substring(0,10));
 		resultVO.setTodoBeginHour(resultVO.getTodoBeginTime().substring(10,12));
 		resultVO.setTodoBeginMin(resultVO.getTodoBeginTime().substring(12,14));

--- a/src/main/java/egovframework/com/cop/smt/mtm/web/EgovMemoTodoController.java
+++ b/src/main/java/egovframework/com/cop/smt/mtm/web/EgovMemoTodoController.java
@@ -117,10 +117,7 @@ public class EgovMemoTodoController {
     	if (loginVO == null || loginVO.getUniqId() == null) {
     		throw new IllegalStateException("인증 정보가 없습니다.");
     	}
-    	MemoTodo memoTodo = memoTodoService.selectMemoTodo(memoTodoVO);
-    	if (memoTodo == null) {
-    		throw new IllegalStateException("권한이 없습니다.");
-    	}
+		MemoTodo memoTodo = selectRequiredMemoTodo(memoTodoVO);
     	// 2026.07.13 KISA 보안취약점 조치
     	if (!loginVO.getUniqId().equals(memoTodo.getWrterId())) {
     		java.util.List<String> auth = EgovUserDetailsHelper.getAuthorities();
@@ -197,9 +194,9 @@ public class EgovMemoTodoController {
     	//할일정료일자(분)
     	model.addAttribute("todoEndMin", getTimeMM());
 
-    	MemoTodoVO resultVO = memoTodoService.selectMemoTodo(memoTodoVO);
+		MemoTodoVO resultVO = selectRequiredMemoTodo(memoTodoVO);
 		// 작성자 본인 또는 관리자만 수정폼에 접근 가능하도록 소유권 검증 (2026.07.13 KISA 조치의 selectMemoTodo와 동일 관례)
-		egovAssertAdminOrOwner(resultVO == null ? null : resultVO.getFrstRegisterId());
+		egovAssertAdminOrOwner(resultVO.getFrstRegisterId());
 		resultVO.setSearchCnd(memoTodoVO.getSearchCnd());
 		resultVO.setSearchWrd(memoTodoVO.getSearchWrd());
 		resultVO.setSearchBgnDe(memoTodoVO.getSearchBgnDe());
@@ -224,7 +221,7 @@ public class EgovMemoTodoController {
 		Boolean isAuthenticated = EgovUserDetailsHelper.isAuthenticated();
 
 		if (bindingResult.hasErrors()) {
-			MemoTodo memoTodo = memoTodoService.selectMemoTodo(memoTodoVO);
+			MemoTodo memoTodo = selectRequiredMemoTodo(memoTodoVO);
 		    model.addAttribute("memoTodo", memoTodo);
 			//할일시작일자(시)
 			model.addAttribute("todoBeginHour", getTimeHH());
@@ -240,8 +237,8 @@ public class EgovMemoTodoController {
 		if (isAuthenticated) {
 		    // 작성자 본인 또는 관리자만 수정 가능하도록 소유권 검증 (selectMemoTodo의 KISA 조치와 동일하게
 		    // 이 파일이 이미 정의해 둔 egovAssertAdminOrOwner를 사용)
-		    MemoTodoVO stored = memoTodoService.selectMemoTodo(memoTodoVO);
-		    egovAssertAdminOrOwner(stored == null ? null : stored.getFrstRegisterId());
+		    MemoTodoVO stored = selectRequiredMemoTodo(memoTodoVO);
+		    egovAssertAdminOrOwner(stored.getFrstRegisterId());
 
 			memoTodoVO.setTodoBeginTime(memoTodoVO.getTodoDe() + memoTodoVO.getTodoBeginHour() + memoTodoVO.getTodoBeginMin());
 			memoTodoVO.setTodoEndTime(memoTodoVO.getTodoDe() + memoTodoVO.getTodoEndHour() + memoTodoVO.getTodoEndMin());
@@ -316,8 +313,8 @@ public class EgovMemoTodoController {
     	}
 
 		// 작성자 본인 또는 관리자만 삭제 가능하도록 소유권 검증
-		MemoTodoVO stored = memoTodoService.selectMemoTodo(memoTodoVO);
-		egovAssertAdminOrOwner(stored == null ? null : stored.getFrstRegisterId());
+		MemoTodoVO stored = selectRequiredMemoTodo(memoTodoVO);
+		egovAssertAdminOrOwner(stored.getFrstRegisterId());
 
     	memoTodoService.deleteMemoTodo(memoTodoVO);
 		return "forward:/cop/smt/mtm/selectMemoTodoList.do";
@@ -409,6 +406,14 @@ public class EgovMemoTodoController {
     	return listMM;
 	}
 
+
+	private MemoTodoVO selectRequiredMemoTodo(MemoTodoVO memoTodoVO) throws Exception {
+		MemoTodoVO stored = memoTodoService.selectMemoTodo(memoTodoVO);
+		if (stored == null) {
+			throw new IllegalStateException("권한이 없습니다.");
+		}
+		return stored;
+	}
 
 	/**
 	 * 2026.07.13 KISA 보안취약점 조치 - 로그인 사용자 확인

--- a/src/test/java/egovframework/com/cop/smt/mtm/service/impl/MemoTodoDAOMissingTodoTest.java
+++ b/src/test/java/egovframework/com/cop/smt/mtm/service/impl/MemoTodoDAOMissingTodoTest.java
@@ -1,0 +1,57 @@
+package egovframework.com.cop.smt.mtm.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import org.junit.jupiter.api.Test;
+
+import egovframework.com.cop.smt.mtm.service.MemoTodoVO;
+
+class MemoTodoDAOMissingTodoTest {
+
+	@Test
+	void missingTodoReturnsNullBeforeSplittingDateAndTime() {
+		StubMemoTodoDAO dao = new StubMemoTodoDAO(null);
+		MemoTodoVO query = new MemoTodoVO();
+		query.setTodoId("999999999");
+
+		assertNull(dao.selectMemoTodo(query));
+		assertSame(query, dao.parameter);
+	}
+
+	@Test
+	void existingTodoKeepsDateTimeFieldsAndOriginalRow() {
+		MemoTodoVO row = new MemoTodoVO();
+		row.setTodoBeginTime("2026-09-090905");
+		row.setTodoEndTime("2026-09-092359");
+
+		MemoTodoVO result = new StubMemoTodoDAO(row).selectMemoTodo(new MemoTodoVO());
+
+		assertSame(row, result);
+		assertEquals("2026-09-09", result.getTodoDe());
+		assertEquals("09", result.getTodoBeginHour());
+		assertEquals("05", result.getTodoBeginMin());
+		assertEquals("23", result.getTodoEndHour());
+		assertEquals("59", result.getTodoEndMin());
+		assertEquals("2026-09-090905", result.getTodoBeginTime());
+		assertEquals("2026-09-092359", result.getTodoEndTime());
+	}
+
+	private static final class StubMemoTodoDAO extends MemoTodoDAO {
+		private final MemoTodoVO row;
+		private Object parameter;
+
+		private StubMemoTodoDAO(MemoTodoVO row) {
+			this.row = row;
+		}
+
+		@Override
+		@SuppressWarnings("unchecked")
+		public <T> T selectOne(String queryId, Object parameter) {
+			assertEquals("MemoTodoDAO.selectMemoTodo", queryId);
+			this.parameter = parameter;
+			return (T) row;
+		}
+	}
+}

--- a/src/test/java/egovframework/com/cop/smt/mtm/web/EgovMemoTodoControllerMissingTodoTest.java
+++ b/src/test/java/egovframework/com/cop/smt/mtm/web/EgovMemoTodoControllerMissingTodoTest.java
@@ -1,0 +1,219 @@
+package egovframework.com.cop.smt.mtm.web;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.ui.ModelMap;
+import org.springframework.validation.BeanPropertyBindingResult;
+
+import egovframework.com.cmm.LoginVO;
+import egovframework.com.cmm.service.EgovUserDetailsService;
+import egovframework.com.cmm.util.EgovUserDetailsHelper;
+import egovframework.com.cop.smt.mtm.service.EgovMemoTodoService;
+import egovframework.com.cop.smt.mtm.service.MemoTodo;
+import egovframework.com.cop.smt.mtm.service.MemoTodoVO;
+
+class EgovMemoTodoControllerMissingTodoTest {
+
+	private static final String OWNER = "USRCNFRM_00000000001";
+	private static final String ADMIN = "USRCNFRM_00000000002";
+	private EgovUserDetailsService previousUserDetailsService;
+	private EgovMemoTodoController controller;
+	private StubMemoTodoService service;
+
+	@BeforeEach
+	void setUp() {
+		previousUserDetailsService = new EgovUserDetailsHelper().getEgovUserDetailsService();
+		service = new StubMemoTodoService();
+		controller = new EgovMemoTodoController();
+		controller.memoTodoService = service;
+	}
+
+	@AfterEach
+	void restoreUserDetailsService() {
+		new EgovUserDetailsHelper().setEgovUserDetailsService(previousUserDetailsService);
+	}
+
+	@ParameterizedTest(name = "{0}, admin={1}")
+	@MethodSource("missingTodoRequests")
+	void missingTodoIsRejectedWithoutMutations(Action action, boolean admin) {
+		bindUser(admin);
+		MemoTodoVO request = request();
+		ModelMap model = new ModelMap();
+
+		IllegalStateException error = assertThrows(IllegalStateException.class,
+				() -> invoke(action, request, model));
+
+		assertEquals("권한이 없습니다.", error.getMessage());
+		assertEquals(1, service.selectCount);
+		assertEquals(request.getTodoId(), service.selectedId);
+		assertEquals(0, service.updateCount);
+		assertEquals(0, service.deleteCount);
+		assertEquals(0, service.insertCount);
+	}
+
+	@ParameterizedTest
+	@ValueSource(booleans = { false, true })
+	void existingTodoDetailIsAvailableToOwnerAndAdmin(boolean admin) throws Exception {
+		bindUser(admin);
+		service.stored = storedTodo();
+		ModelMap model = new ModelMap();
+
+		String view = controller.selectMemoTodo(request(), model);
+
+		assertEquals("egovframework/com/cop/smt/mtm/EgovMemoTodoDetail", view);
+		assertSame(service.stored, model.get("memoTodo"));
+	}
+
+	@ParameterizedTest
+	@ValueSource(booleans = { false, true })
+	void validationErrorsOnExistingTodoKeepFormAndTimeChoices(boolean admin) throws Exception {
+		bindUser(admin);
+		service.stored = storedTodo();
+		ModelMap model = new ModelMap();
+
+		String view = invoke(Action.INVALID_UPDATE, request(), model);
+
+		assertEquals("egovframework/com/cop/smt/mtm/EgovMemoTodoUpdt", view);
+		assertSame(service.stored, model.get("memoTodo"));
+		assertEquals(24, ((List<?>) model.get("todoBeginHour")).size());
+		assertEquals(60, ((List<?>) model.get("todoBeginMin")).size());
+		assertEquals(24, ((List<?>) model.get("todoEndHour")).size());
+		assertEquals(60, ((List<?>) model.get("todoEndMin")).size());
+		assertEquals(0, service.updateCount);
+		assertEquals(0, service.deleteCount);
+	}
+
+	@Test
+	void adminCanStillDeleteAnExistingTodoOwnedByAnotherUser() throws Exception {
+		bindUser(true);
+		service.stored = storedTodo();
+
+		assertEquals("forward:/cop/smt/mtm/selectMemoTodoList.do",
+				controller.deleteMemoTodo(request(), new ModelMap()));
+		assertEquals(1, service.deleteCount);
+	}
+
+	private String invoke(Action action, MemoTodoVO request, ModelMap model) throws Exception {
+		BeanPropertyBindingResult binding = new BeanPropertyBindingResult(request, "memoTodoVO");
+		if (action == Action.INVALID_UPDATE) {
+			binding.reject("errors.required");
+		}
+		switch (action) {
+		case DETAIL:
+			return controller.selectMemoTodo(request, model);
+		case MODIFY_FORM:
+			return controller.modifyMemoTodo(request, binding, model);
+		case UPDATE:
+		case INVALID_UPDATE:
+			return controller.updateMemoTodo(request, binding, model);
+		case DELETE:
+			return controller.deleteMemoTodo(request, model);
+		default:
+			throw new AssertionError(action);
+		}
+	}
+
+	static Stream<Arguments> missingTodoRequests() {
+		return Arrays.stream(Action.values())
+				.flatMap(action -> Stream.of(Arguments.of(action, false), Arguments.of(action, true)));
+	}
+
+	private MemoTodoVO request() {
+		MemoTodoVO request = new MemoTodoVO();
+		request.setTodoId("999999999");
+		request.setTodoDe("2026-09-09");
+		request.setTodoBeginHour("09");
+		request.setTodoBeginMin("30");
+		request.setTodoEndHour("10");
+		request.setTodoEndMin("30");
+		return request;
+	}
+
+	private MemoTodoVO storedTodo() {
+		MemoTodoVO stored = new MemoTodoVO();
+		stored.setTodoId("999999999");
+		stored.setFrstRegisterId(OWNER);
+		stored.setWrterId(OWNER);
+		return stored;
+	}
+
+	private void bindUser(boolean admin) {
+		LoginVO user = new LoginVO();
+		user.setUniqId(admin ? ADMIN : OWNER);
+		new EgovUserDetailsHelper().setEgovUserDetailsService(new EgovUserDetailsService() {
+			@Override
+			public Object getAuthenticatedUser() {
+				return user;
+			}
+
+			@Override
+			public List<String> getAuthorities() {
+				return admin ? List.of("ROLE_ADMIN") : List.of();
+			}
+
+			@Override
+			public Boolean isAuthenticated() {
+				return Boolean.TRUE;
+			}
+		});
+	}
+
+	private enum Action {
+		DETAIL, MODIFY_FORM, UPDATE, INVALID_UPDATE, DELETE
+	}
+
+	private static final class StubMemoTodoService implements EgovMemoTodoService {
+		private MemoTodoVO stored;
+		private int selectCount;
+		private String selectedId;
+		private int updateCount;
+		private int deleteCount;
+		private int insertCount;
+
+		@Override
+		public MemoTodoVO selectMemoTodo(MemoTodoVO request) {
+			selectCount++;
+			selectedId = request.getTodoId();
+			return stored;
+		}
+
+		@Override
+		public void updateMemoTodo(MemoTodo request) {
+			updateCount++;
+		}
+
+		@Override
+		public void deleteMemoTodo(MemoTodo request) {
+			deleteCount++;
+		}
+
+		@Override
+		public void insertMemoTodo(MemoTodo request) {
+			insertCount++;
+		}
+
+		@Override
+		public Map<String, Object> selectMemoTodoList(MemoTodoVO request) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public List<MemoTodoVO> selectMemoTodoListToday(MemoTodoVO request) {
+			throw new UnsupportedOperationException();
+		}
+	}
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

삭제되었거나 존재하지 않는 메모할일을 조회하면 null 결과에서 날짜·시간을 분리하려다 예외가 발생합니다.

## 수정된 소스 내용 Modified source

- DAO는 조회 결과가 없으면 null을 반환하고, 상세·수정·삭제 경로는 기존 오류 처리로 중단합니다.
- 관리자와 수정 검증 실패 분기의 대상 부재 검사 및 정상 동작·소유권 검사를 테스트합니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

JUnit **27개 통과**(신규 17개, 기존 10개). 변경 전에는 조회 결과 부재와 관리자·검증 오류 경로 6개 사례가 실패하는 것을 확인했습니다.

HTTP 통합 검증 26개 조건을 전후 비교했습니다. 사용자·관리자의 대상 부재 처리, 정상 상세·수정폼, 수정·삭제의 DB 반영, 타인 소유 메모 거부를 확인했습니다.

기능별 격리 통합 환경에서 실제 컨트롤러·서비스·DAO·JSP를 실행했습니다. 인증 세션은 테스트용이며, PostgreSQL용 원본 매퍼를 HSQL에서 실행한 결과입니다.

## 테스트 브라우저 Test Browser

- [X] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

Chrome 자동 검증 캡처입니다. 결과표는 실제 HTTP 응답과 DB·파일 저장 관찰값을 정리한 테스트 보고서입니다.

<details>
<summary>수정 전후 및 정상 동작 캡처</summary>

수정 후: DB 수정 내용을 다시 조회한 원본 메모할일 상세 JSP입니다.

![수정 후: DB 수정 내용을 다시 조회한 원본 메모할일 상세 JSP입니다.](https://raw.githubusercontent.com/wizlife/egovframe-common-components/5d345d1872f8c61c526c049cd336c38e9d9801f8/screenshots/memo/01-after-normal-detail.png)

수정 후: 관리자도 없는 메모에 접근하면 기존 일반 오류 JSP로 처리됩니다. 새로운 오류 화면이나 404 응답을 추가한 것은 아닙니다.

![수정 후: 관리자도 없는 메모에 접근하면 기존 일반 오류 JSP로 처리됩니다. 새로운 오류 화면이나 404 응답을 추가한 것은 아닙니다.](https://raw.githubusercontent.com/wizlife/egovframe-common-components/5d345d1872f8c61c526c049cd336c38e9d9801f8/screenshots/memo/02-after-missing-admin-error.png)

수정 후: 실제 HTTP·DB 관찰값으로 작성한 26개 조건의 결과표입니다. 없는 대상은 IllegalStateException으로 중단하고 DB 쓰기를 호출하지 않습니다.

![수정 후: 실제 HTTP·DB 관찰값으로 작성한 26개 조건의 결과표입니다. 없는 대상은 IllegalStateException으로 중단하고 DB 쓰기를 호출하지 않습니다.](https://raw.githubusercontent.com/wizlife/egovframe-common-components/5d345d1872f8c61c526c049cd336c38e9d9801f8/screenshots/memo/03-after-http-results.png)

수정 전: 같은 조건에서 없는 대상의 NullPointerException을 재현한 결과표입니다. 확인 표시는 기존 문제의 재현도 포함합니다.

![수정 전: 같은 조건에서 없는 대상의 NullPointerException을 재현한 결과표입니다. 확인 표시는 기존 문제의 재현도 포함합니다.](https://raw.githubusercontent.com/wizlife/egovframe-common-components/5d345d1872f8c61c526c049cd336c38e9d9801f8/screenshots/memo/04-before-http-results.png)

</details>
