### PR TITLE
fix(pwm): 존재하지 않는 팝업 미리보기 조회 처리

### DIFF
--- a/src/main/java/egovframework/com/uss/ion/pwm/web/EgovPopupManageController.java
+++ b/src/main/java/egovframework/com/uss/ion/pwm/web/EgovPopupManageController.java
@@ -354,17 +354,21 @@ public class EgovPopupManageController {
 
 		// 2026.02.28 KISA 취약점 조취
 		response.setContentType("text/html;charset=utf-8");
+
+		LOGGER.debug("commandMap : {}", commandMap);
+		LOGGER.debug("popupManageVO : {}", popupManageVO);
+
+		PopupManageVO popupManageVOs = egovPopupManageService.selectPopup(popupManageVO);
+		if (popupManageVOs == null) {
+			response.setStatus(HttpServletResponse.SC_NOT_FOUND);
+			return;
+		}
+
+		String sPrint = popupManageVOs.getFileUrl() + "||" + popupManageVOs.getPopupWSize() + "||"
+				+ popupManageVOs.getPopupHSize() + "||" + popupManageVOs.getPopupHlc() + "||"
+				+ popupManageVOs.getPopupWlc() + "||" + popupManageVOs.getStopVewAt();
+
 		PrintWriter out = response.getWriter();
-
-			LOGGER.debug("commandMap : {}", commandMap);
-			LOGGER.debug("popupManageVO : {}", popupManageVO);
-
-			PopupManageVO popupManageVOs = egovPopupManageService.selectPopup(popupManageVO);
-
-			String sPrint = popupManageVOs.getFileUrl() + "||" + popupManageVOs.getPopupWSize() + "||"
-					+ popupManageVOs.getPopupHSize() + "||" + popupManageVOs.getPopupHlc() + "||"
-					+ popupManageVOs.getPopupWlc() + "||" + popupManageVOs.getStopVewAt();
-
 		out.print(EgovWebUtil.clearXSSMinimum(sPrint));
 		out.flush();
 

--- a/src/test/java/egovframework/com/uss/ion/pwm/web/EgovPopupManageControllerInfoAjaxTest.java
+++ b/src/test/java/egovframework/com/uss/ion/pwm/web/EgovPopupManageControllerInfoAjaxTest.java
@@ -1,0 +1,106 @@
+package egovframework.com.uss.ion.pwm.web;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.lang.reflect.Proxy;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import egovframework.com.uss.ion.pwm.service.EgovPopupManageService;
+import egovframework.com.uss.ion.pwm.service.PopupManageVO;
+import jakarta.servlet.ServletException;
+
+class EgovPopupManageControllerInfoAjaxTest {
+
+	private static final String URL = "/uss/ion/pwm/ajaxPopupManageInfo.do";
+	private static final String POPUP_ID = "POPUP_000000000001";
+
+	private MockMvc mockMvc;
+	private PopupManageVO storedPopup;
+	private Exception serviceFailure;
+	private int selectCount;
+
+	@BeforeEach
+	void setUp() {
+		EgovPopupManageService service = (EgovPopupManageService) Proxy.newProxyInstance(
+				getClass().getClassLoader(), new Class<?>[] { EgovPopupManageService.class },
+				(proxy, method, args) -> {
+					if (!"selectPopup".equals(method.getName())) {
+						throw new AssertionError("예상하지 못한 서비스 호출: " + method.getName());
+					}
+					assertEquals(POPUP_ID, ((PopupManageVO) args[0]).getPopupId());
+					selectCount++;
+					if (serviceFailure != null) {
+						throw serviceFailure;
+					}
+					return storedPopup;
+				});
+		EgovPopupManageController controller = new EgovPopupManageController();
+		ReflectionTestUtils.setField(controller, "egovPopupManageService", service);
+		mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+	}
+
+	@AfterEach
+	void requestedPopupIsLookedUpOnce() {
+		assertEquals(1, selectCount);
+	}
+
+	@Test
+	void missingPopupReturnsNotFoundWithEmptyBody() throws Exception {
+		mockMvc.perform(post(URL).param("popupId", POPUP_ID))
+				.andExpect(status().isNotFound())
+				.andExpect(content().string(""));
+	}
+
+	@Test
+	void existingPopupReturnsAllSixFields() throws Exception {
+		storedPopup = popup("popup/sample");
+
+		mockMvc.perform(post(URL).param("popupId", POPUP_ID))
+				.andExpect(status().isOk())
+				.andExpect(content().contentType("text/html;charset=utf-8"))
+				.andExpect(content().string("popup/sample||640||480||10||20||Y"));
+	}
+
+	@Test
+	void existingPopupResponseKeepsEscaping() throws Exception {
+		storedPopup = popup("popup/<한글>&\"'.%2E%2F");
+
+		mockMvc.perform(post(URL).param("popupId", POPUP_ID))
+				.andExpect(status().isOk())
+				.andExpect(content().contentType("text/html;charset=utf-8"))
+				.andExpect(content().string("popup/&lt;한글&gt;&amp;&#34;&#39;&#46;&#46;&#47;||640||480||10||20||Y"));
+	}
+
+	@Test
+	void serviceFailureIsNotTreatedAsMissingPopup() {
+		serviceFailure = new IllegalStateException("팝업 조회 실패");
+
+		ServletException thrown = assertThrows(ServletException.class,
+				() -> mockMvc.perform(post(URL).param("popupId", POPUP_ID)));
+
+		assertSame(serviceFailure, thrown.getCause());
+	}
+
+	private static PopupManageVO popup(String fileUrl) {
+		PopupManageVO popup = new PopupManageVO();
+		popup.setPopupId(POPUP_ID);
+		popup.setFileUrl(fileUrl);
+		popup.setPopupWSize("640");
+		popup.setPopupHSize("480");
+		popup.setPopupHlc("10");
+		popup.setPopupWlc("20");
+		popup.setStopVewAt("Y");
+		return popup;
+	}
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

목록을 연 뒤 팝업이 삭제되거나 존재하지 않는 `popupId`로 미리보기를 요청하면, 조회 결과가 `null`인데도 속성에 접근해 `NullPointerException`이 발생합니다.

## 수정된 소스 내용 Modified source

- 팝업 조회 결과가 없으면 HTTP 404와 빈 본문을 반환합니다.
- 정상 조회의 6개 필드 응답 형식과 특수문자 처리를 유지합니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

standalone MockMvc의 POST 요청 테스트 **4개 통과**: 부재 시 404·빈 본문, 정상 응답, 특수문자 처리, 서비스 예외 전달을 확인했습니다. 수정 전 부재 요청의 예외도 같은 테스트로 재현했습니다.

JUnit Platform Launcher로 실행했으며 전체 제품·테스트 소스 컴파일도 성공했습니다. 서비스 대역을 사용했고 실제 DB·서버는 실행하지 않았습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

브라우저 사용 없이 자동 테스트로 검증했습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

API 응답을 자동 테스트로 검증했으며 브라우저 스크린샷은 없습니다.
