### PR TITLE
fix(mgt): 회의 수정 오류 시 입력값 보존

### DIFF
--- a/src/main/java/egovframework/com/uss/olp/mgt/web/EgovMeetingManageController.java
+++ b/src/main/java/egovframework/com/uss/olp/mgt/web/EgovMeetingManageController.java
@@ -226,7 +226,7 @@ public class EgovMeetingManageController {
 	@PostMapping("/uss/olp/mgt/EgovMeetingManageModifyView.do")
 	public String meetingManageModifyView(
 			@ModelAttribute("searchVO") ComDefaultVO searchVO,
-			MeetingManageVO meetingManageVO,
+			@ModelAttribute("meetingManageVO") MeetingManageVO meetingManageVO,
 			ModelMap model,
     		RedirectAttributes redirectAttributes
     		)
@@ -239,11 +239,54 @@ public class EgovMeetingManageController {
 		}
 		
 		List<EgovMap> resultList = egovMeetingManageService.selectMeetingManageDetail(meetingManageVO);
-		model.addAttribute("resultList", resultList);
+		if (!resultList.isEmpty()) {
+			model.addAttribute("meetingManageVO", meetingModifyForm(resultList.get(0)));
+		}
 
 		return "egovframework/com/uss/olp/mgt/EgovMeetingManageModify";
 	}
 	
+	/** 최초 수정 화면에서 조회 결과를 입력 폼에 담는다. */
+	private MeetingManageVO meetingModifyForm(EgovMap stored) {
+		MeetingManageVO form = new MeetingManageVO();
+		form.setMtgId(EgovStringUtil.isNullToString(stored.get("mtgId")));
+		form.setMtgNm(EgovStringUtil.isNullToString(stored.get("mtgNm")));
+		form.setMtgMtrCn(EgovStringUtil.isNullToString(stored.get("mtgMtrCn")));
+		form.setMtgSn(EgovStringUtil.isNullToString(stored.get("mtgSn")));
+		form.setMtgCo(EgovStringUtil.isNullToString(stored.get("mtgCo")));
+		form.setMtgDe(EgovStringUtil.isNullToString(stored.get("mtgDe")));
+		form.setMtgPlace(EgovStringUtil.isNullToString(stored.get("mtgPlace")));
+		form.setMtgBeginTime(EgovStringUtil.isNullToString(stored.get("mtgBeginTime")));
+		form.setMtgEndTime(EgovStringUtil.isNullToString(stored.get("mtgEndTime")));
+		form.setClsdrMtgAt(EgovStringUtil.isNullToString(stored.get("clsdrMtgAt")));
+		form.setReadngBeginDe(EgovStringUtil.isNullToString(stored.get("readngBeginDe")));
+		form.setReadngAt(EgovStringUtil.isNullToString(stored.get("readngAt")));
+		form.setMtgResultCn(EgovStringUtil.isNullToString(stored.get("mtgResultCn")));
+		form.setMtgResultEnnc(EgovStringUtil.isNullToString(stored.get("mtgResultEnnc")));
+		form.setEtcMatter(EgovStringUtil.isNullToString(stored.get("etcMatter")));
+		form.setMngtDeptId(EgovStringUtil.isNullToString(stored.get("mngtDeptId")));
+		form.setMngtDeptNm(EgovStringUtil.isNullToString(stored.get("mngtDeptNm")));
+		form.setMnaerId(EgovStringUtil.isNullToString(stored.get("mnaerId")));
+		// 기존 수정 화면과 직원 선택 팝업은 주관자 로그인 ID를 표시한다.
+		form.setMnaerNm(EgovStringUtil.isNullToString(stored.get("mnaerIds")));
+		form.setMnaerDeptId(EgovStringUtil.isNullToString(stored.get("mnaerDeptId")));
+		form.setMnaerDeptNm(EgovStringUtil.isNullToString(stored.get("mnaerDeptNm")));
+		form.setMtnAt(EgovStringUtil.isNullToString(stored.get("mtnAt")));
+		form.setNonatdrnCo(EgovStringUtil.isNullToString(stored.get("nonatdrnCo")));
+		form.setAtdrnCo(EgovStringUtil.isNullToString(stored.get("atdrnCo")));
+		String[] begin = form.getMtgBeginTime().split(":");
+		if (begin.length == 2) {
+			form.setMtgBeginHH(begin[0].replaceFirst("^0+(?!$)", ""));
+			form.setMtgBeginMM(begin[1].replaceFirst("^0+(?!$)", ""));
+		}
+		String[] end = form.getMtgEndTime().split(":");
+		if (end.length == 2) {
+			form.setMtgEndHH(end[0].replaceFirst("^0+(?!$)", ""));
+			form.setMtgEndMM(end[1].replaceFirst("^0+(?!$)", ""));
+		}
+		return form;
+	}
+
 	/**
 	  * 회의정보를 수정한다.
 	 * @param searchVO
@@ -273,8 +316,6 @@ public class EgovMeetingManageController {
 		LoginVO loginVO = (LoginVO)EgovUserDetailsHelper.getAuthenticatedUser();
         
     	if(bindingResult.hasErrors()){
-             List<EgovMap> resultList = egovMeetingManageService.selectMeetingManageDetail(meetingManageVO);
-             model.addAttribute("resultList", resultList);
              bindingResult.getAllErrors().forEach(e -> LOGGER.error(e.toString()));
              return "egovframework/com/uss/olp/mgt/EgovMeetingManageModify";
     	}

--- a/src/main/webapp/WEB-INF/jsp/egovframework/com/uss/olp/mgt/EgovMeetingManageModify.jsp
+++ b/src/main/webapp/WEB-INF/jsp/egovframework/com/uss/olp/mgt/EgovMeetingManageModify.jsp
@@ -189,68 +189,67 @@ function fn_egov_SelectBoxValue(sbName)
 		<tr>
 			<th><spring:message code="ussOlpMgt.meetingManageModify.mtgNm"/> <span class="pilsu">*</span></th><!-- 회의제목 -->
 			<td class="left">
-				<input type="text" name="mtgNm" value="${resultList[0].mtgNm}" maxlength="100" title="<spring:message code="ussOlpMgt.meetingManageModify.mtgNm"/>" />
+				<spring:message code="ussOlpMgt.meetingManageModify.mtgNm" var="fieldTitle" />
+				<form:input path="mtgNm" maxlength="100" title="${fieldTitle}" htmlEscape="true" />
 				<div><form:errors path="mtgNm" cssClass="error" /></div>
 			</td>
 		</tr>
 		<tr>
 			<th><spring:message code="ussOlpMgt.meetingManageModify.mtgMtrCn"/> <span class="pilsu">*</span></th><!-- 회의 안건 내용 -->
 			<td class="left">
-				<textarea name="mtgMtrCn" class="textarea"  cols="75" rows="4"  style="width:99%;" title="<spring:message code="ussOlpMgt.meetingManageModify.mtgMtrCn"/>">${resultList[0].mtgMtrCn}</textarea>
+				<spring:message code="ussOlpMgt.meetingManageModify.mtgMtrCn" var="fieldTitle" />
+				<form:textarea path="mtgMtrCn" class="textarea"  cols="75" rows="4"  style="width:99%;" title="${fieldTitle}" htmlEscape="true" />
 				<div><form:errors path="mtgMtrCn" cssClass="error" /></div>
 			</td>
 		</tr>
 		<tr>
 			<th><spring:message code="ussOlpMgt.meetingManageModify.mtgSn"/> <span class="pilsu">*</span></th><!-- 회의순서 -->
 			<td class="left">
-				<input name="mtgSn" type="text" size="73" value="${resultList[0].mtgSn}" maxlength="10" style="width:60px;" title="<spring:message code="ussOlpMgt.meetingManageModify.mtgSn"/>">
+				<spring:message code="ussOlpMgt.meetingManageModify.mtgSn" var="fieldTitle" />
+				<form:input path="mtgSn" size="73" maxlength="10" style="width:60px;" title="${fieldTitle}" htmlEscape="true" />
 				<div><form:errors path="mtgSn" cssClass="error" /></div>
 			</td>
 		</tr>
 		<tr>
 			<th><spring:message code="ussOlpMgt.meetingManageModify.mtgCo"/> <span class="pilsu">*</span></th><!-- 회의회차 -->
 			<td class="left">
-				<input name="mtgCo" type="text" size="73" value="${resultList[0].mtgCo}" maxlength="5" style="width:60px;" title="<spring:message code="ussOlpMgt.meetingManageModify.mtgCo"/>">
+				<spring:message code="ussOlpMgt.meetingManageModify.mtgCo" var="fieldTitle" />
+				<form:input path="mtgCo" size="73" maxlength="5" style="width:60px;" title="${fieldTitle}" htmlEscape="true" />
 				<div><form:errors path="mtgCo" cssClass="error" /></div>
 			</td>
 		</tr>
 		<tr>
 			<th><spring:message code="ussOlpMgt.meetingManageModify.mtgDe"/> <span class="pilsu">*</span></th><!-- 회의일자 -->
 			<td class="left">
-				<input id="mtgDe" type="text" name="mtgDe" value="${resultList[0].mtgDe}" maxlength="10" title="<spring:message code="ussOlpMgt.meetingManageModify.mtgDe"/>" style="width:80px;" />
+				<spring:message code="ussOlpMgt.meetingManageModify.mtgDe" var="fieldTitle" />
+				<form:input id="mtgDe" path="mtgDe" maxlength="10" title="${fieldTitle}" style="width:80px;" htmlEscape="true" />
 				<div><form:errors path="mtgDe" cssClass="error" /></div>
 			</td>
 		</tr>
 		<tr>
 			<th><spring:message code="ussOlpMgt.meetingManageModify.mtgPlace"/> <span class="pilsu">*</span></th><!-- 회의장소 -->
 			<td class="left">
-				<input type="text" name="mtgPlace" value="${resultList[0].mtgPlace}" maxlength="70" title="<spring:message code="ussOlpMgt.meetingManageModify.mtgPlace"/>" style="width:200px;" />
+				<spring:message code="ussOlpMgt.meetingManageModify.mtgPlace" var="fieldTitle" />
+				<form:input path="mtgPlace" maxlength="70" title="${fieldTitle}" style="width:200px;" htmlEscape="true" />
 				<div><form:errors path="mtgPlace" cssClass="error" /></div>
 			</td>
 		</tr>
 		<tr>
 			<th><spring:message code="ussOlpMgt.meetingManageModify.mtgBeginTime"/> <span class="pilsu">*</span></th><!-- 회의시작시간 -->
 			<td class="left">
-				<c:forTokens var="one"
-					items="${resultList[0].mtgBeginTime}"
-					delims=":" varStatus="sts">
-					<c:if test="${sts.count == 1}">
-						<select name="mtgBeginHH" id="mtgBeginHH" title="<spring:message code="ussOlpMgt.meetingManageModify.mtgHH"/>">
-							<c:forEach var="h" begin="1" end="24" step="1">
-							<option value="${h}" <c:if test="${h == one}">selected</c:if>>${h}<spring:message code="ussOlpMgt.meetingManageModify.mtgHH"/></option>
-							</c:forEach>
-						</select>
-					</c:if>
-					<c:if test="${sts.count == 2}">
-						<select name="mtgBeginMM" id="mtgBeginMM" title="<spring:message code="ussOlpMgt.meetingManageModify.mtgMM"/>">
-							<option value="0">0<spring:message code="ussOlpMgt.meetingManageModify.mtgMM"/></option>
-							<c:forEach var="m" begin="1" end="60" step="1">
-							<option value="${m}" <c:if test="${m == one}">selected</c:if>>${m}<spring:message code="ussOlpMgt.meetingManageModify.mtgMM"/></option>
-							</c:forEach>
-						</select>
-					</c:if>
-				</c:forTokens>
-				<input id="mtgBeginTime" name="mtgBeginTime" type="hidden" value="" />
+				<spring:message code="ussOlpMgt.meetingManageModify.mtgHH" var="fieldTitle" />
+				<form:select path="mtgBeginHH" id="mtgBeginHH" title="${fieldTitle}">
+					<c:forEach var="value" begin="1" end="24">
+						<form:option value="${value}">${value}<spring:message code="ussOlpMgt.meetingManageModify.mtgHH"/></form:option>
+					</c:forEach>
+				</form:select>
+				<spring:message code="ussOlpMgt.meetingManageModify.mtgMM" var="fieldTitle" />
+				<form:select path="mtgBeginMM" id="mtgBeginMM" title="${fieldTitle}">
+					<c:forEach var="value" begin="0" end="60">
+						<form:option value="${value}">${value}<spring:message code="ussOlpMgt.meetingManageModify.mtgMM"/></form:option>
+					</c:forEach>
+				</form:select>
+				<form:hidden path="mtgBeginTime" id="mtgBeginTime" htmlEscape="true" />
 				<div><form:errors path="mtgBeginHH" cssClass="error" /></div>
 				<div><form:errors path="mtgBeginMM" cssClass="error" /></div>
 			</td>
@@ -258,27 +257,20 @@ function fn_egov_SelectBoxValue(sbName)
 		<tr>
 			<th><spring:message code="ussOlpMgt.meetingManageModify.mtgEndTime"/> <span class="pilsu">*</span></th><!-- 회의종료시간 -->
 			<td class="left">
-				<c:forTokens var="one"
-					items="${resultList[0].mtgEndTime}"
-					delims=":" varStatus="sts">
-					<c:if test="${sts.count == 1}">
-						<select name="mtgEndHH" id="mtgEndHH" title="<spring:message code="ussOlpMgt.meetingManageModify.mtgHH"/>">
-							<c:forEach var="h" begin="1" end="24" step="1">
-							<option value="${h}" <c:if test="${h == one}">selected</c:if>>${h}<spring:message code="ussOlpMgt.meetingManageModify.mtgHH"/></option>
-							</c:forEach>
-						</select>
-					</c:if>
-					<c:if test="${sts.count == 2}">
-						<select name="mtgEndMM" id="mtgEndMM" title="<spring:message code="ussOlpMgt.meetingManageModify.mtgMM"/>">
-							<option value="0">0<spring:message code="ussOlpMgt.meetingManageModify.mtgMM"/></option>
-							<c:forEach var="m" begin="1" end="60" step="1">
-							<option value="${m}" <c:if test="${m == one}">selected</c:if>>${m}<spring:message code="ussOlpMgt.meetingManageModify.mtgMM"/></option>
-							</c:forEach>
-						</select>
-					</c:if>
-				</c:forTokens>
+				<spring:message code="ussOlpMgt.meetingManageModify.mtgHH" var="fieldTitle" />
+				<form:select path="mtgEndHH" id="mtgEndHH" title="${fieldTitle}">
+					<c:forEach var="value" begin="1" end="24">
+						<form:option value="${value}">${value}<spring:message code="ussOlpMgt.meetingManageModify.mtgHH"/></form:option>
+					</c:forEach>
+				</form:select>
+				<spring:message code="ussOlpMgt.meetingManageModify.mtgMM" var="fieldTitle" />
+				<form:select path="mtgEndMM" id="mtgEndMM" title="${fieldTitle}">
+					<c:forEach var="value" begin="0" end="60">
+						<form:option value="${value}">${value}<spring:message code="ussOlpMgt.meetingManageModify.mtgMM"/></form:option>
+					</c:forEach>
+				</form:select>
 				
-				<input name="mtgEndTime" type="hidden" value="" id="mtgEndTime">
+				<form:hidden path="mtgEndTime" id="mtgEndTime" htmlEscape="true" />
 				<div><form:errors path="mtgEndHH" cssClass="error" /></div>
 				<div><form:errors path="mtgEndMM" cssClass="error" /></div>
 			</td>
@@ -286,92 +278,104 @@ function fn_egov_SelectBoxValue(sbName)
 		<tr>
 			<th><spring:message code="ussOlpMgt.meetingManageModify.clsdrMtgAt"/> <span class="pilsu">*</span></th><!-- 비공개 회의여부 -->
 			<td class="left">
-				<input type="checkbox" name="clsdrMtgAt" value="1" title="<spring:message code="ussOlpMgt.meetingManageModify.clsdrMtgAt"/>" <c:if test="${resultList[0].clsdrMtgAt == '1'}">checked='checked'</c:if> />
+				<spring:message code="ussOlpMgt.meetingManageModify.clsdrMtgAt" var="fieldTitle" />
+				<input type="checkbox" name="clsdrMtgAt" value="1" title="${fn:escapeXml(fieldTitle)}" <c:if test="${meetingManageVO.clsdrMtgAt == '1'}">checked="checked"</c:if> />
 			</td>
 		</tr>
 		<tr>
 			<th><spring:message code="ussOlpMgt.meetingManageModify.readngBeginDe"/> <span class="pilsu">*</span></th><!-- 열람 개시일 -->
 			<td class="left">
-				<input id="readngBeginDe" type="text" name="readngBeginDe" value="${resultList[0].readngBeginDe}" maxlength="10" title="<spring:message code="ussOlpMgt.meetingManageModify.readngBeginDe"/>" style="width:80px;" />
+				<spring:message code="ussOlpMgt.meetingManageModify.readngBeginDe" var="fieldTitle" />
+				<form:input id="readngBeginDe" path="readngBeginDe" maxlength="10" title="${fieldTitle}" style="width:80px;" htmlEscape="true" />
 				<div><form:errors path="readngBeginDe" cssClass="error" /></div>
 			</td>
 		</tr>
 		<tr>
 			<th><spring:message code="ussOlpMgt.meetingManageModify.readngAt"/> <span class="pilsu">*</span></th><!-- 열람 여부 -->
 			<td class="left">
-				<select name="readngAt" title="<spring:message code="ussOlpMgt.meetingManageModify.readngAt"/>">
-					<option value="N" <c:if test="${resultList[0].readngAt == 'N'}">selected</c:if>>N</option>
-					<option value="Y" <c:if test="${resultList[0].readngAt == 'Y'}">selected</c:if>>Y</option>
-				</select>
+				<spring:message code="ussOlpMgt.meetingManageModify.readngAt" var="fieldTitle" />
+				<form:select path="readngAt" title="${fieldTitle}">
+					<form:option value="N">N</form:option>
+					<form:option value="Y">Y</form:option>
+				</form:select>
 			</td>
 		</tr>
 		<tr>
 			<th><spring:message code="ussOlpMgt.meetingManageModify.mtgResultCn"/></th><!-- 회의결과 내용 -->
 			<td class="left">
-				<textarea name="mtgResultCn" cols="75" rows="4"  title="<spring:message code="ussOlpMgt.meetingManageModify.mtgResultCn"/>">${resultList[0].mtgResultCn}</textarea>
+				<spring:message code="ussOlpMgt.meetingManageModify.mtgResultCn" var="fieldTitle" />
+				<form:textarea path="mtgResultCn" cols="75" rows="4"  title="${fieldTitle}" htmlEscape="true" />
 			</td>
 		</tr>
 		<tr>
 			<th><spring:message code="ussOlpMgt.meetingManageModify.mtgResultEnnc"/></th><!-- 회의결과 여부 -->
 			<td class="left">
-				<input type="checkbox" name="mtgResultEnnc" value="1" title="<spring:message code="ussOlpMgt.meetingManageModify.mtgResultEnnc"/>" <c:if test="${resultList[0].mtgResultEnnc == '1'}">checked='checked'</c:if>>
+				<spring:message code="ussOlpMgt.meetingManageModify.mtgResultEnnc" var="fieldTitle" />
+				<input type="checkbox" name="mtgResultEnnc" value="1" title="${fn:escapeXml(fieldTitle)}" <c:if test="${meetingManageVO.mtgResultEnnc == '1'}">checked="checked"</c:if> />
 			</td>
 		</tr>
 		<tr>
 			<th><spring:message code="ussOlpMgt.meetingManageModify.etcMatter"/></th><!-- 기타 사항 -->
 			<td class="left">
-				<textarea name="etcMatter" cols="75" rows="2" title="<spring:message code="ussOlpMgt.meetingManageModify.etcMatter"/>">${resultList[0].etcMatter}</textarea>
+				<spring:message code="ussOlpMgt.meetingManageModify.etcMatter" var="fieldTitle" />
+				<form:textarea path="etcMatter" cols="75" rows="2" title="${fieldTitle}" htmlEscape="true" />
 			</td>
 		</tr>
 		<tr>
 			<th><spring:message code="ussOlpMgt.meetingManageModify.mngtDeptNm"/></th><!-- 주관부서 -->
 			<td class="left">
-				<input id="mngtDeptNm" type="text" name="mngtDeptNm" value="${resultList[0].mngtDeptNm}" maxlength="2000" title="<spring:message code="ussOlpMgt.meetingManageModify.mngtDeptNm"/>" readonly="readonly" style="width:100px;" />
+				<spring:message code="ussOlpMgt.meetingManageModify.mngtDeptNm" var="fieldTitle" />
+				<form:input id="mngtDeptNm" path="mngtDeptNm" maxlength="2000" title="${fieldTitle}" readonly="readonly" style="width:100px;" htmlEscape="true" />
 				<a href="javascript:void(0);" onclick="fn_egov_mngtDeptNm_MeetingManage();return false">
 					<img alt="<spring:message code="ussOlpMgt.meetingManageModify.mngtDeptNm"/>" src="<c:url value='/images/egovframework/com/cmm/btn/btn_search.gif' />" title="<spring:message code="ussOlpMgt.meetingManageModify.mngtDeptNm"/>" />
 				</a>
-				<input id="mngtDeptId" type="hidden" name="mngtDeptId" value="${resultList[0].mngtDeptId}" />
+				<form:hidden id="mngtDeptId" path="mngtDeptId" htmlEscape="true" />
 			</td>
 		</tr>
 		<tr>
 			<th><spring:message code="ussOlpMgt.meetingManageModify.mnaerNm"/></th><!-- 주관자명 -->
 			<td class="left">
-				<input id="mnaerNm" type="text" name="mnaerNm" value="${resultList[0].mnaerIds}" title="<spring:message code="ussOlpMgt.meetingManageModify.mnaerNm"/>" maxlength="2000" readonly="readonly" style="width:100px;" />
+				<spring:message code="ussOlpMgt.meetingManageModify.mnaerNm" var="fieldTitle" />
+				<form:input id="mnaerNm" path="mnaerNm" title="${fieldTitle}" maxlength="2000" readonly="readonly" style="width:100px;" htmlEscape="true" />
 				<a href="javascript:void(0);" onclick="fn_egov_mnaer_MeetingManage();return false">
 					<img alt="주관자ID 찾기버튼" src="<c:url value='/images/egovframework/com/cmm/btn/btn_search.gif' />" title="주관자ID 찾기 버튼" />
 				</a>
-				<input id="mnaerId" type="hidden" name="mnaerId" value="${resultList[0].mnaerId}" />
+				<form:hidden id="mnaerId" path="mnaerId" htmlEscape="true" />
 			</td>
 		</tr>
 		<tr>
 			<th><spring:message code="ussOlpMgt.meetingManageModify.mnaerDeptNm"/></th><!-- 주관자부서 -->
 			<td class="left">
-				<input id="mnaerDeptNm" type="text" name="mnaerDeptNm" title="<spring:message code="ussOlpMgt.meetingManageModify.mnaerDeptNm"/>" value="${resultList[0].mnaerDeptNm}" maxlength="2000" style="width:100px;" readonly="readonly" />
+				<spring:message code="ussOlpMgt.meetingManageModify.mnaerDeptNm" var="fieldTitle" />
+				<form:input id="mnaerDeptNm" path="mnaerDeptNm" title="${fieldTitle}" maxlength="2000" style="width:100px;" readonly="readonly" htmlEscape="true" />
 				<a href="javascript:void(0);" onclick="fn_egov_mnaerDept_MeetingManage();return false">
 					<img src="<c:url value='/images/egovframework/com/cmm/btn/btn_search.gif' />" align="middle" style="border:0px" alt="주관자부서 찾기버튼" title="주관자부서 찾기 버튼">
 				</a>
-				<input name="mnaerDeptId"  id="mnaerDeptId" type="hidden" value="${resultList[0].mnaerDeptId}" >
+				<form:hidden path="mnaerDeptId"  id="mnaerDeptId" htmlEscape="true" />
 			</td>
 		</tr>
 		<tr>
 			<th><spring:message code="ussOlpMgt.meetingManageModify.mtnAt"/></th><!-- 회의여부 -->
 			<td class="left">
-				<select name="mtnAt" title="<spring:message code="ussOlpMgt.meetingManageModify.mtnAt"/>">
-					<option value="Y"  <c:if test="${resultList[0].mtnAt == 'Y'}">selected</c:if>>Y</option>
-					<option value="N"  <c:if test="${resultList[0].mtnAt == 'N'}">selected</c:if>>N</option>
-				</select>
+				<spring:message code="ussOlpMgt.meetingManageModify.mtnAt" var="fieldTitle" />
+				<form:select path="mtnAt" title="${fieldTitle}">
+					<form:option value="Y">Y</form:option>
+					<form:option value="N">N</form:option>
+				</form:select>
 			</td>
 		</tr>
 		<tr>
 			<th><spring:message code="ussOlpMgt.meetingManageModify.nonatdrnCo"/></th><!-- 불참석자수 -->
 			<td class="left">
-				<input id="nonatdrnCo" type="text" name="nonatdrnCo" value="${resultList[0].nonatdrnCo}" title="<spring:message code="ussOlpMgt.meetingManageModify.nonatdrnCo"/>" maxlength="10" style="width:60px;" />
+				<spring:message code="ussOlpMgt.meetingManageModify.nonatdrnCo" var="fieldTitle" />
+				<form:input id="nonatdrnCo" path="nonatdrnCo" title="${fieldTitle}" maxlength="10" style="width:60px;" htmlEscape="true" />
 			</td>
 		</tr>
 		<tr>
 			<th><spring:message code="ussOlpMgt.meetingManageModify.atdrnCo"/></th><!-- 참석자수 -->
 			<td class="left">
-				<input id="atdrnCo" type="text" name="atdrnCo" size="73" value="${resultList[0].atdrnCo}" maxlength="10" title="<spring:message code="ussOlpMgt.meetingManageModify.atdrnCo"/>" style="width:60px;" />
+				<spring:message code="ussOlpMgt.meetingManageModify.atdrnCo" var="fieldTitle" />
+				<form:input id="atdrnCo" path="atdrnCo" size="73" maxlength="10" title="${fieldTitle}" style="width:60px;" htmlEscape="true" />
 			</td>
 		</tr>
 	</table>
@@ -384,7 +388,7 @@ function fn_egov_SelectBoxValue(sbName)
 	<div style="clear:both;"></div>
 </div>
 
-<input name="mtgId" type="hidden" value="<c:out value='${resultList[0].mtgId}'/>">
+<form:hidden path="mtgId" htmlEscape="true" />
 <input name="cmd" type="hidden" value="<c:out value='save'/>">
 </form:form>
 </DIV>

--- a/src/test/java/egovframework/com/uss/olp/mgt/web/EgovMeetingManageModifyTest.java
+++ b/src/test/java/egovframework/com/uss/olp/mgt/web/EgovMeetingManageModifyTest.java
@@ -1,0 +1,212 @@
+package egovframework.com.uss.olp.mgt.web;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+import java.lang.reflect.Proxy;
+import java.util.List;
+import java.util.Map;
+
+import org.egovframe.rte.psl.dataaccess.util.EgovMap;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceLock;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.BeanWrapperImpl;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import egovframework.com.cmm.EgovMessageSource;
+import egovframework.com.cmm.LoginVO;
+import egovframework.com.cmm.service.EgovUserDetailsService;
+import egovframework.com.cmm.util.EgovUserDetailsHelper;
+import egovframework.com.uss.olp.mgt.service.EgovMeetingManageService;
+import egovframework.com.uss.olp.mgt.service.MeetingManageVO;
+
+@ResourceLock("EgovUserDetailsHelper")
+class EgovMeetingManageModifyTest {
+
+	private static final String VIEW = "egovframework/com/uss/olp/mgt/EgovMeetingManageModify";
+	private static final String PREFIX = "/uss/olp/mgt/";
+	private EgovUserDetailsService previousAuth;
+	private LocalValidatorFactoryBean validator;
+	private MockMvc mvc;
+	private EgovMap stored;
+	private MeetingManageVO updated;
+	private boolean authenticated = true;
+	private int reads;
+	private int writes;
+
+	@BeforeEach
+	void setUp() {
+		previousAuth = (EgovUserDetailsService) ReflectionTestUtils.getField(EgovUserDetailsHelper.class, "egovUserDetailsService");
+		LoginVO user = new LoginVO();
+		user.setUniqId("TEST_USER");
+		new EgovUserDetailsHelper().setEgovUserDetailsService(new EgovUserDetailsService() {
+			public Object getAuthenticatedUser() { return authenticated ? user : null; }
+			public List<String> getAuthorities() { return List.of(); }
+			public Boolean isAuthenticated() { return authenticated; }
+		});
+		stored = new EgovMap();
+		validInput().forEach((key, values) -> stored.put(key, values.get(0)));
+		stored.put("mtgNm", "저장된 회의명");
+		stored.put("mtgSn", 1);
+		stored.put("mtgCo", 2);
+		stored.put("mtgBeginTime", "09:00");
+		stored.put("mtgEndTime", "09:05");
+		stored.put("mnaerIds", "stored.login");
+		stored.put("mnaerNm", "저장된 사용자명");
+		stored.put("clsdrMtgAt", "1");
+		stored.put("mtgResultEnnc", "1");
+		EgovMeetingManageService service = (EgovMeetingManageService) Proxy.newProxyInstance(
+				getClass().getClassLoader(), new Class<?>[] {EgovMeetingManageService.class}, (proxy, method, args) -> {
+					assertEquals("MEETING_1", ((MeetingManageVO) args[0]).getMtgId());
+					if ("selectMeetingManageDetail".equals(method.getName())) {
+						reads++;
+						return List.of(stored);
+					}
+					if ("updateMeetingManage".equals(method.getName())) {
+						writes++;
+						updated = (MeetingManageVO) args[0];
+						return null;
+					}
+					throw new AssertionError("Unexpected service call: " + method.getName());
+				});
+		EgovMeetingManageController controller = new EgovMeetingManageController();
+		ReflectionTestUtils.setField(controller, "egovMeetingManageService", service);
+		ReflectionTestUtils.setField(controller, "egovMessageSource", new EgovMessageSource() {
+			@Override
+			public String getMessage(String code) { return code; }
+		});
+		validator = new LocalValidatorFactoryBean();
+		validator.afterPropertiesSet();
+		mvc = MockMvcBuilders.standaloneSetup(controller).setValidator(validator).build();
+	}
+
+	@AfterEach
+	void tearDown() {
+		new EgovUserDetailsHelper().setEgovUserDetailsService(previousAuth);
+		if (validator != null) validator.close();
+	}
+
+	@Test
+	void initialViewBindsStoredFieldsAndNormalizesTimeSelections() throws Exception {
+		Map<String, Object> model = mvc.perform(post(PREFIX + "EgovMeetingManageModifyView.do")
+				.param("mtgId", "MEETING_1").param("mtgNm", "request must not replace stored title"))
+				.andExpect(view().name(VIEW)).andReturn().getModelAndView().getModel();
+		MeetingManageVO form = (MeetingManageVO) model.get("meetingManageVO");
+		BeanWrapperImpl fields = new BeanWrapperImpl(form);
+		for (String key : validInput().keySet()) {
+			if (key.matches("mtg(Begin|End)(HH|MM)") || key.equals("mnaerNm")) continue;
+			assertEquals(String.valueOf(stored.get(key)), fields.getPropertyValue(key), key);
+		}
+		assertEquals("stored.login", form.getMnaerNm());
+		assertEquals("9", form.getMtgBeginHH());
+		assertEquals("0", form.getMtgBeginMM());
+		assertEquals("9", form.getMtgEndHH());
+		assertEquals("5", form.getMtgEndMM());
+		assertEquals("1", form.getClsdrMtgAt());
+		assertEquals("1", form.getMtgResultEnnc());
+		assertSame(form, ((BindingResult) model.get(BindingResult.MODEL_KEY_PREFIX + "meetingManageVO")).getTarget());
+		assertEquals(1, reads);
+		assertEquals(0, writes);
+	}
+
+	@Test
+	void initialViewHandlesNullableDisplayFields() throws Exception {
+		stored.put("mnaerIds", null);
+		stored.put("etcMatter", null);
+		stored.put("mtgBeginTime", null);
+		MeetingManageVO form = (MeetingManageVO) mvc.perform(post(PREFIX + "EgovMeetingManageModifyView.do")
+				.param("mtgId", "MEETING_1")).andExpect(view().name(VIEW)).andReturn().getModelAndView()
+				.getModel().get("meetingManageVO");
+		assertEquals("", form.getMnaerNm());
+		assertEquals("", form.getEtcMatter());
+		assertEquals("", form.getMtgBeginHH());
+		assertEquals("", form.getMtgBeginTime());
+	}
+
+	@ParameterizedTest
+	@ValueSource(booleans = {false, true})
+	void validationErrorPreservesAllSubmittedFieldsAndCheckboxState(boolean checked) throws Exception {
+		MultiValueMap<String, String> params = validInput();
+		params.set("mtgSn", "abc");
+		params.set("mtgNm", "수정한 <회의명> & \"인용\"");
+		params.set("mtgMtrCn", "수정한 안건\n</textarea><script>test</script>");
+		if (checked) {
+			params.set("clsdrMtgAt", "1");
+			params.set("mtgResultEnnc", "1");
+		}
+		Map<String, Object> model = mvc.perform(post(PREFIX + "EgovMeetingManageModify.do").params(params))
+				.andExpect(view().name(VIEW)).andExpect(model().attributeHasFieldErrors("meetingManageVO", "mtgSn"))
+				.andReturn().getModelAndView().getModel();
+		MeetingManageVO form = (MeetingManageVO) model.get("meetingManageVO");
+		BeanWrapperImpl fields = new BeanWrapperImpl(form);
+		params.forEach((key, values) -> {
+			if (!key.startsWith("_")) assertEquals(values.get(0), fields.getPropertyValue(key), key);
+		});
+		assertEquals(checked ? "1" : "", form.getClsdrMtgAt());
+		assertEquals(checked ? "1" : "", form.getMtgResultEnnc());
+		BindingResult errors = (BindingResult) model.get(BindingResult.MODEL_KEY_PREFIX + "meetingManageVO");
+		assertNotNull(errors);
+		assertSame(form, errors.getTarget());
+		assertEquals(1, errors.getErrorCount());
+		assertEquals("abc", errors.getFieldError("mtgSn").getRejectedValue());
+		assertFalse(model.containsKey("resultList"));
+		assertEquals(0, reads);
+		assertEquals(0, writes);
+	}
+
+	@Test
+	void validSubmissionUpdatesOnceAndReturnsToList() throws Exception {
+		MultiValueMap<String, String> params = validInput();
+		mvc.perform(post(PREFIX + "EgovMeetingManageModify.do").params(params))
+				.andExpect(redirectedUrl(PREFIX + "EgovMeetingManageList.do"));
+		assertEquals(0, reads);
+		assertEquals(1, writes);
+		assertEquals("TEST_USER", updated.getLastUpdusrId());
+		assertEquals("", updated.getClsdrMtgAt());
+		assertEquals("", updated.getMtgResultEnnc());
+		BeanWrapperImpl fields = new BeanWrapperImpl(updated);
+		params.forEach((key, values) -> assertEquals(values.get(0), fields.getPropertyValue(key), key));
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = {"EgovMeetingManageModifyView.do", "EgovMeetingManageModify.do"})
+	void unauthenticatedRequestsDoNotReadOrUpdateMeetings(String endpoint) throws Exception {
+		authenticated = false;
+		mvc.perform(post(PREFIX + endpoint).params(validInput()))
+				.andExpect(view().name("redirect:/uat/uia/egovLoginUsr.do"));
+		assertEquals(0, reads);
+		assertEquals(0, writes);
+	}
+
+	private static MultiValueMap<String, String> validInput() {
+		MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+		String[][] fields = {
+			{"mtgId", "MEETING_1"}, {"mtgNm", "수정한 회의명"}, {"mtgMtrCn", "수정한 안건"},
+			{"mtgSn", "3"}, {"mtgCo", "4"}, {"mtgDe", "2026-09-15"}, {"mtgPlace", "수정한 장소"},
+			{"mtgBeginTime", "10:30"}, {"mtgEndTime", "11:45"}, {"mtgBeginHH", "10"}, {"mtgBeginMM", "30"},
+			{"mtgEndHH", "11"}, {"mtgEndMM", "45"}, {"readngBeginDe", "2026-09-16"}, {"readngAt", "N"},
+			{"mtgResultCn", "수정한 결과"}, {"etcMatter", "수정한 기타사항"}, {"mngtDeptId", "NEW_DEPT"},
+			{"mngtDeptNm", "수정한 부서"}, {"mnaerId", "NEW_USER"}, {"mnaerNm", "new.login"},
+			{"mnaerDeptId", "NEW_USER_DEPT"}, {"mnaerDeptNm", "수정한 주관자부서"}, {"mtnAt", "Y"},
+			{"nonatdrnCo", "5"}, {"atdrnCo", "6"}
+		};
+		for (String[] field : fields) params.set(field[0], field[1]);
+		return params;
+	}
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

회의 수정에서 순번 등 한 항목이 검증에 실패하면, 화면이 DB 조회값을 다시 사용해 방금 고친 제목·안건·시간·선택값까지 원래 내용으로 돌아갔습니다.

## 수정된 소스 내용 Modified source

최초 진입은 저장된 값으로 폼을 채우고, 검증 실패 시에는 제출한 값과 오류 정보를 유지합니다. 날짜·시간·체크박스·주관자 선택을 함께 반영하고 입력값을 안전하게 출력합니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

- JUnit **7개 통과**: 최초 표시, null 표시값, 오류 시 입력값·체크박스 보존, 정상 저장, 비로그인 요청을 검증했습니다.
- 실제 HTTP·JSP **4개 통과**: 최초 화면, 체크박스 선택/해제 상태의 검증 실패, 정상 수정 요청을 확인했습니다.
- 브라우저에서 수정 전 입력값 복원 문제와 수정 후 입력값 보존·특수문자 출력·오류 시 저장 미호출을 확인했습니다.
- 전체 제품·테스트 소스 컴파일 성공. 회의 조회·저장과 인증은 테스트 대역을 사용했으며 실제 DB·전체 보안 필터는 검증하지 않았습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [X] 기타 Others (Chromium 자동 테스트)

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

동일한 순번 오류 제출 후 **수정 전**에는 원래 값으로 돌아가고, **수정 후**에는 제출값과 체크 해제 상태가 유지됩니다. 격리된 테스트 환경으로 오류 문구는 메시지 키로 표시됩니다.

수정 전

![수정 전 입력값 복원](https://raw.githubusercontent.com/wizlife/egovframe-common-components/f8c6ed46bc8e4a8361168f29fdf31c5418cb9de6/meeting-before.png)

수정 후

![수정 후 입력값 보존](https://raw.githubusercontent.com/wizlife/egovframe-common-components/f8c6ed46bc8e4a8361168f29fdf31c5418cb9de6/meeting-after.png)
