### PR TITLE
fix: 오류 페이지 뷰 이름에서 error 경로가 빠져 오류 화면 대신 뷰를 찾지 못하던 문제 수정 (13곳)

### DIFF
--- a/src/main/java/egovframework/com/cop/bbs/web/EgovArticleController.java
+++ b/src/main/java/egovframework/com/cop/bbs/web/EgovArticleController.java
@@ -1430,7 +1430,7 @@ public class EgovArticleController {
 		}
 
 		LOGGER.debug("Template > WhiteList mismatch! Please check Admin page!");
-		return "egovframework/com/cmm/egovError";
+		return "egovframework/com/cmm/error/egovError";
 	}
 
 }

--- a/src/main/java/egovframework/com/cop/cmy/web/EgovCommuManageController.java
+++ b/src/main/java/egovframework/com/cop/cmy/web/EgovCommuManageController.java
@@ -568,7 +568,7 @@ public class EgovCommuManageController {
 		// 화이트리스트 등록값이라도 WEB-INF 등 애플리케이션 내부 자원을 가리키는 값은 뷰 이름으로 사용할 수 없다.
 		if (tmplatCours.contains(":") || tmplatCours.startsWith("/") || tmplatCours.toUpperCase(Locale.ROOT).contains("WEB-INF")) {
 			LOGGER.debug("Template > Unsafe tmplatCours rejected: {}", tmplatCours);
-			return "egovframework/com/cmm/egovError";
+			return "egovframework/com/cmm/error/egovError";
 		}
 
 		// 화이트 리스트 체크
@@ -582,7 +582,7 @@ public class EgovCommuManageController {
         }
 
 		LOGGER.debug("Template > WhiteList mismatch! Please check Admin page!");
-		return "egovframework/com/cmm/egovError";
+		return "egovframework/com/cmm/error/egovError";
     }
 
     /**

--- a/src/main/java/egovframework/com/cop/ems/web/EgovSndngMailDetailController.java
+++ b/src/main/java/egovframework/com/cop/ems/web/EgovSndngMailDetailController.java
@@ -69,7 +69,7 @@ public class EgovSndngMailDetailController {
 
 
 		if (sndngMailVO == null || sndngMailVO.getMssageId() == null || sndngMailVO.getMssageId().equals("")) {
-			return "egovframework/com/cmm/egovError";
+			return "egovframework/com/cmm/error/egovError";
 		}
 
 		LoginVO loginVO = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();
@@ -80,7 +80,7 @@ public class EgovSndngMailDetailController {
 		// 1. 발송메일을 상세 조회한다.
 		SndngMailVO resultMailVO = sndngMailDetailService.selectSndngMail(sndngMailVO);
 		if (resultMailVO == null || resultMailVO.getMssageId() == null || resultMailVO.getMssageId().equals("")) {
-			return "egovframework/com/cmm/egovError";
+			return "egovframework/com/cmm/error/egovError";
 		}
 		// 2026.07.13 KISA 보안취약점 조치
 		if (!loginVO.getId().equals(resultMailVO.getDsptchPerson())) {
@@ -97,7 +97,7 @@ public class EgovSndngMailDetailController {
 			return "egovframework/com/cop/ems/EgovMailDetail";
 		} else {
 			// 오류 페이지 이동
-			return "egovframework/com/cmm/egovError";
+			return "egovframework/com/cmm/error/egovError";
 		}
 	}
 
@@ -116,7 +116,7 @@ public class EgovSndngMailDetailController {
 
 
 		if (sndngMailVO == null || sndngMailVO.getMssageId() == null || sndngMailVO.getMssageId().equals("")) {
-			return "egovframework/com/cmm/egovError";
+			return "egovframework/com/cmm/error/egovError";
 		}
 
 		LoginVO loginVO = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();
@@ -125,7 +125,7 @@ public class EgovSndngMailDetailController {
 		}
 		SndngMailVO resultMailVO = sndngMailDetailService.selectSndngMail(sndngMailVO);
 		if (resultMailVO == null || resultMailVO.getMssageId() == null || resultMailVO.getMssageId().equals("")) {
-			return "egovframework/com/cmm/egovError";
+			return "egovframework/com/cmm/error/egovError";
 		}
 		// 2026.07.13 KISA 보안취약점 조치
 		if (!loginVO.getId().equals(resultMailVO.getDsptchPerson())) {

--- a/src/main/java/egovframework/com/cop/ems/web/EgovSndngMailDtlsController.java
+++ b/src/main/java/egovframework/com/cop/ems/web/EgovSndngMailDtlsController.java
@@ -104,7 +104,7 @@ public class EgovSndngMailDtlsController {
 
 
 		if (sndngMailVO == null || sndngMailVO.getMssageId() == null || sndngMailVO.getMssageId().equals("")) {
-			return "egovframework/com/cmm/egovError";
+			return "egovframework/com/cmm/error/egovError";
 		}
 
 		LoginVO loginVO = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();
@@ -113,7 +113,7 @@ public class EgovSndngMailDtlsController {
 		}
 		SndngMailVO resultMailVO = sndngMailDetailService.selectSndngMail(sndngMailVO);
 		if (resultMailVO == null || resultMailVO.getMssageId() == null || resultMailVO.getMssageId().equals("")) {
-			return "egovframework/com/cmm/egovError";
+			return "egovframework/com/cmm/error/egovError";
 		}
 		// 2026.07.13 KISA 보안취약점 조치
 		if (!loginVO.getId().equals(resultMailVO.getDsptchPerson())) {

--- a/src/main/java/egovframework/com/uss/ion/pwm/web/EgovPopupManageController.java
+++ b/src/main/java/egovframework/com/uss/ion/pwm/web/EgovPopupManageController.java
@@ -396,7 +396,7 @@ public class EgovPopupManageController {
 		// 화이트리스트 등록값이라도 WEB-INF 등 애플리케이션 내부 자원을 가리키는 값은 뷰 이름으로 사용할 수 없다.
 		if (fileUrl2.contains(":") || fileUrl2.startsWith("/") || fileUrl2.toUpperCase(Locale.ROOT).contains("WEB-INF")) {
 			LOGGER.debug("Open Popup > Unsafe fileUrl rejected: {}", fileUrl2);
-			return "egovframework/com/cmm/egovError";
+			return "egovframework/com/cmm/error/egovError";
 		}
 
 		List<EgovMap> popupWhiteList = egovPopupManageService.selectPopupWhiteList();
@@ -409,7 +409,7 @@ public class EgovPopupManageController {
 			}
 		}
 		LOGGER.debug("Open Popup > WhiteList mismatch! Please check Admin page!");
-		return "egovframework/com/cmm/egovError";
+		return "egovframework/com/cmm/error/egovError";
 	}
 
 	/**

--- a/src/main/java/egovframework/com/uss/olp/qri/web/EgovQustnrRespondInfoController.java
+++ b/src/main/java/egovframework/com/uss/olp/qri/web/EgovQustnrRespondInfoController.java
@@ -217,7 +217,7 @@ public class EgovQustnrRespondInfoController {
 		}
 
 		LOGGER.debug("QustnrTmplat > WhiteList mismatch! Please check Admin page!");
-		return "egovframework/com/cmm/egovError";
+		return "egovframework/com/cmm/error/egovError";
 	}
 
 	/**


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

### 문제

오류 분기에서 돌려주는 뷰 이름 13곳에 `error` 경로가 빠져 있습니다.

```java
return "egovframework/com/cmm/egovError";        // ← error 없음
```

뷰 리졸버는 `/WEB-INF/jsp/` + 뷰 이름 + `.jsp` 로 해석합니다.

```xml
<bean class="org.springframework.web.servlet.view.UrlBasedViewResolver" p:order="1"
      p:prefix="/WEB-INF/jsp/" p:suffix=".jsp"/>
```

그래서 위 뷰 이름은 `/WEB-INF/jsp/egovframework/com/cmm/egovError.jsp` 를 가리키는데 **그 파일은 없습니다.** 실제 오류 페이지는 `/WEB-INF/jsp/egovframework/com/cmm/error/egovError.jsp` 입니다. Tiles 등 다른 해석 경로도 이 저장소에는 없습니다.

결과적으로 오류를 알려주려던 자리에서 **오류 화면 대신 뷰를 찾지 못해 실패**합니다. 특히 아래 자리들은 뷰 이름 인젝션을 막고 오류 페이지로 보내려는 방어 분기라, 방어가 동작한 순간 오류 화면이 뜨지 않습니다.

```java
// EgovCommuManageController:571, EgovPopupManageController:399
if (tmplatCours.contains(":") || tmplatCours.startsWith("/") || ... ) {
    LOGGER.debug("Template > Unsafe tmplatCours rejected: {}", tmplatCours);
    return "egovframework/com/cmm/egovError";   // ← 여기
}
```

### 같은 저장소가 이미 쓰고 있는 올바른 값

`error` 를 포함한 경로가 이미 6곳과 상수 2개에서 쓰이고 있습니다.

```java
// EgovComUtlController:46, EgovEmplyrManageController:67
private static final String ERROR_VIEW = "egovframework/com/cmm/error/egovError";
```

`EgovComUtlControllerTest` 도 이 값을 기대값으로 쓰고 있습니다.

### 수정

13곳의 문자열을 `"egovframework/com/cmm/error/egovError"` 로 맞췄습니다. 6개 파일, 그 외 변경은 없습니다.

| 파일 | 수정 수 |
|---|---|
| `cop/bbs/web/EgovArticleController.java` | 1 |
| `cop/cmy/web/EgovCommuManageController.java` | 2 |
| `cop/ems/web/EgovSndngMailDetailController.java` | 5 |
| `cop/ems/web/EgovSndngMailDtlsController.java` | 2 |
| `uss/ion/pwm/web/EgovPopupManageController.java` | 2 |
| `uss/olp/qri/web/EgovQustnrRespondInfoController.java` | 1 |

`EgovLoginController` 에도 같은 문자열이 3곳 있으나 **모두 주석 처리된 GPKI 코드 안**이라 건드리지 않았습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

- `mvn -Ptest test` — **Tests run 312, Failures 0, Errors 14**. 오류 14건은 모두 `Failed to load ApplicationContext`(DB·환경 필요)로 변경 전과 동일하며, 이번 변경과 무관합니다.
- 뷰 이름이 가리키는 파일이 실제로 없는지는 파일 목록으로 확인했습니다. `/WEB-INF/jsp/egovframework/com/cmm/` 바로 아래에는 `EgovModal.jsp`·`EgovUnit*.jsp`·`error/`·`fms/` 만 있고 `egovError.jsp` 는 `error/` 안에만 있습니다.

## 함께 말씀드릴 점

컨트롤러가 돌려주는 뷰 이름 719개를 실제 JSP 파일 739개와 대조해 보다가 찾은 건입니다. 같은 방식으로 **대응 JSP 가 없어 보이는 뷰 이름이 이 건 말고도 남아 있습니다**(예: `egovframework/com/cmm/validator`, `.../sym/ccm/ccc/SelectCcmCmmnClCodeDetail.do` 처럼 `.do` 가 뷰 이름으로 들어간 것 등). 다만 성격이 제각각이라 이번 PR 에는 넣지 않았습니다. 정리해서 이슈로 올려 두는 편이 나을지 알려주시면 그렇게 하겠습니다.

## 테스트 브라우저 Test Browser

- [X] 기타 Others

서버 측 뷰 이름 해석 문제라 브라우저가 관여하지 않습니다. JDK 21 · `-Ptest` 프로파일로 확인했습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

화면 캡처 대신 파일 존재 여부와 회귀 결과로 갈음합니다.

```
$ ls src/main/webapp/WEB-INF/jsp/egovframework/com/cmm/
EgovModal.jsp  EgovUnitBottom.jsp  EgovUnitContent.jsp  EgovUnitLeft.jsp
EgovUnitMain.jsp  EgovUnitTop.jsp  error  fms
$ ls src/main/webapp/WEB-INF/jsp/egovframework/com/cmm/error/egovError.jsp
.../com/cmm/error/egovError.jsp

$ mvn -Ptest test
Tests run: 312,  Failures: 0,  Errors: 14      (14건 모두 ApplicationContext 로드 실패, 변경 전과 동일)
```

> 참고: `EgovSndngMailDetailController.java`·`EgovSndngMailDtlsController.java`·`EgovPopupManageController.java` 세 파일은 원본에 **파일 끝 개행이 없어서**, GitHub 웹 편집기로 저장하면서 끝 개행 1줄이 함께 추가됐습니다(각 +1/−1). 그래서 실제 문자열 수정은 13곳인데 diff 는 16줄로 보입니다. 원치 않으시면 되돌리겠습니다.
