### PR TITLE
fix(calendar): 개인 일정 이동 경로 수정

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/egovframework/com/cop/smt/sim/EgovIndvdlSchdulManageDailyList.jsp
+++ b/src/main/webapp/WEB-INF/jsp/egovframework/com/cop/smt/sim/EgovIndvdlSchdulManageDailyList.jsp
@@ -124,7 +124,7 @@ String sTodate = formatter.format(new java.util.Date());
 	
 	function fnEgovSchdulTodate() {
 
-		location.href="<c:url value='/cop/smt/sdm/EgovDeptSchdulManageDailyList.do' />?year=<%=sTodate.substring(0, 4)%>&month=<%=Integer.valueOf(sTodate.substring(4, 6))-1%>&day=<%=sTodate.substring(6, 8)%>&searchCondition=SCHDUL_SE&searchKeyword=" + document.deptSchdulManageVO.schdulSe.value;
+		location.href="<c:url value='/cop/smt/sim/EgovIndvdlSchdulManageDailyList.do' />?year=<%=sTodate.substring(0, 4)%>&month=<%=Integer.valueOf(sTodate.substring(4, 6))-1%>&day=<%=sTodate.substring(6, 8)%>&searchCondition=SCHDUL_SE&searchKeyword=" + document.deptSchdulManageVO.schdulSe.value;
 
 	}
 
@@ -186,7 +186,7 @@ String sTodate = formatter.format(new java.util.Date());
 			<li class="date">&nbsp;</li>
 			
 			<%if(iNowMonth > 0 ){ %>
-			<li><a class="prev" href="<c:url value='/cop/smt/sdm/EgovDeptSchdulManageDailyList.do' />?year=<%=iNowYear%>&amp;month=<%=iNowMonth-1%>&amp;day=<%=iNowDay%>">prev</a></li>
+			<li><a class="prev" href="<c:url value='/cop/smt/sim/EgovIndvdlSchdulManageDailyList.do' />?year=<%=iNowYear%>&amp;month=<%=iNowMonth-1%>&amp;day=<%=iNowDay%>">prev</a></li>
 			<%}%>
 			<li class="date"><%=iNowMonth+1%> <spring:message code="comCopSmtSim.Navi.Month"/> </li> <!-- 월 -->
 			<%if(iNowMonth < 11 ){ %>

--- a/src/main/webapp/WEB-INF/jsp/egovframework/com/cop/smt/sim/EgovIndvdlSchdulManageMonthList.jsp
+++ b/src/main/webapp/WEB-INF/jsp/egovframework/com/cop/smt/sim/EgovIndvdlSchdulManageMonthList.jsp
@@ -126,7 +126,7 @@ String sTodate = formatter.format(new java.util.Date());
 	
 	function fnEgovSchdulTodate() {
 
-		location.href="<c:url value='/cop/smt/sdm/EgovDeptSchdulManageMonthList.do' />?year=<%=sTodate.substring(0, 4)%>&month=<%=Integer.valueOf(sTodate.substring(4, 6))-1%>&searchCondition=SCHDUL_SE&searchKeyword=" + document.IndvdlSchdulManageVO.schdulSe.value;
+		location.href="<c:url value='/cop/smt/sim/EgovIndvdlSchdulManageMonthList.do' />?year=<%=sTodate.substring(0, 4)%>&month=<%=Integer.valueOf(sTodate.substring(4, 6))-1%>&searchCondition=SCHDUL_SE&searchKeyword=" + document.IndvdlSchdulManageVO.schdulSe.value;
 
 	}
 	

--- a/src/main/webapp/WEB-INF/jsp/egovframework/com/cop/smt/sim/EgovIndvdlSchdulManageWeekList.jsp
+++ b/src/main/webapp/WEB-INF/jsp/egovframework/com/cop/smt/sim/EgovIndvdlSchdulManageWeekList.jsp
@@ -139,7 +139,7 @@ String sTodate = formatter.format(new java.util.Date());
 	}
 
 	function fnEgovSchdulTodate() {
-		location.href="<c:url value='/cop/smt/sdm/EgovDeptSchdulManageWeekList.do' />?searchCondition=SCHDUL_SE&searchKeyword=" + document.deptSchdulManageVO.schdulSe.value;
+		location.href="<c:url value='/cop/smt/sim/EgovIndvdlSchdulManageWeekList.do' />?searchCondition=SCHDUL_SE&searchKeyword=" + document.deptSchdulManageVO.schdulSe.value;
 	}
 	
 	window.onload = function(){
@@ -197,7 +197,7 @@ String sTodate = formatter.format(new java.util.Date());
 			<li><a class="next" href="<c:url value='/cop/smt/sim/EgovIndvdlSchdulManageWeekList.do' />?year=<%=iNowYear+1%>&amp;month=<%=iNowMonth%>&amp;week=<%=iNowWeek%>">next</a></li>
 			<li class="date">&nbsp;</li>
 			<%if(iNowMonth > 0 ){ %>
-			<li><a class="prev" href="<c:url value='/cop/smt/sdm/EgovDeptSchdulManageWeekList.do' />?year=<%=iNowYear%>&amp;month=<%=iNowMonth-1%>&amp;week=<%=0%>">prev</a></li>
+			<li><a class="prev" href="<c:url value='/cop/smt/sim/EgovIndvdlSchdulManageWeekList.do' />?year=<%=iNowYear%>&amp;month=<%=iNowMonth-1%>&amp;week=<%=0%>">prev</a></li>
 			<%}%>
 			<li class="date"><%=iNowMonth+1%> <spring:message code="comCopSmtSim.Navi.Month"/></li><!-- 월 -->
 			<%if(iNowMonth < 11 ){ %>


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

개인 일정의 월·주·일간 화면에서 ‘오늘’을 누르거나, 주·일간 화면에서 ‘이전 달’을 누르면 부서 일정으로 이동하는 링크가 있어 수정했습니다.

## 수정된 소스 내용 Modified source

JSP 3개에서 잘못된 링크 5곳을 개인 일정 경로로 변경했습니다. 기존 날짜 및 검색 파라미터는 유지했습니다.

## JUnit 테스트 JUnit tests

- [ ] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

Chromium 자동 테스트 18건 통과: 월·주·일간의 오늘 이동(일정 구분 선택/미선택), 이전·다음 달 및 이전·다음 해 이동을 확인했습니다.
실제 JSP와 컨트롤러를 실행했고 인증·일정 데이터는 테스트 대역을 사용했습니다. 전체 DB 연동 테스트는 수행하지 않았습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [X] 기타 Others (Chromium 자동 테스트)

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

수정 후 일간 ‘오늘’ 이동 및 일정 구분 유지:

![일간 오늘 이동](https://raw.githubusercontent.com/wizlife/egovframe-common-components/92019188a2661856cb0610c92e9265da51bf2b2c/daily-today.png)

수정 후 주간 ‘이전 달’ 이동:

![주간 이전 달 이동](https://raw.githubusercontent.com/wizlife/egovframe-common-components/92019188a2661856cb0610c92e9265da51bf2b2c/week-previous-month.png)

[전체 테스트 결과 및 화면](https://github.com/wizlife/egovframe-common-components/tree/92019188a2661856cb0610c92e9265da51bf2b2c)
