### PR TITLE
test(batch): 배치 실행일 계산 테스트 추가

### DIFF
--- a/src/test/java/egovframework/com/sym/bat/service/BatchSchdulCronExpressionTest.java
+++ b/src/test/java/egovframework/com/sym/bat/service/BatchSchdulCronExpressionTest.java
@@ -1,0 +1,85 @@
+package egovframework.com.sym.bat.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.text.ParseException;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.TimeZone;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.quartz.CronExpression;
+
+class BatchSchdulCronExpressionTest {
+
+	private static final ZoneId SEOUL = ZoneId.of("Asia/Seoul");
+
+	@ParameterizedTest(name = "{0}")
+	@MethodSource("nextExecutions")
+	void 다음_실행일이_실행주기를_따른다(String scenario, BatchSchdul schedule, String after, String expected)
+			throws ParseException {
+		assertEquals(atSeoul(expected), nextExecution(schedule, after));
+	}
+
+	private static Stream<Arguments> nextExecutions() {
+		return Stream.of(
+				Arguments.of("매일: 실행 시각 전에는 오늘 실행", schedule("01", null),
+						"2026-09-09T09:29:59", "2026-09-09T09:30:00"),
+				Arguments.of("매일: 실행 시각부터는 다음 날 실행", schedule("01", null),
+						"2026-09-09T09:30:00", "2026-09-10T09:30:00"),
+				Arguments.of("매주 월·수: 금요일 다음은 월요일", schedule("02", null, "2", "4"),
+						"2026-09-11T09:30:00", "2026-09-14T09:30:00"),
+				Arguments.of("매주 월·수: 월요일 실행 후에는 수요일", schedule("02", null, "2", "4"),
+						"2026-09-14T09:30:00", "2026-09-16T09:30:00"),
+				Arguments.of("매월 31일: 31일이 없는 2월은 건너뜀", schedule("03", "20260131"),
+						"2026-01-31T09:30:00", "2026-03-31T09:30:00"),
+				Arguments.of("매년 2월 29일: 다음 윤년에 실행", schedule("04", "20240229"),
+						"2024-02-29T09:30:00", "2028-02-29T09:30:00"),
+				Arguments.of("한 번: 지정한 날짜에 실행", schedule("05", "20260909"),
+						"2026-09-08T09:30:00", "2026-09-09T09:30:00"));
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "2026-09-09T09:30:00", "2026-09-10T09:30:00" })
+	void 한_번_실행한_일정은_다시_실행되지_않는다(String after) throws ParseException {
+		assertNull(nextExecution(schedule("05", "20260909"), after));
+	}
+
+	@Test
+	void 설정한_초에_실행된다() throws ParseException {
+		BatchSchdul schedule = schedule("01", null);
+		schedule.setExecutSchdulSecnd("15");
+
+		assertEquals(atSeoul("2026-09-09T09:30:15"), nextExecution(schedule, "2026-09-09T09:30:14"));
+	}
+
+	private static BatchSchdul schedule(String cycle, String date, String... weekdays) {
+		BatchSchdul schedule = new BatchSchdul();
+		schedule.setExecutCycle(cycle);
+		schedule.setExecutSchdulDe(date);
+		schedule.setExecutSchdulHour("09");
+		schedule.setExecutSchdulMnt("30");
+		schedule.setExecutSchdulSecnd("00");
+		if (weekdays.length > 0) {
+			schedule.setExecutSchdulDfkSes(weekdays);
+		}
+		return schedule;
+	}
+
+	private static Date nextExecution(BatchSchdul schedule, String after) throws ParseException {
+		CronExpression expression = new CronExpression(schedule.toCronExpression());
+		expression.setTimeZone(TimeZone.getTimeZone(SEOUL));
+		return expression.getNextValidTimeAfter(atSeoul(after));
+	}
+
+	private static Date atSeoul(String dateTime) {
+		return Date.from(LocalDateTime.parse(dateTime).atZone(SEOUL).toInstant());
+	}
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [X] 기타 Others

실행주기를 변환한 뒤 실제 다음 실행일을 확인하는 테스트가 없어, 월말·윤년·일회성 실행의 경계 조건을 자동으로 검증하지 못했습니다.

## 수정된 소스 내용 Modified source

- 실제 Quartz로 매일·선택 요일·매월·매년·일회성 일정의 다음 실행일을 확인하는 테스트 10개를 추가합니다.
- 월말·윤년·실행 완료 후 다음 일정 없음·초 단위를 검증하며, 기준 시각과 시간대를 고정합니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

대상 JUnit **16개 통과**(신규 10개, 기존 DAO 테스트 6개). 전체 제품·테스트 소스 컴파일도 성공했습니다.

JVM 기본 시간대를 Pacific/Honolulu로 바꾼 별도 실행에서도 16개 모두 통과했습니다. 실제 배치 작업이나 DB·서버는 실행하지 않았습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

브라우저 사용 없이 자동 테스트로 검증했습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

화면 변경이 없는 테스트 코드 보강으로 스크린샷은 해당하지 않습니다.
