### PR TITLE
test(cmm): 중복 제출 방지 테스트 보강

### DIFF
--- a/src/test/java/egovframework/com/cmm/util/EgovDoubleSubmitHelperTest.java
+++ b/src/test/java/egovframework/com/cmm/util/EgovDoubleSubmitHelperTest.java
@@ -1,6 +1,12 @@
 package egovframework.com.cmm.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.reflect.Proxy;
 import java.util.Collections;
@@ -16,18 +22,150 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 
 import jakarta.servlet.http.HttpSession;
 
 class EgovDoubleSubmitHelperTest {
 
+	@AfterEach
+	void resetRequestContext() {
+		RequestContextHolder.resetRequestAttributes();
+	}
+
+	@Test
+	void checkAndSaveToken_acceptsDefaultTokenOnceAndAllowsTheRotatedToken() {
+		Map<String, String> tokens = defaultTokens("TOKEN");
+		MockHttpSession session = sessionWithTokens(tokens);
+		bindRequest(session, "TOKEN");
+
+		assertTrue(EgovDoubleSubmitHelper.checkAndSaveToken());
+		String rotatedToken = tokens.get(EgovDoubleSubmitHelper.DEFAULT_TOKEN_KEY);
+		assertNotNull(rotatedToken);
+		assertFalse(rotatedToken.isEmpty());
+		assertNotEquals("TOKEN", rotatedToken);
+
+		bindRequest(session, "TOKEN");
+		assertFalse(EgovDoubleSubmitHelper.checkAndSaveToken());
+		assertEquals(rotatedToken, tokens.get(EgovDoubleSubmitHelper.DEFAULT_TOKEN_KEY));
+
+		bindRequest(session, rotatedToken);
+		assertTrue(EgovDoubleSubmitHelper.checkAndSaveToken());
+		assertNotEquals(rotatedToken, tokens.get(EgovDoubleSubmitHelper.DEFAULT_TOKEN_KEY));
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "WRONG", "" })
+	void checkAndSaveToken_preservesValidTokenAfterAnInvalidSubmission(String invalidToken) {
+		Map<String, String> tokens = defaultTokens("TOKEN");
+		MockHttpSession session = sessionWithTokens(tokens);
+		bindRequest(session, invalidToken);
+
+		assertFalse(EgovDoubleSubmitHelper.checkAndSaveToken());
+		assertEquals(defaultTokens("TOKEN"), tokens);
+
+		bindRequest(session, "TOKEN");
+		assertTrue(EgovDoubleSubmitHelper.checkAndSaveToken());
+	}
+
+	@Test
+	void checkAndSaveToken_keepsFormKeysIndependent() {
+		Map<String, String> tokens = new HashMap<>(Map.of("FORM_A", "TOKEN", "FORM_B", "TOKEN"));
+		MockHttpSession session = sessionWithTokens(tokens);
+		bindRequest(session, "TOKEN");
+
+		assertTrue(EgovDoubleSubmitHelper.checkAndSaveToken("FORM_A"));
+		String firstFormToken = tokens.get("FORM_A");
+		assertNotEquals("TOKEN", firstFormToken);
+		assertEquals("TOKEN", tokens.get("FORM_B"));
+
+		bindRequest(session, "TOKEN");
+		assertTrue(EgovDoubleSubmitHelper.checkAndSaveToken("FORM_B"));
+		assertNotEquals("TOKEN", tokens.get("FORM_B"));
+		assertEquals(firstFormToken, tokens.get("FORM_A"));
+		assertEquals(2, tokens.size());
+	}
+
+	@Test
+	void checkAndSaveToken_keepsSessionsIndependentEvenWithTheSameToken() {
+		Map<String, String> firstTokens = defaultTokens("TOKEN");
+		Map<String, String> secondTokens = defaultTokens("TOKEN");
+		MockHttpSession firstSession = sessionWithTokens(firstTokens);
+		MockHttpSession secondSession = sessionWithTokens(secondTokens);
+		bindRequest(firstSession, "TOKEN");
+
+		assertTrue(EgovDoubleSubmitHelper.checkAndSaveToken());
+		String rotatedFirstToken = firstTokens.get(EgovDoubleSubmitHelper.DEFAULT_TOKEN_KEY);
+		assertEquals(defaultTokens("TOKEN"), secondTokens);
+
+		bindRequest(secondSession, "TOKEN");
+		assertTrue(EgovDoubleSubmitHelper.checkAndSaveToken());
+		assertEquals(rotatedFirstToken, firstTokens.get(EgovDoubleSubmitHelper.DEFAULT_TOKEN_KEY));
+	}
+
+	@Test
+	void checkAndSaveToken_rejectsAnotherSessionsTokenWithoutConsumingEitherToken() {
+		Map<String, String> firstTokens = defaultTokens("FIRST_TOKEN");
+		Map<String, String> secondTokens = defaultTokens("SECOND_TOKEN");
+		MockHttpSession firstSession = sessionWithTokens(firstTokens);
+		MockHttpSession secondSession = sessionWithTokens(secondTokens);
+		bindRequest(secondSession, "FIRST_TOKEN");
+
+		assertFalse(EgovDoubleSubmitHelper.checkAndSaveToken());
+		assertEquals(defaultTokens("FIRST_TOKEN"), firstTokens);
+		assertEquals(defaultTokens("SECOND_TOKEN"), secondTokens);
+
+		bindRequest(firstSession, "FIRST_TOKEN");
+		assertTrue(EgovDoubleSubmitHelper.checkAndSaveToken());
+		bindRequest(secondSession, "SECOND_TOKEN");
+		assertTrue(EgovDoubleSubmitHelper.checkAndSaveToken());
+	}
+
+	@Test
+	void checkAndSaveToken_rejectsUnregisteredFormKeyWithoutChangingStoredTokens() {
+		Map<String, String> tokens = defaultTokens("TOKEN");
+		MockHttpSession session = sessionWithTokens(tokens);
+		bindRequest(session, "TOKEN");
+
+		assertFalse(EgovDoubleSubmitHelper.checkAndSaveToken("UNKNOWN"));
+		assertEquals(defaultTokens("TOKEN"), tokens);
+		assertTrue(EgovDoubleSubmitHelper.checkAndSaveToken());
+	}
+
+	@Test
+	void checkAndSaveToken_reportsMissingSessionTokenConfiguration() {
+		MockHttpSession session = new MockHttpSession();
+		bindRequest(session, "TOKEN");
+
+		assertThrowsExactly(RuntimeException.class, EgovDoubleSubmitHelper::checkAndSaveToken);
+		assertNull(session.getAttribute(EgovDoubleSubmitHelper.SESSION_TOKEN_KEY));
+	}
+
+	@Test
+	void checkAndSaveToken_preservesStoredTokenWhenRequestParameterIsMissing() {
+		Map<String, String> tokens = defaultTokens("TOKEN");
+		MockHttpSession session = sessionWithTokens(tokens);
+		bindRequest(session, null);
+
+		assertThrowsExactly(RuntimeException.class, EgovDoubleSubmitHelper::checkAndSaveToken);
+		assertEquals(defaultTokens("TOKEN"), tokens);
+
+		bindRequest(session, "TOKEN");
+		assertTrue(EgovDoubleSubmitHelper.checkAndSaveToken());
+	}
+
 	@Test
 	void checkAndSaveToken_allowsOnlyOneConcurrentSubmitForSameToken()
 			throws InterruptedException, ExecutionException, TimeoutException {
 		final String token = "TOKEN";
-		Map<String, String> tokenMap = new CoordinatedTokenMap(EgovDoubleSubmitHelper.DEFAULT_TOKEN_KEY);
-		tokenMap.put(EgovDoubleSubmitHelper.DEFAULT_TOKEN_KEY, token);
+		Map<String, String> tokenMap = new CoordinatedTokenMap(EgovDoubleSubmitHelper.DEFAULT_TOKEN_KEY, token);
 		HttpSession session = fakeSessionWithTokenMap(tokenMap);
 
 		ExecutorService pool = Executors.newFixedThreadPool(2);
@@ -45,6 +183,26 @@ class EgovDoubleSubmitHelperTest {
 		} finally {
 			pool.shutdownNow();
 		}
+	}
+
+	private static Map<String, String> defaultTokens(String token) {
+		return new HashMap<>(Map.of(EgovDoubleSubmitHelper.DEFAULT_TOKEN_KEY, token));
+	}
+
+	private static MockHttpSession sessionWithTokens(Map<String, String> tokens) {
+		MockHttpSession session = new MockHttpSession();
+		session.setAttribute(EgovDoubleSubmitHelper.SESSION_TOKEN_KEY, tokens);
+		return session;
+	}
+
+	private static void bindRequest(HttpSession session, String token) {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setMethod("POST");
+		request.setSession(session);
+		if (token != null) {
+			request.setParameter(EgovDoubleSubmitHelper.PARAMETER_NAME, token);
+		}
+		RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
 	}
 
 	private static boolean checkTokenAfterStart(HttpSession session, String token, CountDownLatch start)
@@ -112,8 +270,9 @@ class EgovDoubleSubmitHelperTest {
 		private final CountDownLatch readAttempts = new CountDownLatch(2);
 		private final AtomicBoolean coordinateReads = new AtomicBoolean(true);
 
-		private CoordinatedTokenMap(String tokenKey) {
+		private CoordinatedTokenMap(String tokenKey, String token) {
 			this.tokenKey = tokenKey;
+			super.put(tokenKey, token);
 		}
 
 		@Override


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [X] 기타 Others

기존 테스트가 동시 제출만 다뤄 토큰 재사용·실패 후 재시도·폼과 세션 분리를 확인하지 못했습니다. 동시성 테스트도 초기화 중 읽기 조정이 비활성화되어 검증 조건을 보완할 필요가 있었습니다.

## 수정된 소스 내용 Modified source

- 공개 요청 경로의 토큰 교체·재사용 거부·상태 보존·폼 및 세션 분리 테스트 9개를 추가합니다.
- 기존 동시성 테스트의 초기 토큰 등록을 수정해 읽기 조정이 유지되도록 합니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

대상 JUnit **10개 통과**(신규 9개, 기존 1개). 전체 제품·테스트 소스 컴파일도 성공했습니다.

검증용 복사본에서 세션 잠금을 제거하면 1개, 토큰 교체를 제거하면 3개 테스트가 실패하는 것을 확인했습니다. 제품 코드는 변경하지 않았습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

브라우저 사용 없이 자동 테스트로 검증했습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

화면 변경이 없는 테스트 코드 보강으로 스크린샷은 해당하지 않습니다.
