### PR TITLE
fix: 협업 메뉴가 없는 URL 을 가리키던 문제 수정

### DIFF
--- a/script/dml/altibase/com_DML_altibase.sql
+++ b/script/dml/altibase/com_DML_altibase.sql
@@ -786,11 +786,11 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectAnnvrsryManageList','/uss/ion/ans/','기념일관리','기념일관리','/uss/ion/ans/selectAnnvrsryManageList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBannerList','/uss/ion/bnr/','배너관리','배너관리','/uss/ion/bnr/selectBannerList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBannerMainList','/uss/ion/bnr/','MYPAGE배너관리','MYPAGE배너관리','/uss/ion/bnr/selectBannerMainList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('SelectBBSMasterInfs','/cop/bbs/','게시판속성관리','게시판속성관리','/cop/bbs/SelectBBSMasterInfs.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('SelectBBSMasterInfs','/cop/bbs/','게시판속성관리','게시판속성관리','/cop/bbs/selectBBSMasterInfs.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBbsStats','/sts/bst/','게시물통계','게시물통계','/sts/bst/selectBbsStats.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBBSUseInfs','/cop/com/','게시판사용정보','게시판사용정보','/cop/com/selectBBSUseInfs.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBkmkMenuManageList','/sym/mnu/bmm/','바로가기메뉴관리','바로가기메뉴관리','/sym/mnu/bmm/selectBkmkMenuManageList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectCmmntyInfs','/cop/cmy/','커뮤니티관리','커뮤니티관리','/cop/cmy/selectCmmntyInfs.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectCmmntyInfs','/cop/cmy/','커뮤니티관리','커뮤니티관리','/cop/cmy/selectCommuMasterList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectConectStats','/sts/cst/','접속통계','접속통계','/sts/cst/selectConectStats.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectCtsnnManageList','/uss/ion/ctn/','직원경조사관리','직원경조사관리','/uss/ion/ctn/selectCtsnnManageList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectDeptJobBxList','/cop/smt/djm/','부서업무함관리','부서업무함관리','/cop/smt/djm/selectDeptJobBxList.do');
@@ -818,7 +818,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectProxySvcList','/utl/sys/pxy/','프록시서비스','프록시서비스','/utl/sys/pxy/selectProxySvcList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectReprtStatsListView','/sts/rst/','보고서통계','보고서통계','/sts/rst/selectReprtStatsListView.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectRwardManageList','/uss/ion/rwd/','포상관리','포상관리','/uss/ion/rwd/selectRwardManageList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectScrapList','/cop/scp/','스크랩 목록','스크랩 목록','/cop/scp/selectScrapList.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectScrapList','/cop/scp/','스크랩 목록','스크랩 목록','/cop/scp/selectArticleScrapList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectScrinStats','/sts/sst/','화면통계','화면통계','/sts/sst/selectScrinStats.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectServerEqpmnList','/sym/sym/srv/','서버정보관리','서버정보관리','/sym/sym/srv/selectServerEqpmnList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectServerList','/sym/sym/srv/','서버(S/W)목록','서버(S/W)목록','/sym/sym/srv/selectServerList.do');

--- a/script/dml/cubrid/com_DML_cubrid.sql
+++ b/script/dml/cubrid/com_DML_cubrid.sql
@@ -806,11 +806,11 @@ INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM,
 INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectScrinStats', '/sts/sst/', '화면통계', '화면통계', '/sts/sst/selectScrinStats.do');
 INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectReprtStatsListView', '/sts/rst/', '보고서통계', '보고서통계', '/sts/rst/selectReprtStatsListView.do');
 INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectDtaUseStatsList', '/sts/dst/', '자료이용현황통계', '자료이용현황통계', '/sts/dst/selectDtaUseStatsList.do');
-INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('SelectBBSMasterInfs', '/cop/bbs/', '게시판속성관리', '게시판속성관리', '/cop/bbs/SelectBBSMasterInfs.do');
+INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('SelectBBSMasterInfs', '/cop/bbs/', '게시판속성관리', '게시판속성관리', '/cop/bbs/selectBBSMasterInfs.do');
 INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBBSUseInfs', '/cop/com/', '게시판사용정보', '게시판사용정보', '/cop/com/selectBBSUseInfs.do');
 INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectTemplateInfs', '/cop/tpl/', '템플릿관리', '템플릿관리', '/cop/tpl/selectTemplateInfs.do');
-INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectScrapList', '/cop/scp/', '스크랩 목록', '스크랩 목록', '/cop/scp/selectScrapList.do');
-INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectCmmntyInfs', '/cop/cmy/', '커뮤니티관리', '커뮤니티관리', '/cop/cmy/selectCmmntyInfs.do');
+INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectScrapList', '/cop/scp/', '스크랩 목록', '스크랩 목록', '/cop/scp/selectArticleScrapList.do');
+INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectCmmntyInfs', '/cop/cmy/', '커뮤니티관리', '커뮤니티관리', '/cop/cmy/selectCommuMasterList.do');
 INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectSmsList', '/cop/sms/', '문자메시지', '문자메시지', '/cop/sms/selectSmsList.do');
 INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('EgovDeptSchdulManageList', '/cop/smt/sdm/', '부서일정관리', '부서일정관리', '/cop/smt/sdm/EgovDeptSchdulManageList.do');
 INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('EgovIndvdlSchdulManageList', '/cop/smt/sim/', '일정관리', '일정관리', '/cop/smt/sim/EgovIndvdlSchdulManageList.do');

--- a/script/dml/goldilocks/com_DML_goldilocks.sql
+++ b/script/dml/goldilocks/com_DML_goldilocks.sql
@@ -784,11 +784,11 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectAnnvrsryManageList','/uss/ion/ans/','기념일관리','기념일관리','/uss/ion/ans/selectAnnvrsryManageList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBannerList','/uss/ion/bnr/','배너관리','배너관리','/uss/ion/bnr/selectBannerList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBannerMainList','/uss/ion/bnr/','MYPAGE배너관리','MYPAGE배너관리','/uss/ion/bnr/selectBannerMainList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('SelectBBSMasterInfs','/cop/bbs/','게시판속성관리','게시판속성관리','/cop/bbs/SelectBBSMasterInfs.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('SelectBBSMasterInfs','/cop/bbs/','게시판속성관리','게시판속성관리','/cop/bbs/selectBBSMasterInfs.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBbsStats','/sts/bst/','게시물통계','게시물통계','/sts/bst/selectBbsStats.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBBSUseInfs','/cop/com/','게시판사용정보','게시판사용정보','/cop/com/selectBBSUseInfs.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBkmkMenuManageList','/sym/mnu/bmm/','바로가기메뉴관리','바로가기메뉴관리','/sym/mnu/bmm/selectBkmkMenuManageList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectCmmntyInfs','/cop/cmy/','커뮤니티관리','커뮤니티관리','/cop/cmy/selectCmmntyInfs.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectCmmntyInfs','/cop/cmy/','커뮤니티관리','커뮤니티관리','/cop/cmy/selectCommuMasterList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectConectStats','/sts/cst/','접속통계','접속통계','/sts/cst/selectConectStats.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectCtsnnManageList','/uss/ion/ctn/','직원경조사관리','직원경조사관리','/uss/ion/ctn/selectCtsnnManageList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectDeptJobBxList','/cop/smt/djm/','부서업무함관리','부서업무함관리','/cop/smt/djm/selectDeptJobBxList.do');
@@ -816,7 +816,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectProxySvcList','/utl/sys/pxy/','프록시서비스','프록시서비스','/utl/sys/pxy/selectProxySvcList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectReprtStatsListView','/sts/rst/','보고서통계','보고서통계','/sts/rst/selectReprtStatsListView.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectRwardManageList','/uss/ion/rwd/','포상관리','포상관리','/uss/ion/rwd/selectRwardManageList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectScrapList','/cop/scp/','스크랩 목록','스크랩 목록','/cop/scp/selectScrapList.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectScrapList','/cop/scp/','스크랩 목록','스크랩 목록','/cop/scp/selectArticleScrapList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectScrinStats','/sts/sst/','화면통계','화면통계','/sts/sst/selectScrinStats.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectServerEqpmnList','/sym/sym/srv/','서버정보관리','서버정보관리','/sym/sym/srv/selectServerEqpmnList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectServerList','/sym/sym/srv/','서버(S/W)목록','서버(S/W)목록','/sym/sym/srv/selectServerList.do');

--- a/script/dml/maria/com_DML_maria.sql
+++ b/script/dml/maria/com_DML_maria.sql
@@ -785,11 +785,11 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectAnnvrsryManageList','/uss/ion/ans/','기념일관리','기념일관리','/uss/ion/ans/selectAnnvrsryManageList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBannerList','/uss/ion/bnr/','배너관리','배너관리','/uss/ion/bnr/selectBannerList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBannerMainList','/uss/ion/bnr/','MYPAGE배너관리','MYPAGE배너관리','/uss/ion/bnr/selectBannerMainList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('SelectBBSMasterInfs','/cop/bbs/','게시판속성관리','게시판속성관리','/cop/bbs/SelectBBSMasterInfs.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('SelectBBSMasterInfs','/cop/bbs/','게시판속성관리','게시판속성관리','/cop/bbs/selectBBSMasterInfs.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBbsStats','/sts/bst/','게시물통계','게시물통계','/sts/bst/selectBbsStats.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBBSUseInfs','/cop/com/','게시판사용정보','게시판사용정보','/cop/com/selectBBSUseInfs.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBkmkMenuManageList','/sym/mnu/bmm/','바로가기메뉴관리','바로가기메뉴관리','/sym/mnu/bmm/selectBkmkMenuManageList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectCmmntyInfs','/cop/cmy/','커뮤니티관리','커뮤니티관리','/cop/cmy/selectCmmntyInfs.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectCmmntyInfs','/cop/cmy/','커뮤니티관리','커뮤니티관리','/cop/cmy/selectCommuMasterList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectConectStats','/sts/cst/','접속통계','접속통계','/sts/cst/selectConectStats.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectCtsnnManageList','/uss/ion/ctn/','직원경조사관리','직원경조사관리','/uss/ion/ctn/selectCtsnnManageList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectDeptJobBxList','/cop/smt/djm/','부서업무함관리','부서업무함관리','/cop/smt/djm/selectDeptJobBxList.do');
@@ -817,7 +817,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectProxySvcList','/utl/sys/pxy/','프록시서비스','프록시서비스','/utl/sys/pxy/selectProxySvcList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectReprtStatsListView','/sts/rst/','보고서통계','보고서통계','/sts/rst/selectReprtStatsListView.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectRwardManageList','/uss/ion/rwd/','포상관리','포상관리','/uss/ion/rwd/selectRwardManageList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectScrapList','/cop/scp/','스크랩 목록','스크랩 목록','/cop/scp/selectScrapList.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectScrapList','/cop/scp/','스크랩 목록','스크랩 목록','/cop/scp/selectArticleScrapList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectScrinStats','/sts/sst/','화면통계','화면통계','/sts/sst/selectScrinStats.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectServerEqpmnList','/sym/sym/srv/','서버정보관리','서버정보관리','/sym/sym/srv/selectServerEqpmnList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectServerList','/sym/sym/srv/','서버(S/W)목록','서버(S/W)목록','/sym/sym/srv/selectServerList.do');

--- a/script/dml/mysql/com_DML_mysql.sql
+++ b/script/dml/mysql/com_DML_mysql.sql
@@ -785,11 +785,11 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectAnnvrsryManageList','/uss/ion/ans/','기념일관리','기념일관리','/uss/ion/ans/selectAnnvrsryManageList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBannerList','/uss/ion/bnr/','배너관리','배너관리','/uss/ion/bnr/selectBannerList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBannerMainList','/uss/ion/bnr/','MYPAGE배너관리','MYPAGE배너관리','/uss/ion/bnr/selectBannerMainList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('SelectBBSMasterInfs','/cop/bbs/','게시판속성관리','게시판속성관리','/cop/bbs/SelectBBSMasterInfs.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('SelectBBSMasterInfs','/cop/bbs/','게시판속성관리','게시판속성관리','/cop/bbs/selectBBSMasterInfs.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBbsStats','/sts/bst/','게시물통계','게시물통계','/sts/bst/selectBbsStats.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBBSUseInfs','/cop/com/','게시판사용정보','게시판사용정보','/cop/com/selectBBSUseInfs.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBkmkMenuManageList','/sym/mnu/bmm/','바로가기메뉴관리','바로가기메뉴관리','/sym/mnu/bmm/selectBkmkMenuManageList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectCmmntyInfs','/cop/cmy/','커뮤니티관리','커뮤니티관리','/cop/cmy/selectCmmntyInfs.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectCmmntyInfs','/cop/cmy/','커뮤니티관리','커뮤니티관리','/cop/cmy/selectCommuMasterList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectConectStats','/sts/cst/','접속통계','접속통계','/sts/cst/selectConectStats.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectCtsnnManageList','/uss/ion/ctn/','직원경조사관리','직원경조사관리','/uss/ion/ctn/selectCtsnnManageList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectDeptJobBxList','/cop/smt/djm/','부서업무함관리','부서업무함관리','/cop/smt/djm/selectDeptJobBxList.do');
@@ -817,7 +817,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectProxySvcList','/utl/sys/pxy/','프록시서비스','프록시서비스','/utl/sys/pxy/selectProxySvcList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectReprtStatsListView','/sts/rst/','보고서통계','보고서통계','/sts/rst/selectReprtStatsListView.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectRwardManageList','/uss/ion/rwd/','포상관리','포상관리','/uss/ion/rwd/selectRwardManageList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectScrapList','/cop/scp/','스크랩 목록','스크랩 목록','/cop/scp/selectScrapList.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectScrapList','/cop/scp/','스크랩 목록','스크랩 목록','/cop/scp/selectArticleScrapList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectScrinStats','/sts/sst/','화면통계','화면통계','/sts/sst/selectScrinStats.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectServerEqpmnList','/sym/sym/srv/','서버정보관리','서버정보관리','/sym/sym/srv/selectServerEqpmnList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectServerList','/sym/sym/srv/','서버(S/W)목록','서버(S/W)목록','/sym/sym/srv/selectServerList.do');

--- a/script/dml/oracle/com_DML_oracle.sql
+++ b/script/dml/oracle/com_DML_oracle.sql
@@ -786,11 +786,11 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectAnnvrsryManageList','/uss/ion/ans/','기념일관리','기념일관리','/uss/ion/ans/selectAnnvrsryManageList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBannerList','/uss/ion/bnr/','배너관리','배너관리','/uss/ion/bnr/selectBannerList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBannerMainList','/uss/ion/bnr/','MYPAGE배너관리','MYPAGE배너관리','/uss/ion/bnr/selectBannerMainList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('SelectBBSMasterInfs','/cop/bbs/','게시판속성관리','게시판속성관리','/cop/bbs/SelectBBSMasterInfs.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('SelectBBSMasterInfs','/cop/bbs/','게시판속성관리','게시판속성관리','/cop/bbs/selectBBSMasterInfs.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBbsStats','/sts/bst/','게시물통계','게시물통계','/sts/bst/selectBbsStats.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBBSUseInfs','/cop/com/','게시판사용정보','게시판사용정보','/cop/com/selectBBSUseInfs.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBkmkMenuManageList','/sym/mnu/bmm/','바로가기메뉴관리','바로가기메뉴관리','/sym/mnu/bmm/selectBkmkMenuManageList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectCmmntyInfs','/cop/cmy/','커뮤니티관리','커뮤니티관리','/cop/cmy/selectCmmntyInfs.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectCmmntyInfs','/cop/cmy/','커뮤니티관리','커뮤니티관리','/cop/cmy/selectCommuMasterList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectConectStats','/sts/cst/','접속통계','접속통계','/sts/cst/selectConectStats.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectCtsnnManageList','/uss/ion/ctn/','직원경조사관리','직원경조사관리','/uss/ion/ctn/selectCtsnnManageList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectDeptJobBxList','/cop/smt/djm/','부서업무함관리','부서업무함관리','/cop/smt/djm/selectDeptJobBxList.do');
@@ -818,7 +818,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectProxySvcList','/utl/sys/pxy/','프록시서비스','프록시서비스','/utl/sys/pxy/selectProxySvcList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectReprtStatsListView','/sts/rst/','보고서통계','보고서통계','/sts/rst/selectReprtStatsListView.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectRwardManageList','/uss/ion/rwd/','포상관리','포상관리','/uss/ion/rwd/selectRwardManageList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectScrapList','/cop/scp/','스크랩 목록','스크랩 목록','/cop/scp/selectScrapList.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectScrapList','/cop/scp/','스크랩 목록','스크랩 목록','/cop/scp/selectArticleScrapList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectScrinStats','/sts/sst/','화면통계','화면통계','/sts/sst/selectScrinStats.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectServerEqpmnList','/sym/sym/srv/','서버정보관리','서버정보관리','/sym/sym/srv/selectServerEqpmnList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectServerList','/sym/sym/srv/','서버(S/W)목록','서버(S/W)목록','/sym/sym/srv/selectServerList.do');

--- a/script/dml/postgres/com_DML_postgres.sql
+++ b/script/dml/postgres/com_DML_postgres.sql
@@ -785,11 +785,11 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectAnnvrsryManageList','/uss/ion/ans/','기념일관리','기념일관리','/uss/ion/ans/selectAnnvrsryManageList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBannerList','/uss/ion/bnr/','배너관리','배너관리','/uss/ion/bnr/selectBannerList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBannerMainList','/uss/ion/bnr/','MYPAGE배너관리','MYPAGE배너관리','/uss/ion/bnr/selectBannerMainList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('SelectBBSMasterInfs','/cop/bbs/','게시판속성관리','게시판속성관리','/cop/bbs/SelectBBSMasterInfs.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('SelectBBSMasterInfs','/cop/bbs/','게시판속성관리','게시판속성관리','/cop/bbs/selectBBSMasterInfs.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBbsStats','/sts/bst/','게시물통계','게시물통계','/sts/bst/selectBbsStats.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBBSUseInfs','/cop/com/','게시판사용정보','게시판사용정보','/cop/com/selectBBSUseInfs.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBkmkMenuManageList','/sym/mnu/bmm/','바로가기메뉴관리','바로가기메뉴관리','/sym/mnu/bmm/selectBkmkMenuManageList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectCmmntyInfs','/cop/cmy/','커뮤니티관리','커뮤니티관리','/cop/cmy/selectCmmntyInfs.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectCmmntyInfs','/cop/cmy/','커뮤니티관리','커뮤니티관리','/cop/cmy/selectCommuMasterList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectConectStats','/sts/cst/','접속통계','접속통계','/sts/cst/selectConectStats.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectCtsnnManageList','/uss/ion/ctn/','직원경조사관리','직원경조사관리','/uss/ion/ctn/selectCtsnnManageList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectDeptJobBxList','/cop/smt/djm/','부서업무함관리','부서업무함관리','/cop/smt/djm/selectDeptJobBxList.do');
@@ -817,7 +817,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectProxySvcList','/utl/sys/pxy/','프록시서비스','프록시서비스','/utl/sys/pxy/selectProxySvcList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectReprtStatsListView','/sts/rst/','보고서통계','보고서통계','/sts/rst/selectReprtStatsListView.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectRwardManageList','/uss/ion/rwd/','포상관리','포상관리','/uss/ion/rwd/selectRwardManageList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectScrapList','/cop/scp/','스크랩 목록','스크랩 목록','/cop/scp/selectScrapList.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectScrapList','/cop/scp/','스크랩 목록','스크랩 목록','/cop/scp/selectArticleScrapList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectScrinStats','/sts/sst/','화면통계','화면통계','/sts/sst/selectScrinStats.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectServerEqpmnList','/sym/sym/srv/','서버정보관리','서버정보관리','/sym/sym/srv/selectServerEqpmnList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectServerList','/sym/sym/srv/','서버(S/W)목록','서버(S/W)목록','/sym/sym/srv/selectServerList.do');

--- a/script/dml/tibero/com_DML_tibero.sql
+++ b/script/dml/tibero/com_DML_tibero.sql
@@ -786,11 +786,11 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectAnnvrsryManageList','/uss/ion/ans/','기념일관리','기념일관리','/uss/ion/ans/selectAnnvrsryManageList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBannerList','/uss/ion/bnr/','배너관리','배너관리','/uss/ion/bnr/selectBannerList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBannerMainList','/uss/ion/bnr/','MYPAGE배너관리','MYPAGE배너관리','/uss/ion/bnr/selectBannerMainList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('SelectBBSMasterInfs','/cop/bbs/','게시판속성관리','게시판속성관리','/cop/bbs/SelectBBSMasterInfs.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('SelectBBSMasterInfs','/cop/bbs/','게시판속성관리','게시판속성관리','/cop/bbs/selectBBSMasterInfs.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBbsStats','/sts/bst/','게시물통계','게시물통계','/sts/bst/selectBbsStats.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBBSUseInfs','/cop/com/','게시판사용정보','게시판사용정보','/cop/com/selectBBSUseInfs.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBkmkMenuManageList','/sym/mnu/bmm/','바로가기메뉴관리','바로가기메뉴관리','/sym/mnu/bmm/selectBkmkMenuManageList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectCmmntyInfs','/cop/cmy/','커뮤니티관리','커뮤니티관리','/cop/cmy/selectCmmntyInfs.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectCmmntyInfs','/cop/cmy/','커뮤니티관리','커뮤니티관리','/cop/cmy/selectCommuMasterList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectConectStats','/sts/cst/','접속통계','접속통계','/sts/cst/selectConectStats.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectCtsnnManageList','/uss/ion/ctn/','직원경조사관리','직원경조사관리','/uss/ion/ctn/selectCtsnnManageList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectDeptJobBxList','/cop/smt/djm/','부서업무함관리','부서업무함관리','/cop/smt/djm/selectDeptJobBxList.do');
@@ -818,7 +818,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectProxySvcList','/utl/sys/pxy/','프록시서비스','프록시서비스','/utl/sys/pxy/selectProxySvcList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectReprtStatsListView','/sts/rst/','보고서통계','보고서통계','/sts/rst/selectReprtStatsListView.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectRwardManageList','/uss/ion/rwd/','포상관리','포상관리','/uss/ion/rwd/selectRwardManageList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectScrapList','/cop/scp/','스크랩 목록','스크랩 목록','/cop/scp/selectScrapList.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectScrapList','/cop/scp/','스크랩 목록','스크랩 목록','/cop/scp/selectArticleScrapList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectScrinStats','/sts/sst/','화면통계','화면통계','/sts/sst/selectScrinStats.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectServerEqpmnList','/sym/sym/srv/','서버정보관리','서버정보관리','/sym/sym/srv/selectServerEqpmnList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectServerList','/sym/sym/srv/','서버(S/W)목록','서버(S/W)목록','/sym/sym/srv/selectServerList.do');

--- a/src/script/dml/altibase/sts.sst_insert_altibase.sql
+++ b/src/script/dml/altibase/sts.sst_insert_altibase.sql
@@ -778,11 +778,11 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectAnnvrsryManageList','/uss/ion/ans/','기념일관리','기념일관리','/uss/ion/ans/selectAnnvrsryManageList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBannerList','/uss/ion/bnr/','배너관리','배너관리','/uss/ion/bnr/selectBannerList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBannerMainList','/uss/ion/bnr/','MYPAGE배너관리','MYPAGE배너관리','/uss/ion/bnr/selectBannerMainList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('SelectBBSMasterInfs','/cop/bbs/','게시판속성관리','게시판속성관리','/cop/bbs/SelectBBSMasterInfs.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('SelectBBSMasterInfs','/cop/bbs/','게시판속성관리','게시판속성관리','/cop/bbs/selectBBSMasterInfs.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBbsStats','/sts/bst/','게시물통계','게시물통계','/sts/bst/selectBbsStats.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBBSUseInfs','/cop/com/','게시판사용정보','게시판사용정보','/cop/com/selectBBSUseInfs.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBkmkMenuManageList','/sym/mnu/bmm/','바로가기메뉴관리','바로가기메뉴관리','/sym/mnu/bmm/selectBkmkMenuManageList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectCmmntyInfs','/cop/cmy/','커뮤니티관리','커뮤니티관리','/cop/cmy/selectCmmntyInfs.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectCmmntyInfs','/cop/cmy/','커뮤니티관리','커뮤니티관리','/cop/cmy/selectCommuMasterList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectConectStats','/sts/cst/','접속통계','접속통계','/sts/cst/selectConectStats.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectCtsnnManageList','/uss/ion/ctn/','직원경조사관리','직원경조사관리','/uss/ion/ctn/selectCtsnnManageList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectDeptJobBxList','/cop/smt/djm/','부서업무함관리','부서업무함관리','/cop/smt/djm/selectDeptJobBxList.do');
@@ -810,7 +810,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectProxySvcList','/utl/sys/pxy/','프록시서비스','프록시서비스','/utl/sys/pxy/selectProxySvcList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectReprtStatsListView','/sts/rst/','보고서통계','보고서통계','/sts/rst/selectReprtStatsListView.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectRwardManageList','/uss/ion/rwd/','포상관리','포상관리','/uss/ion/rwd/selectRwardManageList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectScrapList','/cop/scp/','스크랩 목록','스크랩 목록','/cop/scp/selectScrapList.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectScrapList','/cop/scp/','스크랩 목록','스크랩 목록','/cop/scp/selectArticleScrapList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectScrinStats','/sts/sst/','화면통계','화면통계','/sts/sst/selectScrinStats.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectServerEqpmnList','/sym/sym/srv/','서버정보관리','서버정보관리','/sym/sym/srv/selectServerEqpmnList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectServerList','/sym/sym/srv/','서버(S/W)목록','서버(S/W)목록','/sym/sym/srv/selectServerList.do');

--- a/src/script/dml/altibase/sym.mnu_insert_altibase.sql
+++ b/src/script/dml/altibase/sym.mnu_insert_altibase.sql
@@ -784,11 +784,11 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectAnnvrsryManageList','/uss/ion/ans/','기념일관리','기념일관리','/uss/ion/ans/selectAnnvrsryManageList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBannerList','/uss/ion/bnr/','배너관리','배너관리','/uss/ion/bnr/selectBannerList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBannerMainList','/uss/ion/bnr/','MYPAGE배너관리','MYPAGE배너관리','/uss/ion/bnr/selectBannerMainList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('SelectBBSMasterInfs','/cop/bbs/','게시판속성관리','게시판속성관리','/cop/bbs/SelectBBSMasterInfs.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('SelectBBSMasterInfs','/cop/bbs/','게시판속성관리','게시판속성관리','/cop/bbs/selectBBSMasterInfs.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBbsStats','/sts/bst/','게시물통계','게시물통계','/sts/bst/selectBbsStats.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBBSUseInfs','/cop/com/','게시판사용정보','게시판사용정보','/cop/com/selectBBSUseInfs.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBkmkMenuManageList','/sym/mnu/bmm/','바로가기메뉴관리','바로가기메뉴관리','/sym/mnu/bmm/selectBkmkMenuManageList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectCmmntyInfs','/cop/cmy/','커뮤니티관리','커뮤니티관리','/cop/cmy/selectCmmntyInfs.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectCmmntyInfs','/cop/cmy/','커뮤니티관리','커뮤니티관리','/cop/cmy/selectCommuMasterList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectConectStats','/sts/cst/','접속통계','접속통계','/sts/cst/selectConectStats.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectCtsnnManageList','/uss/ion/ctn/','직원경조사관리','직원경조사관리','/uss/ion/ctn/selectCtsnnManageList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectDeptJobBxList','/cop/smt/djm/','부서업무함관리','부서업무함관리','/cop/smt/djm/selectDeptJobBxList.do');
@@ -816,7 +816,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectProxySvcList','/utl/sys/pxy/','프록시서비스','프록시서비스','/utl/sys/pxy/selectProxySvcList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectReprtStatsListView','/sts/rst/','보고서통계','보고서통계','/sts/rst/selectReprtStatsListView.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectRwardManageList','/uss/ion/rwd/','포상관리','포상관리','/uss/ion/rwd/selectRwardManageList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectScrapList','/cop/scp/','스크랩 목록','스크랩 목록','/cop/scp/selectScrapList.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectScrapList','/cop/scp/','스크랩 목록','스크랩 목록','/cop/scp/selectArticleScrapList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectScrinStats','/sts/sst/','화면통계','화면통계','/sts/sst/selectScrinStats.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectServerEqpmnList','/sym/sym/srv/','서버정보관리','서버정보관리','/sym/sym/srv/selectServerEqpmnList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectServerList','/sym/sym/srv/','서버(S/W)목록','서버(S/W)목록','/sym/sym/srv/selectServerList.do');

--- a/src/script/dml/cubrid/sts.sst_insert_cubrid.sql
+++ b/src/script/dml/cubrid/sts.sst_insert_cubrid.sql
@@ -831,11 +831,11 @@ INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM,
 INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectScrinStats', '/sts/sst/', '화면통계', '화면통계', '/sts/sst/selectScrinStats.do');
 INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectReprtStatsListView', '/sts/rst/', '보고서통계', '보고서통계', '/sts/rst/selectReprtStatsListView.do');
 INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectDtaUseStatsList', '/sts/dst/', '자료이용현황통계', '자료이용현황통계', '/sts/dst/selectDtaUseStatsList.do');
-INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('SelectBBSMasterInfs', '/cop/bbs/', '게시판속성관리', '게시판속성관리', '/cop/bbs/SelectBBSMasterInfs.do');
+INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('SelectBBSMasterInfs', '/cop/bbs/', '게시판속성관리', '게시판속성관리', '/cop/bbs/selectBBSMasterInfs.do');
 INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBBSUseInfs', '/cop/com/', '게시판사용정보', '게시판사용정보', '/cop/com/selectBBSUseInfs.do');
 INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectTemplateInfs', '/cop/tpl/', '템플릿관리', '템플릿관리', '/cop/tpl/selectTemplateInfs.do');
-INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectScrapList', '/cop/scp/', '스크랩 목록', '스크랩 목록', '/cop/scp/selectScrapList.do');
-INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectCmmntyInfs', '/cop/cmy/', '커뮤니티관리', '커뮤니티관리', '/cop/cmy/selectCmmntyInfs.do');
+INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectScrapList', '/cop/scp/', '스크랩 목록', '스크랩 목록', '/cop/scp/selectArticleScrapList.do');
+INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectCmmntyInfs', '/cop/cmy/', '커뮤니티관리', '커뮤니티관리', '/cop/cmy/selectCommuMasterList.do');
 INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectSmsList', '/cop/sms/', '문자메시지', '문자메시지', '/cop/sms/selectSmsList.do');
 INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('EgovDeptSchdulManageList', '/cop/smt/sdm/', '부서일정관리', '부서일정관리', '/cop/smt/sdm/EgovDeptSchdulManageList.do');
 INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('EgovIndvdlSchdulManageList', '/cop/smt/sim/', '일정관리', '일정관리', '/cop/smt/sim/EgovIndvdlSchdulManageList.do');

--- a/src/script/dml/cubrid/sym.mnu_insert_cubrid.sql
+++ b/src/script/dml/cubrid/sym.mnu_insert_cubrid.sql
@@ -837,11 +837,11 @@ INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM,
 INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectScrinStats', '/sts/sst/', '화면통계', '화면통계', '/sts/sst/selectScrinStats.do');
 INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectReprtStatsListView', '/sts/rst/', '보고서통계', '보고서통계', '/sts/rst/selectReprtStatsListView.do');
 INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectDtaUseStatsList', '/sts/dst/', '자료이용현황통계', '자료이용현황통계', '/sts/dst/selectDtaUseStatsList.do');
-INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('SelectBBSMasterInfs', '/cop/bbs/', '게시판속성관리', '게시판속성관리', '/cop/bbs/SelectBBSMasterInfs.do');
+INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('SelectBBSMasterInfs', '/cop/bbs/', '게시판속성관리', '게시판속성관리', '/cop/bbs/selectBBSMasterInfs.do');
 INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBBSUseInfs', '/cop/com/', '게시판사용정보', '게시판사용정보', '/cop/com/selectBBSUseInfs.do');
 INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectTemplateInfs', '/cop/tpl/', '템플릿관리', '템플릿관리', '/cop/tpl/selectTemplateInfs.do');
-INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectScrapList', '/cop/scp/', '스크랩 목록', '스크랩 목록', '/cop/scp/selectScrapList.do');
-INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectCmmntyInfs', '/cop/cmy/', '커뮤니티관리', '커뮤니티관리', '/cop/cmy/selectCmmntyInfs.do');
+INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectScrapList', '/cop/scp/', '스크랩 목록', '스크랩 목록', '/cop/scp/selectArticleScrapList.do');
+INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectCmmntyInfs', '/cop/cmy/', '커뮤니티관리', '커뮤니티관리', '/cop/cmy/selectCommuMasterList.do');
 INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectSmsList', '/cop/sms/', '문자메시지', '문자메시지', '/cop/sms/selectSmsList.do');
 INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('EgovDeptSchdulManageList', '/cop/smt/sdm/', '부서일정관리', '부서일정관리', '/cop/smt/sdm/EgovDeptSchdulManageList.do');
 INSERT INTO COMTNPROGRMLIST (PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('EgovIndvdlSchdulManageList', '/cop/smt/sim/', '일정관리', '일정관리', '/cop/smt/sim/EgovIndvdlSchdulManageList.do');

--- a/src/script/dml/goldilocks/sts.sst_insert_goldilocks.sql
+++ b/src/script/dml/goldilocks/sts.sst_insert_goldilocks.sql
@@ -778,11 +778,11 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectAnnvrsryManageList','/uss/ion/ans/','기념일관리','기념일관리','/uss/ion/ans/selectAnnvrsryManageList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBannerList','/uss/ion/bnr/','배너관리','배너관리','/uss/ion/bnr/selectBannerList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBannerMainList','/uss/ion/bnr/','MYPAGE배너관리','MYPAGE배너관리','/uss/ion/bnr/selectBannerMainList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('SelectBBSMasterInfs','/cop/bbs/','게시판속성관리','게시판속성관리','/cop/bbs/SelectBBSMasterInfs.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('SelectBBSMasterInfs','/cop/bbs/','게시판속성관리','게시판속성관리','/cop/bbs/selectBBSMasterInfs.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBbsStats','/sts/bst/','게시물통계','게시물통계','/sts/bst/selectBbsStats.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBBSUseInfs','/cop/com/','게시판사용정보','게시판사용정보','/cop/com/selectBBSUseInfs.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBkmkMenuManageList','/sym/mnu/bmm/','바로가기메뉴관리','바로가기메뉴관리','/sym/mnu/bmm/selectBkmkMenuManageList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectCmmntyInfs','/cop/cmy/','커뮤니티관리','커뮤니티관리','/cop/cmy/selectCmmntyInfs.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectCmmntyInfs','/cop/cmy/','커뮤니티관리','커뮤니티관리','/cop/cmy/selectCommuMasterList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectConectStats','/sts/cst/','접속통계','접속통계','/sts/cst/selectConectStats.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectCtsnnManageList','/uss/ion/ctn/','직원경조사관리','직원경조사관리','/uss/ion/ctn/selectCtsnnManageList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectDeptJobBxList','/cop/smt/djm/','부서업무함관리','부서업무함관리','/cop/smt/djm/selectDeptJobBxList.do');
@@ -810,7 +810,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectProxySvcList','/utl/sys/pxy/','프록시서비스','프록시서비스','/utl/sys/pxy/selectProxySvcList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectReprtStatsListView','/sts/rst/','보고서통계','보고서통계','/sts/rst/selectReprtStatsListView.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectRwardManageList','/uss/ion/rwd/','포상관리','포상관리','/uss/ion/rwd/selectRwardManageList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectScrapList','/cop/scp/','스크랩 목록','스크랩 목록','/cop/scp/selectScrapList.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectScrapList','/cop/scp/','스크랩 목록','스크랩 목록','/cop/scp/selectArticleScrapList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectScrinStats','/sts/sst/','화면통계','화면통계','/sts/sst/selectScrinStats.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectServerEqpmnList','/sym/sym/srv/','서버정보관리','서버정보관리','/sym/sym/srv/selectServerEqpmnList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectServerList','/sym/sym/srv/','서버(S/W)목록','서버(S/W)목록','/sym/sym/srv/selectServerList.do');

--- a/src/script/dml/goldilocks/sym.mnu_insert_goldilocks.sql
+++ b/src/script/dml/goldilocks/sym.mnu_insert_goldilocks.sql
@@ -784,11 +784,11 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectAnnvrsryManageList','/uss/ion/ans/','기념일관리','기념일관리','/uss/ion/ans/selectAnnvrsryManageList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBannerList','/uss/ion/bnr/','배너관리','배너관리','/uss/ion/bnr/selectBannerList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBannerMainList','/uss/ion/bnr/','MYPAGE배너관리','MYPAGE배너관리','/uss/ion/bnr/selectBannerMainList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('SelectBBSMasterInfs','/cop/bbs/','게시판속성관리','게시판속성관리','/cop/bbs/SelectBBSMasterInfs.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('SelectBBSMasterInfs','/cop/bbs/','게시판속성관리','게시판속성관리','/cop/bbs/selectBBSMasterInfs.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBbsStats','/sts/bst/','게시물통계','게시물통계','/sts/bst/selectBbsStats.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBBSUseInfs','/cop/com/','게시판사용정보','게시판사용정보','/cop/com/selectBBSUseInfs.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBkmkMenuManageList','/sym/mnu/bmm/','바로가기메뉴관리','바로가기메뉴관리','/sym/mnu/bmm/selectBkmkMenuManageList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectCmmntyInfs','/cop/cmy/','커뮤니티관리','커뮤니티관리','/cop/cmy/selectCmmntyInfs.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectCmmntyInfs','/cop/cmy/','커뮤니티관리','커뮤니티관리','/cop/cmy/selectCommuMasterList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectConectStats','/sts/cst/','접속통계','접속통계','/sts/cst/selectConectStats.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectCtsnnManageList','/uss/ion/ctn/','직원경조사관리','직원경조사관리','/uss/ion/ctn/selectCtsnnManageList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectDeptJobBxList','/cop/smt/djm/','부서업무함관리','부서업무함관리','/cop/smt/djm/selectDeptJobBxList.do');
@@ -816,7 +816,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectProxySvcList','/utl/sys/pxy/','프록시서비스','프록시서비스','/utl/sys/pxy/selectProxySvcList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectReprtStatsListView','/sts/rst/','보고서통계','보고서통계','/sts/rst/selectReprtStatsListView.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectRwardManageList','/uss/ion/rwd/','포상관리','포상관리','/uss/ion/rwd/selectRwardManageList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectScrapList','/cop/scp/','스크랩 목록','스크랩 목록','/cop/scp/selectScrapList.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectScrapList','/cop/scp/','스크랩 목록','스크랩 목록','/cop/scp/selectArticleScrapList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectScrinStats','/sts/sst/','화면통계','화면통계','/sts/sst/selectScrinStats.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectServerEqpmnList','/sym/sym/srv/','서버정보관리','서버정보관리','/sym/sym/srv/selectServerEqpmnList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectServerList','/sym/sym/srv/','서버(S/W)목록','서버(S/W)목록','/sym/sym/srv/selectServerList.do');

--- a/src/script/dml/maria/sts.sst_insert_maria.sql
+++ b/src/script/dml/maria/sts.sst_insert_maria.sql
@@ -778,11 +778,11 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectAnnvrsryManageList','/uss/ion/ans/','기념일관리','기념일관리','/uss/ion/ans/selectAnnvrsryManageList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBannerList','/uss/ion/bnr/','배너관리','배너관리','/uss/ion/bnr/selectBannerList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBannerMainList','/uss/ion/bnr/','MYPAGE배너관리','MYPAGE배너관리','/uss/ion/bnr/selectBannerMainList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('SelectBBSMasterInfs','/cop/bbs/','게시판속성관리','게시판속성관리','/cop/bbs/SelectBBSMasterInfs.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('SelectBBSMasterInfs','/cop/bbs/','게시판속성관리','게시판속성관리','/cop/bbs/selectBBSMasterInfs.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBbsStats','/sts/bst/','게시물통계','게시물통계','/sts/bst/selectBbsStats.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBBSUseInfs','/cop/com/','게시판사용정보','게시판사용정보','/cop/com/selectBBSUseInfs.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBkmkMenuManageList','/sym/mnu/bmm/','바로가기메뉴관리','바로가기메뉴관리','/sym/mnu/bmm/selectBkmkMenuManageList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectCmmntyInfs','/cop/cmy/','커뮤니티관리','커뮤니티관리','/cop/cmy/selectCmmntyInfs.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectCmmntyInfs','/cop/cmy/','커뮤니티관리','커뮤니티관리','/cop/cmy/selectCommuMasterList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectConectStats','/sts/cst/','접속통계','접속통계','/sts/cst/selectConectStats.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectCtsnnManageList','/uss/ion/ctn/','직원경조사관리','직원경조사관리','/uss/ion/ctn/selectCtsnnManageList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectDeptJobBxList','/cop/smt/djm/','부서업무함관리','부서업무함관리','/cop/smt/djm/selectDeptJobBxList.do');
@@ -810,7 +810,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectProxySvcList','/utl/sys/pxy/','프록시서비스','프록시서비스','/utl/sys/pxy/selectProxySvcList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectReprtStatsListView','/sts/rst/','보고서통계','보고서통계','/sts/rst/selectReprtStatsListView.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectRwardManageList','/uss/ion/rwd/','포상관리','포상관리','/uss/ion/rwd/selectRwardManageList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectScrapList','/cop/scp/','스크랩 목록','스크랩 목록','/cop/scp/selectScrapList.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectScrapList','/cop/scp/','스크랩 목록','스크랩 목록','/cop/scp/selectArticleScrapList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectScrinStats','/sts/sst/','화면통계','화면통계','/sts/sst/selectScrinStats.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectServerEqpmnList','/sym/sym/srv/','서버정보관리','서버정보관리','/sym/sym/srv/selectServerEqpmnList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectServerList','/sym/sym/srv/','서버(S/W)목록','서버(S/W)목록','/sym/sym/srv/selectServerList.do');

--- a/src/script/dml/maria/sym.mnu_insert_maria.sql
+++ b/src/script/dml/maria/sym.mnu_insert_maria.sql
@@ -784,11 +784,11 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectAnnvrsryManageList','/uss/ion/ans/','기념일관리','기념일관리','/uss/ion/ans/selectAnnvrsryManageList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBannerList','/uss/ion/bnr/','배너관리','배너관리','/uss/ion/bnr/selectBannerList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBannerMainList','/uss/ion/bnr/','MYPAGE배너관리','MYPAGE배너관리','/uss/ion/bnr/selectBannerMainList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('SelectBBSMasterInfs','/cop/bbs/','게시판속성관리','게시판속성관리','/cop/bbs/SelectBBSMasterInfs.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('SelectBBSMasterInfs','/cop/bbs/','게시판속성관리','게시판속성관리','/cop/bbs/selectBBSMasterInfs.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBbsStats','/sts/bst/','게시물통계','게시물통계','/sts/bst/selectBbsStats.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBBSUseInfs','/cop/com/','게시판사용정보','게시판사용정보','/cop/com/selectBBSUseInfs.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBkmkMenuManageList','/sym/mnu/bmm/','바로가기메뉴관리','바로가기메뉴관리','/sym/mnu/bmm/selectBkmkMenuManageList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectCmmntyInfs','/cop/cmy/','커뮤니티관리','커뮤니티관리','/cop/cmy/selectCmmntyInfs.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectCmmntyInfs','/cop/cmy/','커뮤니티관리','커뮤니티관리','/cop/cmy/selectCommuMasterList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectConectStats','/sts/cst/','접속통계','접속통계','/sts/cst/selectConectStats.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectCtsnnManageList','/uss/ion/ctn/','직원경조사관리','직원경조사관리','/uss/ion/ctn/selectCtsnnManageList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectDeptJobBxList','/cop/smt/djm/','부서업무함관리','부서업무함관리','/cop/smt/djm/selectDeptJobBxList.do');
@@ -816,7 +816,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectProxySvcList','/utl/sys/pxy/','프록시서비스','프록시서비스','/utl/sys/pxy/selectProxySvcList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectReprtStatsListView','/sts/rst/','보고서통계','보고서통계','/sts/rst/selectReprtStatsListView.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectRwardManageList','/uss/ion/rwd/','포상관리','포상관리','/uss/ion/rwd/selectRwardManageList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectScrapList','/cop/scp/','스크랩 목록','스크랩 목록','/cop/scp/selectScrapList.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectScrapList','/cop/scp/','스크랩 목록','스크랩 목록','/cop/scp/selectArticleScrapList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectScrinStats','/sts/sst/','화면통계','화면통계','/sts/sst/selectScrinStats.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectServerEqpmnList','/sym/sym/srv/','서버정보관리','서버정보관리','/sym/sym/srv/selectServerEqpmnList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectServerList','/sym/sym/srv/','서버(S/W)목록','서버(S/W)목록','/sym/sym/srv/selectServerList.do');

--- a/src/script/dml/mysql/sts.sst_insert_mysql.sql
+++ b/src/script/dml/mysql/sts.sst_insert_mysql.sql
@@ -778,11 +778,11 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectAnnvrsryManageList','/uss/ion/ans/','기념일관리','기념일관리','/uss/ion/ans/selectAnnvrsryManageList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBannerList','/uss/ion/bnr/','배너관리','배너관리','/uss/ion/bnr/selectBannerList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBannerMainList','/uss/ion/bnr/','MYPAGE배너관리','MYPAGE배너관리','/uss/ion/bnr/selectBannerMainList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('SelectBBSMasterInfs','/cop/bbs/','게시판속성관리','게시판속성관리','/cop/bbs/SelectBBSMasterInfs.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('SelectBBSMasterInfs','/cop/bbs/','게시판속성관리','게시판속성관리','/cop/bbs/selectBBSMasterInfs.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBbsStats','/sts/bst/','게시물통계','게시물통계','/sts/bst/selectBbsStats.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBBSUseInfs','/cop/com/','게시판사용정보','게시판사용정보','/cop/com/selectBBSUseInfs.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBkmkMenuManageList','/sym/mnu/bmm/','바로가기메뉴관리','바로가기메뉴관리','/sym/mnu/bmm/selectBkmkMenuManageList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectCmmntyInfs','/cop/cmy/','커뮤니티관리','커뮤니티관리','/cop/cmy/selectCmmntyInfs.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectCmmntyInfs','/cop/cmy/','커뮤니티관리','커뮤니티관리','/cop/cmy/selectCommuMasterList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectConectStats','/sts/cst/','접속통계','접속통계','/sts/cst/selectConectStats.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectCtsnnManageList','/uss/ion/ctn/','직원경조사관리','직원경조사관리','/uss/ion/ctn/selectCtsnnManageList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectDeptJobBxList','/cop/smt/djm/','부서업무함관리','부서업무함관리','/cop/smt/djm/selectDeptJobBxList.do');
@@ -810,7 +810,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectProxySvcList','/utl/sys/pxy/','프록시서비스','프록시서비스','/utl/sys/pxy/selectProxySvcList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectReprtStatsListView','/sts/rst/','보고서통계','보고서통계','/sts/rst/selectReprtStatsListView.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectRwardManageList','/uss/ion/rwd/','포상관리','포상관리','/uss/ion/rwd/selectRwardManageList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectScrapList','/cop/scp/','스크랩 목록','스크랩 목록','/cop/scp/selectScrapList.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectScrapList','/cop/scp/','스크랩 목록','스크랩 목록','/cop/scp/selectArticleScrapList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectScrinStats','/sts/sst/','화면통계','화면통계','/sts/sst/selectScrinStats.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectServerEqpmnList','/sym/sym/srv/','서버정보관리','서버정보관리','/sym/sym/srv/selectServerEqpmnList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectServerList','/sym/sym/srv/','서버(S/W)목록','서버(S/W)목록','/sym/sym/srv/selectServerList.do');

--- a/src/script/dml/mysql/sym.mnu_insert_mysql.sql
+++ b/src/script/dml/mysql/sym.mnu_insert_mysql.sql
@@ -784,11 +784,11 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectAnnvrsryManageList','/uss/ion/ans/','기념일관리','기념일관리','/uss/ion/ans/selectAnnvrsryManageList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBannerList','/uss/ion/bnr/','배너관리','배너관리','/uss/ion/bnr/selectBannerList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBannerMainList','/uss/ion/bnr/','MYPAGE배너관리','MYPAGE배너관리','/uss/ion/bnr/selectBannerMainList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('SelectBBSMasterInfs','/cop/bbs/','게시판속성관리','게시판속성관리','/cop/bbs/SelectBBSMasterInfs.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('SelectBBSMasterInfs','/cop/bbs/','게시판속성관리','게시판속성관리','/cop/bbs/selectBBSMasterInfs.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBbsStats','/sts/bst/','게시물통계','게시물통계','/sts/bst/selectBbsStats.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBBSUseInfs','/cop/com/','게시판사용정보','게시판사용정보','/cop/com/selectBBSUseInfs.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBkmkMenuManageList','/sym/mnu/bmm/','바로가기메뉴관리','바로가기메뉴관리','/sym/mnu/bmm/selectBkmkMenuManageList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectCmmntyInfs','/cop/cmy/','커뮤니티관리','커뮤니티관리','/cop/cmy/selectCmmntyInfs.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectCmmntyInfs','/cop/cmy/','커뮤니티관리','커뮤니티관리','/cop/cmy/selectCommuMasterList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectConectStats','/sts/cst/','접속통계','접속통계','/sts/cst/selectConectStats.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectCtsnnManageList','/uss/ion/ctn/','직원경조사관리','직원경조사관리','/uss/ion/ctn/selectCtsnnManageList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectDeptJobBxList','/cop/smt/djm/','부서업무함관리','부서업무함관리','/cop/smt/djm/selectDeptJobBxList.do');
@@ -816,7 +816,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectProxySvcList','/utl/sys/pxy/','프록시서비스','프록시서비스','/utl/sys/pxy/selectProxySvcList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectReprtStatsListView','/sts/rst/','보고서통계','보고서통계','/sts/rst/selectReprtStatsListView.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectRwardManageList','/uss/ion/rwd/','포상관리','포상관리','/uss/ion/rwd/selectRwardManageList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectScrapList','/cop/scp/','스크랩 목록','스크랩 목록','/cop/scp/selectScrapList.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectScrapList','/cop/scp/','스크랩 목록','스크랩 목록','/cop/scp/selectArticleScrapList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectScrinStats','/sts/sst/','화면통계','화면통계','/sts/sst/selectScrinStats.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectServerEqpmnList','/sym/sym/srv/','서버정보관리','서버정보관리','/sym/sym/srv/selectServerEqpmnList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectServerList','/sym/sym/srv/','서버(S/W)목록','서버(S/W)목록','/sym/sym/srv/selectServerList.do');

--- a/src/script/dml/oracle/sts.sst_insert_oracle.sql
+++ b/src/script/dml/oracle/sts.sst_insert_oracle.sql
@@ -779,11 +779,11 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectAnnvrsryManageList','/uss/ion/ans/','기념일관리','기념일관리','/uss/ion/ans/selectAnnvrsryManageList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBannerList','/uss/ion/bnr/','배너관리','배너관리','/uss/ion/bnr/selectBannerList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBannerMainList','/uss/ion/bnr/','MYPAGE배너관리','MYPAGE배너관리','/uss/ion/bnr/selectBannerMainList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('SelectBBSMasterInfs','/cop/bbs/','게시판속성관리','게시판속성관리','/cop/bbs/SelectBBSMasterInfs.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('SelectBBSMasterInfs','/cop/bbs/','게시판속성관리','게시판속성관리','/cop/bbs/selectBBSMasterInfs.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBbsStats','/sts/bst/','게시물통계','게시물통계','/sts/bst/selectBbsStats.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBBSUseInfs','/cop/com/','게시판사용정보','게시판사용정보','/cop/com/selectBBSUseInfs.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBkmkMenuManageList','/sym/mnu/bmm/','바로가기메뉴관리','바로가기메뉴관리','/sym/mnu/bmm/selectBkmkMenuManageList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectCmmntyInfs','/cop/cmy/','커뮤니티관리','커뮤니티관리','/cop/cmy/selectCmmntyInfs.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectCmmntyInfs','/cop/cmy/','커뮤니티관리','커뮤니티관리','/cop/cmy/selectCommuMasterList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectConectStats','/sts/cst/','접속통계','접속통계','/sts/cst/selectConectStats.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectCtsnnManageList','/uss/ion/ctn/','직원경조사관리','직원경조사관리','/uss/ion/ctn/selectCtsnnManageList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectDeptJobBxList','/cop/smt/djm/','부서업무함관리','부서업무함관리','/cop/smt/djm/selectDeptJobBxList.do');
@@ -811,7 +811,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectProxySvcList','/utl/sys/pxy/','프록시서비스','프록시서비스','/utl/sys/pxy/selectProxySvcList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectReprtStatsListView','/sts/rst/','보고서통계','보고서통계','/sts/rst/selectReprtStatsListView.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectRwardManageList','/uss/ion/rwd/','포상관리','포상관리','/uss/ion/rwd/selectRwardManageList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectScrapList','/cop/scp/','스크랩 목록','스크랩 목록','/cop/scp/selectScrapList.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectScrapList','/cop/scp/','스크랩 목록','스크랩 목록','/cop/scp/selectArticleScrapList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectScrinStats','/sts/sst/','화면통계','화면통계','/sts/sst/selectScrinStats.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectServerEqpmnList','/sym/sym/srv/','서버정보관리','서버정보관리','/sym/sym/srv/selectServerEqpmnList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectServerList','/sym/sym/srv/','서버(S/W)목록','서버(S/W)목록','/sym/sym/srv/selectServerList.do');

--- a/src/script/dml/oracle/sym.mnu_insert_oracle.sql
+++ b/src/script/dml/oracle/sym.mnu_insert_oracle.sql
@@ -785,11 +785,11 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectAnnvrsryManageList','/uss/ion/ans/','기념일관리','기념일관리','/uss/ion/ans/selectAnnvrsryManageList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBannerList','/uss/ion/bnr/','배너관리','배너관리','/uss/ion/bnr/selectBannerList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBannerMainList','/uss/ion/bnr/','MYPAGE배너관리','MYPAGE배너관리','/uss/ion/bnr/selectBannerMainList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('SelectBBSMasterInfs','/cop/bbs/','게시판속성관리','게시판속성관리','/cop/bbs/SelectBBSMasterInfs.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('SelectBBSMasterInfs','/cop/bbs/','게시판속성관리','게시판속성관리','/cop/bbs/selectBBSMasterInfs.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBbsStats','/sts/bst/','게시물통계','게시물통계','/sts/bst/selectBbsStats.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBBSUseInfs','/cop/com/','게시판사용정보','게시판사용정보','/cop/com/selectBBSUseInfs.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBkmkMenuManageList','/sym/mnu/bmm/','바로가기메뉴관리','바로가기메뉴관리','/sym/mnu/bmm/selectBkmkMenuManageList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectCmmntyInfs','/cop/cmy/','커뮤니티관리','커뮤니티관리','/cop/cmy/selectCmmntyInfs.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectCmmntyInfs','/cop/cmy/','커뮤니티관리','커뮤니티관리','/cop/cmy/selectCommuMasterList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectConectStats','/sts/cst/','접속통계','접속통계','/sts/cst/selectConectStats.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectCtsnnManageList','/uss/ion/ctn/','직원경조사관리','직원경조사관리','/uss/ion/ctn/selectCtsnnManageList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectDeptJobBxList','/cop/smt/djm/','부서업무함관리','부서업무함관리','/cop/smt/djm/selectDeptJobBxList.do');
@@ -817,7 +817,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectProxySvcList','/utl/sys/pxy/','프록시서비스','프록시서비스','/utl/sys/pxy/selectProxySvcList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectReprtStatsListView','/sts/rst/','보고서통계','보고서통계','/sts/rst/selectReprtStatsListView.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectRwardManageList','/uss/ion/rwd/','포상관리','포상관리','/uss/ion/rwd/selectRwardManageList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectScrapList','/cop/scp/','스크랩 목록','스크랩 목록','/cop/scp/selectScrapList.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectScrapList','/cop/scp/','스크랩 목록','스크랩 목록','/cop/scp/selectArticleScrapList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectScrinStats','/sts/sst/','화면통계','화면통계','/sts/sst/selectScrinStats.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectServerEqpmnList','/sym/sym/srv/','서버정보관리','서버정보관리','/sym/sym/srv/selectServerEqpmnList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectServerList','/sym/sym/srv/','서버(S/W)목록','서버(S/W)목록','/sym/sym/srv/selectServerList.do');

--- a/src/script/dml/postgres/sts.sst_insert_postgres.sql
+++ b/src/script/dml/postgres/sts.sst_insert_postgres.sql
@@ -778,11 +778,11 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectAnnvrsryManageList','/uss/ion/ans/','기념일관리','기념일관리','/uss/ion/ans/selectAnnvrsryManageList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBannerList','/uss/ion/bnr/','배너관리','배너관리','/uss/ion/bnr/selectBannerList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBannerMainList','/uss/ion/bnr/','MYPAGE배너관리','MYPAGE배너관리','/uss/ion/bnr/selectBannerMainList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('SelectBBSMasterInfs','/cop/bbs/','게시판속성관리','게시판속성관리','/cop/bbs/SelectBBSMasterInfs.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('SelectBBSMasterInfs','/cop/bbs/','게시판속성관리','게시판속성관리','/cop/bbs/selectBBSMasterInfs.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBbsStats','/sts/bst/','게시물통계','게시물통계','/sts/bst/selectBbsStats.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBBSUseInfs','/cop/com/','게시판사용정보','게시판사용정보','/cop/com/selectBBSUseInfs.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBkmkMenuManageList','/sym/mnu/bmm/','바로가기메뉴관리','바로가기메뉴관리','/sym/mnu/bmm/selectBkmkMenuManageList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectCmmntyInfs','/cop/cmy/','커뮤니티관리','커뮤니티관리','/cop/cmy/selectCmmntyInfs.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectCmmntyInfs','/cop/cmy/','커뮤니티관리','커뮤니티관리','/cop/cmy/selectCommuMasterList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectConectStats','/sts/cst/','접속통계','접속통계','/sts/cst/selectConectStats.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectCtsnnManageList','/uss/ion/ctn/','직원경조사관리','직원경조사관리','/uss/ion/ctn/selectCtsnnManageList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectDeptJobBxList','/cop/smt/djm/','부서업무함관리','부서업무함관리','/cop/smt/djm/selectDeptJobBxList.do');
@@ -810,7 +810,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectProxySvcList','/utl/sys/pxy/','프록시서비스','프록시서비스','/utl/sys/pxy/selectProxySvcList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectReprtStatsListView','/sts/rst/','보고서통계','보고서통계','/sts/rst/selectReprtStatsListView.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectRwardManageList','/uss/ion/rwd/','포상관리','포상관리','/uss/ion/rwd/selectRwardManageList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectScrapList','/cop/scp/','스크랩 목록','스크랩 목록','/cop/scp/selectScrapList.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectScrapList','/cop/scp/','스크랩 목록','스크랩 목록','/cop/scp/selectArticleScrapList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectScrinStats','/sts/sst/','화면통계','화면통계','/sts/sst/selectScrinStats.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectServerEqpmnList','/sym/sym/srv/','서버정보관리','서버정보관리','/sym/sym/srv/selectServerEqpmnList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectServerList','/sym/sym/srv/','서버(S/W)목록','서버(S/W)목록','/sym/sym/srv/selectServerList.do');

--- a/src/script/dml/postgres/sym.mnu_insert_postgres.sql
+++ b/src/script/dml/postgres/sym.mnu_insert_postgres.sql
@@ -784,11 +784,11 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectAnnvrsryManageList','/uss/ion/ans/','기념일관리','기념일관리','/uss/ion/ans/selectAnnvrsryManageList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBannerList','/uss/ion/bnr/','배너관리','배너관리','/uss/ion/bnr/selectBannerList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBannerMainList','/uss/ion/bnr/','MYPAGE배너관리','MYPAGE배너관리','/uss/ion/bnr/selectBannerMainList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('SelectBBSMasterInfs','/cop/bbs/','게시판속성관리','게시판속성관리','/cop/bbs/SelectBBSMasterInfs.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('SelectBBSMasterInfs','/cop/bbs/','게시판속성관리','게시판속성관리','/cop/bbs/selectBBSMasterInfs.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBbsStats','/sts/bst/','게시물통계','게시물통계','/sts/bst/selectBbsStats.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBBSUseInfs','/cop/com/','게시판사용정보','게시판사용정보','/cop/com/selectBBSUseInfs.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBkmkMenuManageList','/sym/mnu/bmm/','바로가기메뉴관리','바로가기메뉴관리','/sym/mnu/bmm/selectBkmkMenuManageList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectCmmntyInfs','/cop/cmy/','커뮤니티관리','커뮤니티관리','/cop/cmy/selectCmmntyInfs.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectCmmntyInfs','/cop/cmy/','커뮤니티관리','커뮤니티관리','/cop/cmy/selectCommuMasterList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectConectStats','/sts/cst/','접속통계','접속통계','/sts/cst/selectConectStats.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectCtsnnManageList','/uss/ion/ctn/','직원경조사관리','직원경조사관리','/uss/ion/ctn/selectCtsnnManageList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectDeptJobBxList','/cop/smt/djm/','부서업무함관리','부서업무함관리','/cop/smt/djm/selectDeptJobBxList.do');
@@ -816,7 +816,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectProxySvcList','/utl/sys/pxy/','프록시서비스','프록시서비스','/utl/sys/pxy/selectProxySvcList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectReprtStatsListView','/sts/rst/','보고서통계','보고서통계','/sts/rst/selectReprtStatsListView.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectRwardManageList','/uss/ion/rwd/','포상관리','포상관리','/uss/ion/rwd/selectRwardManageList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectScrapList','/cop/scp/','스크랩 목록','스크랩 목록','/cop/scp/selectScrapList.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectScrapList','/cop/scp/','스크랩 목록','스크랩 목록','/cop/scp/selectArticleScrapList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectScrinStats','/sts/sst/','화면통계','화면통계','/sts/sst/selectScrinStats.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectServerEqpmnList','/sym/sym/srv/','서버정보관리','서버정보관리','/sym/sym/srv/selectServerEqpmnList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectServerList','/sym/sym/srv/','서버(S/W)목록','서버(S/W)목록','/sym/sym/srv/selectServerList.do');

--- a/src/script/dml/tibero/sts.sst_insert_tibero.sql
+++ b/src/script/dml/tibero/sts.sst_insert_tibero.sql
@@ -779,11 +779,11 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectAnnvrsryManageList','/uss/ion/ans/','기념일관리','기념일관리','/uss/ion/ans/selectAnnvrsryManageList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBannerList','/uss/ion/bnr/','배너관리','배너관리','/uss/ion/bnr/selectBannerList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBannerMainList','/uss/ion/bnr/','MYPAGE배너관리','MYPAGE배너관리','/uss/ion/bnr/selectBannerMainList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('SelectBBSMasterInfs','/cop/bbs/','게시판속성관리','게시판속성관리','/cop/bbs/SelectBBSMasterInfs.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('SelectBBSMasterInfs','/cop/bbs/','게시판속성관리','게시판속성관리','/cop/bbs/selectBBSMasterInfs.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBbsStats','/sts/bst/','게시물통계','게시물통계','/sts/bst/selectBbsStats.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBBSUseInfs','/cop/com/','게시판사용정보','게시판사용정보','/cop/com/selectBBSUseInfs.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBkmkMenuManageList','/sym/mnu/bmm/','바로가기메뉴관리','바로가기메뉴관리','/sym/mnu/bmm/selectBkmkMenuManageList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectCmmntyInfs','/cop/cmy/','커뮤니티관리','커뮤니티관리','/cop/cmy/selectCmmntyInfs.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectCmmntyInfs','/cop/cmy/','커뮤니티관리','커뮤니티관리','/cop/cmy/selectCommuMasterList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectConectStats','/sts/cst/','접속통계','접속통계','/sts/cst/selectConectStats.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectCtsnnManageList','/uss/ion/ctn/','직원경조사관리','직원경조사관리','/uss/ion/ctn/selectCtsnnManageList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectDeptJobBxList','/cop/smt/djm/','부서업무함관리','부서업무함관리','/cop/smt/djm/selectDeptJobBxList.do');
@@ -811,7 +811,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectProxySvcList','/utl/sys/pxy/','프록시서비스','프록시서비스','/utl/sys/pxy/selectProxySvcList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectReprtStatsListView','/sts/rst/','보고서통계','보고서통계','/sts/rst/selectReprtStatsListView.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectRwardManageList','/uss/ion/rwd/','포상관리','포상관리','/uss/ion/rwd/selectRwardManageList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectScrapList','/cop/scp/','스크랩 목록','스크랩 목록','/cop/scp/selectScrapList.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectScrapList','/cop/scp/','스크랩 목록','스크랩 목록','/cop/scp/selectArticleScrapList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectScrinStats','/sts/sst/','화면통계','화면통계','/sts/sst/selectScrinStats.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectServerEqpmnList','/sym/sym/srv/','서버정보관리','서버정보관리','/sym/sym/srv/selectServerEqpmnList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectServerList','/sym/sym/srv/','서버(S/W)목록','서버(S/W)목록','/sym/sym/srv/selectServerList.do');

--- a/src/script/dml/tibero/sym.mnu_insert_tibero.sql
+++ b/src/script/dml/tibero/sym.mnu_insert_tibero.sql
@@ -785,11 +785,11 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectAnnvrsryManageList','/uss/ion/ans/','기념일관리','기념일관리','/uss/ion/ans/selectAnnvrsryManageList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBannerList','/uss/ion/bnr/','배너관리','배너관리','/uss/ion/bnr/selectBannerList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBannerMainList','/uss/ion/bnr/','MYPAGE배너관리','MYPAGE배너관리','/uss/ion/bnr/selectBannerMainList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('SelectBBSMasterInfs','/cop/bbs/','게시판속성관리','게시판속성관리','/cop/bbs/SelectBBSMasterInfs.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('SelectBBSMasterInfs','/cop/bbs/','게시판속성관리','게시판속성관리','/cop/bbs/selectBBSMasterInfs.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBbsStats','/sts/bst/','게시물통계','게시물통계','/sts/bst/selectBbsStats.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBBSUseInfs','/cop/com/','게시판사용정보','게시판사용정보','/cop/com/selectBBSUseInfs.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectBkmkMenuManageList','/sym/mnu/bmm/','바로가기메뉴관리','바로가기메뉴관리','/sym/mnu/bmm/selectBkmkMenuManageList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectCmmntyInfs','/cop/cmy/','커뮤니티관리','커뮤니티관리','/cop/cmy/selectCmmntyInfs.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectCmmntyInfs','/cop/cmy/','커뮤니티관리','커뮤니티관리','/cop/cmy/selectCommuMasterList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectConectStats','/sts/cst/','접속통계','접속통계','/sts/cst/selectConectStats.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectCtsnnManageList','/uss/ion/ctn/','직원경조사관리','직원경조사관리','/uss/ion/ctn/selectCtsnnManageList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectDeptJobBxList','/cop/smt/djm/','부서업무함관리','부서업무함관리','/cop/smt/djm/selectDeptJobBxList.do');
@@ -817,7 +817,7 @@ INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, 
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectProxySvcList','/utl/sys/pxy/','프록시서비스','프록시서비스','/utl/sys/pxy/selectProxySvcList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectReprtStatsListView','/sts/rst/','보고서통계','보고서통계','/sts/rst/selectReprtStatsListView.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectRwardManageList','/uss/ion/rwd/','포상관리','포상관리','/uss/ion/rwd/selectRwardManageList.do');
-INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectScrapList','/cop/scp/','스크랩 목록','스크랩 목록','/cop/scp/selectScrapList.do');
+INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectScrapList','/cop/scp/','스크랩 목록','스크랩 목록','/cop/scp/selectArticleScrapList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectScrinStats','/sts/sst/','화면통계','화면통계','/sts/sst/selectScrinStats.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectServerEqpmnList','/sym/sym/srv/','서버정보관리','서버정보관리','/sym/sym/srv/selectServerEqpmnList.do');
 INSERT INTO COMTNPROGRMLIST(PROGRM_FILE_NM, PROGRM_STRE_PATH, PROGRM_KOREAN_NM, PROGRM_DC, URL) VALUES ('selectServerList','/sym/sym/srv/','서버(S/W)목록','서버(S/W)목록','/sym/sym/srv/selectServerList.do');


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

협업 메뉴 3개가 컨트롤러에 없는 URL 을 가리키고 있어서 관리자가 눌러도 404 가 뜹니다.

메뉴 링크는 `COMTNPROGRMLIST.URL` 을 그대로 씁니다. 왼쪽 메뉴를 채우는 `selectMainMenuLeft` 가 그 값을 `CHK_URL` 로 뽑고 `main_left.jsp` 가 여섯 번째 필드에 담고 `EgovMainMenu.js` 가 그 필드로 이동합니다.

```
$ grep -n 'selectMainMenuLeft\|main_left' src/main/java/egovframework/com/sym/mnu/mpm/web/EgovMainMenuManageController.java
157:	 * @return 출력페이지정보 "main_left"
161:	public String selectMainMenuLeft(@ModelAttribute("menuManageVO") MenuManageVO menuManageVO,
177:		List<?> resultList = menuManageService.selectMainMenuLeft(menuManageVO);
179:		return "egovframework/com/main_left";

$ sed -n '37p' src/main/resources/egovframework/mapper/com/sym/mnu/mpm/EgovMainMenu_SQL_mysql.xml
				 , (SELECT C.URL FROM COMTNPROGRMLIST C WHERE B.PROGRM_FILE_NM = C.PROGRM_FILE_NM) AS CHK_URL	

$ sed -n '48p' src/main/webapp/WEB-INF/jsp/egovframework/com/main_left.jsp
		<input type="hidden" name="tmp_menuNm" value="${result.menuNo}|${result.upperMenuId}|${result.menuNm}|${result.relateImagePath}|${result.relateImageNm}|${pageContext.request.contextPath}${result.chkURL}|"/>

$ sed -n '194p' src/main/webapp/js/egovframework/com/sym/mnu/mpm/EgovMainMenu.js
		parent.location.href = path + nodeValues[5];
```

`script/dml` 과 `src/script/dml` 의 시드가 등록하는 URL 이 실제 매핑과 다릅니다. 최초 임포트 시점부터 어긋나 있어 원인은 저장소 이력으로 짚기 어렵습니다.

관리자 계정으로 로그인해 두 URL 을 각각 요청했습니다. 왼쪽이 시드가 등록한 값, 오른쪽이 실제 매핑입니다.

```
$ 관리자(TEST1)로 로그인한 뒤 각 URL 을 요청했다
404    1114  /cop/bbs/SelectBBSMasterInfs.do
200    4510  /cop/bbs/selectBBSMasterInfs.do
404    1114  /cop/cmy/selectCmmntyInfs.do
200    4320  /cop/cmy/selectCommuMasterList.do
404    1114  /cop/scp/selectScrapList.do
200    3764  /cop/scp/selectArticleScrapList.do
```

시드의 URL 을 실제 매핑으로 맞췄습니다. 여덟 개 방언(`altibase`·`cubrid`·`goldilocks`·`maria`·`mysql`·`oracle`·`postgres`·`tibero`)의 통합 스크립트와 개별 스크립트를 같이 고쳐 24개 파일 72줄이 바뀝니다. 메뉴 이름·메뉴 번호·프로그램 파일명은 그대로 두고 URL 만 바꿨습니다.

## JUnit 테스트 JUnit tests

- [ ] JUnit 테스트 JUnit tests
- [x] 수동 테스트 Manual testing

시드 데이터라 단위 테스트로는 확인되지 않습니다. MySQL 8.0 컨테이너에 스크립트를 넣고 톰캣에 올린 뒤 관리자(`ROLE_ADMIN`)로 로그인해 위 URL 들을 직접 요청했습니다. 응답 코드와 바이트 수가 위 출력입니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

브라우저 대신 로그인 세션을 유지한 HTTP 요청으로 확인했습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

검증은 위 요청 결과로 대신합니다.
