### PR TITLE
fix(file): 업로드 파일 저장 전 전체 검증

### DIFF
--- a/src/main/java/egovframework/com/utl/fcc/service/EgovFileUploadUtil.java
+++ b/src/main/java/egovframework/com/utl/fcc/service/EgovFileUploadUtil.java
@@ -105,6 +105,7 @@ public class EgovFileUploadUtil extends EgovFormBasedFileUtil {
 	 */
 	public static List<EgovFormBasedFileVo> uploadFilesExt(MultipartHttpServletRequest mptRequest, String where, long maxFileSize, String extensionWhiteList) throws Exception {
 		List<EgovFormBasedFileVo> list = new ArrayList<>();
+		List<MultipartFile> filesToSave = new ArrayList<>();
 
 		if (mptRequest != null) {
 			Iterator<?> fileIter = mptRequest.getFileNames();
@@ -153,13 +154,19 @@ public class EgovFileUploadUtil extends EgovFormBasedFileUtil {
 					}
 
 					if (fileSize > 0) {
-						try (InputStream is = mFile.getInputStream()) {
-							String fullPath = where + SEPERATOR + vo.getServerSubPath() + SEPERATOR + vo.getPhysicalName() + "_upfile";
-							saveFile(is, new File(EgovWebUtil.filePathBlackList( fullPath )));
-						}
+						filesToSave.add(mFile);
 						list.add(vo);
 					}
 				}
+			}
+		}
+
+		// 모든 파일의 확장자와 크기 검증이 끝난 뒤 저장을 시작한다.
+		for (int i = 0; i < filesToSave.size(); i++) {
+			EgovFormBasedFileVo vo = list.get(i);
+			try (InputStream is = filesToSave.get(i).getInputStream()) {
+				String fullPath = where + SEPERATOR + vo.getServerSubPath() + SEPERATOR + vo.getPhysicalName() + "_upfile";
+				saveFile(is, new File(EgovWebUtil.filePathBlackList(fullPath)));
 			}
 		}
 

--- a/src/test/java/egovframework/com/utl/fcc/service/EgovFileUploadPrevalidationTest.java
+++ b/src/test/java/egovframework/com/utl/fcc/service/EgovFileUploadPrevalidationTest.java
@@ -1,0 +1,116 @@
+package egovframework.com.utl.fcc.service;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.mock.web.MockMultipartHttpServletRequest;
+
+class EgovFileUploadPrevalidationTest {
+
+	@TempDir
+	Path uploadDir;
+
+	@ParameterizedTest
+	@MethodSource("invalidFiles")
+	void rejectsEntireBatchBeforeReadingOrSavingFiles(String filename, byte[] content, boolean invalidFirst,
+			String message) throws Exception {
+		Path existing = uploadDir.resolve("existing.txt");
+		Files.writeString(existing, "existing content");
+		AtomicInteger reads = new AtomicInteger();
+		MockMultipartFile valid = new MockMultipartFile("valid", "valid.png", "image/png", new byte[] {1, 2}) {
+			@Override
+			public InputStream getInputStream() throws IOException {
+				reads.incrementAndGet();
+				return super.getInputStream();
+			}
+		};
+		MockMultipartFile invalid = new MockMultipartFile("invalid", filename, null, content);
+		MockMultipartHttpServletRequest request = new MockMultipartHttpServletRequest();
+		request.addFile(invalidFirst ? invalid : valid);
+		request.addFile(invalidFirst ? valid : invalid);
+
+		SecurityException error = assertThrows(SecurityException.class,
+				() -> EgovFileUploadUtil.uploadFilesExt(request, uploadDir.toString(), 2, ".png"));
+
+		assertEquals(message, error.getMessage());
+		assertEquals(0, reads.get());
+		assertEquals("existing content", Files.readString(existing));
+		try (Stream<Path> entries = Files.list(uploadDir)) {
+			assertEquals(List.of(existing), entries.toList());
+		}
+	}
+
+	private static Stream<Arguments> invalidFiles() {
+		return Stream.of(false, true).flatMap(first -> Stream.of(
+				Arguments.of("empty.exe", new byte[0], first, "Unacceptable file extension."),
+				Arguments.of("blocked.exe", new byte[] {1}, first, "Unacceptable file extension."),
+				Arguments.of("no-extension", new byte[] {1}, first, "Unacceptable file extension."),
+				Arguments.of("large.png", new byte[] {1, 2, 3}, first, "File size exceeds maximum allowed size.")));
+	}
+
+	@Test
+	void savesValidFilesInOrderWithOriginalContentAndNaming() throws Exception {
+		MockMultipartHttpServletRequest request = new MockMultipartHttpServletRequest();
+		request.addFile(new MockMultipartFile("first", "C:\\images\\first.PNG", "image/png", new byte[] {1, 2}));
+		request.addFile(new MockMultipartFile("second", "second.png", "image/png", new byte[] {3}));
+
+		List<EgovFormBasedFileVo> files = EgovFileUploadUtil.uploadFilesExt(request, uploadDir.toString(), 2, ".png");
+
+		assertEquals(List.of("first.PNG", "second.png"), files.stream().map(EgovFormBasedFileVo::getFileName).toList());
+		assertEquals(List.of(2L, 1L), files.stream().map(EgovFormBasedFileVo::getSize).toList());
+		for (EgovFormBasedFileVo file : files) {
+			assertEquals("image/png", file.getContentType());
+			assertTrue(file.getServerSubPath().matches("[0-9]{8}"));
+			assertTrue(file.getPhysicalName().endsWith(".png"));
+		}
+		assertArrayEquals(new byte[] {1, 2}, Files.readAllBytes(storedPath(files.get(0))));
+		assertArrayEquals(new byte[] {3}, Files.readAllBytes(storedPath(files.get(1))));
+		try (Stream<Path> paths = Files.walk(uploadDir)) {
+			assertEquals(2, paths.filter(Files::isRegularFile).count());
+		}
+	}
+
+	@Test
+	void skipsUnnamedAndAllowedEmptyFilesWithoutChangingValidFileOrder() throws Exception {
+		MockMultipartHttpServletRequest request = new MockMultipartHttpServletRequest();
+		request.addFile(new MockMultipartFile("unnamed", "", null, new byte[] {1, 2, 3}));
+		request.addFile(new MockMultipartFile("empty", "empty.png", "image/png", new byte[0]));
+		request.addFile(new MockMultipartFile("valid", "valid.png", "image/png", new byte[] {1}));
+
+		List<EgovFormBasedFileVo> files = EgovFileUploadUtil.uploadFilesExt(request, uploadDir.toString(), 2, ".png");
+
+		assertEquals(1, files.size());
+		assertEquals("valid.png", files.get(0).getFileName());
+		assertArrayEquals(new byte[] {1}, Files.readAllBytes(storedPath(files.get(0))));
+	}
+
+	@Test
+	void emptyRequestsDoNotCreateFiles() throws Exception {
+		assertTrue(EgovFileUploadUtil.uploadFilesExt(null, uploadDir.toString(), 2, ".png").isEmpty());
+		assertTrue(EgovFileUploadUtil.uploadFilesExt(new MockMultipartHttpServletRequest(),
+				uploadDir.toString(), 2, ".png").isEmpty());
+		try (Stream<Path> entries = Files.list(uploadDir)) {
+			assertEquals(0, entries.count());
+		}
+	}
+
+	private Path storedPath(EgovFormBasedFileVo file) {
+		return uploadDir.resolve(file.getServerSubPath()).resolve(file.getPhysicalName() + "_upfile");
+	}
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

여러 파일을 올릴 때 뒤쪽 파일이 검증에 실패해도 앞 파일은 이미 저장되어 남았습니다. 정상 PNG 뒤에 이름이 있는 0바이트 EXE를 보내면 에디터 업로드 경로에서도 이 문제가 발생합니다.

## 수정된 소스 내용 Modified source

모든 파일의 기존 확장자·크기 검증을 마친 뒤 저장하도록 변경합니다. 정상 파일의 순서·내용·이름 규칙과 빈 파일 처리 정책은 유지합니다. 저장 중 I/O 장애의 일괄 복구는 이번 변경에 포함하지 않습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

- 대상 JUnit **13개 통과**(신규 11개, 기존 2개): 실패 파일의 위치별 저장 방지, 기존 파일 보존, 정상 저장을 확인했습니다.
- 실제 HTTP 업로드 **6개 통과**: 두 에디터 경로에서 정상→실패, 실패→정상, 모두 정상 요청을 검증했습니다. 실제 multipart resolver·컨트롤러·저장 유틸리티·JSP를 사용했습니다.
- 수정 전 파일 잔존 재현 및 전체 제품·테스트 소스 컴파일 성공. 테스트용 경로와 URL 암호화 대역을 사용했습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

HTTP 자동 요청으로 검증했습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

화면 변경 없이 파일 저장 여부를 자동 검증한 수정으로 스크린샷은 해당하지 않습니다.
