### PR TITLE
fix(utl): 빈 구분자의 문자열 분리 오류 수정

### DIFF
--- a/src/main/java/egovframework/com/utl/fcc/service/EgovStringUtil.java
+++ b/src/main/java/egovframework/com/utl/fcc/service/EgovStringUtil.java
@@ -552,14 +552,18 @@ public class EgovStringUtil {
 	/**
 	 * 문자열을 지정한 분리자에 의해 배열로 리턴하는 메서드.
 	 * @param source 원본 문자열
-	 * @param separator 분리자
+	 * @param separator 빈 문자열이 아닌 분리자
 	 * @return result 분리자로 나뉘어진 문자열 배열
+	 * @throws IllegalArgumentException 분리자가 빈 문자열인 경우
 	 */
 	public static String[] split(String source, String separator) throws NullPointerException {
 		String[] returnVal = null;
 		int cnt = 1;
 
 		int index = source.indexOf(separator);
+		if (separator.isEmpty()) {
+			throw new IllegalArgumentException("separator must not be empty");
+		}
 		int index0 = 0;
 		// 2026-08-14 content_j split() 구분자 2글자 이상 사용 시 필드에 잔여문자가 남는 오류 수정(index+1 → index + separator.length())
 		while (index >= 0) {
@@ -729,9 +733,10 @@ public class EgovStringUtil {
 	/**
 	 * 문자열을 지정한 분리자에 의해 지정된 길이의 배열로 리턴하는 메서드.
 	 * @param source 원본 문자열
-	 * @param separator 분리자
+	 * @param separator 빈 문자열이 아닌 분리자
 	 * @param arraylength 배열 길이
 	 * @return 분리자로 나뉘어진 문자열 배열
+	 * @throws IllegalArgumentException 분리자가 빈 문자열인 경우
 	 */
 	public static String[] split(String source, String separator, int arraylength) throws NullPointerException {
 		String[] returnVal = new String[arraylength];
@@ -739,6 +744,9 @@ public class EgovStringUtil {
 		int index0 = 0;
 		// 2026-08-14 content_j split() 구분자 2글자 이상 사용 시 필드에 잔여문자가 남는 오류 수정(index+1 → index + separator.length())
 		int index = source.indexOf(separator);
+		if (separator.isEmpty()) {
+			throw new IllegalArgumentException("separator must not be empty");
+		}
 		while (index >= 0 && cnt < (arraylength - 1)) {
 			returnVal[cnt] = source.substring(index0, index);
 			index0 = index + separator.length();

--- a/src/test/java/egovframework/com/utl/fcc/service/EgovStringUtilTest.java
+++ b/src/test/java/egovframework/com/utl/fcc/service/EgovStringUtilTest.java
@@ -1,7 +1,13 @@
 package egovframework.com.utl.fcc.service;
 
+import java.util.stream.Stream;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  *   2024.10.29		Chung10Kr		명사에 맞는 조사 반환 기능 개발
@@ -139,6 +145,84 @@ public class EgovStringUtilTest {
     void splitWithLimit_remainderKeptInLastField(){
         String[] result = EgovStringUtil.split("a::b::c::d", "::", 2);
         Assertions.assertArrayEquals(new String[]{"a", "b::c::d"}, result);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "", "abc" })
+    void splitRejectsEmptySeparator(String source) {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> EgovStringUtil.split(source, ""));
+    }
+
+    @ParameterizedTest
+    @MethodSource("emptySeparatorWithLimits")
+    void splitWithLimitRejectsEmptySeparator(String source, int limit) {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> EgovStringUtil.split(source, "", limit));
+    }
+
+    private static Stream<Arguments> emptySeparatorWithLimits() {
+        return Stream.of(
+                Arguments.of("", 1),
+                Arguments.of("", 3),
+                Arguments.of("abc", 1),
+                Arguments.of("abc", 3));
+    }
+
+    @ParameterizedTest
+    @MethodSource("emptyFieldCases")
+    void splitPreservesEmptyFields(String source, String separator, String[] expected) {
+        Assertions.assertArrayEquals(expected, EgovStringUtil.split(source, separator));
+        Assertions.assertArrayEquals(expected, EgovStringUtil.split(source, separator, expected.length));
+    }
+
+    private static Stream<Arguments> emptyFieldCases() {
+        return Stream.of(
+                Arguments.of("", ",", new String[]{""}),
+                Arguments.of(",a", ",", new String[]{"", "a"}),
+                Arguments.of("a,", ",", new String[]{"a", ""}),
+                Arguments.of("a,,b", ",", new String[]{"a", "", "b"}),
+                Arguments.of("::a::::", "::", new String[]{"", "a", "", ""}));
+    }
+
+    @ParameterizedTest
+    @MethodSource("paddedFieldCases")
+    void splitWithLimitPadsUnusedFields(String source, String[] expected) {
+        Assertions.assertArrayEquals(expected, EgovStringUtil.split(source, "::", 4));
+    }
+
+    private static Stream<Arguments> paddedFieldCases() {
+        return Stream.of(
+                Arguments.of("", new String[]{"", "", "", ""}),
+                Arguments.of("a::b", new String[]{"a", "b", "", ""}));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "", "a::b::c" })
+    void splitWithLimitOnePreservesTheWholeSource(String source) {
+        Assertions.assertArrayEquals(new String[]{source}, EgovStringUtil.split(source, "::", 1));
+    }
+
+    @ParameterizedTest
+    @MethodSource("nullInputs")
+    void splitPreservesNullInputExceptions(String source, String separator) {
+        Assertions.assertThrows(NullPointerException.class, () -> EgovStringUtil.split(source, separator));
+        Assertions.assertThrows(NullPointerException.class, () -> EgovStringUtil.split(source, separator, 2));
+    }
+
+    private static Stream<Arguments> nullInputs() {
+        return Stream.of(
+                Arguments.of(null, ","),
+                Arguments.of("abc", null),
+                Arguments.of(null, null));
+    }
+
+    @Test
+    void splitWithLimitPreservesZeroLengthException() {
+        Assertions.assertThrows(ArrayIndexOutOfBoundsException.class, () -> EgovStringUtil.split("abc", ",", 0));
+    }
+
+    @Test
+    void splitWithLimitPreservesNegativeLengthException() {
+        Assertions.assertThrows(NegativeArraySizeException.class, () -> EgovStringUtil.split("abc", ",", -1));
     }
 
 }


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

`split(source, "")`에 빈 구분자를 전달하면 검색 위치가 바뀌지 않아 반복문이 끝나지 않습니다. 배열 길이를 지정하는 오버로드도 빈 구분자를 허용해 불필요한 빈 필드를 반환합니다.

## 수정된 소스 내용 Modified source

- 두 오버로드가 빈 구분자를 `IllegalArgumentException`으로 거부하도록 수정하고 Javadoc에 명시합니다.
- 정상 분리, 빈 필드, 마지막 필드의 나머지 문자열, 배열 채움 등 기존 동작을 확인하는 테스트를 보강합니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

JUnit Platform Launcher로 대상 **41개 통과**(신규 20개, 기존 21개). 전체 제품·테스트 소스 컴파일도 성공했습니다.

실제 파일을 사용하는 `EgovFileTool`·`EgovFileToolBean` 연계 검증 **6개 통과**: 정상 분리와 내용 있는 파일·빈 파일의 빈 구분자 거부를 확인했습니다. 수정 전 두 파일 처리 경로의 미종료도 별도 JVM에서 재현했습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

브라우저 사용 없이 자동 테스트로 검증했습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

화면 변경이 없는 유틸리티 수정으로 스크린샷은 해당하지 않습니다.
