### PR TITLE
fix(sym.mnu.mcm): 사이트맵 조회가 존재하지 않는 뷰 경로를 가리키던 문제 수정

### DIFF
--- a/src/main/java/egovframework/com/sym/mnu/mcm/web/EgovMenuCreateManageController.java
+++ b/src/main/java/egovframework/com/sym/mnu/mcm/web/EgovMenuCreateManageController.java
@@ -283,7 +283,7 @@ public class EgovMenuCreateManageController {
 		model.addAttribute("list_menulist", resultList);
 
 		model.addAttribute("resultVO", menuSiteMapVO);
-		return "egovframework/com/sym/mnu/mcm/EgovSiteMap";
+		return "egovframework/com/sym/mnu/stm/EgovSiteMap";
 	}
 
 }


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

사이트맵 조회 핸들러가 **JSP 가 없는 뷰 이름**을 돌려줍니다.

```java
// EgovMenuCreateManageController:286
@RequestMapping(value = "/sym/mnu/mcm/EgovSiteMap.do")
public String selectSiteMap(...) {
    ...
    model.addAttribute("list_menulist", resultList);
    model.addAttribute("resultVO", menuSiteMapVO);
    return "egovframework/com/sym/mnu/mcm/EgovSiteMap";   // ← 이 위치에 JSP 없음
}
```

`sym/mnu/mcm/` 아래 JSP 는 `EgovMenuCreat.jsp`·`EgovMenuCreatManage.jsp`·`EgovMenuCreatSiteMap.jsp` 세 개뿐이고 `EgovSiteMap.jsp` 는 없습니다. 같은 이름의 JSP 는 **`sym/mnu/stm/EgovSiteMap.jsp`** 하나이며, 이 파일은 **어느 컨트롤러도 참조하지 않습니다**(stm 쪽 컨트롤러는 `EgovSiteMapng` 만 씁니다).

그 JSP 가 쓰는 모델 속성이 이 핸들러가 담는 값과 맞습니다.

| stm/EgovSiteMap.jsp 가 참조 | 286행 핸들러가 담는 값 |
|---|---|
| `list_menulist` | `model.addAttribute("list_menulist", resultList)` |
| `result1.menuNo`·`menuNm`·`menuOrdr`·`upperMenuId`·`chkURL` | `selectSiteMapByUser` 결과 |
| `resultMsg` | — |

그래서 286행의 뷰 이름을 `sym/mnu/stm/EgovSiteMap` 으로 맞췄습니다.

다르게 보실 수 있는 부분도 밝혀 둡니다. **JSP 를 `sym/mnu/mcm/` 로 옮기는 쪽**이 맞다고 보시면 그렇게 다시 올리겠습니다. 이 PR 은 파일을 옮기지 않는 최소 변경 쪽을 택한 것입니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

- `mvn -Ptest compile` 통과. 문자열 한 줄 변경입니다.
- DB 가 없어 화면 렌더링까지는 확인하지 못했고, **뷰 이름이 가리키는 파일의 존재 여부와 JSP 가 참조하는 모델 속성**으로 판단했습니다.

## 테스트 브라우저 Test Browser

- [X] 기타 Others

서버 측 뷰 이름 해석 문제라 브라우저가 관여하지 않습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

관련: #1319 · #1326. 컨트롤러의 실제 `return` 문 673개를 JSP 739개와 대조하다 나온 건입니다.
