### PR TITLE
fix: 포상관리 상세조회가 소유권을 확인하지 않던 문제 수정

### DIFF
--- a/src/main/java/egovframework/com/uss/ion/rwd/web/EgovRwardManageController.java
+++ b/src/main/java/egovframework/com/uss/ion/rwd/web/EgovRwardManageController.java
@@ -153,6 +153,11 @@ public class EgovRwardManageController {
 
 		// 등록 상세정보
 		RwardManageVO rwardManageVOTemp = egovRwardManageService.selectRwardManage(rwardManageVO);
+		if (rwardManageVOTemp == null) {
+			throw new IllegalStateException("포상 정보가 없습니다.");
+		}
+		// 신청자 본인 또는 관리자만 조회 가능하도록 소유권 검증 (수정·삭제와 동일)
+		egovAssertAdminOrOwner(rwardManageVOTemp.getFrstRegisterId());
 
 		model.addAttribute("rwardManageVO", rwardManageVOTemp);
 		model.addAttribute("message", egovMessageSource.getMessage("success.common.select"));

--- a/src/test/java/egovframework/com/uss/ion/rwd/web/EgovRwardManageControllerOwnershipTest.java
+++ b/src/test/java/egovframework/com/uss/ion/rwd/web/EgovRwardManageControllerOwnershipTest.java
@@ -383,4 +383,52 @@ class EgovRwardManageControllerOwnershipTest {
 		String view = assertDoesNotThrow(() -> controller.selectRwardConfm(vo, rm, model));
 		assertTrue(view.contains("EgovRwardConfm"));
 	}
+
+	// ---- selectRwardManage (상세 열람) ----
+
+	@Test
+	void viewDetailByOutsiderIsRejected() {
+		StubService service = new StubService(OWNER, SANCTNER);
+		EgovRwardManageController controller = controllerWith(service);
+		bindLoginUser(OUTSIDER, List.of());
+
+		RwardManage rm = requestFor("1");
+		RwardManageVO vo = new RwardManageVO();
+		vo.setRwardId("1");
+		ModelMap model = new ModelMap();
+
+		assertThrows(IllegalStateException.class,
+				() -> controller.selectRwardManage(rm, vo, Collections.emptyMap(), model),
+				"A logged-in non-applicant must not be able to view another member's reward nomination detail.");
+	}
+
+	@Test
+	void viewDetailByApplicantSucceeds() throws Exception {
+		StubService service = new StubService(OWNER, SANCTNER);
+		EgovRwardManageController controller = controllerWith(service);
+		bindLoginUser(OWNER, List.of());
+
+		RwardManage rm = requestFor("1");
+		RwardManageVO vo = new RwardManageVO();
+		vo.setRwardId("1");
+		ModelMap model = new ModelMap();
+
+		String view = assertDoesNotThrow(() -> controller.selectRwardManage(rm, vo, Collections.emptyMap(), model));
+		assertTrue(view.contains("EgovRwardDetail"));
+	}
+
+	@Test
+	void viewDetailByAdminSucceedsEvenWhenNotApplicant() throws Exception {
+		StubService service = new StubService(OWNER, SANCTNER);
+		EgovRwardManageController controller = controllerWith(service);
+		bindLoginUser(OUTSIDER, List.of("ROLE_ADMIN"));
+
+		RwardManage rm = requestFor("1");
+		RwardManageVO vo = new RwardManageVO();
+		vo.setRwardId("1");
+		ModelMap model = new ModelMap();
+
+		String view = assertDoesNotThrow(() -> controller.selectRwardManage(rm, vo, Collections.emptyMap(), model));
+		assertTrue(view.contains("EgovRwardDetail"));
+	}
 }

--- a/src/test/java/egovframework/com/uss/ion/rwd/web/EgovRwardManageControllerRwardCodeListTest.java
+++ b/src/test/java/egovframework/com/uss/ion/rwd/web/EgovRwardManageControllerRwardCodeListTest.java
@@ -119,7 +119,9 @@ class EgovRwardManageControllerRwardCodeListTest {
 	void updateFormEntrySuppliesRwardCodeList() throws Exception {
 		RwardManageVO stored = new RwardManageVO();
 		stored.setRwardId("1");
+		stored.setFrstRegisterId(APPLICANT);
 		EgovRwardManageController controller = controllerWith(stored);
+		bindLoginUser(APPLICANT);
 
 		ModelMap model = new ModelMap();
 		String view = controller.selectRwardManage(new RwardManage(), new RwardManageVO(), Map.of("cmd", "updt"),


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`EgovRwardManageController.selectRwardManage` 는 로그인 여부도 보지 않고 요청이 보낸 `rwardId` 로 포상 정보를 읽어 그대로 화면에 싣습니다.

```java
// EgovRwardManageController.java:148
	public String selectRwardManage(@ModelAttribute("rwardManage") RwardManage rwardManage,
			@ModelAttribute("rwardManageVO") RwardManageVO rwardManageVO, @RequestParam Map<?, ?> commandMap,
			ModelMap model) throws Exception {
		String sCmd = commandMap.get("cmd") == null ? "" : (String) commandMap.get("cmd"); // 상세정보 구분
		rwardManageVO.setRwardDe(EgovStringUtil.removeMinusChar(rwardManageVO.getRwardDe()));

		// 등록 상세정보
		RwardManageVO rwardManageVOTemp = egovRwardManageService.selectRwardManage(rwardManageVO);

		model.addAttribute("rwardManageVO", rwardManageVOTemp);
```

같은 컨트롤러의 `updtRwardManage`·`deleteRwardManage`는 신청자 본인 또는 관리자만 접근하도록 소유권을 대조합니다.

```java
// EgovRwardManageController.java:253
		// 신청자 본인 또는 관리자만 수정 가능하도록 소유권 검증
		RwardManageVO stored = egovRwardManageService.selectRwardManage(rwardManageVO);
		if (stored == null) {
			throw new IllegalStateException("포상 정보가 없습니다.");
		}
		egovAssertAdminOrOwner(stored.getFrstRegisterId());
```

| 메서드 | 위치 | 소유권 대조 |
|---|---|---|
| `updtRwardManage` | `:253~257` | `egovAssertAdminOrOwner(stored.getFrstRegisterId())` |
| `deleteRwardManage` | `:322` | `egovAssertAdminOrOwner(stored.getFrstRegisterId())` |
| `selectRwardManage` | `:155` | 없음 |

목록 화면 `EgovRwardManageList.jsp` 는 `rwardId` 를 히든 필드로 실어 POST 합니다.

```
function fncRwardManageDetail(rwardId){
	var varForm				 = document.all["listForm"];
	varForm.rwardId.value = rwardId;
	varForm.action           = "<c:url value='/uss/ion/rwd/EgovRwardManageDetail.do'/>";
```

`rwardId` 는 `EgovIdGnrService` 로 발급되는 순번 문자열(`idgenRwardManageService.getNextStringId()`)이라 예측 가능하고, 요청 본문의 이 값은 클라이언트가 정합니다. 다른 사용자의 `rwardId` 로 바꾸면 그 사람의 포상자명·소속·포상구분·포상명·포상일자·공적사항과 첨부파일까지 그대로 화면에 실리고, `cmd=updt` 를 붙이면 그 값이 채워진 수정 폼까지 그대로 받습니다(실제 수정 POST 는 `updtRwardManage` 가 다시 대조하므로 막힙니다).

`EgovRwardManageController.java` 안에 이미 있는 `egovAssertAdminOrOwner` 를 읽어온 레코드의 신청자로 호출하도록 두 줄 추가했습니다.

```diff
 		// 등록 상세정보
 		RwardManageVO rwardManageVOTemp = egovRwardManageService.selectRwardManage(rwardManageVO);
+		if (rwardManageVOTemp == null) {
+			throw new IllegalStateException("포상 정보가 없습니다.");
+		}
+		// 신청자 본인 또는 관리자만 조회 가능하도록 소유권 검증 (수정·삭제와 동일)
+		egovAssertAdminOrOwner(rwardManageVOTemp.getFrstRegisterId());
 
 		model.addAttribute("rwardManageVO", rwardManageVOTemp);
 		model.addAttribute("message", egovMessageSource.getMessage("success.common.select"));
```

`ROLE_ADMIN` 예외도 형제 경로와 같은 헬퍼를 쓰므로 동일하게 동작합니다. 신청자 본인과 관리자의 화면은 바뀌지 않습니다.

## JUnit 테스트 JUnit tests

- [x] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

기존 `EgovRwardManageControllerOwnershipTest` 에 `selectRwardManage` 케이스 셋(타인 거부·신청자 본인 허용·관리자 허용)을 추가했습니다. 같은 클래스를 다루는 `EgovRwardManageControllerRwardCodeListTest` 의 `updateFormEntrySuppliesRwardCodeList` 는 로그인·신청자 설정 없이 이 메서드를 호출하고 있어, 소유권 검증을 추가하면 그대로 거부됩니다. 실제 사용 흐름(본인이 자기 신청 건의 수정화면에 들어가는 경우)에 맞게 로그인·신청자를 설정하도록 같이 고쳤습니다.

`pom.xml` 의 surefire 설정이 `<skipTests>true</skipTests>` 로 고정돼 있어, 아래 출력은 그 값을 `${skipTests}` 로 잠시 파라미터화해 받은 것이고 값은 되돌려 뒀습니다.

수정 전:

```
[ERROR] Tests run: 13, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.209 s <<< FAILURE! -- in egovframework.com.uss.ion.rwd.web.EgovRwardManageControllerOwnershipTest
[ERROR]   EgovRwardManageControllerOwnershipTest.viewDetailByOutsiderIsRejected:400 A logged-in non-applicant must not be able to view another member's reward nomination detail. ==> Expected java.lang.IllegalStateException to be thrown, but nothing was thrown.
[ERROR] Tests run: 13, Failures: 1, Errors: 0, Skipped: 0
```

수정 후:

```
[INFO] Tests run: 13, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.210 s -- in egovframework.com.uss.ion.rwd.web.EgovRwardManageControllerOwnershipTest
[INFO] Tests run: 13, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

같은 패키지의 `EgovRwardManageControllerRwardCodeListTest` 도 함께 돌려 그대로 통과합니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

컨트롤러를 직접 호출하는 JUnit 테스트로 확인했습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

검증은 위 JUnit 출력으로 대신합니다.
