### PR TITLE
fix: 온라인헬프 메뉴가 없는 URL 을 가리키던 문제 수정

### DIFF
--- a/script/dml/altibase/com_DML_altibase.sql
+++ b/script/dml/altibase/com_DML_altibase.sql
@@ -743,7 +743,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('EgovUserManage','/uss/umt/','업무사용자관리','업무사용자관리','/uss/umt/EgovEmplyrManage.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('EgovVcatnConfmList','/uss/ion/vct/','휴가승인관리','휴가승인관리','/uss/ion/vct/EgovVcatnConfmList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('EgovVcatnManageList','/uss/ion/vct/','휴가관리','휴가관리','/uss/ion/vct/EgovVcatnManageList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('FaqListInqire','/uss/olh/faq/','FAQ관리','FAQ관리','/uss/olh/faq/FaqListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('FaqListInqire','/uss/olh/faq/','FAQ관리','FAQ관리','/uss/olh/faq/selectFaqList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getBackupOpertList','/sym/sym/bak/','백업관리','백업관리','/sym/sym/bak/getBackupOpertList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getBackupResultList','/sym/sym/bak/','백업결과관리','백업결과관리','/sym/sym/bak/getBackupResultList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getBatchOpertList','/sym/bat/','배치작업관리','배치작업관리','/sym/bat/getBatchOpertList.do');
@@ -757,10 +757,10 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getMainImageResult','/uss/ion/msi/','메인이미지 반영결과보기','메인이미지 반영결과보기','/uss/ion/msi/getMainImageResult.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getSystemCntcList','/ssi/syi/sim/','시스템연계관리','시스템연계관리','/ssi/syi/sim/getSystemCntcList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getTrsmrcvMntrngList','/utl/sys/trm/','송수신모니터링','송수신모니터링','/utl/sys/trm/getTrsmrcvMntrngList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('HpcmListInqire','/uss/olh/hpc/','도움말','도움말','/uss/olh/hpc/HpcmListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('HpcmListInqire','/uss/olh/hpc/','도움말','도움말','/uss/olh/hpc/selectHpcmList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('insertSndngMailView','/cop/ems/','메일발송','메일발송','/cop/ems/insertSndngMailView.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWord','/uss/olh/awm/','행정전문용어사전','행정전문용어사전','/uss/olh/awm/listAdministrationWord.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWordManage','/uss/olh/awm/','행정전문용어사전관리','행정전문용어사전관리','/uss/olh/awm/listAdministrationWordManage.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWord','/uss/olh/awm/','행정전문용어사전','행정전문용어사전','/uss/olh/awm/selectAdministrationWordList.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWordManage','/uss/olh/awm/','행정전문용어사전관리','행정전문용어사전관리','/uss/olh/awm/selectAdministrationWordManageList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listIndvdlInfoPolicy','/uss/sam/ipm/','개인정보보호정책확인','개인정보보호정책확인','/uss/sam/ipm/listIndvdlInfoPolicy.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listNoteRecptn','/uss/ion/ntr/','받은쪽지함관리','받은쪽지함관리','/uss/ion/ntr/listNoteRecptn.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listNoteTrnsmit','/uss/ion/nts/','보낸쪽지함관리','보낸쪽지함관리','/uss/ion/nts/listNoteTrnsmit.do');
@@ -778,7 +778,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('NewsInfoListInqire','/uss/ion/nws/','뉴스관리','뉴스관리','/uss/ion/nws/NewsInfoListInqire.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('OnlineManualUserList','/uss/olh/omn/','사용자온라인매뉴얼','사용자온라인매뉴얼','/uss/olh/omn/selectOnlineManualList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('QnaAnswerListInqire','/uss/olh/qnm/','Q&amp;A답변관리','Q&amp;A답변관리','/uss/olh/qnm/QnaAnswerListInqire.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('QnaListInqire','/uss/olh/qna/','Q&amp;A관리','Q&amp;A관리','/uss/olh/qna/QnaListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('QnaListInqire','/uss/olh/qna/','Q&amp;A관리','Q&amp;A관리','/uss/olh/qna/selectQnaList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('RecomendSiteListInqire','/uss/ion/rec/','추천사이트관리','추천사이트관리','/uss/ion/rec/RecomendSiteListInqire.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('registEgovNoteManage','/uss/ion/ntm/','쪽지관리','쪽지관리','/uss/ion/ntm/registEgovNoteManage.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectAdbkList','/cop/adb/','주소록관리','주소록관리','/cop/adb/selectAdbkList.do');
@@ -839,7 +839,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectWikMnthngReprtList','/cop/smt/wmr/','주간/월간보고관리','주간/월간보고관리','/cop/smt/wmr/selectWikMnthngReprtList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('SiteListInqire','/uss/ion/sit/','사이트관리','사이트관리','/uss/ion/sit/SiteListInqire.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('StplatListInqire','/uss/sam/stp/','약관관리','약관관리','/uss/sam/stp/StplatListInqire.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('WordDicaryListInqire','/uss/olh/wor/','용어사전','용어사전','/uss/olh/wor/WordDicaryListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('WordDicaryListInqire','/uss/olh/wor/','용어사전','용어사전','/uss/olh/wor/selectWordDicaryList.do');
 
 -- 메뉴정보
 INSERT INTO COMTNMENUINFO(MENU_NM, PROGRM_FILE_NM, MENU_NO, UPPER_MENU_NO, MENU_ORDR, MENU_DC, RELATE_IMAGE_PATH, RELATE_IMAGE_NM) VALUES ('root','dir',0,0,1,'root','/','/');

--- a/script/dml/cubrid/com_DML_cubrid.sql
+++ b/script/dml/cubrid/com_DML_cubrid.sql
@@ -750,8 +750,8 @@ INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM,
 INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectCtsnnManageList', '/uss/ion/ctn/', '직원경조사관리', '직원경조사관리', '/uss/ion/ctn/selectCtsnnManageList.do');
 INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('EgovCtsnnConfmList', '/uss/ion/ctn/', '직원경조사승인관리', '직원경조사승인관리', '/uss/ion/ctn/EgovCtsnnConfmList.do');
 INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('QnaAnswerListInqire', '/uss/olh/qnm/', 'Q&amp;A답변관리', 'Q&amp;A답변관리', '/uss/olh/qnm/QnaAnswerListInqire.do');
-INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWord', '/uss/olh/awm/', '행정전문용어사전', '행정전문용어사전', '/uss/olh/awm/listAdministrationWord.do');
-INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWordManage', '/uss/olh/awm/', '행정전문용어사전관리', '행정전문용어사전관리', '/uss/olh/awm/listAdministrationWordManage.do');
+INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWord', '/uss/olh/awm/', '행정전문용어사전', '행정전문용어사전', '/uss/olh/awm/selectAdministrationWordList.do');
+INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWordManage', '/uss/olh/awm/', '행정전문용어사전관리', '행정전문용어사전관리', '/uss/olh/awm/selectAdministrationWordManageList.do');
 INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listOnlineManual', '/uss/olh/omm/', '온라인매뉴얼', '온라인매뉴얼', '/uss/olh/omm/selectOnlineManualList.do');
 INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('OnlineManualUserList', '/uss/olh/omn/', '사용자온라인매뉴얼', '사용자온라인매뉴얼', '/uss/olh/omn/selectOnlineManualList.do');
 INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('CnsltListInqire', '/uss/olp/cns/', '상담관리', '상담관리', '/uss/olp/cns/CnsltListInqire.do');
@@ -788,10 +788,10 @@ INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM,
 INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('StplatListInqire', '/uss/sam/stp/', '약관관리', '약관관리', '/uss/sam/stp/StplatListInqire.do');
 INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('CpyrhtPrtcPolicyListInqire', '/uss/sam/cpy/', '저작권보호정책', '저작권보호정책', '/uss/sam/cpy/CpyrhtPrtcPolicyListInqire.do');
 INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listIndvdlInfoPolicy', '/uss/sam/ipm/', '개인정보보호정책확인', '개인정보보호정책확인', '/uss/sam/ipm/listIndvdlInfoPolicy.do');
-INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('HpcmListInqire', '/uss/olh/hpc/', '도움말', '도움말', '/uss/olh/hpc/HpcmListInqire.do');
-INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('WordDicaryListInqire', '/uss/olh/wor/', '용어사전', '용어사전', '/uss/olh/wor/WordDicaryListInqire.do');
-INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('FaqListInqire', '/uss/olh/faq/', 'FAQ관리', 'FAQ관리', '/uss/olh/faq/FaqListInqire.do');
-INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('QnaListInqire', '/uss/olh/qna/', 'Q&amp;A관리', 'Q&amp;A관리', '/uss/olh/qna/QnaListInqire.do');
+INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('HpcmListInqire', '/uss/olh/hpc/', '도움말', '도움말', '/uss/olh/hpc/selectHpcmList.do');
+INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('WordDicaryListInqire', '/uss/olh/wor/', '용어사전', '용어사전', '/uss/olh/wor/selectWordDicaryList.do');
+INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('FaqListInqire', '/uss/olh/faq/', 'FAQ관리', 'FAQ관리', '/uss/olh/faq/selectFaqList.do');
+INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('QnaListInqire', '/uss/olh/qna/', 'Q&amp;A관리', 'Q&amp;A관리', '/uss/olh/qna/selectQnaList.do');
 INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('dir', 'dir', '디렉토리', '디렉토리', 'dir');
 INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('egovLoginUsr', '/uat/uia/', '로그인', '로그인', '/uat/uia/egovLoginUsr.do');
 INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectLoginPolicyList', '/uat/uap/', '로그인정책관리', '로그인정책관리', '/uat/uap/selectLoginPolicyList.do');

--- a/script/dml/goldilocks/com_DML_goldilocks.sql
+++ b/script/dml/goldilocks/com_DML_goldilocks.sql
@@ -741,7 +741,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('EgovUserManage','/uss/umt/','업무사용자관리','업무사용자관리','/uss/umt/EgovEmplyrManage.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('EgovVcatnConfmList','/uss/ion/vct/','휴가승인관리','휴가승인관리','/uss/ion/vct/EgovVcatnConfmList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('EgovVcatnManageList','/uss/ion/vct/','휴가관리','휴가관리','/uss/ion/vct/EgovVcatnManageList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('FaqListInqire','/uss/olh/faq/','FAQ관리','FAQ관리','/uss/olh/faq/FaqListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('FaqListInqire','/uss/olh/faq/','FAQ관리','FAQ관리','/uss/olh/faq/selectFaqList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getBackupOpertList','/sym/sym/bak/','백업관리','백업관리','/sym/sym/bak/getBackupOpertList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getBackupResultList','/sym/sym/bak/','백업결과관리','백업결과관리','/sym/sym/bak/getBackupResultList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getBatchOpertList','/sym/bat/','배치작업관리','배치작업관리','/sym/bat/getBatchOpertList.do');
@@ -755,10 +755,10 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getMainImageResult','/uss/ion/msi/','메인이미지 반영결과보기','메인이미지 반영결과보기','/uss/ion/msi/getMainImageResult.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getSystemCntcList','/ssi/syi/sim/','시스템연계관리','시스템연계관리','/ssi/syi/sim/getSystemCntcList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getTrsmrcvMntrngList','/utl/sys/trm/','송수신모니터링','송수신모니터링','/utl/sys/trm/getTrsmrcvMntrngList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('HpcmListInqire','/uss/olh/hpc/','도움말','도움말','/uss/olh/hpc/HpcmListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('HpcmListInqire','/uss/olh/hpc/','도움말','도움말','/uss/olh/hpc/selectHpcmList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('insertSndngMailView','/cop/ems/','메일발송','메일발송','/cop/ems/insertSndngMailView.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWord','/uss/olh/awm/','행정전문용어사전','행정전문용어사전','/uss/olh/awm/listAdministrationWord.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWordManage','/uss/olh/awm/','행정전문용어사전관리','행정전문용어사전관리','/uss/olh/awm/listAdministrationWordManage.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWord','/uss/olh/awm/','행정전문용어사전','행정전문용어사전','/uss/olh/awm/selectAdministrationWordList.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWordManage','/uss/olh/awm/','행정전문용어사전관리','행정전문용어사전관리','/uss/olh/awm/selectAdministrationWordManageList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listIndvdlInfoPolicy','/uss/sam/ipm/','개인정보보호정책확인','개인정보보호정책확인','/uss/sam/ipm/listIndvdlInfoPolicy.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listNoteRecptn','/uss/ion/ntr/','받은쪽지함관리','받은쪽지함관리','/uss/ion/ntr/listNoteRecptn.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listNoteTrnsmit','/uss/ion/nts/','보낸쪽지함관리','보낸쪽지함관리','/uss/ion/nts/listNoteTrnsmit.do');
@@ -776,7 +776,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('NewsInfoListInqire','/uss/ion/nws/','뉴스관리','뉴스관리','/uss/ion/nws/NewsInfoListInqire.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('OnlineManualUserList','/uss/olh/omn/','사용자온라인매뉴얼','사용자온라인매뉴얼','/uss/olh/omn/selectOnlineManualList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('QnaAnswerListInqire','/uss/olh/qnm/','Q&amp;A답변관리','Q&amp;A답변관리','/uss/olh/qnm/QnaAnswerListInqire.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('QnaListInqire','/uss/olh/qna/','Q&amp;A관리','Q&amp;A관리','/uss/olh/qna/QnaListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('QnaListInqire','/uss/olh/qna/','Q&amp;A관리','Q&amp;A관리','/uss/olh/qna/selectQnaList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('RecomendSiteListInqire','/uss/ion/rec/','추천사이트관리','추천사이트관리','/uss/ion/rec/RecomendSiteListInqire.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('registEgovNoteManage','/uss/ion/ntm/','쪽지관리','쪽지관리','/uss/ion/ntm/registEgovNoteManage.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectAdbkList','/cop/adb/','주소록관리','주소록관리','/cop/adb/selectAdbkList.do');
@@ -837,7 +837,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectWikMnthngReprtList','/cop/smt/wmr/','주간/월간보고관리','주간/월간보고관리','/cop/smt/wmr/selectWikMnthngReprtList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('SiteListInqire','/uss/ion/sit/','사이트관리','사이트관리','/uss/ion/sit/SiteListInqire.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('StplatListInqire','/uss/sam/stp/','약관관리','약관관리','/uss/sam/stp/StplatListInqire.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('WordDicaryListInqire','/uss/olh/wor/','용어사전','용어사전','/uss/olh/wor/WordDicaryListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('WordDicaryListInqire','/uss/olh/wor/','용어사전','용어사전','/uss/olh/wor/selectWordDicaryList.do');
 
 -- 메뉴정보
 INSERT INTO COMTNMENUINFO(MENU_NM, PROGRM_FILE_NM, MENU_NO, UPPER_MENU_NO, MENU_ORDR, MENU_DC, RELATE_IMAGE_PATH, RELATE_IMAGE_NM) VALUES ('root','dir',0,0,1,'root','/','/');

--- a/script/dml/maria/com_DML_maria.sql
+++ b/script/dml/maria/com_DML_maria.sql
@@ -742,7 +742,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('EgovUserManage','/uss/umt/','업무사용자관리','업무사용자관리','/uss/umt/EgovEmplyrManage.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('EgovVcatnConfmList','/uss/ion/vct/','휴가승인관리','휴가승인관리','/uss/ion/vct/EgovVcatnConfmList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('EgovVcatnManageList','/uss/ion/vct/','휴가관리','휴가관리','/uss/ion/vct/EgovVcatnManageList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('FaqListInqire','/uss/olh/faq/','FAQ관리','FAQ관리','/uss/olh/faq/FaqListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('FaqListInqire','/uss/olh/faq/','FAQ관리','FAQ관리','/uss/olh/faq/selectFaqList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getBackupOpertList','/sym/sym/bak/','백업관리','백업관리','/sym/sym/bak/getBackupOpertList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getBackupResultList','/sym/sym/bak/','백업결과관리','백업결과관리','/sym/sym/bak/getBackupResultList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getBatchOpertList','/sym/bat/','배치작업관리','배치작업관리','/sym/bat/getBatchOpertList.do');
@@ -756,10 +756,10 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getMainImageResult','/uss/ion/msi/','메인이미지 반영결과보기','메인이미지 반영결과보기','/uss/ion/msi/getMainImageResult.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getSystemCntcList','/ssi/syi/sim/','시스템연계관리','시스템연계관리','/ssi/syi/sim/getSystemCntcList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getTrsmrcvMntrngList','/utl/sys/trm/','송수신모니터링','송수신모니터링','/utl/sys/trm/getTrsmrcvMntrngList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('HpcmListInqire','/uss/olh/hpc/','도움말','도움말','/uss/olh/hpc/HpcmListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('HpcmListInqire','/uss/olh/hpc/','도움말','도움말','/uss/olh/hpc/selectHpcmList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('insertSndngMailView','/cop/ems/','메일발송','메일발송','/cop/ems/insertSndngMailView.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWord','/uss/olh/awm/','행정전문용어사전','행정전문용어사전','/uss/olh/awm/listAdministrationWord.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWordManage','/uss/olh/awm/','행정전문용어사전관리','행정전문용어사전관리','/uss/olh/awm/listAdministrationWordManage.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWord','/uss/olh/awm/','행정전문용어사전','행정전문용어사전','/uss/olh/awm/selectAdministrationWordList.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWordManage','/uss/olh/awm/','행정전문용어사전관리','행정전문용어사전관리','/uss/olh/awm/selectAdministrationWordManageList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listIndvdlInfoPolicy','/uss/sam/ipm/','개인정보보호정책확인','개인정보보호정책확인','/uss/sam/ipm/listIndvdlInfoPolicy.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listNoteRecptn','/uss/ion/ntr/','받은쪽지함관리','받은쪽지함관리','/uss/ion/ntr/listNoteRecptn.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listNoteTrnsmit','/uss/ion/nts/','보낸쪽지함관리','보낸쪽지함관리','/uss/ion/nts/listNoteTrnsmit.do');
@@ -777,7 +777,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('NewsInfoListInqire','/uss/ion/nws/','뉴스관리','뉴스관리','/uss/ion/nws/NewsInfoListInqire.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('OnlineManualUserList','/uss/olh/omn/','사용자온라인매뉴얼','사용자온라인매뉴얼','/uss/olh/omn/selectOnlineManualList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('QnaAnswerListInqire','/uss/olh/qnm/','Q&amp;A답변관리','Q&amp;A답변관리','/uss/olh/qnm/QnaAnswerListInqire.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('QnaListInqire','/uss/olh/qna/','Q&amp;A관리','Q&amp;A관리','/uss/olh/qna/QnaListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('QnaListInqire','/uss/olh/qna/','Q&amp;A관리','Q&amp;A관리','/uss/olh/qna/selectQnaList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('RecomendSiteListInqire','/uss/ion/rec/','추천사이트관리','추천사이트관리','/uss/ion/rec/RecomendSiteListInqire.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('registEgovNoteManage','/uss/ion/ntm/','쪽지관리','쪽지관리','/uss/ion/ntm/registEgovNoteManage.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectAdbkList','/cop/adb/','주소록관리','주소록관리','/cop/adb/selectAdbkList.do');
@@ -838,7 +838,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectWikMnthngReprtList','/cop/smt/wmr/','주간/월간보고관리','주간/월간보고관리','/cop/smt/wmr/selectWikMnthngReprtList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('SiteListInqire','/uss/ion/sit/','사이트관리','사이트관리','/uss/ion/sit/SiteListInqire.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('StplatListInqire','/uss/sam/stp/','약관관리','약관관리','/uss/sam/stp/StplatListInqire.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('WordDicaryListInqire','/uss/olh/wor/','용어사전','용어사전','/uss/olh/wor/WordDicaryListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('WordDicaryListInqire','/uss/olh/wor/','용어사전','용어사전','/uss/olh/wor/selectWordDicaryList.do');
 
 -- 메뉴정보
 INSERT INTO COMTNMENUINFO(MENU_NM, PROGRM_FILE_NM, MENU_NO, UPPER_MENU_NO, MENU_ORDR, MENU_DC, RELATE_IMAGE_PATH, RELATE_IMAGE_NM) VALUES ('root','dir',0,0,1,'root','/','/');

--- a/script/dml/mysql/com_DML_mysql.sql
+++ b/script/dml/mysql/com_DML_mysql.sql
@@ -742,7 +742,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('EgovUserManage','/uss/umt/','업무사용자관리','업무사용자관리','/uss/umt/EgovEmplyrManage.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('EgovVcatnConfmList','/uss/ion/vct/','휴가승인관리','휴가승인관리','/uss/ion/vct/EgovVcatnConfmList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('EgovVcatnManageList','/uss/ion/vct/','휴가관리','휴가관리','/uss/ion/vct/EgovVcatnManageList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('FaqListInqire','/uss/olh/faq/','FAQ관리','FAQ관리','/uss/olh/faq/FaqListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('FaqListInqire','/uss/olh/faq/','FAQ관리','FAQ관리','/uss/olh/faq/selectFaqList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getBackupOpertList','/sym/sym/bak/','백업관리','백업관리','/sym/sym/bak/getBackupOpertList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getBackupResultList','/sym/sym/bak/','백업결과관리','백업결과관리','/sym/sym/bak/getBackupResultList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getBatchOpertList','/sym/bat/','배치작업관리','배치작업관리','/sym/bat/getBatchOpertList.do');
@@ -756,10 +756,10 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getMainImageResult','/uss/ion/msi/','메인이미지 반영결과보기','메인이미지 반영결과보기','/uss/ion/msi/getMainImageResult.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getSystemCntcList','/ssi/syi/sim/','시스템연계관리','시스템연계관리','/ssi/syi/sim/getSystemCntcList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getTrsmrcvMntrngList','/utl/sys/trm/','송수신모니터링','송수신모니터링','/utl/sys/trm/getTrsmrcvMntrngList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('HpcmListInqire','/uss/olh/hpc/','도움말','도움말','/uss/olh/hpc/HpcmListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('HpcmListInqire','/uss/olh/hpc/','도움말','도움말','/uss/olh/hpc/selectHpcmList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('insertSndngMailView','/cop/ems/','메일발송','메일발송','/cop/ems/insertSndngMailView.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWord','/uss/olh/awm/','행정전문용어사전','행정전문용어사전','/uss/olh/awm/listAdministrationWord.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWordManage','/uss/olh/awm/','행정전문용어사전관리','행정전문용어사전관리','/uss/olh/awm/listAdministrationWordManage.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWord','/uss/olh/awm/','행정전문용어사전','행정전문용어사전','/uss/olh/awm/selectAdministrationWordList.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWordManage','/uss/olh/awm/','행정전문용어사전관리','행정전문용어사전관리','/uss/olh/awm/selectAdministrationWordManageList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listIndvdlInfoPolicy','/uss/sam/ipm/','개인정보보호정책확인','개인정보보호정책확인','/uss/sam/ipm/listIndvdlInfoPolicy.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listNoteRecptn','/uss/ion/ntr/','받은쪽지함관리','받은쪽지함관리','/uss/ion/ntr/listNoteRecptn.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listNoteTrnsmit','/uss/ion/nts/','보낸쪽지함관리','보낸쪽지함관리','/uss/ion/nts/listNoteTrnsmit.do');
@@ -777,7 +777,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('NewsInfoListInqire','/uss/ion/nws/','뉴스관리','뉴스관리','/uss/ion/nws/NewsInfoListInqire.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('OnlineManualUserList','/uss/olh/omn/','사용자온라인매뉴얼','사용자온라인매뉴얼','/uss/olh/omn/selectOnlineManualList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('QnaAnswerListInqire','/uss/olh/qnm/','Q&amp;A답변관리','Q&amp;A답변관리','/uss/olh/qnm/QnaAnswerListInqire.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('QnaListInqire','/uss/olh/qna/','Q&amp;A관리','Q&amp;A관리','/uss/olh/qna/QnaListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('QnaListInqire','/uss/olh/qna/','Q&amp;A관리','Q&amp;A관리','/uss/olh/qna/selectQnaList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('RecomendSiteListInqire','/uss/ion/rec/','추천사이트관리','추천사이트관리','/uss/ion/rec/RecomendSiteListInqire.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('registEgovNoteManage','/uss/ion/ntm/','쪽지관리','쪽지관리','/uss/ion/ntm/registEgovNoteManage.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectAdbkList','/cop/adb/','주소록관리','주소록관리','/cop/adb/selectAdbkList.do');
@@ -838,7 +838,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectWikMnthngReprtList','/cop/smt/wmr/','주간/월간보고관리','주간/월간보고관리','/cop/smt/wmr/selectWikMnthngReprtList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('SiteListInqire','/uss/ion/sit/','사이트관리','사이트관리','/uss/ion/sit/SiteListInqire.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('StplatListInqire','/uss/sam/stp/','약관관리','약관관리','/uss/sam/stp/StplatListInqire.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('WordDicaryListInqire','/uss/olh/wor/','용어사전','용어사전','/uss/olh/wor/WordDicaryListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('WordDicaryListInqire','/uss/olh/wor/','용어사전','용어사전','/uss/olh/wor/selectWordDicaryList.do');
 
 -- 메뉴정보
 INSERT INTO COMTNMENUINFO(MENU_NM, PROGRM_FILE_NM, MENU_NO, UPPER_MENU_NO, MENU_ORDR, MENU_DC, RELATE_IMAGE_PATH, RELATE_IMAGE_NM) VALUES ('root','dir',0,0,1,'root','/','/');

--- a/script/dml/oracle/com_DML_oracle.sql
+++ b/script/dml/oracle/com_DML_oracle.sql
@@ -743,7 +743,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('EgovUserManage','/uss/umt/','업무사용자관리','업무사용자관리','/uss/umt/EgovEmplyrManage.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('EgovVcatnConfmList','/uss/ion/vct/','휴가승인관리','휴가승인관리','/uss/ion/vct/EgovVcatnConfmList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('EgovVcatnManageList','/uss/ion/vct/','휴가관리','휴가관리','/uss/ion/vct/EgovVcatnManageList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('FaqListInqire','/uss/olh/faq/','FAQ관리','FAQ관리','/uss/olh/faq/FaqListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('FaqListInqire','/uss/olh/faq/','FAQ관리','FAQ관리','/uss/olh/faq/selectFaqList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getBackupOpertList','/sym/sym/bak/','백업관리','백업관리','/sym/sym/bak/getBackupOpertList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getBackupResultList','/sym/sym/bak/','백업결과관리','백업결과관리','/sym/sym/bak/getBackupResultList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getBatchOpertList','/sym/bat/','배치작업관리','배치작업관리','/sym/bat/getBatchOpertList.do');
@@ -757,10 +757,10 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getMainImageResult','/uss/ion/msi/','메인이미지 반영결과보기','메인이미지 반영결과보기','/uss/ion/msi/getMainImageResult.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getSystemCntcList','/ssi/syi/sim/','시스템연계관리','시스템연계관리','/ssi/syi/sim/getSystemCntcList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getTrsmrcvMntrngList','/utl/sys/trm/','송수신모니터링','송수신모니터링','/utl/sys/trm/getTrsmrcvMntrngList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('HpcmListInqire','/uss/olh/hpc/','도움말','도움말','/uss/olh/hpc/HpcmListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('HpcmListInqire','/uss/olh/hpc/','도움말','도움말','/uss/olh/hpc/selectHpcmList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('insertSndngMailView','/cop/ems/','메일발송','메일발송','/cop/ems/insertSndngMailView.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWord','/uss/olh/awm/','행정전문용어사전','행정전문용어사전','/uss/olh/awm/listAdministrationWord.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWordManage','/uss/olh/awm/','행정전문용어사전관리','행정전문용어사전관리','/uss/olh/awm/listAdministrationWordManage.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWord','/uss/olh/awm/','행정전문용어사전','행정전문용어사전','/uss/olh/awm/selectAdministrationWordList.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWordManage','/uss/olh/awm/','행정전문용어사전관리','행정전문용어사전관리','/uss/olh/awm/selectAdministrationWordManageList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listIndvdlInfoPolicy','/uss/sam/ipm/','개인정보보호정책확인','개인정보보호정책확인','/uss/sam/ipm/listIndvdlInfoPolicy.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listNoteRecptn','/uss/ion/ntr/','받은쪽지함관리','받은쪽지함관리','/uss/ion/ntr/listNoteRecptn.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listNoteTrnsmit','/uss/ion/nts/','보낸쪽지함관리','보낸쪽지함관리','/uss/ion/nts/listNoteTrnsmit.do');
@@ -778,7 +778,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('NewsInfoListInqire','/uss/ion/nws/','뉴스관리','뉴스관리','/uss/ion/nws/NewsInfoListInqire.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('OnlineManualUserList','/uss/olh/omn/','사용자온라인매뉴얼','사용자온라인매뉴얼','/uss/olh/omn/selectOnlineManualList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('QnaAnswerListInqire','/uss/olh/qnm/','Q&amp;A답변관리','Q&amp;A답변관리','/uss/olh/qnm/QnaAnswerListInqire.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('QnaListInqire','/uss/olh/qna/','Q&amp;A관리','Q&amp;A관리','/uss/olh/qna/QnaListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('QnaListInqire','/uss/olh/qna/','Q&amp;A관리','Q&amp;A관리','/uss/olh/qna/selectQnaList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('RecomendSiteListInqire','/uss/ion/rec/','추천사이트관리','추천사이트관리','/uss/ion/rec/RecomendSiteListInqire.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('registEgovNoteManage','/uss/ion/ntm/','쪽지관리','쪽지관리','/uss/ion/ntm/registEgovNoteManage.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectAdbkList','/cop/adb/','주소록관리','주소록관리','/cop/adb/selectAdbkList.do');
@@ -839,7 +839,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectWikMnthngReprtList','/cop/smt/wmr/','주간/월간보고관리','주간/월간보고관리','/cop/smt/wmr/selectWikMnthngReprtList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('SiteListInqire','/uss/ion/sit/','사이트관리','사이트관리','/uss/ion/sit/SiteListInqire.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('StplatListInqire','/uss/sam/stp/','약관관리','약관관리','/uss/sam/stp/StplatListInqire.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('WordDicaryListInqire','/uss/olh/wor/','용어사전','용어사전','/uss/olh/wor/WordDicaryListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('WordDicaryListInqire','/uss/olh/wor/','용어사전','용어사전','/uss/olh/wor/selectWordDicaryList.do');
 
 -- 메뉴정보
 INSERT INTO COMTNMENUINFO(MENU_NM, PROGRM_FILE_NM, MENU_NO, UPPER_MENU_NO, MENU_ORDR, MENU_DC, RELATE_IMAGE_PATH, RELATE_IMAGE_NM) VALUES ('root','dir',0,0,1,'root','/','/');

--- a/script/dml/postgres/com_DML_postgres.sql
+++ b/script/dml/postgres/com_DML_postgres.sql
@@ -742,7 +742,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('EgovUserManage','/uss/umt/','업무사용자관리','업무사용자관리','/uss/umt/EgovEmplyrManage.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('EgovVcatnConfmList','/uss/ion/vct/','휴가승인관리','휴가승인관리','/uss/ion/vct/EgovVcatnConfmList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('EgovVcatnManageList','/uss/ion/vct/','휴가관리','휴가관리','/uss/ion/vct/EgovVcatnManageList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('FaqListInqire','/uss/olh/faq/','FAQ관리','FAQ관리','/uss/olh/faq/FaqListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('FaqListInqire','/uss/olh/faq/','FAQ관리','FAQ관리','/uss/olh/faq/selectFaqList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getBackupOpertList','/sym/sym/bak/','백업관리','백업관리','/sym/sym/bak/getBackupOpertList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getBackupResultList','/sym/sym/bak/','백업결과관리','백업결과관리','/sym/sym/bak/getBackupResultList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getBatchOpertList','/sym/bat/','배치작업관리','배치작업관리','/sym/bat/getBatchOpertList.do');
@@ -756,10 +756,10 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getMainImageResult','/uss/ion/msi/','메인이미지 반영결과보기','메인이미지 반영결과보기','/uss/ion/msi/getMainImageResult.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getSystemCntcList','/ssi/syi/sim/','시스템연계관리','시스템연계관리','/ssi/syi/sim/getSystemCntcList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getTrsmrcvMntrngList','/utl/sys/trm/','송수신모니터링','송수신모니터링','/utl/sys/trm/getTrsmrcvMntrngList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('HpcmListInqire','/uss/olh/hpc/','도움말','도움말','/uss/olh/hpc/HpcmListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('HpcmListInqire','/uss/olh/hpc/','도움말','도움말','/uss/olh/hpc/selectHpcmList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('insertSndngMailView','/cop/ems/','메일발송','메일발송','/cop/ems/insertSndngMailView.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWord','/uss/olh/awm/','행정전문용어사전','행정전문용어사전','/uss/olh/awm/listAdministrationWord.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWordManage','/uss/olh/awm/','행정전문용어사전관리','행정전문용어사전관리','/uss/olh/awm/listAdministrationWordManage.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWord','/uss/olh/awm/','행정전문용어사전','행정전문용어사전','/uss/olh/awm/selectAdministrationWordList.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWordManage','/uss/olh/awm/','행정전문용어사전관리','행정전문용어사전관리','/uss/olh/awm/selectAdministrationWordManageList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listIndvdlInfoPolicy','/uss/sam/ipm/','개인정보보호정책확인','개인정보보호정책확인','/uss/sam/ipm/listIndvdlInfoPolicy.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listNoteRecptn','/uss/ion/ntr/','받은쪽지함관리','받은쪽지함관리','/uss/ion/ntr/listNoteRecptn.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listNoteTrnsmit','/uss/ion/nts/','보낸쪽지함관리','보낸쪽지함관리','/uss/ion/nts/listNoteTrnsmit.do');
@@ -777,7 +777,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('NewsInfoListInqire','/uss/ion/nws/','뉴스관리','뉴스관리','/uss/ion/nws/NewsInfoListInqire.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('OnlineManualUserList','/uss/olh/omn/','사용자온라인매뉴얼','사용자온라인매뉴얼','/uss/olh/omn/selectOnlineManualList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('QnaAnswerListInqire','/uss/olh/qnm/','Q&amp;A답변관리','Q&amp;A답변관리','/uss/olh/qnm/QnaAnswerListInqire.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('QnaListInqire','/uss/olh/qna/','Q&amp;A관리','Q&amp;A관리','/uss/olh/qna/QnaListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('QnaListInqire','/uss/olh/qna/','Q&amp;A관리','Q&amp;A관리','/uss/olh/qna/selectQnaList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('RecomendSiteListInqire','/uss/ion/rec/','추천사이트관리','추천사이트관리','/uss/ion/rec/RecomendSiteListInqire.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('registEgovNoteManage','/uss/ion/ntm/','쪽지관리','쪽지관리','/uss/ion/ntm/registEgovNoteManage.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectAdbkList','/cop/adb/','주소록관리','주소록관리','/cop/adb/selectAdbkList.do');
@@ -838,7 +838,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectWikMnthngReprtList','/cop/smt/wmr/','주간/월간보고관리','주간/월간보고관리','/cop/smt/wmr/selectWikMnthngReprtList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('SiteListInqire','/uss/ion/sit/','사이트관리','사이트관리','/uss/ion/sit/SiteListInqire.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('StplatListInqire','/uss/sam/stp/','약관관리','약관관리','/uss/sam/stp/StplatListInqire.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('WordDicaryListInqire','/uss/olh/wor/','용어사전','용어사전','/uss/olh/wor/WordDicaryListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('WordDicaryListInqire','/uss/olh/wor/','용어사전','용어사전','/uss/olh/wor/selectWordDicaryList.do');
 
 -- 메뉴정보
 INSERT INTO COMTNMENUINFO(MENU_NM, PROGRM_FILE_NM, MENU_NO, UPPER_MENU_NO, MENU_ORDR, MENU_DC, RELATE_IMAGE_PATH, RELATE_IMAGE_NM) VALUES ('root','dir',0,0,1,'root','/','/');

--- a/script/dml/tibero/com_DML_tibero.sql
+++ b/script/dml/tibero/com_DML_tibero.sql
@@ -743,7 +743,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('EgovUserManage','/uss/umt/','업무사용자관리','업무사용자관리','/uss/umt/EgovEmplyrManage.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('EgovVcatnConfmList','/uss/ion/vct/','휴가승인관리','휴가승인관리','/uss/ion/vct/EgovVcatnConfmList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('EgovVcatnManageList','/uss/ion/vct/','휴가관리','휴가관리','/uss/ion/vct/EgovVcatnManageList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('FaqListInqire','/uss/olh/faq/','FAQ관리','FAQ관리','/uss/olh/faq/FaqListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('FaqListInqire','/uss/olh/faq/','FAQ관리','FAQ관리','/uss/olh/faq/selectFaqList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getBackupOpertList','/sym/sym/bak/','백업관리','백업관리','/sym/sym/bak/getBackupOpertList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getBackupResultList','/sym/sym/bak/','백업결과관리','백업결과관리','/sym/sym/bak/getBackupResultList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getBatchOpertList','/sym/bat/','배치작업관리','배치작업관리','/sym/bat/getBatchOpertList.do');
@@ -757,10 +757,10 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getMainImageResult','/uss/ion/msi/','메인이미지 반영결과보기','메인이미지 반영결과보기','/uss/ion/msi/getMainImageResult.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getSystemCntcList','/ssi/syi/sim/','시스템연계관리','시스템연계관리','/ssi/syi/sim/getSystemCntcList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getTrsmrcvMntrngList','/utl/sys/trm/','송수신모니터링','송수신모니터링','/utl/sys/trm/getTrsmrcvMntrngList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('HpcmListInqire','/uss/olh/hpc/','도움말','도움말','/uss/olh/hpc/HpcmListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('HpcmListInqire','/uss/olh/hpc/','도움말','도움말','/uss/olh/hpc/selectHpcmList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('insertSndngMailView','/cop/ems/','메일발송','메일발송','/cop/ems/insertSndngMailView.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWord','/uss/olh/awm/','행정전문용어사전','행정전문용어사전','/uss/olh/awm/listAdministrationWord.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWordManage','/uss/olh/awm/','행정전문용어사전관리','행정전문용어사전관리','/uss/olh/awm/listAdministrationWordManage.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWord','/uss/olh/awm/','행정전문용어사전','행정전문용어사전','/uss/olh/awm/selectAdministrationWordList.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWordManage','/uss/olh/awm/','행정전문용어사전관리','행정전문용어사전관리','/uss/olh/awm/selectAdministrationWordManageList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listIndvdlInfoPolicy','/uss/sam/ipm/','개인정보보호정책확인','개인정보보호정책확인','/uss/sam/ipm/listIndvdlInfoPolicy.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listNoteRecptn','/uss/ion/ntr/','받은쪽지함관리','받은쪽지함관리','/uss/ion/ntr/listNoteRecptn.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listNoteTrnsmit','/uss/ion/nts/','보낸쪽지함관리','보낸쪽지함관리','/uss/ion/nts/listNoteTrnsmit.do');
@@ -778,7 +778,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('NewsInfoListInqire','/uss/ion/nws/','뉴스관리','뉴스관리','/uss/ion/nws/NewsInfoListInqire.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('OnlineManualUserList','/uss/olh/omn/','사용자온라인매뉴얼','사용자온라인매뉴얼','/uss/olh/omn/selectOnlineManualList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('QnaAnswerListInqire','/uss/olh/qnm/','Q&amp;A답변관리','Q&amp;A답변관리','/uss/olh/qnm/QnaAnswerListInqire.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('QnaListInqire','/uss/olh/qna/','Q&amp;A관리','Q&amp;A관리','/uss/olh/qna/QnaListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('QnaListInqire','/uss/olh/qna/','Q&amp;A관리','Q&amp;A관리','/uss/olh/qna/selectQnaList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('RecomendSiteListInqire','/uss/ion/rec/','추천사이트관리','추천사이트관리','/uss/ion/rec/RecomendSiteListInqire.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('registEgovNoteManage','/uss/ion/ntm/','쪽지관리','쪽지관리','/uss/ion/ntm/registEgovNoteManage.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectAdbkList','/cop/adb/','주소록관리','주소록관리','/cop/adb/selectAdbkList.do');
@@ -839,7 +839,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectWikMnthngReprtList','/cop/smt/wmr/','주간/월간보고관리','주간/월간보고관리','/cop/smt/wmr/selectWikMnthngReprtList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('SiteListInqire','/uss/ion/sit/','사이트관리','사이트관리','/uss/ion/sit/SiteListInqire.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('StplatListInqire','/uss/sam/stp/','약관관리','약관관리','/uss/sam/stp/StplatListInqire.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('WordDicaryListInqire','/uss/olh/wor/','용어사전','용어사전','/uss/olh/wor/WordDicaryListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('WordDicaryListInqire','/uss/olh/wor/','용어사전','용어사전','/uss/olh/wor/selectWordDicaryList.do');
 
 -- 메뉴정보
 INSERT INTO COMTNMENUINFO(MENU_NM, PROGRM_FILE_NM, MENU_NO, UPPER_MENU_NO, MENU_ORDR, MENU_DC, RELATE_IMAGE_PATH, RELATE_IMAGE_NM) VALUES ('root','dir',0,0,1,'root','/','/');

--- a/src/script/dml/altibase/sts.sst_insert_altibase.sql
+++ b/src/script/dml/altibase/sts.sst_insert_altibase.sql
@@ -735,7 +735,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('EgovUserManage','/uss/umt/','업무사용자관리','업무사용자관리','/uss/umt/EgovEmplyrManage.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('EgovVcatnConfmList','/uss/ion/vct/','휴가승인관리','휴가승인관리','/uss/ion/vct/EgovVcatnConfmList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('EgovVcatnManageList','/uss/ion/vct/','휴가관리','휴가관리','/uss/ion/vct/EgovVcatnManageList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('FaqListInqire','/uss/olh/faq/','FAQ관리','FAQ관리','/uss/olh/faq/FaqListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('FaqListInqire','/uss/olh/faq/','FAQ관리','FAQ관리','/uss/olh/faq/selectFaqList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getBackupOpertList','/sym/sym/bak/','백업관리','백업관리','/sym/sym/bak/getBackupOpertList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getBackupResultList','/sym/sym/bak/','백업결과관리','백업결과관리','/sym/sym/bak/getBackupResultList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getBatchOpertList','/sym/bat/','배치작업관리','배치작업관리','/sym/bat/getBatchOpertList.do');
@@ -749,10 +749,10 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getMainImageResult','/uss/ion/msi/','메인이미지 반영결과보기','메인이미지 반영결과보기','/uss/ion/msi/getMainImageResult.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getSystemCntcList','/ssi/syi/sim/','시스템연계관리','시스템연계관리','/ssi/syi/sim/getSystemCntcList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getTrsmrcvMntrngList','/utl/sys/trm/','송수신모니터링','송수신모니터링','/utl/sys/trm/getTrsmrcvMntrngList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('HpcmListInqire','/uss/olh/hpc/','도움말','도움말','/uss/olh/hpc/HpcmListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('HpcmListInqire','/uss/olh/hpc/','도움말','도움말','/uss/olh/hpc/selectHpcmList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('insertSndngMailView','/cop/ems/','메일발송','메일발송','/cop/ems/insertSndngMailView.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWord','/uss/olh/awm/','행정전문용어사전','행정전문용어사전','/uss/olh/awm/listAdministrationWord.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWordManage','/uss/olh/awm/','행정전문용어사전관리','행정전문용어사전관리','/uss/olh/awm/listAdministrationWordManage.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWord','/uss/olh/awm/','행정전문용어사전','행정전문용어사전','/uss/olh/awm/selectAdministrationWordList.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWordManage','/uss/olh/awm/','행정전문용어사전관리','행정전문용어사전관리','/uss/olh/awm/selectAdministrationWordManageList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listIndvdlInfoPolicy','/uss/sam/ipm/','개인정보보호정책확인','개인정보보호정책확인','/uss/sam/ipm/listIndvdlInfoPolicy.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listNoteRecptn','/uss/ion/ntr/','받은쪽지함관리','받은쪽지함관리','/uss/ion/ntr/listNoteRecptn.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listNoteTrnsmit','/uss/ion/nts/','보낸쪽지함관리','보낸쪽지함관리','/uss/ion/nts/listNoteTrnsmit.do');
@@ -770,7 +770,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('NewsInfoListInqire','/uss/ion/nws/','뉴스관리','뉴스관리','/uss/ion/nws/NewsInfoListInqire.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('OnlineManualUserList','/uss/olh/omn/','사용자온라인매뉴얼','사용자온라인매뉴얼','/uss/olh/omn/selectOnlineManualList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('QnaAnswerListInqire','/uss/olh/qnm/','Q&amp;A답변관리','Q&amp;A답변관리','/uss/olh/qnm/QnaAnswerListInqire.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('QnaListInqire','/uss/olh/qna/','Q&amp;A관리','Q&amp;A관리','/uss/olh/qna/QnaListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('QnaListInqire','/uss/olh/qna/','Q&amp;A관리','Q&amp;A관리','/uss/olh/qna/selectQnaList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('RecomendSiteListInqire','/uss/ion/rec/','추천사이트관리','추천사이트관리','/uss/ion/rec/RecomendSiteListInqire.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('registEgovNoteManage','/uss/ion/ntm/','쪽지관리','쪽지관리','/uss/ion/ntm/registEgovNoteManage.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectAdbkList','/cop/adb/','주소록관리','주소록관리','/cop/adb/selectAdbkList.do');
@@ -831,7 +831,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectWikMnthngReprtList','/cop/smt/wmr/','주간/월간보고관리','주간/월간보고관리','/cop/smt/wmr/selectWikMnthngReprtList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('SiteListInqire','/uss/ion/sit/','사이트관리','사이트관리','/uss/ion/sit/SiteListInqire.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('StplatListInqire','/uss/sam/stp/','약관관리','약관관리','/uss/sam/stp/StplatListInqire.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('WordDicaryListInqire','/uss/olh/wor/','용어사전','용어사전','/uss/olh/wor/WordDicaryListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('WordDicaryListInqire','/uss/olh/wor/','용어사전','용어사전','/uss/olh/wor/selectWordDicaryList.do');
 
 /* 메뉴정보 */
 INSERT INTO COMTNMENUINFO(MENU_NM, PROGRM_FILE_NM, MENU_NO, UPPER_MENU_NO, MENU_ORDR, MENU_DC, RELATE_IMAGE_PATH, RELATE_IMAGE_NM) VALUES ('root','dir',0,0,1,'root','/','/');

--- a/src/script/dml/altibase/sym.mnu_insert_altibase.sql
+++ b/src/script/dml/altibase/sym.mnu_insert_altibase.sql
@@ -741,7 +741,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('EgovUserManage','/uss/umt/','업무사용자관리','업무사용자관리','/uss/umt/EgovEmplyrManage.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('EgovVcatnConfmList','/uss/ion/vct/','휴가승인관리','휴가승인관리','/uss/ion/vct/EgovVcatnConfmList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('EgovVcatnManageList','/uss/ion/vct/','휴가관리','휴가관리','/uss/ion/vct/EgovVcatnManageList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('FaqListInqire','/uss/olh/faq/','FAQ관리','FAQ관리','/uss/olh/faq/FaqListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('FaqListInqire','/uss/olh/faq/','FAQ관리','FAQ관리','/uss/olh/faq/selectFaqList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getBackupOpertList','/sym/sym/bak/','백업관리','백업관리','/sym/sym/bak/getBackupOpertList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getBackupResultList','/sym/sym/bak/','백업결과관리','백업결과관리','/sym/sym/bak/getBackupResultList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getBatchOpertList','/sym/bat/','배치작업관리','배치작업관리','/sym/bat/getBatchOpertList.do');
@@ -755,10 +755,10 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getMainImageResult','/uss/ion/msi/','메인이미지 반영결과보기','메인이미지 반영결과보기','/uss/ion/msi/getMainImageResult.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getSystemCntcList','/ssi/syi/sim/','시스템연계관리','시스템연계관리','/ssi/syi/sim/getSystemCntcList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getTrsmrcvMntrngList','/utl/sys/trm/','송수신모니터링','송수신모니터링','/utl/sys/trm/getTrsmrcvMntrngList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('HpcmListInqire','/uss/olh/hpc/','도움말','도움말','/uss/olh/hpc/HpcmListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('HpcmListInqire','/uss/olh/hpc/','도움말','도움말','/uss/olh/hpc/selectHpcmList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('insertSndngMailView','/cop/ems/','메일발송','메일발송','/cop/ems/insertSndngMailView.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWord','/uss/olh/awm/','행정전문용어사전','행정전문용어사전','/uss/olh/awm/listAdministrationWord.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWordManage','/uss/olh/awm/','행정전문용어사전관리','행정전문용어사전관리','/uss/olh/awm/listAdministrationWordManage.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWord','/uss/olh/awm/','행정전문용어사전','행정전문용어사전','/uss/olh/awm/selectAdministrationWordList.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWordManage','/uss/olh/awm/','행정전문용어사전관리','행정전문용어사전관리','/uss/olh/awm/selectAdministrationWordManageList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listIndvdlInfoPolicy','/uss/sam/ipm/','개인정보보호정책확인','개인정보보호정책확인','/uss/sam/ipm/listIndvdlInfoPolicy.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listNoteRecptn','/uss/ion/ntr/','받은쪽지함관리','받은쪽지함관리','/uss/ion/ntr/listNoteRecptn.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listNoteTrnsmit','/uss/ion/nts/','보낸쪽지함관리','보낸쪽지함관리','/uss/ion/nts/listNoteTrnsmit.do');
@@ -776,7 +776,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('NewsInfoListInqire','/uss/ion/nws/','뉴스관리','뉴스관리','/uss/ion/nws/NewsInfoListInqire.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('OnlineManualUserList','/uss/olh/omn/','사용자온라인매뉴얼','사용자온라인매뉴얼','/uss/olh/omn/selectOnlineManualList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('QnaAnswerListInqire','/uss/olh/qnm/','Q&amp;A답변관리','Q&amp;A답변관리','/uss/olh/qnm/QnaAnswerListInqire.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('QnaListInqire','/uss/olh/qna/','Q&amp;A관리','Q&amp;A관리','/uss/olh/qna/QnaListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('QnaListInqire','/uss/olh/qna/','Q&amp;A관리','Q&amp;A관리','/uss/olh/qna/selectQnaList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('RecomendSiteListInqire','/uss/ion/rec/','추천사이트관리','추천사이트관리','/uss/ion/rec/RecomendSiteListInqire.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('registEgovNoteManage','/uss/ion/ntm/','쪽지관리','쪽지관리','/uss/ion/ntm/registEgovNoteManage.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectAdbkList','/cop/adb/','주소록관리','주소록관리','/cop/adb/selectAdbkList.do');
@@ -837,7 +837,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectWikMnthngReprtList','/cop/smt/wmr/','주간/월간보고관리','주간/월간보고관리','/cop/smt/wmr/selectWikMnthngReprtList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('SiteListInqire','/uss/ion/sit/','사이트관리','사이트관리','/uss/ion/sit/SiteListInqire.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('StplatListInqire','/uss/sam/stp/','약관관리','약관관리','/uss/sam/stp/StplatListInqire.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('WordDicaryListInqire','/uss/olh/wor/','용어사전','용어사전','/uss/olh/wor/WordDicaryListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('WordDicaryListInqire','/uss/olh/wor/','용어사전','용어사전','/uss/olh/wor/selectWordDicaryList.do');
 
 /* 메뉴정보 */
 INSERT INTO COMTNMENUINFO(MENU_NM, PROGRM_FILE_NM, MENU_NO, UPPER_MENU_NO, MENU_ORDR, MENU_DC, RELATE_IMAGE_PATH, RELATE_IMAGE_NM) VALUES ('root','dir',0,0,1,'root','/','/');

--- a/src/script/dml/cubrid/sts.sst_insert_cubrid.sql
+++ b/src/script/dml/cubrid/sts.sst_insert_cubrid.sql
@@ -775,8 +775,8 @@ INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM,
 INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectCtsnnManageList', '/uss/ion/ctn/', '직원경조사관리', '직원경조사관리', '/uss/ion/ctn/selectCtsnnManageList.do');
 INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('EgovCtsnnConfmList', '/uss/ion/ctn/', '직원경조사승인관리', '직원경조사승인관리', '/uss/ion/ctn/EgovCtsnnConfmList.do');
 INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('QnaAnswerListInqire', '/uss/olh/qnm/', 'Q&amp;A답변관리', 'Q&amp;A답변관리', '/uss/olh/qnm/QnaAnswerListInqire.do');
-INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWord', '/uss/olh/awm/', '행정전문용어사전', '행정전문용어사전', '/uss/olh/awm/listAdministrationWord.do');
-INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWordManage', '/uss/olh/awm/', '행정전문용어사전관리', '행정전문용어사전관리', '/uss/olh/awm/listAdministrationWordManage.do');
+INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWord', '/uss/olh/awm/', '행정전문용어사전', '행정전문용어사전', '/uss/olh/awm/selectAdministrationWordList.do');
+INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWordManage', '/uss/olh/awm/', '행정전문용어사전관리', '행정전문용어사전관리', '/uss/olh/awm/selectAdministrationWordManageList.do');
 INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listOnlineManual', '/uss/olh/omm/', '온라인매뉴얼', '온라인매뉴얼', '/uss/olh/omm/selectOnlineManualList.do');
 INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('OnlineManualUserList', '/uss/olh/omn/', '사용자온라인매뉴얼', '사용자온라인매뉴얼', '/uss/olh/omn/selectOnlineManualList.do');
 INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('CnsltListInqire', '/uss/olp/cns/', '상담관리', '상담관리', '/uss/olp/cns/CnsltListInqire.do');
@@ -813,10 +813,10 @@ INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM,
 INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('StplatListInqire', '/uss/sam/stp/', '약관관리', '약관관리', '/uss/sam/stp/StplatListInqire.do');
 INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('CpyrhtPrtcPolicyListInqire', '/uss/sam/cpy/', '저작권보호정책', '저작권보호정책', '/uss/sam/cpy/CpyrhtPrtcPolicyListInqire.do');
 INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listIndvdlInfoPolicy', '/uss/sam/ipm/', '개인정보보호정책확인', '개인정보보호정책확인', '/uss/sam/ipm/listIndvdlInfoPolicy.do');
-INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('HpcmListInqire', '/uss/olh/hpc/', '도움말', '도움말', '/uss/olh/hpc/HpcmListInqire.do');
-INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('WordDicaryListInqire', '/uss/olh/wor/', '용어사전', '용어사전', '/uss/olh/wor/WordDicaryListInqire.do');
-INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('FaqListInqire', '/uss/olh/faq/', 'FAQ관리', 'FAQ관리', '/uss/olh/faq/FaqListInqire.do');
-INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('QnaListInqire', '/uss/olh/qna/', 'Q&amp;A관리', 'Q&amp;A관리', '/uss/olh/qna/QnaListInqire.do');
+INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('HpcmListInqire', '/uss/olh/hpc/', '도움말', '도움말', '/uss/olh/hpc/selectHpcmList.do');
+INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('WordDicaryListInqire', '/uss/olh/wor/', '용어사전', '용어사전', '/uss/olh/wor/selectWordDicaryList.do');
+INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('FaqListInqire', '/uss/olh/faq/', 'FAQ관리', 'FAQ관리', '/uss/olh/faq/selectFaqList.do');
+INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('QnaListInqire', '/uss/olh/qna/', 'Q&amp;A관리', 'Q&amp;A관리', '/uss/olh/qna/selectQnaList.do');
 INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('dir', 'dir', '디렉토리', '디렉토리', 'dir');
 INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('egovLoginUsr', '/uat/uia/', '로그인', '로그인', '/uat/uia/egovLoginUsr.do');
 INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectLoginPolicyList', '/uat/uap/', '로그인정책관리', '로그인정책관리', '/uat/uap/selectLoginPolicyList.do');

--- a/src/script/dml/cubrid/sym.mnu_insert_cubrid.sql
+++ b/src/script/dml/cubrid/sym.mnu_insert_cubrid.sql
@@ -781,8 +781,8 @@ INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM,
 INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectCtsnnManageList', '/uss/ion/ctn/', '직원경조사관리', '직원경조사관리', '/uss/ion/ctn/selectCtsnnManageList.do');
 INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('EgovCtsnnConfmList', '/uss/ion/ctn/', '직원경조사승인관리', '직원경조사승인관리', '/uss/ion/ctn/EgovCtsnnConfmList.do');
 INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('QnaAnswerListInqire', '/uss/olh/qnm/', 'Q&amp;A답변관리', 'Q&amp;A답변관리', '/uss/olh/qnm/QnaAnswerListInqire.do');
-INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWord', '/uss/olh/awm/', '행정전문용어사전', '행정전문용어사전', '/uss/olh/awm/listAdministrationWord.do');
-INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWordManage', '/uss/olh/awm/', '행정전문용어사전관리', '행정전문용어사전관리', '/uss/olh/awm/listAdministrationWordManage.do');
+INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWord', '/uss/olh/awm/', '행정전문용어사전', '행정전문용어사전', '/uss/olh/awm/selectAdministrationWordList.do');
+INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWordManage', '/uss/olh/awm/', '행정전문용어사전관리', '행정전문용어사전관리', '/uss/olh/awm/selectAdministrationWordManageList.do');
 INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listOnlineManual', '/uss/olh/omm/', '온라인매뉴얼', '온라인매뉴얼', '/uss/olh/omm/selectOnlineManualList.do');
 INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('OnlineManualUserList', '/uss/olh/omn/', '사용자온라인매뉴얼', '사용자온라인매뉴얼', '/uss/olh/omn/selectOnlineManualList.do');
 INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('CnsltListInqire', '/uss/olp/cns/', '상담관리', '상담관리', '/uss/olp/cns/CnsltListInqire.do');
@@ -819,10 +819,10 @@ INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM,
 INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('StplatListInqire', '/uss/sam/stp/', '약관관리', '약관관리', '/uss/sam/stp/StplatListInqire.do');
 INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('CpyrhtPrtcPolicyListInqire', '/uss/sam/cpy/', '저작권보호정책', '저작권보호정책', '/uss/sam/cpy/CpyrhtPrtcPolicyListInqire.do');
 INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listIndvdlInfoPolicy', '/uss/sam/ipm/', '개인정보보호정책확인', '개인정보보호정책확인', '/uss/sam/ipm/listIndvdlInfoPolicy.do');
-INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('HpcmListInqire', '/uss/olh/hpc/', '도움말', '도움말', '/uss/olh/hpc/HpcmListInqire.do');
-INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('WordDicaryListInqire', '/uss/olh/wor/', '용어사전', '용어사전', '/uss/olh/wor/WordDicaryListInqire.do');
-INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('FaqListInqire', '/uss/olh/faq/', 'FAQ관리', 'FAQ관리', '/uss/olh/faq/FaqListInqire.do');
-INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('QnaListInqire', '/uss/olh/qna/', 'Q&amp;A관리', 'Q&amp;A관리', '/uss/olh/qna/QnaListInqire.do');
+INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('HpcmListInqire', '/uss/olh/hpc/', '도움말', '도움말', '/uss/olh/hpc/selectHpcmList.do');
+INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('WordDicaryListInqire', '/uss/olh/wor/', '용어사전', '용어사전', '/uss/olh/wor/selectWordDicaryList.do');
+INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('FaqListInqire', '/uss/olh/faq/', 'FAQ관리', 'FAQ관리', '/uss/olh/faq/selectFaqList.do');
+INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('QnaListInqire', '/uss/olh/qna/', 'Q&amp;A관리', 'Q&amp;A관리', '/uss/olh/qna/selectQnaList.do');
 INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('dir', 'dir', '디렉토리', '디렉토리', 'dir');
 INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('egovLoginUsr', '/uat/uia/', '로그인', '로그인', '/uat/uia/egovLoginUsr.do');
 INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectLoginPolicyList', '/uat/uap/', '로그인정책관리', '로그인정책관리', '/uat/uap/selectLoginPolicyList.do');

--- a/src/script/dml/goldilocks/sts.sst_insert_goldilocks.sql
+++ b/src/script/dml/goldilocks/sts.sst_insert_goldilocks.sql
@@ -735,7 +735,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('EgovUserManage','/uss/umt/','업무사용자관리','업무사용자관리','/uss/umt/EgovEmplyrManage.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('EgovVcatnConfmList','/uss/ion/vct/','휴가승인관리','휴가승인관리','/uss/ion/vct/EgovVcatnConfmList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('EgovVcatnManageList','/uss/ion/vct/','휴가관리','휴가관리','/uss/ion/vct/EgovVcatnManageList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('FaqListInqire','/uss/olh/faq/','FAQ관리','FAQ관리','/uss/olh/faq/FaqListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('FaqListInqire','/uss/olh/faq/','FAQ관리','FAQ관리','/uss/olh/faq/selectFaqList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getBackupOpertList','/sym/sym/bak/','백업관리','백업관리','/sym/sym/bak/getBackupOpertList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getBackupResultList','/sym/sym/bak/','백업결과관리','백업결과관리','/sym/sym/bak/getBackupResultList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getBatchOpertList','/sym/bat/','배치작업관리','배치작업관리','/sym/bat/getBatchOpertList.do');
@@ -749,10 +749,10 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getMainImageResult','/uss/ion/msi/','메인이미지 반영결과보기','메인이미지 반영결과보기','/uss/ion/msi/getMainImageResult.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getSystemCntcList','/ssi/syi/sim/','시스템연계관리','시스템연계관리','/ssi/syi/sim/getSystemCntcList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getTrsmrcvMntrngList','/utl/sys/trm/','송수신모니터링','송수신모니터링','/utl/sys/trm/getTrsmrcvMntrngList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('HpcmListInqire','/uss/olh/hpc/','도움말','도움말','/uss/olh/hpc/HpcmListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('HpcmListInqire','/uss/olh/hpc/','도움말','도움말','/uss/olh/hpc/selectHpcmList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('insertSndngMailView','/cop/ems/','메일발송','메일발송','/cop/ems/insertSndngMailView.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWord','/uss/olh/awm/','행정전문용어사전','행정전문용어사전','/uss/olh/awm/listAdministrationWord.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWordManage','/uss/olh/awm/','행정전문용어사전관리','행정전문용어사전관리','/uss/olh/awm/listAdministrationWordManage.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWord','/uss/olh/awm/','행정전문용어사전','행정전문용어사전','/uss/olh/awm/selectAdministrationWordList.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWordManage','/uss/olh/awm/','행정전문용어사전관리','행정전문용어사전관리','/uss/olh/awm/selectAdministrationWordManageList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listIndvdlInfoPolicy','/uss/sam/ipm/','개인정보보호정책확인','개인정보보호정책확인','/uss/sam/ipm/listIndvdlInfoPolicy.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listNoteRecptn','/uss/ion/ntr/','받은쪽지함관리','받은쪽지함관리','/uss/ion/ntr/listNoteRecptn.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listNoteTrnsmit','/uss/ion/nts/','보낸쪽지함관리','보낸쪽지함관리','/uss/ion/nts/listNoteTrnsmit.do');
@@ -770,7 +770,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('NewsInfoListInqire','/uss/ion/nws/','뉴스관리','뉴스관리','/uss/ion/nws/NewsInfoListInqire.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('OnlineManualUserList','/uss/olh/omn/','사용자온라인매뉴얼','사용자온라인매뉴얼','/uss/olh/omn/selectOnlineManualList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('QnaAnswerListInqire','/uss/olh/qnm/','Q&amp;A답변관리','Q&amp;A답변관리','/uss/olh/qnm/QnaAnswerListInqire.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('QnaListInqire','/uss/olh/qna/','Q&amp;A관리','Q&amp;A관리','/uss/olh/qna/QnaListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('QnaListInqire','/uss/olh/qna/','Q&amp;A관리','Q&amp;A관리','/uss/olh/qna/selectQnaList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('RecomendSiteListInqire','/uss/ion/rec/','추천사이트관리','추천사이트관리','/uss/ion/rec/RecomendSiteListInqire.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('registEgovNoteManage','/uss/ion/ntm/','쪽지관리','쪽지관리','/uss/ion/ntm/registEgovNoteManage.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectAdbkList','/cop/adb/','주소록관리','주소록관리','/cop/adb/selectAdbkList.do');
@@ -831,7 +831,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectWikMnthngReprtList','/cop/smt/wmr/','주간/월간보고관리','주간/월간보고관리','/cop/smt/wmr/selectWikMnthngReprtList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('SiteListInqire','/uss/ion/sit/','사이트관리','사이트관리','/uss/ion/sit/SiteListInqire.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('StplatListInqire','/uss/sam/stp/','약관관리','약관관리','/uss/sam/stp/StplatListInqire.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('WordDicaryListInqire','/uss/olh/wor/','용어사전','용어사전','/uss/olh/wor/WordDicaryListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('WordDicaryListInqire','/uss/olh/wor/','용어사전','용어사전','/uss/olh/wor/selectWordDicaryList.do');
 
 /* 메뉴정보 */
 INSERT INTO COMTNMENUINFO(MENU_NM, PROGRM_FILE_NM, MENU_NO, UPPER_MENU_NO, MENU_ORDR, MENU_DC, RELATE_IMAGE_PATH, RELATE_IMAGE_NM) VALUES ('root','dir',0,0,1,'root','/','/');

--- a/src/script/dml/goldilocks/sym.mnu_insert_goldilocks.sql
+++ b/src/script/dml/goldilocks/sym.mnu_insert_goldilocks.sql
@@ -741,7 +741,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('EgovUserManage','/uss/umt/','업무사용자관리','업무사용자관리','/uss/umt/EgovEmplyrManage.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('EgovVcatnConfmList','/uss/ion/vct/','휴가승인관리','휴가승인관리','/uss/ion/vct/EgovVcatnConfmList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('EgovVcatnManageList','/uss/ion/vct/','휴가관리','휴가관리','/uss/ion/vct/EgovVcatnManageList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('FaqListInqire','/uss/olh/faq/','FAQ관리','FAQ관리','/uss/olh/faq/FaqListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('FaqListInqire','/uss/olh/faq/','FAQ관리','FAQ관리','/uss/olh/faq/selectFaqList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getBackupOpertList','/sym/sym/bak/','백업관리','백업관리','/sym/sym/bak/getBackupOpertList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getBackupResultList','/sym/sym/bak/','백업결과관리','백업결과관리','/sym/sym/bak/getBackupResultList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getBatchOpertList','/sym/bat/','배치작업관리','배치작업관리','/sym/bat/getBatchOpertList.do');
@@ -755,10 +755,10 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getMainImageResult','/uss/ion/msi/','메인이미지 반영결과보기','메인이미지 반영결과보기','/uss/ion/msi/getMainImageResult.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getSystemCntcList','/ssi/syi/sim/','시스템연계관리','시스템연계관리','/ssi/syi/sim/getSystemCntcList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getTrsmrcvMntrngList','/utl/sys/trm/','송수신모니터링','송수신모니터링','/utl/sys/trm/getTrsmrcvMntrngList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('HpcmListInqire','/uss/olh/hpc/','도움말','도움말','/uss/olh/hpc/HpcmListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('HpcmListInqire','/uss/olh/hpc/','도움말','도움말','/uss/olh/hpc/selectHpcmList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('insertSndngMailView','/cop/ems/','메일발송','메일발송','/cop/ems/insertSndngMailView.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWord','/uss/olh/awm/','행정전문용어사전','행정전문용어사전','/uss/olh/awm/listAdministrationWord.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWordManage','/uss/olh/awm/','행정전문용어사전관리','행정전문용어사전관리','/uss/olh/awm/listAdministrationWordManage.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWord','/uss/olh/awm/','행정전문용어사전','행정전문용어사전','/uss/olh/awm/selectAdministrationWordList.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWordManage','/uss/olh/awm/','행정전문용어사전관리','행정전문용어사전관리','/uss/olh/awm/selectAdministrationWordManageList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listIndvdlInfoPolicy','/uss/sam/ipm/','개인정보보호정책확인','개인정보보호정책확인','/uss/sam/ipm/listIndvdlInfoPolicy.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listNoteRecptn','/uss/ion/ntr/','받은쪽지함관리','받은쪽지함관리','/uss/ion/ntr/listNoteRecptn.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listNoteTrnsmit','/uss/ion/nts/','보낸쪽지함관리','보낸쪽지함관리','/uss/ion/nts/listNoteTrnsmit.do');
@@ -776,7 +776,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('NewsInfoListInqire','/uss/ion/nws/','뉴스관리','뉴스관리','/uss/ion/nws/NewsInfoListInqire.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('OnlineManualUserList','/uss/olh/omn/','사용자온라인매뉴얼','사용자온라인매뉴얼','/uss/olh/omn/selectOnlineManualList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('QnaAnswerListInqire','/uss/olh/qnm/','Q&amp;A답변관리','Q&amp;A답변관리','/uss/olh/qnm/QnaAnswerListInqire.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('QnaListInqire','/uss/olh/qna/','Q&amp;A관리','Q&amp;A관리','/uss/olh/qna/QnaListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('QnaListInqire','/uss/olh/qna/','Q&amp;A관리','Q&amp;A관리','/uss/olh/qna/selectQnaList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('RecomendSiteListInqire','/uss/ion/rec/','추천사이트관리','추천사이트관리','/uss/ion/rec/RecomendSiteListInqire.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('registEgovNoteManage','/uss/ion/ntm/','쪽지관리','쪽지관리','/uss/ion/ntm/registEgovNoteManage.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectAdbkList','/cop/adb/','주소록관리','주소록관리','/cop/adb/selectAdbkList.do');
@@ -837,7 +837,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectWikMnthngReprtList','/cop/smt/wmr/','주간/월간보고관리','주간/월간보고관리','/cop/smt/wmr/selectWikMnthngReprtList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('SiteListInqire','/uss/ion/sit/','사이트관리','사이트관리','/uss/ion/sit/SiteListInqire.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('StplatListInqire','/uss/sam/stp/','약관관리','약관관리','/uss/sam/stp/StplatListInqire.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('WordDicaryListInqire','/uss/olh/wor/','용어사전','용어사전','/uss/olh/wor/WordDicaryListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('WordDicaryListInqire','/uss/olh/wor/','용어사전','용어사전','/uss/olh/wor/selectWordDicaryList.do');
 
 /* 메뉴정보 */
 INSERT INTO COMTNMENUINFO(MENU_NM, PROGRM_FILE_NM, MENU_NO, UPPER_MENU_NO, MENU_ORDR, MENU_DC, RELATE_IMAGE_PATH, RELATE_IMAGE_NM) VALUES ('root','dir',0,0,1,'root','/','/');

--- a/src/script/dml/maria/sts.sst_insert_maria.sql
+++ b/src/script/dml/maria/sts.sst_insert_maria.sql
@@ -735,7 +735,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('EgovUserManage','/uss/umt/','업무사용자관리','업무사용자관리','/uss/umt/EgovEmplyrManage.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('EgovVcatnConfmList','/uss/ion/vct/','휴가승인관리','휴가승인관리','/uss/ion/vct/EgovVcatnConfmList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('EgovVcatnManageList','/uss/ion/vct/','휴가관리','휴가관리','/uss/ion/vct/EgovVcatnManageList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('FaqListInqire','/uss/olh/faq/','FAQ관리','FAQ관리','/uss/olh/faq/FaqListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('FaqListInqire','/uss/olh/faq/','FAQ관리','FAQ관리','/uss/olh/faq/selectFaqList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getBackupOpertList','/sym/sym/bak/','백업관리','백업관리','/sym/sym/bak/getBackupOpertList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getBackupResultList','/sym/sym/bak/','백업결과관리','백업결과관리','/sym/sym/bak/getBackupResultList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getBatchOpertList','/sym/bat/','배치작업관리','배치작업관리','/sym/bat/getBatchOpertList.do');
@@ -749,10 +749,10 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getMainImageResult','/uss/ion/msi/','메인이미지 반영결과보기','메인이미지 반영결과보기','/uss/ion/msi/getMainImageResult.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getSystemCntcList','/ssi/syi/sim/','시스템연계관리','시스템연계관리','/ssi/syi/sim/getSystemCntcList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getTrsmrcvMntrngList','/utl/sys/trm/','송수신모니터링','송수신모니터링','/utl/sys/trm/getTrsmrcvMntrngList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('HpcmListInqire','/uss/olh/hpc/','도움말','도움말','/uss/olh/hpc/HpcmListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('HpcmListInqire','/uss/olh/hpc/','도움말','도움말','/uss/olh/hpc/selectHpcmList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('insertSndngMailView','/cop/ems/','메일발송','메일발송','/cop/ems/insertSndngMailView.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWord','/uss/olh/awm/','행정전문용어사전','행정전문용어사전','/uss/olh/awm/listAdministrationWord.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWordManage','/uss/olh/awm/','행정전문용어사전관리','행정전문용어사전관리','/uss/olh/awm/listAdministrationWordManage.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWord','/uss/olh/awm/','행정전문용어사전','행정전문용어사전','/uss/olh/awm/selectAdministrationWordList.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWordManage','/uss/olh/awm/','행정전문용어사전관리','행정전문용어사전관리','/uss/olh/awm/selectAdministrationWordManageList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listIndvdlInfoPolicy','/uss/sam/ipm/','개인정보보호정책확인','개인정보보호정책확인','/uss/sam/ipm/listIndvdlInfoPolicy.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listNoteRecptn','/uss/ion/ntr/','받은쪽지함관리','받은쪽지함관리','/uss/ion/ntr/listNoteRecptn.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listNoteTrnsmit','/uss/ion/nts/','보낸쪽지함관리','보낸쪽지함관리','/uss/ion/nts/listNoteTrnsmit.do');
@@ -770,7 +770,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('NewsInfoListInqire','/uss/ion/nws/','뉴스관리','뉴스관리','/uss/ion/nws/NewsInfoListInqire.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('OnlineManualUserList','/uss/olh/omn/','사용자온라인매뉴얼','사용자온라인매뉴얼','/uss/olh/omn/selectOnlineManualList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('QnaAnswerListInqire','/uss/olh/qnm/','Q&amp;A답변관리','Q&amp;A답변관리','/uss/olh/qnm/QnaAnswerListInqire.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('QnaListInqire','/uss/olh/qna/','Q&amp;A관리','Q&amp;A관리','/uss/olh/qna/QnaListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('QnaListInqire','/uss/olh/qna/','Q&amp;A관리','Q&amp;A관리','/uss/olh/qna/selectQnaList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('RecomendSiteListInqire','/uss/ion/rec/','추천사이트관리','추천사이트관리','/uss/ion/rec/RecomendSiteListInqire.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('registEgovNoteManage','/uss/ion/ntm/','쪽지관리','쪽지관리','/uss/ion/ntm/registEgovNoteManage.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectAdbkList','/cop/adb/','주소록관리','주소록관리','/cop/adb/selectAdbkList.do');
@@ -831,7 +831,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectWikMnthngReprtList','/cop/smt/wmr/','주간/월간보고관리','주간/월간보고관리','/cop/smt/wmr/selectWikMnthngReprtList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('SiteListInqire','/uss/ion/sit/','사이트관리','사이트관리','/uss/ion/sit/SiteListInqire.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('StplatListInqire','/uss/sam/stp/','약관관리','약관관리','/uss/sam/stp/StplatListInqire.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('WordDicaryListInqire','/uss/olh/wor/','용어사전','용어사전','/uss/olh/wor/WordDicaryListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('WordDicaryListInqire','/uss/olh/wor/','용어사전','용어사전','/uss/olh/wor/selectWordDicaryList.do');
 
 /* 메뉴정보 */
 INSERT INTO COMTNMENUINFO(MENU_NM, PROGRM_FILE_NM, MENU_NO, UPPER_MENU_NO, MENU_ORDR, MENU_DC, RELATE_IMAGE_PATH, RELATE_IMAGE_NM) VALUES ('root','dir',0,0,1,'root','/','/');

--- a/src/script/dml/maria/sym.mnu_insert_maria.sql
+++ b/src/script/dml/maria/sym.mnu_insert_maria.sql
@@ -741,7 +741,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('EgovUserManage','/uss/umt/','업무사용자관리','업무사용자관리','/uss/umt/EgovEmplyrManage.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('EgovVcatnConfmList','/uss/ion/vct/','휴가승인관리','휴가승인관리','/uss/ion/vct/EgovVcatnConfmList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('EgovVcatnManageList','/uss/ion/vct/','휴가관리','휴가관리','/uss/ion/vct/EgovVcatnManageList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('FaqListInqire','/uss/olh/faq/','FAQ관리','FAQ관리','/uss/olh/faq/FaqListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('FaqListInqire','/uss/olh/faq/','FAQ관리','FAQ관리','/uss/olh/faq/selectFaqList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getBackupOpertList','/sym/sym/bak/','백업관리','백업관리','/sym/sym/bak/getBackupOpertList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getBackupResultList','/sym/sym/bak/','백업결과관리','백업결과관리','/sym/sym/bak/getBackupResultList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getBatchOpertList','/sym/bat/','배치작업관리','배치작업관리','/sym/bat/getBatchOpertList.do');
@@ -755,10 +755,10 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getMainImageResult','/uss/ion/msi/','메인이미지 반영결과보기','메인이미지 반영결과보기','/uss/ion/msi/getMainImageResult.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getSystemCntcList','/ssi/syi/sim/','시스템연계관리','시스템연계관리','/ssi/syi/sim/getSystemCntcList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getTrsmrcvMntrngList','/utl/sys/trm/','송수신모니터링','송수신모니터링','/utl/sys/trm/getTrsmrcvMntrngList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('HpcmListInqire','/uss/olh/hpc/','도움말','도움말','/uss/olh/hpc/HpcmListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('HpcmListInqire','/uss/olh/hpc/','도움말','도움말','/uss/olh/hpc/selectHpcmList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('insertSndngMailView','/cop/ems/','메일발송','메일발송','/cop/ems/insertSndngMailView.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWord','/uss/olh/awm/','행정전문용어사전','행정전문용어사전','/uss/olh/awm/listAdministrationWord.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWordManage','/uss/olh/awm/','행정전문용어사전관리','행정전문용어사전관리','/uss/olh/awm/listAdministrationWordManage.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWord','/uss/olh/awm/','행정전문용어사전','행정전문용어사전','/uss/olh/awm/selectAdministrationWordList.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWordManage','/uss/olh/awm/','행정전문용어사전관리','행정전문용어사전관리','/uss/olh/awm/selectAdministrationWordManageList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listIndvdlInfoPolicy','/uss/sam/ipm/','개인정보보호정책확인','개인정보보호정책확인','/uss/sam/ipm/listIndvdlInfoPolicy.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listNoteRecptn','/uss/ion/ntr/','받은쪽지함관리','받은쪽지함관리','/uss/ion/ntr/listNoteRecptn.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listNoteTrnsmit','/uss/ion/nts/','보낸쪽지함관리','보낸쪽지함관리','/uss/ion/nts/listNoteTrnsmit.do');
@@ -776,7 +776,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('NewsInfoListInqire','/uss/ion/nws/','뉴스관리','뉴스관리','/uss/ion/nws/NewsInfoListInqire.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('OnlineManualUserList','/uss/olh/omn/','사용자온라인매뉴얼','사용자온라인매뉴얼','/uss/olh/omn/selectOnlineManualList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('QnaAnswerListInqire','/uss/olh/qnm/','Q&amp;A답변관리','Q&amp;A답변관리','/uss/olh/qnm/QnaAnswerListInqire.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('QnaListInqire','/uss/olh/qna/','Q&amp;A관리','Q&amp;A관리','/uss/olh/qna/QnaListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('QnaListInqire','/uss/olh/qna/','Q&amp;A관리','Q&amp;A관리','/uss/olh/qna/selectQnaList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('RecomendSiteListInqire','/uss/ion/rec/','추천사이트관리','추천사이트관리','/uss/ion/rec/RecomendSiteListInqire.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('registEgovNoteManage','/uss/ion/ntm/','쪽지관리','쪽지관리','/uss/ion/ntm/registEgovNoteManage.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectAdbkList','/cop/adb/','주소록관리','주소록관리','/cop/adb/selectAdbkList.do');
@@ -837,7 +837,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectWikMnthngReprtList','/cop/smt/wmr/','주간/월간보고관리','주간/월간보고관리','/cop/smt/wmr/selectWikMnthngReprtList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('SiteListInqire','/uss/ion/sit/','사이트관리','사이트관리','/uss/ion/sit/SiteListInqire.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('StplatListInqire','/uss/sam/stp/','약관관리','약관관리','/uss/sam/stp/StplatListInqire.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('WordDicaryListInqire','/uss/olh/wor/','용어사전','용어사전','/uss/olh/wor/WordDicaryListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('WordDicaryListInqire','/uss/olh/wor/','용어사전','용어사전','/uss/olh/wor/selectWordDicaryList.do');
 
 /* 메뉴정보 */
 INSERT INTO COMTNMENUINFO(MENU_NM, PROGRM_FILE_NM, MENU_NO, UPPER_MENU_NO, MENU_ORDR, MENU_DC, RELATE_IMAGE_PATH, RELATE_IMAGE_NM) VALUES ('root','dir',0,0,1,'root','/','/');

--- a/src/script/dml/mysql/sts.sst_insert_mysql.sql
+++ b/src/script/dml/mysql/sts.sst_insert_mysql.sql
@@ -735,7 +735,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('EgovUserManage','/uss/umt/','업무사용자관리','업무사용자관리','/uss/umt/EgovEmplyrManage.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('EgovVcatnConfmList','/uss/ion/vct/','휴가승인관리','휴가승인관리','/uss/ion/vct/EgovVcatnConfmList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('EgovVcatnManageList','/uss/ion/vct/','휴가관리','휴가관리','/uss/ion/vct/EgovVcatnManageList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('FaqListInqire','/uss/olh/faq/','FAQ관리','FAQ관리','/uss/olh/faq/FaqListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('FaqListInqire','/uss/olh/faq/','FAQ관리','FAQ관리','/uss/olh/faq/selectFaqList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getBackupOpertList','/sym/sym/bak/','백업관리','백업관리','/sym/sym/bak/getBackupOpertList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getBackupResultList','/sym/sym/bak/','백업결과관리','백업결과관리','/sym/sym/bak/getBackupResultList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getBatchOpertList','/sym/bat/','배치작업관리','배치작업관리','/sym/bat/getBatchOpertList.do');
@@ -749,10 +749,10 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getMainImageResult','/uss/ion/msi/','메인이미지 반영결과보기','메인이미지 반영결과보기','/uss/ion/msi/getMainImageResult.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getSystemCntcList','/ssi/syi/sim/','시스템연계관리','시스템연계관리','/ssi/syi/sim/getSystemCntcList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getTrsmrcvMntrngList','/utl/sys/trm/','송수신모니터링','송수신모니터링','/utl/sys/trm/getTrsmrcvMntrngList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('HpcmListInqire','/uss/olh/hpc/','도움말','도움말','/uss/olh/hpc/HpcmListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('HpcmListInqire','/uss/olh/hpc/','도움말','도움말','/uss/olh/hpc/selectHpcmList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('insertSndngMailView','/cop/ems/','메일발송','메일발송','/cop/ems/insertSndngMailView.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWord','/uss/olh/awm/','행정전문용어사전','행정전문용어사전','/uss/olh/awm/listAdministrationWord.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWordManage','/uss/olh/awm/','행정전문용어사전관리','행정전문용어사전관리','/uss/olh/awm/listAdministrationWordManage.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWord','/uss/olh/awm/','행정전문용어사전','행정전문용어사전','/uss/olh/awm/selectAdministrationWordList.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWordManage','/uss/olh/awm/','행정전문용어사전관리','행정전문용어사전관리','/uss/olh/awm/selectAdministrationWordManageList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listIndvdlInfoPolicy','/uss/sam/ipm/','개인정보보호정책확인','개인정보보호정책확인','/uss/sam/ipm/listIndvdlInfoPolicy.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listNoteRecptn','/uss/ion/ntr/','받은쪽지함관리','받은쪽지함관리','/uss/ion/ntr/listNoteRecptn.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listNoteTrnsmit','/uss/ion/nts/','보낸쪽지함관리','보낸쪽지함관리','/uss/ion/nts/listNoteTrnsmit.do');
@@ -770,7 +770,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('NewsInfoListInqire','/uss/ion/nws/','뉴스관리','뉴스관리','/uss/ion/nws/NewsInfoListInqire.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('OnlineManualUserList','/uss/olh/omn/','사용자온라인매뉴얼','사용자온라인매뉴얼','/uss/olh/omn/selectOnlineManualList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('QnaAnswerListInqire','/uss/olh/qnm/','Q&amp;A답변관리','Q&amp;A답변관리','/uss/olh/qnm/QnaAnswerListInqire.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('QnaListInqire','/uss/olh/qna/','Q&amp;A관리','Q&amp;A관리','/uss/olh/qna/QnaListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('QnaListInqire','/uss/olh/qna/','Q&amp;A관리','Q&amp;A관리','/uss/olh/qna/selectQnaList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('RecomendSiteListInqire','/uss/ion/rec/','추천사이트관리','추천사이트관리','/uss/ion/rec/RecomendSiteListInqire.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('registEgovNoteManage','/uss/ion/ntm/','쪽지관리','쪽지관리','/uss/ion/ntm/registEgovNoteManage.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectAdbkList','/cop/adb/','주소록관리','주소록관리','/cop/adb/selectAdbkList.do');
@@ -831,7 +831,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectWikMnthngReprtList','/cop/smt/wmr/','주간/월간보고관리','주간/월간보고관리','/cop/smt/wmr/selectWikMnthngReprtList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('SiteListInqire','/uss/ion/sit/','사이트관리','사이트관리','/uss/ion/sit/SiteListInqire.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('StplatListInqire','/uss/sam/stp/','약관관리','약관관리','/uss/sam/stp/StplatListInqire.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('WordDicaryListInqire','/uss/olh/wor/','용어사전','용어사전','/uss/olh/wor/WordDicaryListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('WordDicaryListInqire','/uss/olh/wor/','용어사전','용어사전','/uss/olh/wor/selectWordDicaryList.do');
 
 /* 메뉴정보 */
 INSERT INTO COMTNMENUINFO(MENU_NM, PROGRM_FILE_NM, MENU_NO, UPPER_MENU_NO, MENU_ORDR, MENU_DC, RELATE_IMAGE_PATH, RELATE_IMAGE_NM) VALUES ('root','dir',0,0,1,'root','/','/');

--- a/src/script/dml/mysql/sym.mnu_insert_mysql.sql
+++ b/src/script/dml/mysql/sym.mnu_insert_mysql.sql
@@ -741,7 +741,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('EgovUserManage','/uss/umt/','업무사용자관리','업무사용자관리','/uss/umt/EgovEmplyrManage.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('EgovVcatnConfmList','/uss/ion/vct/','휴가승인관리','휴가승인관리','/uss/ion/vct/EgovVcatnConfmList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('EgovVcatnManageList','/uss/ion/vct/','휴가관리','휴가관리','/uss/ion/vct/EgovVcatnManageList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('FaqListInqire','/uss/olh/faq/','FAQ관리','FAQ관리','/uss/olh/faq/FaqListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('FaqListInqire','/uss/olh/faq/','FAQ관리','FAQ관리','/uss/olh/faq/selectFaqList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getBackupOpertList','/sym/sym/bak/','백업관리','백업관리','/sym/sym/bak/getBackupOpertList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getBackupResultList','/sym/sym/bak/','백업결과관리','백업결과관리','/sym/sym/bak/getBackupResultList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getBatchOpertList','/sym/bat/','배치작업관리','배치작업관리','/sym/bat/getBatchOpertList.do');
@@ -755,10 +755,10 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getMainImageResult','/uss/ion/msi/','메인이미지 반영결과보기','메인이미지 반영결과보기','/uss/ion/msi/getMainImageResult.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getSystemCntcList','/ssi/syi/sim/','시스템연계관리','시스템연계관리','/ssi/syi/sim/getSystemCntcList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getTrsmrcvMntrngList','/utl/sys/trm/','송수신모니터링','송수신모니터링','/utl/sys/trm/getTrsmrcvMntrngList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('HpcmListInqire','/uss/olh/hpc/','도움말','도움말','/uss/olh/hpc/HpcmListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('HpcmListInqire','/uss/olh/hpc/','도움말','도움말','/uss/olh/hpc/selectHpcmList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('insertSndngMailView','/cop/ems/','메일발송','메일발송','/cop/ems/insertSndngMailView.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWord','/uss/olh/awm/','행정전문용어사전','행정전문용어사전','/uss/olh/awm/listAdministrationWord.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWordManage','/uss/olh/awm/','행정전문용어사전관리','행정전문용어사전관리','/uss/olh/awm/listAdministrationWordManage.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWord','/uss/olh/awm/','행정전문용어사전','행정전문용어사전','/uss/olh/awm/selectAdministrationWordList.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWordManage','/uss/olh/awm/','행정전문용어사전관리','행정전문용어사전관리','/uss/olh/awm/selectAdministrationWordManageList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listIndvdlInfoPolicy','/uss/sam/ipm/','개인정보보호정책확인','개인정보보호정책확인','/uss/sam/ipm/listIndvdlInfoPolicy.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listNoteRecptn','/uss/ion/ntr/','받은쪽지함관리','받은쪽지함관리','/uss/ion/ntr/listNoteRecptn.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listNoteTrnsmit','/uss/ion/nts/','보낸쪽지함관리','보낸쪽지함관리','/uss/ion/nts/listNoteTrnsmit.do');
@@ -776,7 +776,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('NewsInfoListInqire','/uss/ion/nws/','뉴스관리','뉴스관리','/uss/ion/nws/NewsInfoListInqire.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('OnlineManualUserList','/uss/olh/omn/','사용자온라인매뉴얼','사용자온라인매뉴얼','/uss/olh/omn/selectOnlineManualList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('QnaAnswerListInqire','/uss/olh/qnm/','Q&amp;A답변관리','Q&amp;A답변관리','/uss/olh/qnm/QnaAnswerListInqire.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('QnaListInqire','/uss/olh/qna/','Q&amp;A관리','Q&amp;A관리','/uss/olh/qna/QnaListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('QnaListInqire','/uss/olh/qna/','Q&amp;A관리','Q&amp;A관리','/uss/olh/qna/selectQnaList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('RecomendSiteListInqire','/uss/ion/rec/','추천사이트관리','추천사이트관리','/uss/ion/rec/RecomendSiteListInqire.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('registEgovNoteManage','/uss/ion/ntm/','쪽지관리','쪽지관리','/uss/ion/ntm/registEgovNoteManage.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectAdbkList','/cop/adb/','주소록관리','주소록관리','/cop/adb/selectAdbkList.do');
@@ -837,7 +837,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectWikMnthngReprtList','/cop/smt/wmr/','주간/월간보고관리','주간/월간보고관리','/cop/smt/wmr/selectWikMnthngReprtList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('SiteListInqire','/uss/ion/sit/','사이트관리','사이트관리','/uss/ion/sit/SiteListInqire.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('StplatListInqire','/uss/sam/stp/','약관관리','약관관리','/uss/sam/stp/StplatListInqire.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('WordDicaryListInqire','/uss/olh/wor/','용어사전','용어사전','/uss/olh/wor/WordDicaryListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('WordDicaryListInqire','/uss/olh/wor/','용어사전','용어사전','/uss/olh/wor/selectWordDicaryList.do');
 
 /* 메뉴정보 */
 INSERT INTO COMTNMENUINFO(MENU_NM, PROGRM_FILE_NM, MENU_NO, UPPER_MENU_NO, MENU_ORDR, MENU_DC, RELATE_IMAGE_PATH, RELATE_IMAGE_NM) VALUES ('root','dir',0,0,1,'root','/','/');

--- a/src/script/dml/oracle/sts.sst_insert_oracle.sql
+++ b/src/script/dml/oracle/sts.sst_insert_oracle.sql
@@ -736,7 +736,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('EgovUserManage','/uss/umt/','업무사용자관리','업무사용자관리','/uss/umt/EgovEmplyrManage.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('EgovVcatnConfmList','/uss/ion/vct/','휴가승인관리','휴가승인관리','/uss/ion/vct/EgovVcatnConfmList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('EgovVcatnManageList','/uss/ion/vct/','휴가관리','휴가관리','/uss/ion/vct/EgovVcatnManageList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('FaqListInqire','/uss/olh/faq/','FAQ관리','FAQ관리','/uss/olh/faq/FaqListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('FaqListInqire','/uss/olh/faq/','FAQ관리','FAQ관리','/uss/olh/faq/selectFaqList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getBackupOpertList','/sym/sym/bak/','백업관리','백업관리','/sym/sym/bak/getBackupOpertList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getBackupResultList','/sym/sym/bak/','백업결과관리','백업결과관리','/sym/sym/bak/getBackupResultList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getBatchOpertList','/sym/bat/','배치작업관리','배치작업관리','/sym/bat/getBatchOpertList.do');
@@ -750,10 +750,10 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getMainImageResult','/uss/ion/msi/','메인이미지 반영결과보기','메인이미지 반영결과보기','/uss/ion/msi/getMainImageResult.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getSystemCntcList','/ssi/syi/sim/','시스템연계관리','시스템연계관리','/ssi/syi/sim/getSystemCntcList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getTrsmrcvMntrngList','/utl/sys/trm/','송수신모니터링','송수신모니터링','/utl/sys/trm/getTrsmrcvMntrngList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('HpcmListInqire','/uss/olh/hpc/','도움말','도움말','/uss/olh/hpc/HpcmListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('HpcmListInqire','/uss/olh/hpc/','도움말','도움말','/uss/olh/hpc/selectHpcmList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('insertSndngMailView','/cop/ems/','메일발송','메일발송','/cop/ems/insertSndngMailView.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWord','/uss/olh/awm/','행정전문용어사전','행정전문용어사전','/uss/olh/awm/listAdministrationWord.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWordManage','/uss/olh/awm/','행정전문용어사전관리','행정전문용어사전관리','/uss/olh/awm/listAdministrationWordManage.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWord','/uss/olh/awm/','행정전문용어사전','행정전문용어사전','/uss/olh/awm/selectAdministrationWordList.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWordManage','/uss/olh/awm/','행정전문용어사전관리','행정전문용어사전관리','/uss/olh/awm/selectAdministrationWordManageList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listIndvdlInfoPolicy','/uss/sam/ipm/','개인정보보호정책확인','개인정보보호정책확인','/uss/sam/ipm/listIndvdlInfoPolicy.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listNoteRecptn','/uss/ion/ntr/','받은쪽지함관리','받은쪽지함관리','/uss/ion/ntr/listNoteRecptn.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listNoteTrnsmit','/uss/ion/nts/','보낸쪽지함관리','보낸쪽지함관리','/uss/ion/nts/listNoteTrnsmit.do');
@@ -771,7 +771,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('NewsInfoListInqire','/uss/ion/nws/','뉴스관리','뉴스관리','/uss/ion/nws/NewsInfoListInqire.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('OnlineManualUserList','/uss/olh/omn/','사용자온라인매뉴얼','사용자온라인매뉴얼','/uss/olh/omn/selectOnlineManualList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('QnaAnswerListInqire','/uss/olh/qnm/','Q&amp;A답변관리','Q&amp;A답변관리','/uss/olh/qnm/QnaAnswerListInqire.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('QnaListInqire','/uss/olh/qna/','Q&amp;A관리','Q&amp;A관리','/uss/olh/qna/QnaListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('QnaListInqire','/uss/olh/qna/','Q&amp;A관리','Q&amp;A관리','/uss/olh/qna/selectQnaList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('RecomendSiteListInqire','/uss/ion/rec/','추천사이트관리','추천사이트관리','/uss/ion/rec/RecomendSiteListInqire.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('registEgovNoteManage','/uss/ion/ntm/','쪽지관리','쪽지관리','/uss/ion/ntm/registEgovNoteManage.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectAdbkList','/cop/adb/','주소록관리','주소록관리','/cop/adb/selectAdbkList.do');
@@ -832,7 +832,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectWikMnthngReprtList','/cop/smt/wmr/','주간/월간보고관리','주간/월간보고관리','/cop/smt/wmr/selectWikMnthngReprtList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('SiteListInqire','/uss/ion/sit/','사이트관리','사이트관리','/uss/ion/sit/SiteListInqire.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('StplatListInqire','/uss/sam/stp/','약관관리','약관관리','/uss/sam/stp/StplatListInqire.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('WordDicaryListInqire','/uss/olh/wor/','용어사전','용어사전','/uss/olh/wor/WordDicaryListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('WordDicaryListInqire','/uss/olh/wor/','용어사전','용어사전','/uss/olh/wor/selectWordDicaryList.do');
 
 /* 메뉴정보 */
 INSERT INTO COMTNMENUINFO(MENU_NM, PROGRM_FILE_NM, MENU_NO, UPPER_MENU_NO, MENU_ORDR, MENU_DC, RELATE_IMAGE_PATH, RELATE_IMAGE_NM) VALUES ('root','dir',0,0,1,'root','/','/');

--- a/src/script/dml/oracle/sym.mnu_insert_oracle.sql
+++ b/src/script/dml/oracle/sym.mnu_insert_oracle.sql
@@ -742,7 +742,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('EgovUserManage','/uss/umt/','업무사용자관리','업무사용자관리','/uss/umt/EgovEmplyrManage.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('EgovVcatnConfmList','/uss/ion/vct/','휴가승인관리','휴가승인관리','/uss/ion/vct/EgovVcatnConfmList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('EgovVcatnManageList','/uss/ion/vct/','휴가관리','휴가관리','/uss/ion/vct/EgovVcatnManageList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('FaqListInqire','/uss/olh/faq/','FAQ관리','FAQ관리','/uss/olh/faq/FaqListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('FaqListInqire','/uss/olh/faq/','FAQ관리','FAQ관리','/uss/olh/faq/selectFaqList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getBackupOpertList','/sym/sym/bak/','백업관리','백업관리','/sym/sym/bak/getBackupOpertList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getBackupResultList','/sym/sym/bak/','백업결과관리','백업결과관리','/sym/sym/bak/getBackupResultList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getBatchOpertList','/sym/bat/','배치작업관리','배치작업관리','/sym/bat/getBatchOpertList.do');
@@ -756,10 +756,10 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getMainImageResult','/uss/ion/msi/','메인이미지 반영결과보기','메인이미지 반영결과보기','/uss/ion/msi/getMainImageResult.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getSystemCntcList','/ssi/syi/sim/','시스템연계관리','시스템연계관리','/ssi/syi/sim/getSystemCntcList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getTrsmrcvMntrngList','/utl/sys/trm/','송수신모니터링','송수신모니터링','/utl/sys/trm/getTrsmrcvMntrngList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('HpcmListInqire','/uss/olh/hpc/','도움말','도움말','/uss/olh/hpc/HpcmListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('HpcmListInqire','/uss/olh/hpc/','도움말','도움말','/uss/olh/hpc/selectHpcmList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('insertSndngMailView','/cop/ems/','메일발송','메일발송','/cop/ems/insertSndngMailView.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWord','/uss/olh/awm/','행정전문용어사전','행정전문용어사전','/uss/olh/awm/listAdministrationWord.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWordManage','/uss/olh/awm/','행정전문용어사전관리','행정전문용어사전관리','/uss/olh/awm/listAdministrationWordManage.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWord','/uss/olh/awm/','행정전문용어사전','행정전문용어사전','/uss/olh/awm/selectAdministrationWordList.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWordManage','/uss/olh/awm/','행정전문용어사전관리','행정전문용어사전관리','/uss/olh/awm/selectAdministrationWordManageList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listIndvdlInfoPolicy','/uss/sam/ipm/','개인정보보호정책확인','개인정보보호정책확인','/uss/sam/ipm/listIndvdlInfoPolicy.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listNoteRecptn','/uss/ion/ntr/','받은쪽지함관리','받은쪽지함관리','/uss/ion/ntr/listNoteRecptn.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listNoteTrnsmit','/uss/ion/nts/','보낸쪽지함관리','보낸쪽지함관리','/uss/ion/nts/listNoteTrnsmit.do');
@@ -777,7 +777,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('NewsInfoListInqire','/uss/ion/nws/','뉴스관리','뉴스관리','/uss/ion/nws/NewsInfoListInqire.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('OnlineManualUserList','/uss/olh/omn/','사용자온라인매뉴얼','사용자온라인매뉴얼','/uss/olh/omn/selectOnlineManualList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('QnaAnswerListInqire','/uss/olh/qnm/','Q&amp;A답변관리','Q&amp;A답변관리','/uss/olh/qnm/QnaAnswerListInqire.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('QnaListInqire','/uss/olh/qna/','Q&amp;A관리','Q&amp;A관리','/uss/olh/qna/QnaListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('QnaListInqire','/uss/olh/qna/','Q&amp;A관리','Q&amp;A관리','/uss/olh/qna/selectQnaList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('RecomendSiteListInqire','/uss/ion/rec/','추천사이트관리','추천사이트관리','/uss/ion/rec/RecomendSiteListInqire.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('registEgovNoteManage','/uss/ion/ntm/','쪽지관리','쪽지관리','/uss/ion/ntm/registEgovNoteManage.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectAdbkList','/cop/adb/','주소록관리','주소록관리','/cop/adb/selectAdbkList.do');
@@ -838,7 +838,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectWikMnthngReprtList','/cop/smt/wmr/','주간/월간보고관리','주간/월간보고관리','/cop/smt/wmr/selectWikMnthngReprtList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('SiteListInqire','/uss/ion/sit/','사이트관리','사이트관리','/uss/ion/sit/SiteListInqire.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('StplatListInqire','/uss/sam/stp/','약관관리','약관관리','/uss/sam/stp/StplatListInqire.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('WordDicaryListInqire','/uss/olh/wor/','용어사전','용어사전','/uss/olh/wor/WordDicaryListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('WordDicaryListInqire','/uss/olh/wor/','용어사전','용어사전','/uss/olh/wor/selectWordDicaryList.do');
 
 /* 메뉴정보 */
 INSERT INTO COMTNMENUINFO(MENU_NM, PROGRM_FILE_NM, MENU_NO, UPPER_MENU_NO, MENU_ORDR, MENU_DC, RELATE_IMAGE_PATH, RELATE_IMAGE_NM) VALUES ('root','dir',0,0,1,'root','/','/');

--- a/src/script/dml/postgres/sts.sst_insert_postgres.sql
+++ b/src/script/dml/postgres/sts.sst_insert_postgres.sql
@@ -735,7 +735,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('EgovUserManage','/uss/umt/','업무사용자관리','업무사용자관리','/uss/umt/EgovEmplyrManage.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('EgovVcatnConfmList','/uss/ion/vct/','휴가승인관리','휴가승인관리','/uss/ion/vct/EgovVcatnConfmList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('EgovVcatnManageList','/uss/ion/vct/','휴가관리','휴가관리','/uss/ion/vct/EgovVcatnManageList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('FaqListInqire','/uss/olh/faq/','FAQ관리','FAQ관리','/uss/olh/faq/FaqListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('FaqListInqire','/uss/olh/faq/','FAQ관리','FAQ관리','/uss/olh/faq/selectFaqList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getBackupOpertList','/sym/sym/bak/','백업관리','백업관리','/sym/sym/bak/getBackupOpertList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getBackupResultList','/sym/sym/bak/','백업결과관리','백업결과관리','/sym/sym/bak/getBackupResultList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getBatchOpertList','/sym/bat/','배치작업관리','배치작업관리','/sym/bat/getBatchOpertList.do');
@@ -749,10 +749,10 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getMainImageResult','/uss/ion/msi/','메인이미지 반영결과보기','메인이미지 반영결과보기','/uss/ion/msi/getMainImageResult.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getSystemCntcList','/ssi/syi/sim/','시스템연계관리','시스템연계관리','/ssi/syi/sim/getSystemCntcList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getTrsmrcvMntrngList','/utl/sys/trm/','송수신모니터링','송수신모니터링','/utl/sys/trm/getTrsmrcvMntrngList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('HpcmListInqire','/uss/olh/hpc/','도움말','도움말','/uss/olh/hpc/HpcmListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('HpcmListInqire','/uss/olh/hpc/','도움말','도움말','/uss/olh/hpc/selectHpcmList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('insertSndngMailView','/cop/ems/','메일발송','메일발송','/cop/ems/insertSndngMailView.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWord','/uss/olh/awm/','행정전문용어사전','행정전문용어사전','/uss/olh/awm/listAdministrationWord.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWordManage','/uss/olh/awm/','행정전문용어사전관리','행정전문용어사전관리','/uss/olh/awm/listAdministrationWordManage.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWord','/uss/olh/awm/','행정전문용어사전','행정전문용어사전','/uss/olh/awm/selectAdministrationWordList.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWordManage','/uss/olh/awm/','행정전문용어사전관리','행정전문용어사전관리','/uss/olh/awm/selectAdministrationWordManageList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listIndvdlInfoPolicy','/uss/sam/ipm/','개인정보보호정책확인','개인정보보호정책확인','/uss/sam/ipm/listIndvdlInfoPolicy.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listNoteRecptn','/uss/ion/ntr/','받은쪽지함관리','받은쪽지함관리','/uss/ion/ntr/listNoteRecptn.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listNoteTrnsmit','/uss/ion/nts/','보낸쪽지함관리','보낸쪽지함관리','/uss/ion/nts/listNoteTrnsmit.do');
@@ -770,7 +770,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('NewsInfoListInqire','/uss/ion/nws/','뉴스관리','뉴스관리','/uss/ion/nws/NewsInfoListInqire.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('OnlineManualUserList','/uss/olh/omn/','사용자온라인매뉴얼','사용자온라인매뉴얼','/uss/olh/omn/selectOnlineManualList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('QnaAnswerListInqire','/uss/olh/qnm/','Q&amp;A답변관리','Q&amp;A답변관리','/uss/olh/qnm/QnaAnswerListInqire.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('QnaListInqire','/uss/olh/qna/','Q&amp;A관리','Q&amp;A관리','/uss/olh/qna/QnaListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('QnaListInqire','/uss/olh/qna/','Q&amp;A관리','Q&amp;A관리','/uss/olh/qna/selectQnaList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('RecomendSiteListInqire','/uss/ion/rec/','추천사이트관리','추천사이트관리','/uss/ion/rec/RecomendSiteListInqire.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('registEgovNoteManage','/uss/ion/ntm/','쪽지관리','쪽지관리','/uss/ion/ntm/registEgovNoteManage.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectAdbkList','/cop/adb/','주소록관리','주소록관리','/cop/adb/selectAdbkList.do');
@@ -831,7 +831,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectWikMnthngReprtList','/cop/smt/wmr/','주간/월간보고관리','주간/월간보고관리','/cop/smt/wmr/selectWikMnthngReprtList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('SiteListInqire','/uss/ion/sit/','사이트관리','사이트관리','/uss/ion/sit/SiteListInqire.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('StplatListInqire','/uss/sam/stp/','약관관리','약관관리','/uss/sam/stp/StplatListInqire.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('WordDicaryListInqire','/uss/olh/wor/','용어사전','용어사전','/uss/olh/wor/WordDicaryListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('WordDicaryListInqire','/uss/olh/wor/','용어사전','용어사전','/uss/olh/wor/selectWordDicaryList.do');
 
 /* 메뉴정보 */
 INSERT INTO COMTNMENUINFO(MENU_NM, PROGRM_FILE_NM, MENU_NO, UPPER_MENU_NO, MENU_ORDR, MENU_DC, RELATE_IMAGE_PATH, RELATE_IMAGE_NM) VALUES ('root','dir',0,0,1,'root','/','/');

--- a/src/script/dml/postgres/sym.mnu_insert_postgres.sql
+++ b/src/script/dml/postgres/sym.mnu_insert_postgres.sql
@@ -741,7 +741,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('EgovUserManage','/uss/umt/','업무사용자관리','업무사용자관리','/uss/umt/EgovEmplyrManage.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('EgovVcatnConfmList','/uss/ion/vct/','휴가승인관리','휴가승인관리','/uss/ion/vct/EgovVcatnConfmList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('EgovVcatnManageList','/uss/ion/vct/','휴가관리','휴가관리','/uss/ion/vct/EgovVcatnManageList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('FaqListInqire','/uss/olh/faq/','FAQ관리','FAQ관리','/uss/olh/faq/FaqListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('FaqListInqire','/uss/olh/faq/','FAQ관리','FAQ관리','/uss/olh/faq/selectFaqList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getBackupOpertList','/sym/sym/bak/','백업관리','백업관리','/sym/sym/bak/getBackupOpertList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getBackupResultList','/sym/sym/bak/','백업결과관리','백업결과관리','/sym/sym/bak/getBackupResultList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getBatchOpertList','/sym/bat/','배치작업관리','배치작업관리','/sym/bat/getBatchOpertList.do');
@@ -755,10 +755,10 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getMainImageResult','/uss/ion/msi/','메인이미지 반영결과보기','메인이미지 반영결과보기','/uss/ion/msi/getMainImageResult.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getSystemCntcList','/ssi/syi/sim/','시스템연계관리','시스템연계관리','/ssi/syi/sim/getSystemCntcList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getTrsmrcvMntrngList','/utl/sys/trm/','송수신모니터링','송수신모니터링','/utl/sys/trm/getTrsmrcvMntrngList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('HpcmListInqire','/uss/olh/hpc/','도움말','도움말','/uss/olh/hpc/HpcmListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('HpcmListInqire','/uss/olh/hpc/','도움말','도움말','/uss/olh/hpc/selectHpcmList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('insertSndngMailView','/cop/ems/','메일발송','메일발송','/cop/ems/insertSndngMailView.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWord','/uss/olh/awm/','행정전문용어사전','행정전문용어사전','/uss/olh/awm/listAdministrationWord.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWordManage','/uss/olh/awm/','행정전문용어사전관리','행정전문용어사전관리','/uss/olh/awm/listAdministrationWordManage.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWord','/uss/olh/awm/','행정전문용어사전','행정전문용어사전','/uss/olh/awm/selectAdministrationWordList.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWordManage','/uss/olh/awm/','행정전문용어사전관리','행정전문용어사전관리','/uss/olh/awm/selectAdministrationWordManageList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listIndvdlInfoPolicy','/uss/sam/ipm/','개인정보보호정책확인','개인정보보호정책확인','/uss/sam/ipm/listIndvdlInfoPolicy.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listNoteRecptn','/uss/ion/ntr/','받은쪽지함관리','받은쪽지함관리','/uss/ion/ntr/listNoteRecptn.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listNoteTrnsmit','/uss/ion/nts/','보낸쪽지함관리','보낸쪽지함관리','/uss/ion/nts/listNoteTrnsmit.do');
@@ -776,7 +776,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('NewsInfoListInqire','/uss/ion/nws/','뉴스관리','뉴스관리','/uss/ion/nws/NewsInfoListInqire.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('OnlineManualUserList','/uss/olh/omn/','사용자온라인매뉴얼','사용자온라인매뉴얼','/uss/olh/omn/selectOnlineManualList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('QnaAnswerListInqire','/uss/olh/qnm/','Q&amp;A답변관리','Q&amp;A답변관리','/uss/olh/qnm/QnaAnswerListInqire.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('QnaListInqire','/uss/olh/qna/','Q&amp;A관리','Q&amp;A관리','/uss/olh/qna/QnaListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('QnaListInqire','/uss/olh/qna/','Q&amp;A관리','Q&amp;A관리','/uss/olh/qna/selectQnaList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('RecomendSiteListInqire','/uss/ion/rec/','추천사이트관리','추천사이트관리','/uss/ion/rec/RecomendSiteListInqire.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('registEgovNoteManage','/uss/ion/ntm/','쪽지관리','쪽지관리','/uss/ion/ntm/registEgovNoteManage.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectAdbkList','/cop/adb/','주소록관리','주소록관리','/cop/adb/selectAdbkList.do');
@@ -837,7 +837,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectWikMnthngReprtList','/cop/smt/wmr/','주간/월간보고관리','주간/월간보고관리','/cop/smt/wmr/selectWikMnthngReprtList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('SiteListInqire','/uss/ion/sit/','사이트관리','사이트관리','/uss/ion/sit/SiteListInqire.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('StplatListInqire','/uss/sam/stp/','약관관리','약관관리','/uss/sam/stp/StplatListInqire.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('WordDicaryListInqire','/uss/olh/wor/','용어사전','용어사전','/uss/olh/wor/WordDicaryListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('WordDicaryListInqire','/uss/olh/wor/','용어사전','용어사전','/uss/olh/wor/selectWordDicaryList.do');
 
 /* 메뉴정보 */
 INSERT INTO COMTNMENUINFO(MENU_NM, PROGRM_FILE_NM, MENU_NO, UPPER_MENU_NO, MENU_ORDR, MENU_DC, RELATE_IMAGE_PATH, RELATE_IMAGE_NM) VALUES ('root','dir',0,0,1,'root','/','/');

--- a/src/script/dml/tibero/sts.sst_insert_tibero.sql
+++ b/src/script/dml/tibero/sts.sst_insert_tibero.sql
@@ -736,7 +736,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('EgovUserManage','/uss/umt/','업무사용자관리','업무사용자관리','/uss/umt/EgovEmplyrManage.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('EgovVcatnConfmList','/uss/ion/vct/','휴가승인관리','휴가승인관리','/uss/ion/vct/EgovVcatnConfmList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('EgovVcatnManageList','/uss/ion/vct/','휴가관리','휴가관리','/uss/ion/vct/EgovVcatnManageList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('FaqListInqire','/uss/olh/faq/','FAQ관리','FAQ관리','/uss/olh/faq/FaqListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('FaqListInqire','/uss/olh/faq/','FAQ관리','FAQ관리','/uss/olh/faq/selectFaqList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getBackupOpertList','/sym/sym/bak/','백업관리','백업관리','/sym/sym/bak/getBackupOpertList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getBackupResultList','/sym/sym/bak/','백업결과관리','백업결과관리','/sym/sym/bak/getBackupResultList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getBatchOpertList','/sym/bat/','배치작업관리','배치작업관리','/sym/bat/getBatchOpertList.do');
@@ -750,10 +750,10 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getMainImageResult','/uss/ion/msi/','메인이미지 반영결과보기','메인이미지 반영결과보기','/uss/ion/msi/getMainImageResult.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getSystemCntcList','/ssi/syi/sim/','시스템연계관리','시스템연계관리','/ssi/syi/sim/getSystemCntcList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getTrsmrcvMntrngList','/utl/sys/trm/','송수신모니터링','송수신모니터링','/utl/sys/trm/getTrsmrcvMntrngList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('HpcmListInqire','/uss/olh/hpc/','도움말','도움말','/uss/olh/hpc/HpcmListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('HpcmListInqire','/uss/olh/hpc/','도움말','도움말','/uss/olh/hpc/selectHpcmList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('insertSndngMailView','/cop/ems/','메일발송','메일발송','/cop/ems/insertSndngMailView.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWord','/uss/olh/awm/','행정전문용어사전','행정전문용어사전','/uss/olh/awm/listAdministrationWord.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWordManage','/uss/olh/awm/','행정전문용어사전관리','행정전문용어사전관리','/uss/olh/awm/listAdministrationWordManage.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWord','/uss/olh/awm/','행정전문용어사전','행정전문용어사전','/uss/olh/awm/selectAdministrationWordList.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWordManage','/uss/olh/awm/','행정전문용어사전관리','행정전문용어사전관리','/uss/olh/awm/selectAdministrationWordManageList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listIndvdlInfoPolicy','/uss/sam/ipm/','개인정보보호정책확인','개인정보보호정책확인','/uss/sam/ipm/listIndvdlInfoPolicy.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listNoteRecptn','/uss/ion/ntr/','받은쪽지함관리','받은쪽지함관리','/uss/ion/ntr/listNoteRecptn.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listNoteTrnsmit','/uss/ion/nts/','보낸쪽지함관리','보낸쪽지함관리','/uss/ion/nts/listNoteTrnsmit.do');
@@ -771,7 +771,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('NewsInfoListInqire','/uss/ion/nws/','뉴스관리','뉴스관리','/uss/ion/nws/NewsInfoListInqire.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('OnlineManualUserList','/uss/olh/omn/','사용자온라인매뉴얼','사용자온라인매뉴얼','/uss/olh/omn/selectOnlineManualList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('QnaAnswerListInqire','/uss/olh/qnm/','Q&amp;A답변관리','Q&amp;A답변관리','/uss/olh/qnm/QnaAnswerListInqire.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('QnaListInqire','/uss/olh/qna/','Q&amp;A관리','Q&amp;A관리','/uss/olh/qna/QnaListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('QnaListInqire','/uss/olh/qna/','Q&amp;A관리','Q&amp;A관리','/uss/olh/qna/selectQnaList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('RecomendSiteListInqire','/uss/ion/rec/','추천사이트관리','추천사이트관리','/uss/ion/rec/RecomendSiteListInqire.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('registEgovNoteManage','/uss/ion/ntm/','쪽지관리','쪽지관리','/uss/ion/ntm/registEgovNoteManage.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectAdbkList','/cop/adb/','주소록관리','주소록관리','/cop/adb/selectAdbkList.do');
@@ -832,7 +832,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectWikMnthngReprtList','/cop/smt/wmr/','주간/월간보고관리','주간/월간보고관리','/cop/smt/wmr/selectWikMnthngReprtList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('SiteListInqire','/uss/ion/sit/','사이트관리','사이트관리','/uss/ion/sit/SiteListInqire.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('StplatListInqire','/uss/sam/stp/','약관관리','약관관리','/uss/sam/stp/StplatListInqire.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('WordDicaryListInqire','/uss/olh/wor/','용어사전','용어사전','/uss/olh/wor/WordDicaryListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('WordDicaryListInqire','/uss/olh/wor/','용어사전','용어사전','/uss/olh/wor/selectWordDicaryList.do');
 
 /* 메뉴정보 */
 INSERT INTO COMTNMENUINFO(MENU_NM, PROGRM_FILE_NM, MENU_NO, UPPER_MENU_NO, MENU_ORDR, MENU_DC, RELATE_IMAGE_PATH, RELATE_IMAGE_NM) VALUES ('root','dir',0,0,1,'root','/','/');

--- a/src/script/dml/tibero/sym.mnu_insert_tibero.sql
+++ b/src/script/dml/tibero/sym.mnu_insert_tibero.sql
@@ -742,7 +742,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('EgovUserManage','/uss/umt/','업무사용자관리','업무사용자관리','/uss/umt/EgovEmplyrManage.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('EgovVcatnConfmList','/uss/ion/vct/','휴가승인관리','휴가승인관리','/uss/ion/vct/EgovVcatnConfmList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('EgovVcatnManageList','/uss/ion/vct/','휴가관리','휴가관리','/uss/ion/vct/EgovVcatnManageList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('FaqListInqire','/uss/olh/faq/','FAQ관리','FAQ관리','/uss/olh/faq/FaqListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('FaqListInqire','/uss/olh/faq/','FAQ관리','FAQ관리','/uss/olh/faq/selectFaqList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getBackupOpertList','/sym/sym/bak/','백업관리','백업관리','/sym/sym/bak/getBackupOpertList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getBackupResultList','/sym/sym/bak/','백업결과관리','백업결과관리','/sym/sym/bak/getBackupResultList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getBatchOpertList','/sym/bat/','배치작업관리','배치작업관리','/sym/bat/getBatchOpertList.do');
@@ -756,10 +756,10 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getMainImageResult','/uss/ion/msi/','메인이미지 반영결과보기','메인이미지 반영결과보기','/uss/ion/msi/getMainImageResult.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getSystemCntcList','/ssi/syi/sim/','시스템연계관리','시스템연계관리','/ssi/syi/sim/getSystemCntcList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('getTrsmrcvMntrngList','/utl/sys/trm/','송수신모니터링','송수신모니터링','/utl/sys/trm/getTrsmrcvMntrngList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('HpcmListInqire','/uss/olh/hpc/','도움말','도움말','/uss/olh/hpc/HpcmListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('HpcmListInqire','/uss/olh/hpc/','도움말','도움말','/uss/olh/hpc/selectHpcmList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('insertSndngMailView','/cop/ems/','메일발송','메일발송','/cop/ems/insertSndngMailView.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWord','/uss/olh/awm/','행정전문용어사전','행정전문용어사전','/uss/olh/awm/listAdministrationWord.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWordManage','/uss/olh/awm/','행정전문용어사전관리','행정전문용어사전관리','/uss/olh/awm/listAdministrationWordManage.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWord','/uss/olh/awm/','행정전문용어사전','행정전문용어사전','/uss/olh/awm/selectAdministrationWordList.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listAdministrationWordManage','/uss/olh/awm/','행정전문용어사전관리','행정전문용어사전관리','/uss/olh/awm/selectAdministrationWordManageList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listIndvdlInfoPolicy','/uss/sam/ipm/','개인정보보호정책확인','개인정보보호정책확인','/uss/sam/ipm/listIndvdlInfoPolicy.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listNoteRecptn','/uss/ion/ntr/','받은쪽지함관리','받은쪽지함관리','/uss/ion/ntr/listNoteRecptn.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('listNoteTrnsmit','/uss/ion/nts/','보낸쪽지함관리','보낸쪽지함관리','/uss/ion/nts/listNoteTrnsmit.do');
@@ -777,7 +777,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('NewsInfoListInqire','/uss/ion/nws/','뉴스관리','뉴스관리','/uss/ion/nws/NewsInfoListInqire.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('OnlineManualUserList','/uss/olh/omn/','사용자온라인매뉴얼','사용자온라인매뉴얼','/uss/olh/omn/selectOnlineManualList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('QnaAnswerListInqire','/uss/olh/qnm/','Q&amp;A답변관리','Q&amp;A답변관리','/uss/olh/qnm/QnaAnswerListInqire.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('QnaListInqire','/uss/olh/qna/','Q&amp;A관리','Q&amp;A관리','/uss/olh/qna/QnaListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('QnaListInqire','/uss/olh/qna/','Q&amp;A관리','Q&amp;A관리','/uss/olh/qna/selectQnaList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('RecomendSiteListInqire','/uss/ion/rec/','추천사이트관리','추천사이트관리','/uss/ion/rec/RecomendSiteListInqire.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('registEgovNoteManage','/uss/ion/ntm/','쪽지관리','쪽지관리','/uss/ion/ntm/registEgovNoteManage.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectAdbkList','/cop/adb/','주소록관리','주소록관리','/cop/adb/selectAdbkList.do');
@@ -838,7 +838,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectWikMnthngReprtList','/cop/smt/wmr/','주간/월간보고관리','주간/월간보고관리','/cop/smt/wmr/selectWikMnthngReprtList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('SiteListInqire','/uss/ion/sit/','사이트관리','사이트관리','/uss/ion/sit/SiteListInqire.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('StplatListInqire','/uss/sam/stp/','약관관리','약관관리','/uss/sam/stp/StplatListInqire.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('WordDicaryListInqire','/uss/olh/wor/','용어사전','용어사전','/uss/olh/wor/WordDicaryListInqire.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('WordDicaryListInqire','/uss/olh/wor/','용어사전','용어사전','/uss/olh/wor/selectWordDicaryList.do');
 
 /* 메뉴정보 */
 INSERT INTO COMTNMENUINFO(MENU_NM, PROGRM_FILE_NM, MENU_NO, UPPER_MENU_NO, MENU_ORDR, MENU_DC, RELATE_IMAGE_PATH, RELATE_IMAGE_NM) VALUES ('root','dir',0,0,1,'root','/','/');


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

온라인헬프 메뉴 6개가 컨트롤러에 없는 URL 을 가리키고 있어서 관리자가 눌러도 404 가 뜹니다.

메뉴 링크는 `COMTNPROGRMLIST.URL` 을 그대로 씁니다. 왼쪽 메뉴를 채우는 `selectMainMenuLeft` 가 그 값을 `CHK_URL` 로 뽑고 `main_left.jsp` 가 여섯 번째 필드에 담고 `EgovMainMenu.js` 가 그 필드로 이동합니다.

```
$ grep -n 'selectMainMenuLeft\|main_left' src/main/java/egovframework/com/sym/mnu/mpm/web/EgovMainMenuManageController.java
157:	 * @return 출력페이지정보 "main_left"
161:	public String selectMainMenuLeft(@ModelAttribute("menuManageVO") MenuManageVO menuManageVO,
177:		List<?> resultList = menuManageService.selectMainMenuLeft(menuManageVO);
179:		return "egovframework/com/main_left";

$ sed -n '37p' src/main/resources/egovframework/mapper/com/sym/mnu/mpm/EgovMainMenu_SQL_mysql.xml
				 , (SELECT C.URL FROM COMTNPROGRMLIST C WHERE B.PROGRM_FILE_NM = C.PROGRM_FILE_NM) AS CHK_URL	

$ sed -n '48p' src/main/webapp/WEB-INF/jsp/egovframework/com/main_left.jsp
		<input type="hidden" name="tmp_menuNm" value="${result.menuNo}|${result.upperMenuId}|${result.menuNm}|${result.relateImagePath}|${result.relateImageNm}|${pageContext.request.contextPath}${result.chkURL}|"/>

$ sed -n '194p' src/main/webapp/js/egovframework/com/sym/mnu/mpm/EgovMainMenu.js
		parent.location.href = path + nodeValues[5];
```

`script/dml` 과 `src/script/dml` 의 시드가 등록하는 URL 이 실제 매핑과 다릅니다. 최초 임포트 시점부터 어긋나 있어 원인은 저장소 이력으로 짚기 어렵습니다.

관리자 계정으로 로그인해 두 URL 을 각각 요청했습니다. 왼쪽이 시드가 등록한 값, 오른쪽이 실제 매핑입니다.

```
$ 관리자(TEST1)로 로그인한 뒤 각 URL 을 요청했다
404    1114  /uss/olh/faq/FaqListInqire.do
200    3949  /uss/olh/faq/selectFaqList.do
404    1114  /uss/olh/qna/QnaListInqire.do
200    4342  /uss/olh/qna/selectQnaList.do
404    1114  /uss/olh/hpc/HpcmListInqire.do
200    4094  /uss/olh/hpc/selectHpcmList.do
404    1114  /uss/olh/wor/WordDicaryListInqire.do
200    4294  /uss/olh/wor/selectWordDicaryList.do
404    1114  /uss/olh/awm/listAdministrationWord.do
200    4516  /uss/olh/awm/selectAdministrationWordList.do
404    1114  /uss/olh/awm/listAdministrationWordManage.do
200    4868  /uss/olh/awm/selectAdministrationWordManageList.do
```

같은 사용자지원 메뉴 아래 `Q&A답변관리`(`/uss/olh/qnm/QnaAnswerListInqire.do`)도 같은 증상이지만 뺐습니다. 그쪽은 `PROGRM_STRE_PATH` 까지 `/uss/olh/qna/` 로 바뀌어야 해서 URL 한 컬럼만 고치는 이 PR 의 범위를 넘습니다.

시드의 URL 을 실제 매핑으로 맞췄습니다. 여덟 개 방언(`altibase`·`cubrid`·`goldilocks`·`maria`·`mysql`·`oracle`·`postgres`·`tibero`)의 통합 스크립트와 개별 스크립트를 같이 고쳐 24개 파일 144줄이 바뀝니다. 메뉴 이름·메뉴 번호·프로그램 파일명은 그대로 두고 URL 만 바꿨습니다.

## JUnit 테스트 JUnit tests

- [ ] JUnit 테스트 JUnit tests
- [x] 수동 테스트 Manual testing

시드 데이터라 단위 테스트로는 확인되지 않습니다. MySQL 8.0 컨테이너에 스크립트를 넣고 톰캣에 올린 뒤 관리자(`ROLE_ADMIN`)로 로그인해 위 URL 들을 직접 요청했습니다. 응답 코드와 바이트 수가 위 출력입니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

브라우저 대신 로그인 세션을 유지한 HTTP 요청으로 확인했습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

검증은 위 요청 결과로 대신합니다.
